### PR TITLE
Add error import when catch error in XML import

### DIFF
--- a/process/src/jobs/import/index.ts
+++ b/process/src/jobs/import/index.ts
@@ -206,10 +206,10 @@ const importPublisher = async (publisher: Publisher, start: Date) => {
     // STATS
     obj.missionCount = await MissionModel.countDocuments({ publisherId: publisher._id, deletedAt: null });
     obj.refusedCount = await MissionModel.countDocuments({ publisherId: publisher._id, deletedAt: null, statusCode: "REFUSED" });
-  } catch (error) {
+  } catch (error: any) {
     captureException(error, `Error while importing publisher ${publisher.name}`);
     obj.status = "FAILED";
-    obj.error = JSON.stringify(error);
+    obj.error = error.message;
   }
 
   obj.endedAt = new Date();

--- a/process/src/jobs/import/index.ts
+++ b/process/src/jobs/import/index.ts
@@ -208,8 +208,8 @@ const importPublisher = async (publisher: Publisher, start: Date) => {
     obj.refusedCount = await MissionModel.countDocuments({ publisherId: publisher._id, deletedAt: null, statusCode: "REFUSED" });
   } catch (error) {
     captureException(error, `Error while importing publisher ${publisher.name}`);
-    console.error(JSON.stringify(error, null, 2));
     obj.status = "FAILED";
+    obj.error = JSON.stringify(error);
   }
 
   obj.endedAt = new Date();

--- a/process/src/jobs/warnings/import.ts
+++ b/process/src/jobs/warnings/import.ts
@@ -43,7 +43,7 @@ export const checkImports = async (publishers: Publisher[]) => {
           publisherLogo: publisher.logo,
         };
         await WarningModel.create(obj);
-        const res = await postMessage({ text: `Alerte détectée: ${publisher.name} - Erreur de flux` }, SLACK_WARNING_CHANNEL_ID);
+        const res = await postMessage({ text: `Alerte détectée: ${publisher.name} - Erreur de flux \n ${lastImport.doc.error}` }, SLACK_WARNING_CHANNEL_ID);
         if (res.error) console.error(res.error);
         else console.log("Slack message sent");
         continue;

--- a/process/src/models/import.ts
+++ b/process/src/models/import.ts
@@ -45,6 +45,10 @@ const schema = new Schema<Import>({
     type: String,
     required: true,
   },
+  error: {
+    type: String,
+    default: null,
+  },
   failed: {
     // any[]
     type: Object,

--- a/process/src/types/index.d.ts
+++ b/process/src/types/index.d.ts
@@ -142,6 +142,7 @@ export interface Import {
   startedAt: Date;
   endedAt: Date | null;
   status: "SUCCESS" | "FAILED";
+  error: string | null;
   failed: any;
 }
 export interface Mission {


### PR DESCRIPTION
## Description

Ajout de l'erreur catch lorsque la mise a jour des missions avec le flux XML a levé une erreur

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Investigation-erreurs-de-flux-pour-Service-Civique-autres-partenaires-Pessac-1dd72a322d50807ca4abcf8dda6dd5fa?pvs=4)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
