### PR TITLE
Fix mission sorting on volontariat mission + add organizationReseaux index

### DIFF
--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -500,7 +500,6 @@ const buildLocationQuery = (widget: Widget, lon: number | undefined, lat: number
     }
 
     if (remote && remote.includes("yes") && !remote.includes("no")) {
-      console.log("1.2");
       where.remote = "full";
       return where;
     }

--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -121,6 +121,7 @@ router.get("/:id/search", async (req: Request, res: Response, next: NextFunction
       deleted: false,
     } as { [key: string]: any };
 
+    const sort = {} as { [key: string]: any };
     // Todo: test
     // const organizationExclusions = await OrganizationExclusionModel.find({ excludedForPublisherId: widget.publishers });
     // if (organizationExclusions.length) where.organizationClientId = { $nin: organizationExclusions.map((e) => e.organizationClientId) };
@@ -145,6 +146,8 @@ router.get("/:id/search", async (req: Request, res: Response, next: NextFunction
     const whereLocation = buildLocationQuery(widget, query.data.lon, query.data.lat, query.data.remote);
     if (whereLocation["addresses.geoPoint"]) {
       where["addresses.geoPoint"] = whereLocation["addresses.geoPoint"];
+    } else {
+      sort.remote = -1;
     }
     if (whereLocation.$and) {
       where.$and.push(whereLocation.$and);
@@ -220,7 +223,7 @@ router.get("/:id/search", async (req: Request, res: Response, next: NextFunction
     }
 
     const missions = await MissionModel.find(where)
-      .sort({ remote: -1 })
+      .sort(sort)
       .limit(query.data.size)
       .skip(query.data.from)
       .select({
@@ -470,6 +473,7 @@ router.get("/:id/aggs", cors({ origin: "*" }), async (req: Request, res: Respons
 
 const buildLocationQuery = (widget: Widget, lon: number | undefined, lat: number | undefined, remote: string | string[] | undefined) => {
   const where = {} as { [key: string]: any };
+
   if (widget.location && widget.location.lat && widget.location.lon) {
     const distance = getDistanceKm(widget.distance && widget.distance !== "Aucun" ? widget.distance : "50km");
     where["addresses.geoPoint"] = {
@@ -478,9 +482,13 @@ const buildLocationQuery = (widget: Widget, lon: number | undefined, lat: number
         $maxDistance: distance * 1000,
       },
     };
-  } else if (lat && lon) {
+    return where;
+  }
+
+  if (lat && lon) {
     const distance = getDistanceKm("50km");
-    if (remote && remote.includes("no") && !remote.includes("yes")) {
+
+    if (widget.type === "volontariat" || (remote && remote.includes("no") && !remote.includes("yes"))) {
       where.remote = "no";
       where["addresses.geoPoint"] = {
         $nearSphere: {
@@ -488,27 +496,34 @@ const buildLocationQuery = (widget: Widget, lon: number | undefined, lat: number
           $maxDistance: distance * 1000,
         },
       };
-    } else if (remote && remote.includes("yes") && !remote.includes("no")) {
-      where.remote = "full";
-    } else {
-      where.$and = {
-        $or: [
-          {
-            "addresses.geoPoint": {
-              $geoWithin: { $centerSphere: [[lon, lat], distance / EARTH_RADIUS] },
-            },
-          },
-          { remote: "full" },
-        ],
-      };
+      return where;
     }
-  } else {
+
     if (remote && remote.includes("yes") && !remote.includes("no")) {
-      where.$and = { $or: [{ remote: "full" }, { remote: "possible" }] };
+      console.log("1.2");
+      where.remote = "full";
+      return where;
     }
-    if (remote && remote.includes("no") && !remote.includes("yes")) {
-      where.remote = "no";
-    }
+
+    where.$and = {
+      $or: [
+        {
+          "addresses.geoPoint": {
+            $geoWithin: { $centerSphere: [[lon, lat], distance / EARTH_RADIUS] },
+          },
+        },
+        { remote: "full" },
+      ],
+    };
+    return where;
+  }
+  if (remote && remote.includes("yes") && !remote.includes("no")) {
+    where.$and = { $or: [{ remote: "full" }, { remote: "possible" }] };
+    return where;
+  }
+  if (remote && remote.includes("no") && !remote.includes("yes")) {
+    where.remote = "no";
+    return where;
   }
   return where;
 };

--- a/api/src/models/mission.ts
+++ b/api/src/models/mission.ts
@@ -216,6 +216,8 @@ schema.index({ departmentName: 1 });
 schema.index({ organizationName: 1 });
 schema.index({ organizationRNA: 1 });
 schema.index({ organizationClientId: 1 });
+schema.index({ organizationReseaux: 1 });
+
 schema.index({ geoPoint: "2dsphere" });
 schema.index({ "addresses.geoPoint": "2dsphere" });
 

--- a/widget/pages/index.js
+++ b/widget/pages/index.js
@@ -376,15 +376,15 @@ export const getServerSideProps = async (context) => {
     }));
 
     if (context.query.lat && context.query.lon) {
+      const lat = parseFloat(context.query.lat);
+      const lon = parseFloat(context.query.lon);
+
       missions.forEach((mission) => {
         if (mission.addresses && mission.addresses.length > 1) {
           mission.addresses.sort((a, b) => {
             if (!a.location || !b.location) {
               return 0;
             }
-
-            const lat = parseFloat(context.query.lat);
-            const lon = parseFloat(context.query.lon);
 
             const distA = calculateDistance(lat, lon, a.location.lat, a.location.lon);
             const distB = calculateDistance(lat, lon, b.location.lat, b.location.lon);


### PR DESCRIPTION
## Description

Fix de l'ordre d'apparition des missions dans les widgets de volontariat quand une localisation est précisée + ajout d'un index sur `organizationReseaux` pour gagner en performance

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Le-ranking-des-missions-dans-le-widget-lorsque-qu-une-localisation-est-s-lectionn-e-n-est-pas-satisf-22472a322d5080feaff4d0a4e51bae3d?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [x] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
