### PR TITLE
Mission history events Metabase tracking

### DIFF
--- a/.github/workflows/process-tests.yml
+++ b/.github/workflows/process-tests.yml
@@ -1,0 +1,34 @@
+name: Process Tests
+
+on:
+  push:
+    branches: [main, staging]
+    paths:
+      - "process/**"
+  pull_request:
+    branches: [main, staging]
+    paths:
+      - "process/**"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          cache: "npm"
+          cache-dependency-path: "process/package-lock.json"
+
+      - name: Install dependencies
+        run: cd process && npm ci
+
+      - name: Run tests
+        run: cd process && npm run test:ci

--- a/process/package-lock.json
+++ b/process/package-lock.json
@@ -47,8 +47,8 @@
         "@types/react": "19.1.2",
         "@types/uuid": "10.0.0",
         "@types/yauzl": "2.10.3",
+        "mongodb-memory-server": "^10.1.4",
         "nodemon": "3.1.9",
-        "prettier-plugin-organize-imports": "4.1.0",
         "prisma": "6.2.1",
         "vitest": "3.1.1"
       }
@@ -3089,6 +3089,23 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/async-mutex/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -3135,6 +3152,13 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.12",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
@@ -3178,6 +3202,14 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/base64-arraybuffer": {
       "version": "1.0.2",
@@ -3439,6 +3471,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4269,6 +4314,13 @@
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-json-patch": {
       "version": "3.1.1",
@@ -5301,6 +5353,179 @@
         "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
+    "node_modules/mongodb-memory-server": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-10.1.4.tgz",
+      "integrity": "sha512-+oKQ/kc3CX+816oPFRtaF0CN4vNcGKNjpOQe4bHo/21A3pMD+lC7Xz1EX5HP7siCX4iCpVchDMmCOFXVQSGkUg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "10.1.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.1.4.tgz",
+      "integrity": "sha512-o8fgY7ZalEd8pGps43fFPr/hkQu1L8i6HFEGbsTfA2zDOW0TopgpswaBCqDr0qD7ptibyPfB5DmC+UlIxbThzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.3.7",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.15.9",
+        "https-proxy-agent": "^7.0.5",
+        "mongodb": "^6.9.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.6.3",
+        "tar-stream": "^3.1.7",
+        "tslib": "^2.7.0",
+        "yauzl": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/mongodb-memory-server/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/mongoose": {
       "version": "8.13.2",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.13.2.tgz",
@@ -5447,6 +5672,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
       }
     },
     "node_modules/node-releases": {
@@ -5918,38 +6156,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-plugin-organize-imports": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.1.0.tgz",
-      "integrity": "sha512-5aWRdCgv645xaa58X8lOxzZoiHAldAPChljr/MT0crXVOWTZ+Svl4hIWlz+niYSlO6ikE5UXkN1JrRvIP2ut0A==",
-      "dev": true,
-      "peerDependencies": {
-        "prettier": ">=2.0",
-        "typescript": ">=2.9",
-        "vue-tsc": "^2.1.0"
-      },
-      "peerDependenciesMeta": {
-        "vue-tsc": {
-          "optional": true
-        }
       }
     },
     "node_modules/prisma": {
@@ -6817,6 +7023,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamx": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
     "node_modules/strnum": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.0.5.tgz",
@@ -6884,6 +7104,28 @@
       "funding": {
         "type": "Buy me a coffee",
         "url": "https://www.buymeacoffee.com/systeminfo"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-segmentation": {

--- a/process/package.json
+++ b/process/package.json
@@ -60,6 +60,7 @@
     "@types/react": "19.1.2",
     "@types/uuid": "10.0.0",
     "@types/yauzl": "2.10.3",
+    "mongodb-memory-server": "^10.1.4",
     "nodemon": "3.1.9",
     "prisma": "6.2.1",
     "vitest": "3.1.1"

--- a/process/package.json
+++ b/process/package.json
@@ -19,7 +19,7 @@
     "lint:fix": "eslint --ext .js,.ts src/ --fix",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:ci": "vitest run --pool=forks"
   },
   "dependencies": {
     "@babel/core": "7.26.10",

--- a/process/prisma/schema.prisma
+++ b/process/prisma/schema.prisma
@@ -612,14 +612,14 @@ model MissionHistoryEvent {
 }
 
 enum MissionHistoryEventType {
-  MissionsModifiedStartDate
-  MissionsModifiedEndDate
+  MissionDeleted
+  MissionModifiedStartDate
+  MissionModifiedEndDate
   MissionModifiedDescription
   MissionModifiedActivityDomain
   MissionModifiedPlaces
-  MissionModifiedAdresses
-  MissionsModifiedJVAModerationStatus
-  MissionsModifiedApiEngModerationStatus
+  MissionModifiedJVAModerationStatus
+  MissionModifiedApiEngModerationStatus
   MissionModifiedOther
 }
 

--- a/process/prisma/schema.prisma
+++ b/process/prisma/schema.prisma
@@ -341,7 +341,7 @@ model Mission {
   organization                    Organization? @relation(fields: [matched_organization_id], references: [id])
   partner                         Partner?      @relation(fields: [partner_id], references: [id])
   moderation_events               ModerationEvent[]
-  history                         MissionHistory[] @relation("MissionHistory")
+  history_events                  MissionHistoryEvent[] @relation("MissionHistoryEvent")
 
   @@index([client_id], map: "mission_client_id")
   @@index([matched_organization_id], map: "mission_matched_organization_id")
@@ -600,18 +600,28 @@ model PartnerToWidget {
   @@index([widget_id])
 }
 
-model MissionHistory {
+model MissionHistoryEvent {
   id                String    @id @default(uuid())
   date              DateTime  @default(now())
-  state             Json      // All fields that have changed
-  metadata          Json?
+  type              MissionHistoryEventType
   mission_id        String    
 
-  mission           Mission?  @relation("MissionHistory", fields: [mission_id], references: [id])
+  mission           Mission?  @relation("MissionHistoryEvent", fields: [mission_id], references: [id])
   
   @@index([mission_id])
 }
 
+enum MissionHistoryEventType {
+  MissionsModifiedStartDate
+  MissionsModifiedEndDate
+  MissionModifiedDescription
+  MissionModifiedActivityDomain
+  MissionModifiedPlaces
+  MissionModifiedAdresses
+  MissionsModifiedJVAModerationStatus
+  MissionsModifiedApiEngModerationStatus
+  MissionModifiedOther
+}
 
 enum MissionType {
   benevolat

--- a/process/prisma/schema.prisma
+++ b/process/prisma/schema.prisma
@@ -612,16 +612,16 @@ model MissionHistoryEvent {
 }
 
 enum MissionHistoryEventType {
-  MissionCreated
-  MissionDeleted
-  MissionModifiedStartDate
-  MissionModifiedEndDate
-  MissionModifiedDescription
-  MissionModifiedActivityDomain
-  MissionModifiedPlaces
-  MissionModifiedJVAModerationStatus
-  MissionModifiedApiEngModerationStatus
-  MissionModifiedOther
+  Created
+  Deleted
+  UpdatedStartDate
+  UpdatedEndDate
+  UpdatedDescription
+  UpdatedActivityDomain
+  UpdatedPlaces
+  UpdatedJVAModerationStatus
+  UpdatedApiEngModerationStatus
+  UpdatedOther
 }
 
 enum MissionType {

--- a/process/prisma/schema.prisma
+++ b/process/prisma/schema.prisma
@@ -612,6 +612,7 @@ model MissionHistoryEvent {
 }
 
 enum MissionHistoryEventType {
+  MissionCreated
   MissionDeleted
   MissionModifiedStartDate
   MissionModifiedEndDate

--- a/process/src/config.ts
+++ b/process/src/config.ts
@@ -27,3 +27,7 @@ export const REGION = process.env.SCW_REGION || "fr-par";
 
 export const SCW_ACCESS_KEY = process.env.SCW_ACCESS_KEY;
 export const SCW_SECRET_KEY = process.env.SCW_SECRET_KEY;
+
+// Ids
+export const JVA_ID = "5f5931496c7ea514150a818f"; // JeVeuxAider Id
+export const SC_ID = "5f99dbe75eb1ad767733b206"; // Service Civique Id

--- a/process/src/jobs/import/utils/__tests__/transformers.test.ts
+++ b/process/src/jobs/import/utils/__tests__/transformers.test.ts
@@ -275,9 +275,27 @@ describe("transformMongoMissionToPg", () => {
 });
 
 describe("getMissionHistoryEventTypeFromState", () => {
+  it("should return only MissionCreated event type", () => {
+    const result = getMissionHistoryEventTypeFromState({
+      metadata: { created: true },
+      state: {
+        startAt: "2023-01-01",
+        endAt: "2023-01-02",
+        description: "Description",
+        domain: "Domaine",
+      },
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(1);
+    expect(result).toContain(MissionHistoryEventType.MissionCreated);
+  });
+
   it("should return MissionsDeleted event type", () => {
     const result = getMissionHistoryEventTypeFromState({
-      deletedAt: "2023-01-01",
+      state: {
+        deletedAt: "2023-01-01",
+      },
     });
 
     expect(Array.isArray(result)).toBe(true);
@@ -287,7 +305,9 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
   it("should return MissionsModifiedStartDate event type", () => {
     const result = getMissionHistoryEventTypeFromState({
-      startAt: "2023-01-01",
+      state: {
+        startAt: "2023-01-01",
+      },
     });
 
     expect(Array.isArray(result)).toBe(true);
@@ -297,7 +317,9 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
   it("should return MissionsModifiedEndDate event type", () => {
     const result = getMissionHistoryEventTypeFromState({
-      endAt: "2023-01-01",
+      state: {
+        endAt: "2023-01-01",
+      },
     });
 
     expect(Array.isArray(result)).toBe(true);
@@ -307,7 +329,9 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
   it("should return MissionModifiedDescription event type", () => {
     const result = getMissionHistoryEventTypeFromState({
-      description: "Description",
+      state: {
+        description: "Description",
+      },
     });
 
     expect(Array.isArray(result)).toBe(true);
@@ -317,7 +341,9 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
   it("should return MissionModifiedActivityDomain event type", () => {
     const result = getMissionHistoryEventTypeFromState({
-      domain: "Domaine",
+      state: {
+        domain: "Domaine",
+      },
     });
 
     expect(Array.isArray(result)).toBe(true);
@@ -327,7 +353,9 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
   it("should return MissionModifiedPlaces event type", () => {
     const result = getMissionHistoryEventTypeFromState({
-      places: 1,
+      state: {
+        places: 1,
+      },
     });
 
     expect(Array.isArray(result)).toBe(true);
@@ -337,7 +365,9 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
   it("should return MissionModifiedJVAModerationStatus event type", () => {
     const result = getMissionHistoryEventTypeFromState({
-      [`moderation_${JVA_ID}_status`]: "status",
+      state: {
+        [`moderation_${JVA_ID}_status`]: "status",
+      },
     });
 
     expect(Array.isArray(result)).toBe(true);
@@ -347,7 +377,9 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
   it("should return MissionModifiedApiEngModerationStatus event type", () => {
     const result = getMissionHistoryEventTypeFromState({
-      //jva_moderation_status: 'status',
+      state: {
+        status: "accepted",
+      },
     });
 
     expect(Array.isArray(result)).toBe(true);
@@ -357,7 +389,9 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
   it("should return MissionModifiedOther event type", () => {
     const result = getMissionHistoryEventTypeFromState({
-      other: "value",
+      state: {
+        other: "value",
+      },
     });
 
     expect(Array.isArray(result)).toBe(true);
@@ -367,10 +401,12 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
   it("Should return multiple event types", () => {
     const result = getMissionHistoryEventTypeFromState({
-      startAt: "2023-01-01",
-      endAt: "2023-01-02",
-      description: "Description",
-      domain: "Domaine",
+      state: {
+        startAt: "2023-01-01",
+        endAt: "2023-01-02",
+        description: "Description",
+        domain: "Domaine",
+      },
     });
 
     expect(Array.isArray(result)).toBe(true);

--- a/process/src/jobs/import/utils/__tests__/transformers.test.ts
+++ b/process/src/jobs/import/utils/__tests__/transformers.test.ts
@@ -180,6 +180,7 @@ describe("transformMongoMissionToPg", () => {
         state: baseHistoryState,
         metadata: {
           reason: "reason",
+          action: "created",
         },
       },
     ],
@@ -277,7 +278,7 @@ describe("transformMongoMissionToPg", () => {
 describe("getMissionHistoryEventTypeFromState", () => {
   it("should return only MissionCreated event type", () => {
     const result = getMissionHistoryEventTypeFromState({
-      metadata: { created: true },
+      metadata: { action: "created" },
       state: {
         startAt: "2023-01-01",
         endAt: "2023-01-02",

--- a/process/src/jobs/import/utils/__tests__/transformers.test.ts
+++ b/process/src/jobs/import/utils/__tests__/transformers.test.ts
@@ -3,7 +3,7 @@ import { Schema } from "mongoose";
 import { describe, expect, it } from "vitest";
 import { JVA_ID } from "../../../../config";
 import { Mission as MongoMission } from "../../../../types";
-import { getMissionHistoryEventTypeFromState, transformMongoMissionToPg } from "../transformers";
+import { getTypeFromMissionHistoryEvent, transformMongoMissionToPg } from "../transformers";
 
 // TODO: is this interface defined in the project?
 interface Address {
@@ -229,7 +229,7 @@ describe("transformMongoMissionToPg", () => {
 
     expect(result?.history.length).toBe(1);
     expect(result?.history[0].date).toEqual(new Date("2023-01-20"));
-    expect(result?.history[0].type).toBeDefined(); // Value will be checked by getMissionHistoryEventTypeFromState test
+    expect(result?.history[0].type).toBeDefined(); // Value will be checked by getTypeFromMissionHistoryEvent test
   });
 
   it("should handle a mission with no organization match", () => {
@@ -275,9 +275,9 @@ describe("transformMongoMissionToPg", () => {
   });
 });
 
-describe("getMissionHistoryEventTypeFromState", () => {
+describe("getTypeFromMissionHistoryEvent", () => {
   it("should return only MissionCreated event type", () => {
-    const result = getMissionHistoryEventTypeFromState({
+    const result = getTypeFromMissionHistoryEvent({
       metadata: { action: "created" },
       state: {
         startAt: "2023-01-01",
@@ -289,11 +289,11 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(1);
-    expect(result).toContain(MissionHistoryEventType.MissionCreated);
+    expect(result).toContain(MissionHistoryEventType.Created);
   });
 
   it("should return MissionsDeleted event type", () => {
-    const result = getMissionHistoryEventTypeFromState({
+    const result = getTypeFromMissionHistoryEvent({
       state: {
         deletedAt: "2023-01-01",
       },
@@ -301,11 +301,11 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(1);
-    expect(result).toContain(MissionHistoryEventType.MissionDeleted);
+    expect(result).toContain(MissionHistoryEventType.Deleted);
   });
 
   it("should return MissionsModifiedStartDate event type", () => {
-    const result = getMissionHistoryEventTypeFromState({
+    const result = getTypeFromMissionHistoryEvent({
       state: {
         startAt: "2023-01-01",
       },
@@ -313,11 +313,11 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(1);
-    expect(result).toContain(MissionHistoryEventType.MissionModifiedStartDate);
+    expect(result).toContain(MissionHistoryEventType.UpdatedStartDate);
   });
 
   it("should return MissionsModifiedEndDate event type", () => {
-    const result = getMissionHistoryEventTypeFromState({
+    const result = getTypeFromMissionHistoryEvent({
       state: {
         endAt: "2023-01-01",
       },
@@ -325,11 +325,11 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(1);
-    expect(result).toContain(MissionHistoryEventType.MissionModifiedEndDate);
+    expect(result).toContain(MissionHistoryEventType.UpdatedEndDate);
   });
 
   it("should return MissionModifiedDescription event type", () => {
-    const result = getMissionHistoryEventTypeFromState({
+    const result = getTypeFromMissionHistoryEvent({
       state: {
         description: "Description",
       },
@@ -337,11 +337,11 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(1);
-    expect(result).toContain(MissionHistoryEventType.MissionModifiedDescription);
+    expect(result).toContain(MissionHistoryEventType.UpdatedDescription);
   });
 
   it("should return MissionModifiedActivityDomain event type", () => {
-    const result = getMissionHistoryEventTypeFromState({
+    const result = getTypeFromMissionHistoryEvent({
       state: {
         domain: "Domaine",
       },
@@ -349,11 +349,11 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(1);
-    expect(result).toContain(MissionHistoryEventType.MissionModifiedActivityDomain);
+    expect(result).toContain(MissionHistoryEventType.UpdatedActivityDomain);
   });
 
   it("should return MissionModifiedPlaces event type", () => {
-    const result = getMissionHistoryEventTypeFromState({
+    const result = getTypeFromMissionHistoryEvent({
       state: {
         places: 1,
       },
@@ -361,11 +361,11 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(1);
-    expect(result).toContain(MissionHistoryEventType.MissionModifiedPlaces);
+    expect(result).toContain(MissionHistoryEventType.UpdatedPlaces);
   });
 
   it("should return MissionModifiedJVAModerationStatus event type", () => {
-    const result = getMissionHistoryEventTypeFromState({
+    const result = getTypeFromMissionHistoryEvent({
       state: {
         [`moderation_${JVA_ID}_status`]: "status",
       },
@@ -373,11 +373,11 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(1);
-    expect(result).toContain(MissionHistoryEventType.MissionModifiedJVAModerationStatus);
+    expect(result).toContain(MissionHistoryEventType.UpdatedJVAModerationStatus);
   });
 
   it("should return MissionModifiedApiEngModerationStatus event type", () => {
-    const result = getMissionHistoryEventTypeFromState({
+    const result = getTypeFromMissionHistoryEvent({
       state: {
         status: "accepted",
       },
@@ -385,11 +385,11 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(1);
-    expect(result).toContain(MissionHistoryEventType.MissionModifiedApiEngModerationStatus);
+    expect(result).toContain(MissionHistoryEventType.UpdatedApiEngModerationStatus);
   });
 
   it("should return MissionModifiedOther event type", () => {
-    const result = getMissionHistoryEventTypeFromState({
+    const result = getTypeFromMissionHistoryEvent({
       state: {
         other: "value",
       },
@@ -397,11 +397,11 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(1);
-    expect(result).toContain(MissionHistoryEventType.MissionModifiedOther);
+    expect(result).toContain(MissionHistoryEventType.UpdatedOther);
   });
 
   it("Should return multiple event types", () => {
-    const result = getMissionHistoryEventTypeFromState({
+    const result = getTypeFromMissionHistoryEvent({
       state: {
         startAt: "2023-01-01",
         endAt: "2023-01-02",
@@ -412,9 +412,9 @@ describe("getMissionHistoryEventTypeFromState", () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(4);
-    expect(result).toContain(MissionHistoryEventType.MissionModifiedStartDate);
-    expect(result).toContain(MissionHistoryEventType.MissionModifiedEndDate);
-    expect(result).toContain(MissionHistoryEventType.MissionModifiedDescription);
-    expect(result).toContain(MissionHistoryEventType.MissionModifiedActivityDomain);
+    expect(result).toContain(MissionHistoryEventType.UpdatedStartDate);
+    expect(result).toContain(MissionHistoryEventType.UpdatedEndDate);
+    expect(result).toContain(MissionHistoryEventType.UpdatedDescription);
+    expect(result).toContain(MissionHistoryEventType.UpdatedActivityDomain);
   });
 });

--- a/process/src/jobs/import/utils/db.ts
+++ b/process/src/jobs/import/utils/db.ts
@@ -145,11 +145,11 @@ const writePg = async (publisher: Publisher, importDoc: Import) => {
     })
     .flat();
 
-  const resHistory = await prisma.missionHistory.createMany({
+  const resHistory = await prisma.missionHistoryEvent.createMany({
     data: pgCreateHistory.map((h) => ({
       ...h,
-      state: h.state as any,
-      metadata: h.metadata as any,
+      mission_id: h.mission_id,
+      type: getMissionHistoryEventTypeFromState(h.state),
     })),
   });
   console.log(`[${publisher.name}] Postgres created ${resHistory.count} history entries`);
@@ -193,13 +193,12 @@ const writePg = async (publisher: Publisher, importDoc: Import) => {
       });
 
       // Replace history
-      await prisma.missionHistory.deleteMany({ where: { mission_id: mission.id } });
-      await prisma.missionHistory.createMany({
+      await prisma.missionHistoryEvent.deleteMany({ where: { mission_id: mission.id } });
+      await prisma.missionHistoryEvent.createMany({
         data: obj.history.map((e) => ({
           ...e,
           mission_id: mission.id,
-          state: e.state as any, // Cast state to any to resolve type incompatibility with Prisma
-          metadata: e.metadata as any,
+          type: getMissionHistoryEventTypeFromState(e.state),
         })),
       });
 

--- a/process/src/jobs/import/utils/transformers.ts
+++ b/process/src/jobs/import/utils/transformers.ts
@@ -148,7 +148,7 @@ export const transformMongoMissionToPg = (
   // Transform history entries
   const history: MissionHistoryEntry[] =
     doc.__history?.flatMap((history) =>
-      getMissionHistoryEventTypeFromState(history.state).map((type) => ({
+      getMissionHistoryEventTypeFromState(history).map((type) => ({
         date: history.date,
         mission_id: obj.id,
         type,
@@ -159,14 +159,21 @@ export const transformMongoMissionToPg = (
 };
 
 /**
- * Analyze a state object and determine which MissionHistoryEventTypes to assign
- * @param state The state object to analyze
+ * Analyze a mission history entry and determine which MissionHistoryEventTypes to assign
+ *
+ * @param missionHistory The mission history entry containing state and metadata
  * @returns An array of MissionHistoryEventTypes
  */
 export const getMissionHistoryEventTypeFromState = (
-  state: Record<string, any>
+  missionHistory: any // TODO
 ): MissionHistoryEventType[] => {
   const eventTypes: MissionHistoryEventType[] = [];
+  const { state, metadata } = missionHistory;
+
+  // For creation type, return only MissionCreated
+  if (metadata && "created" in metadata) {
+    return [MissionHistoryEventType.MissionCreated];
+  }
 
   if ("deletedAt" in state) {
     eventTypes.push(MissionHistoryEventType.MissionDeleted);

--- a/process/src/jobs/import/utils/transformers.ts
+++ b/process/src/jobs/import/utils/transformers.ts
@@ -171,7 +171,7 @@ export const getMissionHistoryEventTypeFromState = (
   const { state, metadata } = missionHistory;
 
   // For creation type, return only MissionCreated
-  if (metadata && "created" in metadata) {
+  if (metadata && "action" in metadata && metadata.action === "created") {
     return [MissionHistoryEventType.MissionCreated];
   }
 

--- a/process/src/jobs/import/utils/transformers.ts
+++ b/process/src/jobs/import/utils/transformers.ts
@@ -148,7 +148,7 @@ export const transformMongoMissionToPg = (
   // Transform history entries
   const history: MissionHistoryEntry[] =
     doc.__history?.flatMap((history) =>
-      getMissionHistoryEventTypeFromState(history).map((type) => ({
+      getTypeFromMissionHistoryEvent(history).map((type) => ({
         date: history.date,
         mission_id: obj.id,
         type,
@@ -164,7 +164,7 @@ export const transformMongoMissionToPg = (
  * @param missionHistory The mission history entry containing state and metadata
  * @returns An array of MissionHistoryEventTypes
  */
-export const getMissionHistoryEventTypeFromState = (
+export const getTypeFromMissionHistoryEvent = (
   missionHistory: any // TODO
 ): MissionHistoryEventType[] => {
   const eventTypes: MissionHistoryEventType[] = [];
@@ -172,43 +172,43 @@ export const getMissionHistoryEventTypeFromState = (
 
   // For creation type, return only MissionCreated
   if (metadata && "action" in metadata && metadata.action === "created") {
-    return [MissionHistoryEventType.MissionCreated];
+    return [MissionHistoryEventType.Created];
   }
 
   if ("deletedAt" in state) {
-    eventTypes.push(MissionHistoryEventType.MissionDeleted);
+    eventTypes.push(MissionHistoryEventType.Deleted);
   }
 
   if ("startAt" in state) {
-    eventTypes.push(MissionHistoryEventType.MissionModifiedStartDate);
+    eventTypes.push(MissionHistoryEventType.UpdatedStartDate);
   }
 
   if ("endAt" in state) {
-    eventTypes.push(MissionHistoryEventType.MissionModifiedEndDate);
+    eventTypes.push(MissionHistoryEventType.UpdatedEndDate);
   }
 
   if ("description" in state || "descriptionHtml" in state) {
-    eventTypes.push(MissionHistoryEventType.MissionModifiedDescription);
+    eventTypes.push(MissionHistoryEventType.UpdatedDescription);
   }
 
   if ("domain" in state) {
-    eventTypes.push(MissionHistoryEventType.MissionModifiedActivityDomain);
+    eventTypes.push(MissionHistoryEventType.UpdatedActivityDomain);
   }
 
   if ("places" in state) {
-    eventTypes.push(MissionHistoryEventType.MissionModifiedPlaces);
+    eventTypes.push(MissionHistoryEventType.UpdatedPlaces);
   }
 
   if (state.hasOwnProperty(`moderation_${JVA_ID}_status`)) {
-    eventTypes.push(MissionHistoryEventType.MissionModifiedJVAModerationStatus);
+    eventTypes.push(MissionHistoryEventType.UpdatedJVAModerationStatus);
   }
 
   if ("status" in state || "statusCode" in state) {
-    eventTypes.push(MissionHistoryEventType.MissionModifiedApiEngModerationStatus);
+    eventTypes.push(MissionHistoryEventType.UpdatedApiEngModerationStatus);
   }
 
   if (eventTypes.length === 0) {
-    eventTypes.push(MissionHistoryEventType.MissionModifiedOther);
+    eventTypes.push(MissionHistoryEventType.UpdatedOther);
   }
 
   return eventTypes;

--- a/process/src/plugins/__tests__/history-plugin.test.ts
+++ b/process/src/plugins/__tests__/history-plugin.test.ts
@@ -1,523 +1,228 @@
-import { Schema } from "mongoose";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { historyPlugin } from "../history-plugin";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import mongoose, { Document, Schema } from "mongoose";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-interface HistoryEntry {
-  date: Date;
-  state: Record<string, any>;
-  metadata?: Record<string, any>;
+import { HISTORY_ACTIONS, HistoryEntry, historyPlugin } from "../history-plugin";
+
+// MongoDB Memory Server setup
+// Note: This configuration could be extracted to a separate setup.ts file
+// when more tests will use MongoMemoryServer
+let mongoServer: MongoMemoryServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
+  await mongoose.connect(mongoUri);
+});
+
+beforeEach(async () => {
+  // Clear all collections before each test
+  const collections = mongoose.connection.collections;
+  for (const key in collections) {
+    const collection = collections[key];
+    await collection.deleteMany({});
+  }
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+// Define interfaces for our test models
+interface TestDocument extends Document {
+  name: string;
+  description?: string;
+  status?: string;
+  tags?: string[];
+  counter?: number;
+  updatedAt?: Date;
+  __history?: HistoryEntry[];
+  getHistory: () => HistoryEntry[];
 }
 
-// Import constants from history-plugin.ts to ensure consistency
-const HISTORY_ACTIONS = {
-  CREATED: "created",
-  UPDATED: "updated",
-} as const;
-
-class MockDocument {
-  isNew = false;
-
-  isModified = vi.fn();
-
-  modifiedPaths = vi.fn();
-
-  get = vi.fn();
-
-  toObject = vi.fn();
-
-  __history: HistoryEntry[] = [];
-
-  constructor(initialData: Record<string, any> = {}) {
-    Object.assign(this, initialData);
-  }
-
-  save(): Promise<MockDocument> {
-    return Promise.resolve(this);
-  }
+interface TestModel extends mongoose.Model<TestDocument> {
+  withHistoryContext: (metadata: Record<string, any>) => {
+    save: (doc: TestDocument) => Promise<TestDocument>;
+    bulkWrite: (operations: any[]) => Promise<any>;
+  };
+  bulkWriteWithHistory: (operations: any[]) => Promise<any>;
 }
 
-class MockSchema {
-  paths: Record<string, any> = {};
+describe("History Plugin Integration Tests", () => {
+  let TestModel: TestModel;
 
-  methods: Record<string, any> = {};
+  beforeEach(async () => {
+    // Create a new schema and model for each test
+    const testSchema = new Schema(
+      {
+        name: { type: String, required: true },
+        description: String,
+        status: String,
+        tags: [String],
+        counter: Number,
+        updatedAt: { type: Date, default: Date.now },
+      },
+      { timestamps: true }
+    );
 
-  statics: Record<string, any> = {};
-
-  pre = vi.fn();
-
-  add = vi.fn();
-
-  path = vi.fn();
-
-  constructor() {
-    this.path.mockImplementation((pathName: string) => {
-      return this.paths[pathName];
-    });
-  }
-}
-
-describe("History Plugin", () => {
-  let schema: MockSchema;
-  let preHook: (next: () => void) => void;
-  let doc: MockDocument;
-
-  beforeEach(() => {
-    vi.resetAllMocks();
-
-    schema = new MockSchema();
-
-    historyPlugin(schema as unknown as Schema, {
+    // Apply the history plugin
+    testSchema.plugin(historyPlugin, {
       historyField: "__history",
-      omit: ["updatedAt", "__v", "__history"],
+      omit: ["updatedAt", "__v", "__history", "createdAt"],
       maxEntries: 10,
     });
 
-    preHook = schema.pre.mock.calls.find((call) => call[0] === "save")?.[1];
-
-    doc = new MockDocument({
-      name: "Test Document",
-      description: "Test Description",
-      status: "pending",
-      updatedAt: new Date(),
-      __v: 0,
-    });
+    // Create a new model with the schema
+    // Use a unique model name for each test to avoid OverwriteModelError
+    const modelName = `Test${Date.now()}`;
+    TestModel = mongoose.model<TestDocument, TestModel>(modelName, testSchema);
   });
 
-  it("should add __history field to schema if it does not exist", () => {
-    expect(schema.add).toHaveBeenCalled();
-    const addCall = schema.add.mock.calls[0][0];
-    expect(addCall).toHaveProperty("__history");
-  });
-
-  it("should add methods to schema", () => {
-    expect(schema.methods).toHaveProperty("getHistory");
-    expect(schema.statics).toHaveProperty("withHistoryContext");
-  });
-
-  it("should not create history entry for new documents without fields", () => {
-    doc.isNew = true;
-
-    // Mock toObject to return empty object
-    doc.toObject.mockReturnValue({});
-
-    const next = vi.fn();
-
-    preHook.call(doc, next);
-
-    expect(next).toHaveBeenCalled();
-    expect(doc.__history.length).toBe(0);
-  });
-
-  it("should create history entry with full state and 'created' action for new documents", () => {
-    doc.isNew = true;
-
-    // Setup document with initial values
-    const initialData = {
+  it("should create history entry with 'created' action for new documents", async () => {
+    const doc = new TestModel({
       name: "New Document",
       description: "Initial Description",
       status: "draft",
       tags: ["test", "new"],
       counter: 1,
-    };
-
-    // Mock toObject to return all fields
-    doc.toObject.mockReturnValue({
-      ...initialData,
-      updatedAt: new Date(),
-      __v: 0,
-      __history: [],
     });
 
-    // Mock get to return field values
-    doc.get.mockImplementation((path: string) => {
-      if (initialData.hasOwnProperty(path)) {
-        return (initialData as Record<string, any>)[path];
-      }
-      if (path === "updatedAt") {
-        return new Date();
-      }
-      if (path === "__v") {
-        return 0;
-      }
-      if (path === "__history") {
-        return [];
-      }
-      return null;
-    });
+    await doc.save();
+    const history = doc.getHistory();
 
-    const next = vi.fn();
-
-    preHook.call(doc, next);
-
-    expect(next).toHaveBeenCalled();
-    expect(doc.__history.length).toBe(1);
+    // Verify history was created
+    expect(history.length).toBe(1);
 
     // Verify all fields (except omitted ones) are in the state
-    expect(doc.__history[0].state).toHaveProperty("name", "New Document");
-    expect(doc.__history[0].state).toHaveProperty("description", "Initial Description");
-    expect(doc.__history[0].state).toHaveProperty("status", "draft");
-    expect(doc.__history[0].state).toHaveProperty("tags");
-    expect(doc.__history[0].state).toHaveProperty("counter", 1);
+    expect(history[0].state).toHaveProperty("name", "New Document");
+    expect(history[0].state).toHaveProperty("description", "Initial Description");
+    expect(history[0].state).toHaveProperty("status", "draft");
+    expect(history[0].state).toHaveProperty("tags");
+    expect(history[0].state).toHaveProperty("counter", 1);
 
     // Verify omitted fields are not in the state
-    expect(doc.__history[0].state).not.toHaveProperty("updatedAt");
-    expect(doc.__history[0].state).not.toHaveProperty("__v");
-    expect(doc.__history[0].state).not.toHaveProperty("__history");
+    expect(history[0].state).not.toHaveProperty("updatedAt");
+    expect(history[0].state).not.toHaveProperty("__v");
+    expect(history[0].state).not.toHaveProperty("__history");
+    expect(history[0].state).not.toHaveProperty("createdAt");
 
     // Verify action metadata
-    expect(doc.__history[0].metadata).toHaveProperty("action", HISTORY_ACTIONS.CREATED);
+    expect(history[0].metadata).toHaveProperty("action", HISTORY_ACTIONS.CREATED);
   });
 
-  it("should create history entry when document is updated", () => {
-    doc.isNew = false;
-
-    doc.modifiedPaths.mockReturnValue(["name", "status"]);
-    doc.isModified.mockImplementation((path: string) => ["name", "status"].includes(path));
-    doc.get.mockImplementation((path: string) => {
-      if (path === "name") {
-        return "Updated Name";
-      }
-      if (path === "status") {
-        return "active";
-      }
-      return null;
+  it("should create history entry with 'updated' action when document is updated", async () => {
+    const doc = new TestModel({
+      name: "Original Name",
+      status: "pending",
     });
+    await doc.save();
 
-    const next = vi.fn();
+    // Update the document
+    doc.name = "Updated Name";
+    doc.status = "active";
+    await doc.save();
 
-    preHook.call(doc, next);
+    const history = doc.getHistory();
 
-    expect(next).toHaveBeenCalled();
-    expect(doc.__history.length).toBe(1);
-    expect(doc.__history[0].state).toHaveProperty("name", "Updated Name");
-    expect(doc.__history[0].state).toHaveProperty("status", "active");
+    // Verify history entries
+    expect(history.length).toBe(2);
+
+    // First entry should be the creation
+    expect(history[0].metadata).toHaveProperty("action", HISTORY_ACTIONS.CREATED);
+    expect(history[0].state).toHaveProperty("name", "Original Name");
+    expect(history[0].state).toHaveProperty("status", "pending");
+
+    // Second entry should be the update
+    expect(history[1].metadata).toHaveProperty("action", HISTORY_ACTIONS.UPDATED);
+    expect(history[1].state).toHaveProperty("name", "Updated Name");
+    expect(history[1].state).toHaveProperty("status", "active");
   });
 
-  it("should create history entry when document is updated with 'updated' action", () => {
-    doc.isNew = false;
-
-    doc.modifiedPaths.mockReturnValue(["name", "status"]);
-    doc.isModified.mockImplementation((path: string) => ["name", "status"].includes(path));
-    doc.get.mockImplementation((path: string) => {
-      if (path === "name") {
-        return "Updated Name";
-      }
-      if (path === "status") {
-        return "active";
-      }
-      return null;
+  it("should add metadata to history entry when using withHistoryContext", async () => {
+    const doc = new TestModel({
+      name: "Test Document",
+      status: "pending",
     });
+    await doc.save();
 
-    const next = vi.fn();
-
-    preHook.call(doc, next);
-
-    expect(next).toHaveBeenCalled();
-    expect(doc.__history.length).toBe(1);
-    expect(doc.__history[0].state).toHaveProperty("name", "Updated Name");
-    expect(doc.__history[0].state).toHaveProperty("status", "active");
-
-    // Verify action metadata
-    expect(doc.__history[0].metadata).toHaveProperty("action", HISTORY_ACTIONS.UPDATED);
-  });
-
-  it("should ignore fields specified in omit option", () => {
-    doc.isNew = false;
-
-    doc.modifiedPaths.mockReturnValue(["name", "updatedAt"]);
-    doc.isModified.mockImplementation((path: string) => ["name", "updatedAt"].includes(path));
-    doc.get.mockImplementation((path: string) => {
-      if (path === "name") {
-        return "Updated Name";
-      }
-      if (path === "updatedAt") {
-        return new Date();
-      }
-      return null;
-    });
-
-    const next = vi.fn();
-
-    preHook.call(doc, next);
-
-    expect(next).toHaveBeenCalled();
-    expect(doc.__history.length).toBe(1);
-    expect(doc.__history[0].state).toHaveProperty("name");
-    expect(doc.__history[0].state).not.toHaveProperty("updatedAt");
-  });
-
-  it("should add metadata to history entry when using withHistoryContext", () => {
-    doc.isNew = false;
-
-    doc.modifiedPaths.mockReturnValue(["name"]);
-    doc.isModified.mockImplementation((path: string) => path === "name");
-    doc.get.mockImplementation((path: string) => {
-      if (path === "name") {
-        return "Updated with Context";
-      }
-      return null;
-    });
-
-    const withHistoryContext = schema.statics.withHistoryContext;
-
-    const metadata = {
+    // Use withHistoryContext to add metadata
+    doc.name = "Updated with Context";
+    await TestModel.withHistoryContext({
       reason: "Testing withHistoryContext",
-    };
+      userId: "user-123",
+    }).save(doc);
 
-    const contextualSave = withHistoryContext(metadata);
+    const history = doc.getHistory();
 
-    const next = vi.fn();
+    // Verify history entries
+    expect(history.length).toBe(2);
 
-    preHook.call(doc, next);
-
-    expect(next).toHaveBeenCalled();
-    expect(doc.__history.length).toBe(1);
-
-    contextualSave.save(doc);
-
-    preHook.call(doc, next);
-
-    expect(doc.__history.length).toBe(2);
-    expect(doc.__history[1].metadata).toHaveProperty("reason", "Testing withHistoryContext");
-  });
-
-  it("should retrieve full history using getHistory", () => {
-    const now = new Date();
-    const pastDate1 = new Date(now.getTime() - 3000); // 3 seconds ago
-    const pastDate2 = new Date(now.getTime() - 2000); // 2 seconds ago
-
-    doc.__history = [
-      {
-        date: pastDate1,
-        state: { name: "First Update", status: "in-progress", counter: 1 },
-      },
-      {
-        date: pastDate2,
-        state: { name: "Second Update", counter: 2 },
-      },
-      {
-        date: now,
-        state: { name: "Final Update", status: "completed", counter: 3 },
-      },
-    ];
-
-    doc.toObject.mockReturnValue({
-      name: "Final Update",
-      status: "completed",
-      counter: 3,
-      description: "Test Description",
-    });
-
-    const getHistory = schema.methods.getHistory;
-    const history = getHistory.call(doc);
-
-    expect(history).toEqual(doc.__history);
-  });
-
-  it("should retrieve full history using getHistory", () => {
-    doc.__history = [
-      {
-        date: new Date(),
-        state: { name: "First Update" },
-      },
-      {
-        date: new Date(),
-        state: { status: "in-progress" },
-      },
-      {
-        date: new Date(),
-        state: { name: "Second Update" },
-      },
-    ];
-
-    const getHistory = schema.methods.getHistory;
-    const history = getHistory.call(doc);
-    expect(history).toEqual(doc.__history);
-    expect(history.length).toBe(3);
+    // Second entry should have the metadata
+    expect(history[1].metadata).toHaveProperty("reason", "Testing withHistoryContext");
+    expect(history[1].metadata).toHaveProperty("userId", "user-123");
+    expect(history[1].metadata).toHaveProperty("action", HISTORY_ACTIONS.UPDATED);
   });
 
   it("should track history for bulkWrite operations", async () => {
-    const mockModel = {
-      bulkWrite: vi.fn().mockResolvedValue({ modifiedCount: 2 }),
-      find: vi.fn(),
-      withHistoryContext: schema.statics.withHistoryContext,
-    };
-
-    const mockDoc1 = new MockDocument({
-      _id: "123",
+    const doc1 = await TestModel.create({
+      _id: new mongoose.Types.ObjectId(),
       name: "Document 1",
       status: "pending",
       counter: 5,
-      __history: [],
     });
 
-    const mockDoc2 = new MockDocument({
-      _id: "456",
+    const doc2 = await TestModel.create({
+      _id: new mongoose.Types.ObjectId(),
       name: "Document 2",
       status: "active",
       counter: 10,
-      __history: [],
     });
 
-    mockModel.find.mockResolvedValue([mockDoc1, mockDoc2]);
-
+    // Prepare bulk operations
     const operations = [
       {
         updateOne: {
-          filter: { _id: "123" },
-          update: { $set: { name: "Updated Document 1", counter: 5 } }, // counter is unchanged
+          filter: { _id: doc1._id },
+          update: { $set: { name: "Updated Document 1" } },
         },
       },
       {
         updateOne: {
-          filter: { _id: "456" },
-          update: { $set: { status: "completed", counter: 15 } }, // both fields changed
+          filter: { _id: doc2._id },
+          update: { $set: { status: "completed", counter: 15 } },
         },
       },
     ];
 
-    const withContext = mockModel.withHistoryContext.call(mockModel, { reason: "Test update" });
-    await withContext.bulkWrite(operations);
+    await TestModel.withHistoryContext({
+      reason: "Test bulk update",
+    }).bulkWrite(operations);
 
-    expect(mockModel.bulkWrite).toHaveBeenCalledWith(operations);
+    const updatedDoc1 = await TestModel.findById(doc1._id);
+    const updatedDoc2 = await TestModel.findById(doc2._id);
 
-    expect(mockModel.find).toHaveBeenCalledWith({
-      $or: [{ _id: "123" }, { _id: "456" }],
-    });
+    const history1 = updatedDoc1!.getHistory();
+    expect(history1.length).toBe(2);
+    expect(history1[1].state).toHaveProperty("name", "Updated Document 1");
+    expect(history1[1].state).not.toHaveProperty("counter"); // Unchanged field
+    expect(history1[1].metadata).toHaveProperty("reason", "Test bulk update");
 
-    expect(mockDoc1.__history.length).toBe(1);
-    expect(mockDoc1.__history[0].state).toHaveProperty("name", "Updated Document 1");
-    expect(mockDoc1.__history[0].state).not.toHaveProperty("counter"); // Unchanged field should not be in history
-    expect(mockDoc1.__history[0].metadata).toHaveProperty("reason", "Test update");
-
-    expect(mockDoc2.__history.length).toBe(1);
-    expect(mockDoc2.__history[0].state).toHaveProperty("status", "completed");
-    expect(mockDoc2.__history[0].state).toHaveProperty("counter", 15);
-    expect(mockDoc2.__history[0].metadata).toHaveProperty("reason", "Test update");
+    const history2 = updatedDoc2!.getHistory();
+    expect(history2.length).toBe(2);
+    expect(history2[1].state).toHaveProperty("status", "completed");
+    expect(history2[1].state).toHaveProperty("counter", 15);
+    expect(history2[1].metadata).toHaveProperty("reason", "Test bulk update");
   });
 
-  it("should not create history entries for unchanged fields in bulkWrite", async () => {
-    const mockModel = {
-      bulkWrite: vi.fn().mockResolvedValue({ modifiedCount: 1 }),
-      find: vi.fn(),
-      withHistoryContext: schema.statics.withHistoryContext,
-    };
-
-    const mockDoc = new MockDocument({
-      _id: "789",
-      name: "Test Document",
-      description: "Original description",
-      status: "pending",
-      __history: [],
-    });
-
-    mockModel.find.mockResolvedValue([mockDoc]);
-
-    const operations = [
-      {
-        updateOne: {
-          filter: { _id: "789" },
-          update: {
-            $set: {
-              name: "Test Document", // Same value as current
-              description: "Updated description", // Changed value
-              status: "pending", // Same value as current
-            },
-          },
-        },
-      },
-    ];
-
-    const withContext = mockModel.withHistoryContext.call(mockModel, {
-      reason: "Test unchanged fields",
-    });
-    await withContext.bulkWrite(operations);
-
-    expect(mockModel.bulkWrite).toHaveBeenCalledWith(operations);
-
-    expect(mockModel.find).toHaveBeenCalledWith({
-      $or: [{ _id: "789" }],
-    });
-
-    expect(mockDoc.__history.length).toBe(1);
-    expect(mockDoc.__history[0].state).toHaveProperty("description", "Updated description");
-    expect(mockDoc.__history[0].state).not.toHaveProperty("name"); // Unchanged field
-    expect(mockDoc.__history[0].state).not.toHaveProperty("status"); // Unchanged field
-    expect(mockDoc.__history[0].metadata).toHaveProperty("reason", "Test unchanged fields");
-  });
-
-  it("should handle bulkWrite with no changes", async () => {
-    const mockModel = {
-      bulkWrite: vi.fn().mockResolvedValue({ modifiedCount: 0 }),
-      find: vi.fn(),
-      withHistoryContext: schema.statics.withHistoryContext,
-    };
-
-    const mockDoc = new MockDocument({
-      _id: "999",
-      name: "No Change Document",
-      __history: [],
-    });
-
-    mockModel.find.mockResolvedValue([mockDoc]);
-
-    const operations = [
-      {
-        updateOne: {
-          filter: { _id: "999" },
-          update: { $set: { name: "No Change Document" } }, // Same value
-        },
-      },
-    ];
-
-    const withContext = mockModel.withHistoryContext.call(mockModel, { reason: "Test no changes" });
-    await withContext.bulkWrite(operations);
-
-    expect(mockModel.bulkWrite).toHaveBeenCalledWith(operations);
-    expect(mockModel.find).toHaveBeenCalled();
-    expect(mockDoc.__history.length).toBe(0);
-  });
-
-  it("should create history entry with full state and 'created' action for bulkWrite insertOne operations", async () => {
-    const mockModel = {
-      bulkWrite: vi.fn().mockResolvedValue({ insertedCount: 1 }),
-      find: vi.fn(),
-      findById: vi.fn(),
-      withHistoryContext: schema.statics.withHistoryContext,
-    };
-
-    // Mock document that will be "inserted"
-    const insertedDoc = new MockDocument({
-      _id: "insert-123",
-      name: "New Bulk Document",
-      description: "Bulk Insert Description",
-      status: "draft",
-      tags: ["test", "bulk"],
-      counter: 5,
-      __history: [],
-    });
-
-    // Mock findById to return our inserted document
-    mockModel.findById.mockResolvedValue(insertedDoc);
-
-    // Setup the document's toObject method
-    insertedDoc.toObject.mockReturnValue({
-      _id: "insert-123",
-      name: "New Bulk Document",
-      description: "Bulk Insert Description",
-      status: "draft",
-      tags: ["test", "bulk"],
-      counter: 5,
-      updatedAt: new Date(),
-      __v: 0,
-      __history: [],
-    });
-
+  it("should create history entry with 'created' action for bulkWrite insertOne operations", async () => {
+    // Prepare bulk insert operation
+    const newDocId = new mongoose.Types.ObjectId();
     const operations = [
       {
         insertOne: {
           document: {
-            _id: "insert-123",
+            _id: newDocId,
             name: "New Bulk Document",
             description: "Bulk Insert Description",
             status: "draft",
@@ -528,80 +233,53 @@ describe("History Plugin", () => {
       },
     ];
 
-    const withContext = mockModel.withHistoryContext.call(mockModel, {
+    await TestModel.withHistoryContext({
       reason: "Test bulk insert",
-    });
+    }).bulkWrite(operations);
 
-    await withContext.bulkWrite(operations);
+    // Verify document was inserted
+    const insertedDoc = await TestModel.findById(newDocId);
+    expect(insertedDoc).not.toBeNull();
+    expect(insertedDoc!.name).toBe("New Bulk Document");
 
-    // Verify the bulkWrite was called
-    expect(mockModel.bulkWrite).toHaveBeenCalledWith(operations);
-
-    // Verify findById was called to get the inserted document
-    expect(mockModel.findById).toHaveBeenCalledWith("insert-123");
-
-    // A second bulkWrite should have been called to update history
-    expect(mockModel.bulkWrite).toHaveBeenCalledTimes(2);
-
-    // Check that a history entry was created with the right data
-    const historyUpdateCall = mockModel.bulkWrite.mock.calls[1][0];
-    expect(historyUpdateCall).toHaveLength(1);
-    expect(historyUpdateCall[0].updateOne.filter).toEqual({ _id: "insert-123" });
-
-    // Get the history entry from the update operation
-    const historyEntry = historyUpdateCall[0].updateOne.update.$set.__history[0];
+    const history = insertedDoc!.getHistory();
+    expect(history.length).toBe(1);
 
     // Verify all fields are in the state
-    expect(historyEntry.state).toHaveProperty("name", "New Bulk Document");
-    expect(historyEntry.state).toHaveProperty("description", "Bulk Insert Description");
-    expect(historyEntry.state).toHaveProperty("status", "draft");
-    expect(historyEntry.state).toHaveProperty("tags");
-    expect(historyEntry.state).toHaveProperty("counter", 5);
-
-    // Verify omitted fields are not in the state
-    expect(historyEntry.state).not.toHaveProperty("updatedAt");
-    expect(historyEntry.state).not.toHaveProperty("__v");
-    expect(historyEntry.state).not.toHaveProperty("__history");
+    expect(history[0].state).toHaveProperty("name", "New Bulk Document");
+    expect(history[0].state).toHaveProperty("description", "Bulk Insert Description");
+    expect(history[0].state).toHaveProperty("status", "draft");
+    expect(history[0].state).toHaveProperty("tags");
+    expect(history[0].state).toHaveProperty("counter", 5);
 
     // Verify action metadata
-    expect(historyEntry.metadata).toHaveProperty("action", HISTORY_ACTIONS.CREATED);
-    expect(historyEntry.metadata).toHaveProperty("reason", "Test bulk insert");
+    expect(history[0].metadata).toHaveProperty("action", HISTORY_ACTIONS.CREATED);
+    expect(history[0].metadata).toHaveProperty("reason", "Test bulk insert");
   });
 
-  it("should limit history entries to maxEntries", () => {
-    doc.isNew = false;
-
-    doc.__history = Array.from({ length: 9 }, (_, i) => ({
-      date: new Date(),
-      state: { counter: i + 1 },
-    }));
-
-    doc.modifiedPaths.mockReturnValue(["counter"]);
-    doc.isModified.mockImplementation((path: string) => path === "counter");
-    doc.get.mockImplementation((path: string) => {
-      if (path === "counter") {
-        return 10;
-      }
-      return null;
+  it("should limit history entries to maxEntries", async () => {
+    const doc = await TestModel.create({
+      name: "Test Document",
+      counter: 0,
     });
 
-    const next = vi.fn();
+    // Update the document 11 times (1 create + 11 updates = 12 entries)
+    // But maxEntries is set to 10, so we should only keep the 10 most recent
+    for (let i = 1; i <= 11; i++) {
+      doc.counter = i;
+      await doc.save();
+    }
 
-    preHook.call(doc, next);
+    const history = doc.getHistory();
 
-    expect(doc.__history.length).toBe(10);
+    // Verify history length is limited to maxEntries
+    expect(history.length).toBe(10);
 
-    doc.get.mockImplementation((path: string) => {
-      if (path === "counter") {
-        return 11;
-      }
-      return null;
-    });
+    // Verify the oldest entries were removed
+    // The first entry should now be the update with counter=2
+    expect(history[0].state).toHaveProperty("counter", 2);
 
-    preHook.call(doc, next);
-
-    expect(doc.__history.length).toBe(10);
-    expect(doc.__history[0].state.counter).toBe(2);
-    expect(doc.__history[9].state.counter).toBe(11);
+    // The last entry should be the update with counter=11
+    expect(history[9].state).toHaveProperty("counter", 11);
   });
 });


### PR DESCRIPTION
## Description

- Mise en place de la table `MissionHistoryEvent` pour pouvoir accéder aux différents changements d'états de mission dans Metabase
- Evolution du plugin history pour tracker la création d'objet
- Réécriture des tests du plugin pour qu'ils soient plus lisibles / maintenables (mock -> mongo-memory-server)

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Rajouter-des-v-nements-de-modification-des-missions-rattach-s-la-table-MissionHistory-1e772a322d5080f6b9fdfbcd4ed0eb08?pvs=4)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

