### PR TITLE
Refacto de la sync pg des exclusions des organisations

### DIFF
--- a/api/src/models/publisher.ts
+++ b/api/src/models/publisher.ts
@@ -17,16 +17,6 @@ const publisherSchema = new Schema<Diffuseur>(
   { timestamps: true },
 );
 
-const excludedOrganizationSchema = new Schema<any>(
-  {
-    publisherId: { type: String, ref: "publisher" },
-    publisherName: { type: String, required: true, trim: true },
-    organizationClientId: { type: String },
-    organizationName: { type: String, trim: true },
-  },
-  { timestamps: true },
-);
-
 const schema = new Schema<Publisher>(
   {
     name: { type: String, required: true, trim: true },
@@ -59,7 +49,6 @@ const schema = new Schema<Publisher>(
     campaign: { type: Boolean, default: false },
 
     // Depreciated
-    excludedOrganizations: { type: [excludedOrganizationSchema] },
     mission_type: { type: String, default: null, enum: ["benevolat", "volontariat", null] },
     role_promoteur: { type: Boolean, default: false },
     role_annonceur_api: { type: Boolean, default: false },

--- a/process/prisma/migrations/20250430125735_add_unique_constraint/migration.sql
+++ b/process/prisma/migrations/20250430125735_add_unique_constraint/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[excluded_by_publisher_id,excluded_for_publisher_id,organization_client_id]` on the table `OrganizationExclusion` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "OrganizationExclusion_excluded_by_publisher_id_excluded_for_key" ON "OrganizationExclusion"("excluded_by_publisher_id", "excluded_for_publisher_id", "organization_client_id");

--- a/process/prisma/schema.prisma
+++ b/process/prisma/schema.prisma
@@ -493,6 +493,8 @@ model OrganizationExclusion {
 
   excluded_for_publisher_id String
   excluded_for_publisher Partner @relation("ExcludedForPublisher", fields: [excluded_for_publisher_id], references: [id])
+
+  @@unique([excluded_by_publisher_id, excluded_for_publisher_id, organization_client_id])
 }
 
 model User {

--- a/process/src/jobs/metabase/index.ts
+++ b/process/src/jobs/metabase/index.ts
@@ -1,4 +1,5 @@
 import importPartners from "./partner";
+import importOrganizationExclusion from "./organization-exclusion";
 import importUsers from "./user";
 import importCampaigns from "./campaign";
 import importWidgets from "./widget";
@@ -26,6 +27,7 @@ const handler = async () => {
     missions: { created: 0, updated: 0 },
     moderation_events: { created: 0, updated: 0 },
     organization_name_matches: { created: 0, updated: 0 },
+    organization_exclusion: { created: 0, updated: 0 },
     imports: { created: 0, updated: null },
     prints: { created: 0, updated: null },
     clicks: { created: 0, updated: null },
@@ -39,6 +41,11 @@ const handler = async () => {
   const partners = await importPartners();
   stats.partners.created += partners?.created || 0;
   stats.partners.updated += partners?.updated || 0;
+
+  const organization_exclusion = await importOrganizationExclusion();
+  stats.organization_exclusion.created += organization_exclusion?.created || 0;
+  stats.organization_exclusion.updated += organization_exclusion?.deleted || 0;
+
   const users = await importUsers();
   stats.users.created += users?.created || 0;
   stats.users.updated += users?.updated || 0;

--- a/process/src/jobs/metabase/organization-exclusion.ts
+++ b/process/src/jobs/metabase/organization-exclusion.ts
@@ -1,0 +1,92 @@
+import prisma from "../../db/postgres";
+import PublisherModel from "../../models/publisher";
+import { captureException } from "../../error";
+import { Publisher, OrganizationExclusion } from "../../types";
+import { OrganizationExclusion as PgOrganizationExclusion, Partner as PgPartner } from "@prisma/client";
+import OrganizationExclusionModel from "../../models/organization-exclusion";
+import { an } from "vitest/dist/chunks/reporters.d.CfRkRKN2";
+
+const buildData = (doc: OrganizationExclusion, partners: { [key: string]: string }) => {
+  const partnerIdBy = partners[doc.excludedByPublisherId.toString()];
+  if (!partnerIdBy) {
+    console.log(`[OrganizationExclusion] Partner ${doc.excludedByPublisherId.toString()} not found for excluded organization ${doc.organizationClientId}`);
+    return null;
+  }
+  const partnerIdFor = partners[doc.excludedForPublisherId.toString()];
+  if (!partnerIdFor) {
+    console.log(`[OrganizationExclusion] Partner ${doc.excludedForPublisherId.toString()} not found for excluded organization ${doc.organizationClientId}`);
+    return null;
+  }
+
+  const obj = {
+    old_id: doc._id?.toString(),
+    organization_client_id: doc.organizationClientId,
+    organization_name: doc.organizationName,
+    excluded_by_publisher_id: partnerIdBy,
+    excluded_for_publisher_id: partnerIdFor,
+    created_at: new Date(doc.createdAt),
+    updated_at: new Date(doc.updatedAt),
+  } as PgOrganizationExclusion;
+
+  return obj;
+};
+
+const handler = async () => {
+  try {
+    const start = new Date();
+    console.log(`[OrganizationExclusion] Starting at ${start.toISOString()}`);
+
+    const data = await OrganizationExclusionModel.find().lean();
+    console.log(`[OrganizationExclusion] Found ${data.length} docs to sync.`);
+
+    const stored = await prisma.organizationExclusion.findMany({
+      include: { excluded_by_publisher: { select: { id: true, old_id: true } }, excluded_for_publisher: { select: { id: true, old_id: true } } },
+    });
+    console.log(`[OrganizationExclusion] Found ${Object.keys(stored).length} docs in database.`);
+
+    const partners = {} as { [key: string]: string };
+    await prisma.partner.findMany({ select: { old_id: true, id: true } }).then((data) => data.forEach((d) => (partners[d.old_id] = d.id)));
+
+    let created = 0;
+    for (const doc of data) {
+      const exists = stored.find(
+        (d) =>
+          d.excluded_by_publisher.old_id === doc.excludedByPublisherId &&
+          d.excluded_for_publisher.old_id === doc.excludedForPublisherId &&
+          d.organization_client_id === doc.organizationClientId,
+      );
+      if (!exists) {
+        const obj = buildData(doc, partners);
+        if (!obj) continue;
+        try {
+          await prisma.organizationExclusion.create({ data: obj });
+          created++;
+        } catch (error: any) {
+          if (error.code !== "P2002") throw error;
+        }
+      }
+    }
+
+    let deleted = 0;
+    for (const doc of stored) {
+      if (
+        !data.find(
+          (d) =>
+            d.excludedByPublisherId === doc.excluded_by_publisher.old_id &&
+            d.excludedForPublisherId === doc.excluded_for_publisher.old_id &&
+            d.organizationClientId === doc.organization_client_id,
+        )
+      ) {
+        await prisma.organizationExclusion.delete({ where: { id: doc.id } });
+        deleted++;
+      }
+    }
+
+    console.log(`[OrganizationExclusion] Ended at ${new Date().toISOString()} in ${(Date.now() - start.getTime()) / 1000}s, created ${created}, deleted ${deleted}`);
+    return { created, deleted };
+  } catch (error) {
+    captureException(error, "[Partners] Error while syncing docs.");
+  }
+};
+
+export default handler;

--- a/process/src/jobs/metabase/organization-exclusion.ts
+++ b/process/src/jobs/metabase/organization-exclusion.ts
@@ -62,6 +62,7 @@ const handler = async () => {
           await prisma.organizationExclusion.create({ data: obj });
           created++;
         } catch (error: any) {
+          // P2002 === unique constraint violation, In case we write a duplicate, we just ignore it.
           if (error.code !== "P2002") throw error;
         }
       }

--- a/process/src/jobs/metabase/partner.ts
+++ b/process/src/jobs/metabase/partner.ts
@@ -2,7 +2,7 @@ import prisma from "../../db/postgres";
 import PublisherModel from "../../models/publisher";
 import { captureException } from "../../error";
 import { Publisher } from "../../types";
-import { OrganizationExclusion, Partner as PgPartner } from "@prisma/client";
+import { Partner as PgPartner } from "@prisma/client";
 
 const buildData = (doc: Publisher) => {
   const obj = {
@@ -19,33 +19,6 @@ const buildData = (doc: Publisher) => {
   } as PgPartner;
 
   return obj;
-};
-
-const buildExcludedOrganizations = (doc: Publisher, partnerForId: string, partners: { [key: string]: { old_id: string; id: string; updated_at: Date } }) => {
-  const excludedOrganizations = doc.excludedOrganizations
-    .map((e) => {
-      if (!e._id) {
-        console.log(`[Partners] Excluded organization ${e.organizationClientId} has no _id`);
-        return null;
-      }
-      const partnerBy = partners[e.publisherId.toString()];
-      if (!partnerBy) {
-        console.log(`[Partners] Partner ${e.publisherId.toString()} not found for excluded organization ${e.organizationClientId}`);
-        return null;
-      }
-      return {
-        old_id: e._id.toString(),
-        organization_client_id: e.organizationClientId,
-        organization_name: e.organizationName,
-        excluded_by_publisher_id: partnerBy.id,
-        excluded_for_publisher_id: partnerForId,
-        created_at: new Date(e.createdAt),
-        updated_at: new Date(e.updatedAt),
-      } as OrganizationExclusion;
-    })
-    .filter((e) => e !== null);
-
-  return excludedOrganizations;
 };
 
 const isDateEqual = (a: Date, b: Date) => new Date(a).getTime() === new Date(b).getTime();
@@ -65,31 +38,18 @@ const handler = async () => {
     let created = 0;
     let updated = 0;
     let processed = 0;
+
     for (const doc of data) {
       if (processed % 10 === 0) console.log(`[Partners] Processed ${processed}/${data.length} docs, created ${created}, updated ${updated}`);
 
       const exists = stored[doc._id.toString()];
       const obj = buildData(doc as Publisher);
       if (!exists) {
-        const res = await prisma.partner.create({ data: obj });
+        await prisma.partner.create({ data: obj });
         created++;
-        stored[res.old_id] = { old_id: res.old_id, id: res.id, updated_at: res.updated_at };
-        const organizationExclusions = buildExcludedOrganizations(doc as Publisher, res.id, stored);
-        // console.log("create organizationExclusions", organizationExclusions);
-        if (organizationExclusions.length) {
-          await prisma.organizationExclusion.createMany({ data: organizationExclusions, skipDuplicates: true });
-        }
       } else if (!isDateEqual(exists.updated_at, obj.updated_at)) {
         await prisma.partner.update({ where: { old_id: obj.old_id }, data: obj });
         updated++;
-        const organizationExclusions = buildExcludedOrganizations(doc as Publisher, exists.id, stored);
-        if (processed < 10) {
-          console.log("update organizationExclusions", organizationExclusions);
-        }
-        if (organizationExclusions.length) {
-          await prisma.organizationExclusion.deleteMany({ where: { excluded_for_publisher_id: exists.id } });
-          await prisma.organizationExclusion.createMany({ data: organizationExclusions, skipDuplicates: true });
-        }
       }
       processed++;
     }

--- a/process/src/models/organization-exclusion.ts
+++ b/process/src/models/organization-exclusion.ts
@@ -1,0 +1,25 @@
+import { Schema, model } from "mongoose";
+
+import { OrganizationExclusion } from "../types";
+
+const MODELNAME = "organization-exclusion";
+
+const schema = new Schema<OrganizationExclusion>(
+  {
+    excludedByPublisherId: { type: String, ref: "publisher" },
+    excludedByPublisherName: { type: String, required: true, trim: true },
+
+    excludedForPublisherId: { type: String, ref: "publisher" },
+    excludedForPublisherName: { type: String, required: true, trim: true },
+
+    organizationClientId: { type: String },
+    organizationName: { type: String, trim: true },
+  },
+  { timestamps: true },
+);
+
+schema.index({ excludedByPublisherId: 1, excludedForPublisherId: 1, organizationClientId: 1 }, { unique: true });
+schema.index({ excludedForPublisherId: 1 });
+
+const OrganizationExclusionModel = model<OrganizationExclusion>(MODELNAME, schema);
+export default OrganizationExclusionModel;

--- a/process/src/models/publisher.ts
+++ b/process/src/models/publisher.ts
@@ -1,6 +1,6 @@
 import { Schema, model } from "mongoose";
 
-import { Diffuseur, Publisher, PublisherExcludedOrganization } from "../types";
+import { Diffuseur, Publisher } from "../types";
 
 const MODELNAME = "publisher";
 
@@ -13,16 +13,6 @@ const publisherSchema = new Schema<Diffuseur>(
     // Old to migrate
     publisher: { type: String, ref: "publisher" },
     mission_type: { type: String, default: null, enum: ["benevolat", "volontariat", null] },
-  },
-  { timestamps: true },
-);
-
-const excludedOrganizationSchema = new Schema<PublisherExcludedOrganization>(
-  {
-    publisherId: { type: String, ref: "publisher" },
-    publisherName: { type: String, required: true, trim: true },
-    organizationClientId: { type: String },
-    organizationName: { type: String, trim: true },
   },
   { timestamps: true },
 );
@@ -50,7 +40,6 @@ const schema = new Schema<Publisher>(
     lastSyncAt: { type: Date },
 
     publishers: { type: [publisherSchema] },
-    excludedOrganizations: { type: [excludedOrganizationSchema] },
     description: { type: String, default: "" },
     lead: { type: String, default: "" },
     deletedAt: { type: Date, default: null },

--- a/process/src/types/index.d.ts
+++ b/process/src/types/index.d.ts
@@ -405,16 +405,20 @@ export interface Diffuseur {
   mission_type?: string | null; // missionType
 }
 
-export interface PublisherExcludedOrganization {
+export interface OrganizationExclusion {
   _id?: Schema.Types.ObjectId;
-  publisherId: string;
-  publisherName: string;
+  excludedByPublisherId: string;
+  excludedByPublisherName: string;
+
+  excludedForPublisherId: string;
+  excludedForPublisherName: string;
+
   organizationClientId: string;
   organizationName: string;
+
   createdAt: Date;
   updatedAt: Date;
 }
-
 export interface StatsReport {
   publisherId: string;
   publisherName: string;


### PR DESCRIPTION
## Description

La synchronisation avec la base de données PG pour la table exclusion des organisations ne marchait pas

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Metabase-Exclucions-des-orga-sur-MB-1e472a322d5080648772de06e6ee347a)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
