### PR TITLE
Set up dynamic height for both widgets

### DIFF
--- a/app/src/scenes/widget/Edit.jsx
+++ b/app/src/scenes/widget/Edit.jsx
@@ -566,21 +566,21 @@ const Frame = ({ widget }) => {
 
 const IFRAMES = {
   benevolat: {
-    carousel: `<iframe title="Trouver une mission de bénévolat" border="0" frameborder="0" style="display:block; width:100%;" loading="lazy" allowfullscreen allow="geolocation" src="${BENEVOLAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '780px': '686px'"></iframe>`,
-    page: `<iframe title="Trouver une mission de bénévolat" border="0" frameborder="0" style="display:block; width:100%;" loading="lazy" allowfullscreen allow="geolocation" src="${BENEVOLAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '3424px': this.offsetWidth < 1024 ? '1862px': '1314px'"></iframe>`,
+    carousel: `<iframe id="engagement-widget" title="Trouver une mission de bénévolat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${BENEVOLAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '780px': '686px'"></iframe>`,
+    page: `<iframe id="engagement-widget" title="Trouver une mission de bénévolat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${BENEVOLAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '3424px': this.offsetWidth < 1024 ? '1862px': '1314px'"></iframe>`,
   },
   volontariat: {
-    carousel: `<iframe title="Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '670px': '600px'"></iframe>`,
-    page: `<iframe title="Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '2200px': this.offsetWidth < 1024 ? '1350px': '1050px'"></iframe>`,
+    carousel: `<iframe id="engagement-widget" title="Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '670px': '600px'"></iframe>`,
+    page: `<iframe id="engagement-widget" title="Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '2200px': this.offsetWidth < 1024 ? '1350px': '1050px'"></iframe>`,
   },
 };
 
 const JVA_LOGO = `<div style="padding:10px; display:flex; justify-content:center; align-items:center;">
-  <img src="https://apicivique.s3.eu-west-3.amazonaws.com/jvalogo.svg"/>
+  <img src="https://apicivique.s3.eu-west-3.amazonaws.com/jvalogo.svg" alt="Logo JeVeuxAider"/>
   <div style="color:#666666; font-style:normal; font-size:13px; padding:8px;">Proposé par la plateforme publique du bénévolat
     <a href="https://www.jeveuxaider.gouv.fr/" target="_blank">JeVeuxAider.gouv.fr</a>
   </div>
-</div>`;
+</div><script>(function(){window.addEventListener('message',function(e){try{var d=e.data;if(d&&d.type==='resize'&&d.height&&d.source==='api-engagement-widget'){document.getElementById('engagement-widget').style.height=d.height+'px'}}catch(err){console.error(err)}})})();</script>`;
 
 const Code = ({ widget }) => {
   const handleCopy = () => {

--- a/widget-benevolat/pages/index.js
+++ b/widget-benevolat/pages/index.js
@@ -13,6 +13,7 @@ import Grid from "../components/Grid";
 import Filters from "../components/Filters";
 import { calculateDistance } from "../utils";
 import useStore from "../store";
+import resizeHelper from "../utils/resizeHelper";
 
 /**
  * Layout widget --> max-width: 1152px
@@ -63,6 +64,13 @@ const Home = ({ widget, missions, apiUrl, total, request, environment }) => {
     } else {
       console.log("Geolocation is not supported by this browser.");
     }
+  }, []);
+
+  useEffect(() => {
+    const cleanup = resizeHelper.setupResizeObserver();
+    return () => {
+      if (typeof cleanup === 'function') cleanup();
+    };
   }, []);
 
   useEffect(() => {

--- a/widget-benevolat/utils/resizeHelper.js
+++ b/widget-benevolat/utils/resizeHelper.js
@@ -1,0 +1,66 @@
+/**
+ * Iframe dynamic height management
+ * Send the height of the iframe to the parent window
+ */
+
+var sendHeightToParent = function() {
+  if (typeof window === 'undefined') return;
+  
+  try {
+    var height = document.body.scrollHeight;
+    window.parent.postMessage(
+      { 
+        type: 'resize', 
+        height: height,
+        source: 'api-engagement-widget'
+      }, 
+      '*'
+    );
+  } catch (error) {
+    console.error('Erreur lors de l\'envoi de la hauteur à la page parente:', error);
+  }
+};
+
+var setupResizeObserver = function() {
+  if (typeof window === 'undefined') return;
+  
+  var observer = new MutationObserver(function() {
+    sendHeightToParent();
+  });
+  
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    characterData: true
+  });
+  
+  window.addEventListener('load', sendHeightToParent);
+  
+  window.addEventListener('load', function() {
+    var images = document.querySelectorAll('img');
+    images.forEach(function(img) {
+      if (img.complete) {
+        sendHeightToParent();
+      } else {
+        img.addEventListener('load', sendHeightToParent);
+      }
+    });
+  });
+  
+  window.addEventListener('resize', sendHeightToParent);
+  
+  var interval = setInterval(sendHeightToParent, 1000);
+  
+  return function() {
+    observer.disconnect();
+    clearInterval(interval);
+    window.removeEventListener('load', sendHeightToParent);
+    window.removeEventListener('resize', sendHeightToParent);
+  };
+};
+
+module.exports = {
+  sendHeightToParent: sendHeightToParent,
+  setupResizeObserver: setupResizeObserver
+};

--- a/widget-volontariat/pages/index.js
+++ b/widget-volontariat/pages/index.js
@@ -15,6 +15,7 @@ import Filters from "../components/Filters";
 import { calculateDistance } from "../utils";
 import { usePlausible } from "next-plausible";
 import useStore from "../store";
+import resizeHelper from "../utils/resizeHelper";
 
 /**
  * Layout widget --> max-width: 1152px
@@ -72,6 +73,13 @@ const Home = ({ widget, apiUrl, missions, total, request, environment }) => {
     } else {
       console.log("Geolocation is not supported by this browser.");
     }
+  }, []);
+
+  useEffect(() => {
+    const cleanup = resizeHelper.setupResizeObserver();
+    return () => {
+      if (typeof cleanup === 'function') cleanup();
+    };
   }, []);
 
   useEffect(() => {

--- a/widget-volontariat/utils/resizeHelper.js
+++ b/widget-volontariat/utils/resizeHelper.js
@@ -1,0 +1,64 @@
+/**
+ * Iframe dynamic height management
+ * Send the height of the iframe to the parent window
+ */
+
+var sendHeightToParent = function() {
+  if (typeof window === 'undefined') return;
+  
+  try {
+    var height = document.body.scrollHeight;
+    window.parent.postMessage(
+      { 
+        type: 'resize', 
+        height: height,
+        source: 'api-engagement-widget'
+      }, 
+      '*'
+    );
+  } catch (error) {
+    console.error('Erreur lors de l\'envoi de la hauteur à la page parente:', error);
+  }
+};
+
+var setupResizeObserver = function() {
+  if (typeof window === 'undefined') return;
+  
+  var observer = new MutationObserver(function() {
+    sendHeightToParent();
+  });
+  
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    characterData: true
+  });
+  
+  window.addEventListener('load', sendHeightToParent);
+  
+  window.addEventListener('load', function() {
+    var images = document.querySelectorAll('img');
+    images.forEach(function(img) {
+      if (img.complete) {
+        sendHeightToParent();
+      } else {
+        img.addEventListener('load', sendHeightToParent);
+      }
+    });
+  });
+  
+  window.addEventListener('resize', sendHeightToParent);
+  
+  var interval = setInterval(sendHeightToParent, 1000);
+  
+  return function() {
+    observer.disconnect();
+    clearInterval(interval);
+  };
+};
+
+module.exports = {
+  sendHeightToParent: sendHeightToParent,
+  setupResizeObserver: setupResizeObserver
+};


### PR DESCRIPTION
## Description

La hauteur du widget s'adapte désormais à son contenu. 
Une nouvelle installation sera nécessaire chez les partenaires qui le souhaitent - rien de bloquant néanmoins sur les anciennes versions. 

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Adaptation-hauteur-widget-pour-le-mobile-1ce72a322d5080859ee5dd456a83c1b9?pvs=4)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [X] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Mise en place d'un observable côté widget qui détecte la hauteur du contenu 
- Envoi à la page parente d'un événement avec la hauteur en pixels
- Dans le nouveau script d'installation, on écoute cet événement et on adapte la hauteur en conséquence. 

NB : Le code est dupliqué mais c'est identifié dans [ce ticket de refacto](https://www.notion.so/jeveuxaider/Adaptation-hauteur-widget-pour-le-mobile-1ce72a322d5080859ee5dd456a83c1b9?pvs=4). 
