### PR TITLE
Remove organisation_is_rup from Postgres

### DIFF
--- a/process/prisma/migrations/20250507082943_remove_organization_is_rup/migration.sql
+++ b/process/prisma/migrations/20250507082943_remove_organization_is_rup/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `organization_is_rup` on the `Mission` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Mission" DROP COLUMN "organization_is_rup";

--- a/process/prisma/schema.prisma
+++ b/process/prisma/schema.prisma
@@ -329,7 +329,6 @@ model Mission {
   organization_department_code_verified String?
   organization_department_name_verified String?
   organization_region_verified    String?
-  organization_is_rup             Boolean?
   is_siren_verified               Boolean?
   is_siret_verified              Boolean?
   is_rna_verified                 Boolean?


### PR DESCRIPTION
## Description

Remove organisation_is_rup du schema postgres car non utilisé

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Enlever-le-champs-organisation_is_rup-du-schema-de-mission-de-la-base-postgres-1e572a322d50807e8f27e27114db2ba9?pvs=4)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x]  Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
