### PR TITLE
fix kpi creation bug

### DIFF
--- a/process/prisma/migrations/20250513095529_fix_kpi_model/migration.sql
+++ b/process/prisma/migrations/20250513095529_fix_kpi_model/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Kpi" ALTER COLUMN "available_jva_mission_count" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "KpiBotLess" ALTER COLUMN "available_jva_mission_count" DROP NOT NULL;

--- a/process/prisma/schema.prisma
+++ b/process/prisma/schema.prisma
@@ -174,7 +174,7 @@ model Kpi {
   date                                                DateTime @unique
   available_benevolat_mission_count                   Int
   available_volontariat_mission_count                 Int
-  available_jva_mission_count                         Int
+  available_jva_mission_count                         Int?
   available_benevolat_given_by_partner_place_count    Int
   available_volontariat_given_by_partner_place_count  Int
   available_benevolat_attributed_by_api_place_count   Int
@@ -207,7 +207,7 @@ model KpiBotLess {
   date                                                DateTime @unique
   available_benevolat_mission_count                   Int
   available_volontariat_mission_count                 Int
-  available_jva_mission_count                         Int
+  available_jva_mission_count                         Int?
   available_benevolat_given_by_partner_place_count    Int
   available_volontariat_given_by_partner_place_count  Int
   available_benevolat_attributed_by_api_place_count   Int

--- a/process/src/jobs/metabase/index.ts
+++ b/process/src/jobs/metabase/index.ts
@@ -6,6 +6,7 @@ import importCampaigns from "./campaign";
 import importClicks from "./click";
 import importImports from "./import";
 import importKpi from "./kpi";
+import importKpiBotless from "./kpi-botless";
 import importLoginHistory from "./login-history";
 import importMissions from "./mission";
 import importModerationEvents from "./moderation-event";
@@ -36,6 +37,7 @@ const handler = async () => {
     requests: { created: 0, updated: null },
     login_history: { created: 0, updated: null },
     kpi: { created: 0, updated: null },
+    kpiBotless: { created: 0, updated: null },
   };
 
   const partners = await importPartners();
@@ -81,6 +83,8 @@ const handler = async () => {
   stats.login_history.created += login_history?.created || 0;
   const kpi = await importKpi();
   stats.kpi.created += kpi?.created || 0;
+  const kpiBotless = await importKpiBotless();
+  stats.kpiBotless.created += kpiBotless?.created || 0;
 
   // Send message to slack
   const text = `${Object.entries(stats)


### PR DESCRIPTION
## Description

Fix de la creation des KPI qui ne marchait plus depuis l'ajout du compte de mission de JVA

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/On-n-enregistre-plus-les-donn-es-KPI-s-dans-Metatabse-depuis-le-4-mai-1f172a322d5080a4850cf4bf099b5337?pvs=4)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
