### PR TITLE
Add campaign tracker in the Postgres

### DIFF
--- a/process/prisma/migrations/20250522130200_add_campaign_tracker/migration.sql
+++ b/process/prisma/migrations/20250522130200_add_campaign_tracker/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "CampaignTracker" (
+    "id" TEXT NOT NULL,
+    "campaign_id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+
+    CONSTRAINT "CampaignTracker_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "campaign_tracker_campaign_id" ON "CampaignTracker"("campaign_id");
+
+-- AddForeignKey
+ALTER TABLE "CampaignTracker" ADD CONSTRAINT "CampaignTracker_campaign_id_fkey" FOREIGN KEY ("campaign_id") REFERENCES "Campaign"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/process/prisma/schema.prisma
+++ b/process/prisma/schema.prisma
@@ -86,16 +86,30 @@ model Campaign {
   reassigned_by_user_id   String?
   reassigned_by_user_name String?
   type                    String?
+  
   accounts                Account[]
   applies                 Apply[]
   annonceur               Partner      @relation("AnnonceurCampaign", fields: [annonceur_id], references: [id])
   diffuseur               Partner      @relation("DiffuseurCampaign", fields: [diffuseur_id], references: [id])
   clicks                  Click[]
   impressions             Impression[]
+  trackers                CampaignTracker[]
 
   @@index([diffuseur_id], map: "campaign_diffuseur_id")
   @@index([annonceur_id], map: "campaign_annonceur_id")
 }
+
+model CampaignTracker {
+  id String @id @default(uuid())
+  campaign_id String
+  key String
+  value String
+
+  campaign Campaign @relation(fields: [campaign_id], references: [id])
+
+  @@index([campaign_id], map: "campaign_tracker_campaign_id")
+}
+
 
 model Click {
   id              String      @id @default(uuid())


### PR DESCRIPTION
## Description

Add the campaign tracker in the postgres db during the cross systeme

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Metabase-int-grer-les-param-tres-de-suivi-statistique-du-BO-API-1e672a322d5080fba6c3d192fc64fbf6?pvs=4)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
