### PR TITLE
Fix des du calcule des aggregations pour les filtres du widget

### DIFF
--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -406,7 +406,7 @@ const buildLocationAggs = (widget: Widget, lon: number | undefined, lat: number 
     const distance = getDistanceKm(widget.distance && widget.distance !== "Aucun" ? widget.distance : "50km");
     where["addresses.geoPoint"] = {
       $geoWithin: {
-        $centerSphere: [[widget.location.lat, widget.location.lon], distance / EARTH_RADIUS],
+        $centerSphere: [[widget.location.lon, widget.location.lat], distance / EARTH_RADIUS],
       },
     };
   } else if (lat && lon) {


### PR DESCRIPTION
## Description

Fix des du calcule des aggregations pour les filtres du widget où l'ordre pour la latitude et la longitude n'est le bon lorsqu'une latitude etait precisée sur un widget

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Filtres-de-widget-volontariat-vide-1e372a322d5080bbb1cbc001ca70f021?pvs=4)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
