### PR TITLE
Fix widget DayPicker style

### DIFF
--- a/widget-volontariat/components/Filters.jsx
+++ b/widget-volontariat/components/Filters.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { usePlausible } from "next-plausible";
-import { DayPicker } from "react-day-picker";
+import { DayPicker, getDefaultClassNames } from "react-day-picker";
 import fr from "date-fns/locale/fr";
 import { RiArrowUpSLine, RiArrowDownSLine, RiCheckboxFill, RiCheckboxBlankLine, RiRadioButtonLine, RiCircleLine, RiMapPin2Fill, RiCloseFill } from "react-icons/ri";
 
@@ -374,6 +374,7 @@ const DateFilter = ({ selected, onChange, position = "left-0", width = "w-80" })
   const plausible = usePlausible();
   const [isOpen, setIsOpen] = useState(false);
   const ref = useRef(null);
+  const defaultClassNames = getDefaultClassNames();
 
   useEffect(() => {
     const handleClickOutside = (event) => {
@@ -417,13 +418,20 @@ const DateFilter = ({ selected, onChange, position = "left-0", width = "w-80" })
               plausible("Date selected", { props: { date: date.toLocaleDateString("fr") }, u: url });
             }}
             className="w-full flex justify-center border-none"
+            style={{
+              '--rdp-accent-color': color,
+            }}
             modifiers={{
               selected: (date) => selected && date.toLocaleDateString("fr") === selected.value.toLocaleDateString("fr"),
             }}
             modifiersStyles={{
               selected: {
                 backgroundColor: color,
-              },
+                color: 'white',
+                borderRadius: '9999px',
+                display: 'flex',
+                justifyContent: 'center',
+              }
             }}
           />
           <div className="pt-2 pb-1 px-6 w-full flex justify-start border-t border-[#DDDDDD]">

--- a/widget-volontariat/components/Filters.jsx
+++ b/widget-volontariat/components/Filters.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { usePlausible } from "next-plausible";
-import { DayPicker, getDefaultClassNames } from "react-day-picker";
+import { DayPicker } from "react-day-picker";
 import fr from "date-fns/locale/fr";
 import { RiArrowUpSLine, RiArrowDownSLine, RiCheckboxFill, RiCheckboxBlankLine, RiRadioButtonLine, RiCircleLine, RiMapPin2Fill, RiCloseFill } from "react-icons/ri";
 
@@ -374,7 +374,6 @@ const DateFilter = ({ selected, onChange, position = "left-0", width = "w-80" })
   const plausible = usePlausible();
   const [isOpen, setIsOpen] = useState(false);
   const ref = useRef(null);
-  const defaultClassNames = getDefaultClassNames();
 
   useEffect(() => {
     const handleClickOutside = (event) => {


### PR DESCRIPTION
## Description

La mise à jour de DayPicker (encore !) apportait des changements bloquants sur le styling. 
Voici le nouveau rendu : 
![image](https://github.com/user-attachments/assets/495041ac-f9d1-47c5-bb99-256f85944678)

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Widget-volontariat-Affichage-du-datepicker-bugg-1e372a322d50804aa029db7673b84f11?pvs=4)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
