### PR TITLE
Fix mission tracker URL util

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -36,6 +36,7 @@ export const REGION = process.env.REGION || "fr-par";
 export const SC_ID = "5f99dbe75eb1ad767733b206"; // Service Civique Id
 export const JVA_ID = "5f5931496c7ea514150a818f"; // JeVeuxAider Id
 export const LBC_ID = "60cd04a0d2321e05a743fa8d"; // Leboncoin Id
+export const LETUDIANT_ID = "65251e076c0781cafb6ba76d"; // Letudiant Id
 
 export const DEFAULT_AVATAR = "https://api-engagement-bucket.s3.fr-par.scw.cloud/img/default.jpg";
 

--- a/api/src/jobs/letudiant/__tests__/transformers.test.ts
+++ b/api/src/jobs/letudiant/__tests__/transformers.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { SC_ID } from "../../../config";
+import { LETUDIANT_ID } from "../../../config";
 import { PilotyMandatoryData } from "../../../services/piloty/types";
-import { Mission } from "../../../types";
-import { getMissionTrackedApplicationUrl } from "../../../utils/mission";
+import { Mission, MissionType } from "../../../types";
 import { MEDIA_PUBLIC_ID } from "../config";
 import { missionToPilotyCompany, missionToPilotyJob } from "../transformers";
 
 vi.mock("../../../utils/mission", () => ({
-  getMissionTrackedApplicationUrl: vi.fn((mission) => `https://api-engagement.beta.gouv.fr/r/${mission._id}/${mission.publisherId}`),
+  getMissionTrackedApplicationUrl: vi.fn((mission, publisherId) => `https://api-engagement.beta.gouv.fr/r/${mission._id}/${publisherId}`),
 }));
 
 const mockCompanyId = "test-company-public-id";
@@ -41,6 +40,7 @@ describe("L'Etudiant Transformers", () => {
   describe("missionToPilotyJob", () => {
     const baseMission: Partial<Mission> = {
       title: "Super Mission de Test",
+      type: MissionType.BENEVOLAT,
       descriptionHtml: "<p>Une description 素晴らしい HTML.</p>",
       applicationUrl: "https://example.com/apply",
       organizationDescription: "Description de l'organisation.",
@@ -66,18 +66,17 @@ describe("L'Etudiant Transformers", () => {
       expect(result.localisation).toBe(mission.city);
       expect(result.description_job).toBe("<p>Une description 素晴らしい HTML.</p>");
       expect(result.application_method).toBe("external_apply");
-      expect(getMissionTrackedApplicationUrl).toHaveBeenCalledWith(mission);
-      expect(result.application_url).toBe(`https://api-engagement.beta.gouv.fr/r/${mission._id}/${mission.publisherId}`);
+      expect(result.application_url).toBe(`https://api-engagement.beta.gouv.fr/r/${mission._id}/${LETUDIANT_ID}`);
       expect(result.state).toBe("published");
       expect(result.remote_policy_id).toBeUndefined();
       expect(result.position_level).toBe("employee");
       expect(result.description_company).toBe(mission.organizationDescription);
     });
 
-    it("should correctly transform a mission for Service Civique", () => {
+    it("should correctly transform a volontariat mission", () => {
       const mission: Mission = {
         ...baseMission,
-        publisherId: SC_ID,
+        type: MissionType.VOLONTARIAT,
         domain: "education",
         remote: "full",
         city: "Marseille",
@@ -91,7 +90,6 @@ describe("L'Etudiant Transformers", () => {
     it("should set localisation to 'A distance' for full remote missions and set remote_policy_id", () => {
       const mission: Mission = {
         ...baseMission,
-        publisherId: "any_id",
         domain: "culture-loisirs",
         remote: "full",
         city: "Paris", // City should be ignored for localisation
@@ -154,20 +152,20 @@ describe("L'Etudiant Transformers", () => {
       expect(result.job_category_id).toBe(mockMandatoryData.jobCategories.autre);
     });
 
-    it('should decode HTML entities in description_job', () => {
+    it("should decode HTML entities in description_job", () => {
       const mission: Mission = {
         ...baseMission,
-        publisherId: 'any_id',
-        domain: 'sante',
-        remote: 'no',
-        city: 'Lyon',
+        publisherId: "any_id",
+        domain: "sante",
+        remote: "no",
+        city: "Lyon",
         deletedAt: null,
-        descriptionHtml: 'Description with &lt;p&gt;html&lt;/p&gt; tags.',
+        descriptionHtml: "Description with &lt;p&gt;html&lt;/p&gt; tags.",
       } as Mission;
 
       const result = missionToPilotyJob(mission, mockCompanyId, mockMandatoryData);
 
-      expect(result.description_job).toBe('Description with <p>html</p> tags.');
+      expect(result.description_job).toBe("Description with <p>html</p> tags.");
     });
 
     /**

--- a/api/src/jobs/letudiant/transformers.ts
+++ b/api/src/jobs/letudiant/transformers.ts
@@ -1,9 +1,9 @@
-import { SC_ID } from "../../config";
+import { LETUDIANT_ID } from "../../config";
 import { PilotyCompanyPayload, PilotyJobPayload, PilotyMandatoryData } from "../../services/piloty/types";
-import { Mission } from "../../types";
+import { Mission, MissionType } from "../../types";
 import { getMissionTrackedApplicationUrl } from "../../utils/mission";
 import { MEDIA_PUBLIC_ID } from "./config";
-import { decodeHtml } from './utils';
+import { decodeHtml } from "./utils";
 
 /**
  * Transform a mission into a Piloty job payload
@@ -29,12 +29,12 @@ export function missionToPilotyJob(mission: Mission, companyId: string, mandator
     media_public_id: MEDIA_PUBLIC_ID,
     company_public_id: companyId,
     name: mission.title,
-    contract_id: mission.publisherId === SC_ID ? mandatoryData.contracts.volontariat : mandatoryData.contracts.benevolat,
+    contract_id: mission.type === MissionType.VOLONTARIAT ? mandatoryData.contracts.volontariat : mandatoryData.contracts.benevolat,
     job_category_id: mandatoryData.jobCategories[mission.domain] ?? mandatoryData.jobCategories["autre"],
     localisation: mission.remote === "full" ? "A distance" : mission.city || "",
     description_job: decodeHtml(mission.descriptionHtml),
     application_method: "external_apply",
-    application_url: getMissionTrackedApplicationUrl(mission),
+    application_url: getMissionTrackedApplicationUrl(mission, LETUDIANT_ID),
     state: mission.deletedAt ? "archived" : "published",
     remote_policy_id: mission.remote === "full" ? mandatoryData.remotePolicies.full : undefined,
     position_level: "employee",

--- a/api/src/jobs/linkedin/transformers.ts
+++ b/api/src/jobs/linkedin/transformers.ts
@@ -1,4 +1,5 @@
 import { Mission } from "../../types";
+import { getMissionTrackedApplicationUrl } from "../../utils/mission";
 import { LINKEDIN_COMPANY_ID, LINKEDIN_ID, LINKEDIN_INDUSTRY_CODE } from "./config";
 import { LinkedInJob } from "./types";
 
@@ -34,7 +35,7 @@ export function missionToLinkedinJob(mission: Mission, defaultCompany: string): 
   const job = {
     jobtype: "VOLUNTEER",
     partnerJobId: String(mission._id),
-    applyUrl: `https://api.api-engagement.beta.gouv.fr/r/${mission._id}/${LINKEDIN_ID}`,
+    applyUrl: getMissionTrackedApplicationUrl(mission, LINKEDIN_ID),
     title: `Bénévolat - ${mission.title}`,
     description: initialDescription
       ? `Ceci est une mission de bénévolat pour <strong>${mission.organizationName}</strong><br>${mission.description.replace(/\n/g, "<br>").replace(/\u000b/g, "")}`

--- a/api/src/utils/__tests__/mission.test.ts
+++ b/api/src/utils/__tests__/mission.test.ts
@@ -15,10 +15,9 @@ describe("getMissionTrackedApplicationUrl", () => {
   it("should return the correct tracked application URL using mocked config", () => {
     const mockMission = {
       _id: "mission123",
-      publisherId: "publisher456",
     } as unknown as Mission; // Simple mock of Mission object
 
-    const actualUrl = getMissionTrackedApplicationUrl(mockMission);
+    const actualUrl = getMissionTrackedApplicationUrl(mockMission, "publisher456");
 
     expect(actualUrl).toBe("https://api.test.com/r/mission123/publisher456");
   });

--- a/api/src/utils/mission.ts
+++ b/api/src/utils/mission.ts
@@ -2,11 +2,12 @@ import { API_URL } from "../config";
 import { Mission } from "../types";
 
 /**
- * Format the tracked application URL for a mission
+ * Format the tracked application URL for a mission and a given publisher
  *
  * @param mission The mission to format the URL for
+ * @param publisherId The publisher ID to format the URL for
  * @returns The tracked application URL
  */
-export const getMissionTrackedApplicationUrl = (mission: Mission) => {
-  return `${API_URL}/r/${mission._id}/${mission.publisherId}`;
+export const getMissionTrackedApplicationUrl = (mission: Mission, publisherId: string) => {
+  return `${API_URL}/r/${mission._id}/${publisherId}`;
 };

--- a/api/src/v0/mission.ts
+++ b/api/src/v0/mission.ts
@@ -543,7 +543,7 @@ const buildData = (data: Mission, publisherId: string, moderator: boolean = fals
     country: address ? address.country : undefined,
     location: address ? address.location : undefined,
     addresses: data.addresses,
-    applicationUrl: getMissionTrackedApplicationUrl(data),
+    applicationUrl: getMissionTrackedApplicationUrl(data, publisherId),
     associationLogo: data.associationLogo,
     associationAddress: data.associationAddress,
     associationCity: data.associationCity,

--- a/api/src/v2/mission.ts
+++ b/api/src/v2/mission.ts
@@ -183,7 +183,7 @@ const buildData = (data: Mission, publisherId: string, moderator: boolean = fals
     country: address ? address.country : undefined,
     location: address ? address.location : undefined,
     addresses: data.addresses,
-    applicationUrl: getMissionTrackedApplicationUrl(data),
+    applicationUrl: getMissionTrackedApplicationUrl(data, publisherId),
     associationLogo: data.associationLogo,
     associationAddress: data.associationAddress,
     associationCity: data.associationCity,


### PR DESCRIPTION
## Description

Régression embarquée dans #272 : on doit générer un lien tracké pour le publisher qui diffuse, pas relatif  au publisher de la mission (annonceur). 

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire