### PR TITLE
Clean model #widget

### DIFF
--- a/api/.eslintignore
+++ b/api/.eslintignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+script-model-review
 coverage
 .github
 *.js.map

--- a/api/script-model-review/widget.ts
+++ b/api/script-model-review/widget.ts
@@ -1,0 +1,71 @@
+/**
+ * Script to clean the data in the data base. It has 2 differents parts:
+ * - refactoFields: Refactor / Rename the fields in the document to stick to a better naming convention
+ * - cleanUnusedFields: Clean the unused fields in the document
+ */
+
+import dotenv from "dotenv";
+dotenv.config({ path: "../.env" });
+
+import mongoose from "mongoose";
+import "../src/db/mongo";
+
+import WidgetModel from "../src/models/widget";
+
+const cleanUnusedFields = async (widget: any) => {
+  const allFields = Object.keys(widget);
+  const schemaFields = Object.keys(WidgetModel.schema.paths);
+  const extraFields = allFields.filter((field) => !schemaFields.includes(field));
+
+  if (extraFields.length === 0) {
+    console.log(`Widget ${widget._id} has no extra fields`);
+    return;
+  }
+
+  console.log(`Widget ${widget._id} has ${extraFields.join(", ")} as extra fields`);
+
+  const widgetMongo = await WidgetModel.findById(widget._id);
+  if (!widgetMongo) {
+    console.log(`Widget ${widget._id} not found`);
+    return;
+  }
+  for (const field of extraFields) {
+    widgetMongo.set(field, undefined, { strict: false });
+  }
+  await widgetMongo.save();
+  console.log(`Widget ${widget._id} cleaned`);
+};
+
+const refactoFields = async (widget: any) => {
+  const updates: any = {};
+  updates.deletedAt = widget.deleted ? widget.updatedAt : null;
+  await WidgetModel.findByIdAndUpdate(widget._id, updates);
+  console.log(`Widget ${widget._id} updated`);
+};
+
+const main = async () => {
+  // Wait 3s to make sure the connection is established
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+
+  const widgets = await mongoose.connection.db.collection("widgets").find({}).toArray();
+  console.log(`Found ${widgets.length} widgets`);
+
+  for (const widget of widgets) {
+    await refactoFields(widget);
+    await cleanUnusedFields(widget);
+  }
+};
+
+if (require.main === module) {
+  const start = new Date();
+  console.log("Start migration at ", start.toLocaleString());
+  main()
+    .then(() => {
+      console.log("Total time", (Date.now() - start.getTime()) / 1000, "seconds");
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/api/script-model-review/widget.ts
+++ b/api/script-model-review/widget.ts
@@ -24,22 +24,23 @@ const cleanUnusedFields = async (widget: any) => {
 
   console.log(`Widget ${widget._id} has ${extraFields.join(", ")} as extra fields`);
 
-  const widgetMongo = await WidgetModel.findById(widget._id);
-  if (!widgetMongo) {
-    console.log(`Widget ${widget._id} not found`);
-    return;
-  }
+  const unset: any = {};
   for (const field of extraFields) {
-    widgetMongo.set(field, undefined, { strict: false });
+    unset[field] = 1;
   }
-  await widgetMongo.save();
+  await mongoose.connection.db
+    .collection("widgets")
+    .updateOne({ _id: widget._id }, { $unset: unset });
   console.log(`Widget ${widget._id} cleaned`);
 };
 
 const refactoFields = async (widget: any) => {
   const updates: any = {};
   updates.deletedAt = widget.deleted ? widget.updatedAt : null;
-  await WidgetModel.findByIdAndUpdate(widget._id, updates);
+
+  await mongoose.connection.db
+    .collection("widgets")
+    .updateOne({ _id: widget._id }, { $set: updates });
   console.log(`Widget ${widget._id} updated`);
 };
 

--- a/api/src/controllers/widget.ts
+++ b/api/src/controllers/widget.ts
@@ -37,7 +37,7 @@ router.post(
         return res.status(400).send({ ok: false, code: INVALID_BODY, error: body.error });
       }
 
-      const where = { deleted: false, active: body.data.active } as { [key: string]: any };
+      const where = { deletedAt: null, active: body.data.active } as { [key: string]: any };
 
       if (body.data.fromPublisherId) {
         if (req.user.role !== "admin" && !req.user.publishers.includes(body.data.fromPublisherId)) {
@@ -204,24 +204,20 @@ router.post(
 
       const exists = await WidgetModel.findOne({ name: body.data.name });
       if (exists) {
-        return res
-          .status(409)
-          .send({
-            ok: false,
-            code: RESSOURCE_ALREADY_EXIST,
-            message: `Widget ${body.data.name} already exist`,
-          });
+        return res.status(409).send({
+          ok: false,
+          code: RESSOURCE_ALREADY_EXIST,
+          message: `Widget ${body.data.name} already exist`,
+        });
       }
 
       const fromPublisher = await PublisherModel.findById(body.data.fromPublisherId);
       if (!fromPublisher) {
-        return res
-          .status(404)
-          .send({
-            ok: false,
-            code: NOT_FOUND,
-            message: `Publisher ${body.data.fromPublisherId} not found`,
-          });
+        return res.status(404).send({
+          ok: false,
+          code: NOT_FOUND,
+          message: `Publisher ${body.data.fromPublisherId} not found`,
+        });
       }
 
       const obj = {
@@ -380,9 +376,9 @@ router.delete(
 
       const widget = await WidgetModel.findById(params.data.id);
       if (!widget) {
-        return res.status(404).send({ ok: false, code: NOT_FOUND });
+        return res.status(200).send({ ok: true });
       }
-      widget.deleted = true;
+      widget.deletedAt = new Date();
       await widget.save();
       res.status(200).send({ ok: true });
     } catch (error) {

--- a/api/src/models/widget.ts
+++ b/api/src/models/widget.ts
@@ -6,7 +6,7 @@ const MODELNAME = "widget";
 const schema = new Schema<Widget>(
   {
     name: { type: String, required: true },
-    color: { type: String },
+    color: { type: String, default: "#000091" },
     style: { type: String, enum: ["carousel", "page"], default: "page" },
     type: { type: String, enum: ["benevolat", "volontariat"], default: "benevolat" },
     location: {
@@ -43,28 +43,12 @@ const schema = new Schema<Widget>(
       description:
         "Boolean that says if the mission of the widget should be the ones moderated by JVA",
     },
-    display: { type: String, default: "full", enum: ["full", "line"] },
+
     url: { type: String },
     fromPublisherId: { type: String, required: true },
     fromPublisherName: { type: String },
-    active: {
-      type: Boolean,
-      required: true,
-      default: true,
-      documentation: {
-        generated: true,
-        description: "Boolean that says if the widget is still active or not",
-      },
-    },
-    deleted: {
-      type: Boolean,
-      required: true,
-      default: false,
-      documentation: {
-        generated: true,
-        description: "Boolean that says if the widget is deleted or not",
-      },
-    },
+    active: { type: Boolean, required: true, default: true },
+    deletedAt: { type: Date, default: null },
   },
   {
     timestamps: true,

--- a/api/src/types/index.d.ts
+++ b/api/src/types/index.d.ts
@@ -729,7 +729,7 @@ export type Warning = {
   updatedAt: Date;
 };
 
-export type Widget = {
+export interface Widget {
   _id: Schema.Types.ObjectId;
   name: string;
   color: string;
@@ -760,7 +760,7 @@ export type Widget = {
   deletedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
-};
+}
 
 export type EsQuery = {
   bool: {

--- a/api/src/types/index.d.ts
+++ b/api/src/types/index.d.ts
@@ -752,13 +752,12 @@ export type Widget = {
     fieldType?: string;
   }[];
   publishers: string[];
-  display: "full" | "line";
   url: string;
   jvaModeration: boolean;
   fromPublisherId: string;
   fromPublisherName: string;
   active: boolean;
-  deleted: boolean;
+  deletedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 };

--- a/process/src/jobs/metabase/widget.ts
+++ b/process/src/jobs/metabase/widget.ts
@@ -29,7 +29,7 @@ const buildData = (doc: Widget, partners: { id: string; old_id: string }[]) => {
     jva_moderation: doc.jvaModeration || false,
 
     diffuseur_id: diffuseur.id,
-    deleted_at: doc.deleted ? new Date(doc.updatedAt) : null,
+    deleted_at: doc.deletedAt || null,
     created_at: doc.createdAt,
     updated_at: doc.updatedAt,
   } as PgWidget;

--- a/process/src/models/widget.ts
+++ b/process/src/models/widget.ts
@@ -6,7 +6,7 @@ const MODELNAME = "widget";
 const schema = new Schema<Widget>(
   {
     name: { type: String, required: true },
-    color: { type: String },
+    color: { type: String, default: "#000091" },
     style: { type: String, enum: ["carousel", "page"], default: "page" },
     type: { type: String, enum: ["benevolat", "volontariat"], default: "benevolat" },
     location: {
@@ -43,28 +43,12 @@ const schema = new Schema<Widget>(
       description:
         "Boolean that says if the mission of the widget should be the ones moderated by JVA",
     },
-    display: { type: String, default: "full", enum: ["full", "line"] },
+
     url: { type: String },
     fromPublisherId: { type: String, required: true },
     fromPublisherName: { type: String },
-    active: {
-      type: Boolean,
-      required: true,
-      default: true,
-      documentation: {
-        generated: true,
-        description: "Boolean that says if the widget is still active or not",
-      },
-    },
-    deleted: {
-      type: Boolean,
-      required: true,
-      default: false,
-      documentation: {
-        generated: true,
-        description: "Boolean that says if the widget is deleted or not",
-      },
-    },
+    active: { type: Boolean, required: true, default: true },
+    deletedAt: { type: Date, default: null },
   },
   {
     timestamps: true,

--- a/process/src/types/index.d.ts
+++ b/process/src/types/index.d.ts
@@ -816,7 +816,7 @@ export interface WarningBot {
   updatedAt: Date;
 }
 
-export type Widget = {
+export interface Widget {
   _id: Schema.Types.ObjectId;
   name: string;
   color: string;
@@ -839,16 +839,15 @@ export type Widget = {
     fieldType?: string;
   }[];
   publishers: string[];
-  display: "full" | "line";
   url: string;
   jvaModeration: boolean;
   fromPublisherId: string;
   fromPublisherName: string;
   active: boolean;
-  deleted: boolean;
+  deletedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
-};
+}
 
 export type EsQuery = {
   bool: {


### PR DESCRIPTION
## Description

Nettoyage du modele de widget dans Mongo.


## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Nettoyage-des-mod-les-de-donn-es-Mongo-1d972a322d5080a199a2c606cb9fb836?pvs=4) partie Widget

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

J'ai ajouté le dossier /script-model-review qui comportera tous les scripts a faire tourner lorsque les PR seront merge pour que tout fonctionne. Ici le script transforme deleted -> deletedAt et enleve tout les champs hors du schema
