### PR TITLE
Delete moderation 300 char restriction

### DIFF
--- a/process/src/jobs/import/utils/__tests__/moderation.test.ts
+++ b/process/src/jobs/import/utils/__tests__/moderation.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { COUNTRIES } from "../../../../constants/countries";
+import { DOMAINS } from "../../../../constants/domains";
+import { Mission } from "../../../../types";
+import { getModeration } from "../moderation";
+
+describe("getModeration", () => {
+  let mission: Partial<Mission>;
+
+  beforeEach(() => {
+    mission = {
+      title: "Une mission valide",
+      clientId: "test-client",
+      description: "Une description valide.",
+      applicationUrl: "http://example.com",
+      country: COUNTRIES[Math.floor(Math.random() * COUNTRIES.length)],
+      remote: "no",
+      places: 5,
+      domain: DOMAINS[Math.floor(Math.random() * DOMAINS.length)],
+      organizationName: "Organisation Valide",
+    };
+  });
+
+  it("should set statusCode to ACCEPTED for a valid mission", () => {
+    getModeration(mission as Mission);
+    expect(mission.statusCode).toBe("ACCEPTED");
+    expect(mission.statusComment).toBe("");
+  });
+
+  it("should set status to REFUSED for missing title", () => {
+    mission.title = "";
+    getModeration(mission as Mission);
+    expect(mission.statusCode).toBe("REFUSED");
+    expect(mission.statusComment).toBe("Titre manquant");
+  });
+
+  it("should set status to REFUSED for title with encoding issue", () => {
+    mission.title = "Titre avec un probl&#232;me";
+    getModeration(mission as Mission);
+    expect(mission.statusCode).toBe("REFUSED");
+    expect(mission.statusComment).toBe("Problème d'encodage dans le titre");
+  });
+
+  it("should set status to REFUSED for a single-word title", () => {
+    mission.title = "Titre";
+    getModeration(mission as Mission);
+    expect(mission.statusCode).toBe("REFUSED");
+    expect(mission.statusComment).toBe("Le titre est trop court (1 seul mot)");
+  });
+
+  it("should set status to REFUSED for missing clientId", () => {
+    delete mission.clientId;
+    getModeration(mission as Mission);
+    expect(mission.statusCode).toBe("REFUSED");
+    expect(mission.statusComment).toBe("ClientId manquant");
+  });
+
+  it("should set status to REFUSED for missing description", () => {
+    mission.description = "";
+    getModeration(mission as Mission);
+    expect(mission.statusCode).toBe("REFUSED");
+    expect(mission.statusComment).toBe("Description manquante");
+  });
+
+  it("should set status to REFUSED for description with encoding issue", () => {
+    mission.description = "Description avec un probl&#232;me";
+    getModeration(mission as Mission);
+    expect(mission.statusCode).toBe("REFUSED");
+    expect(mission.statusComment).toBe("Problème d'encodage dans la description");
+  });
+
+  it("should truncate description and set status to REFUSED if it's too long", () => {
+    mission.description = "a".repeat(20001);
+    getModeration(mission as Mission);
+    expect(mission.description?.length).toBe(20000);
+    expect(mission.statusCode).toBe("REFUSED");
+    expect(mission.statusComment).toBe("La description est trop longue (plus de 20000 caractères)");
+  });
+
+  it("should set status to REFUSED for missing applicationUrl", () => {
+    mission.applicationUrl = "";
+    getModeration(mission as Mission);
+    expect(mission.statusCode).toBe("REFUSED");
+    expect(mission.statusComment).toBe("URL de candidature manquant");
+  });
+
+  it("should set status to REFUSED for invalid country", () => {
+    mission.country = "Pays Invalide";
+    getModeration(mission as Mission);
+    expect(mission.statusCode).toBe("REFUSED");
+    expect(mission.statusComment).toBe('Pays non valide : "Pays Invalide"');
+  });
+
+  it("should set status to REFUSED for invalid remote value", () => {
+    (mission as any).remote = "maybe";
+    getModeration(mission as Mission);
+    expect(mission.statusCode).toBe("REFUSED");
+    expect(mission.statusComment).toBe("Valeur remote non valide (no, possible ou full)");
+  });
+
+  it("should set status to REFUSED for invalid places", () => {
+    mission.places = 0;
+    getModeration(mission as Mission);
+    expect(mission.statusCode).toBe("REFUSED");
+    expect(mission.statusComment).toBe("Nombre de places invalide (doit être supérieur à 0)");
+  });
+
+  it("should set status to REFUSED for invalid domain", () => {
+    mission.domain = "Domaine Invalide";
+    getModeration(mission as Mission);
+    expect(mission.statusCode).toBe("REFUSED");
+    expect(mission.statusComment).toBe('Domaine non valide : "Domaine Invalide"');
+  });
+
+  it("should set status to REFUSED for organizationName with encoding issue", () => {
+    mission.organizationName = "Organisation avec un probl&#232;me";
+    getModeration(mission as Mission);
+    expect(mission.statusCode).toBe("REFUSED");
+    expect(mission.statusComment).toBe("Problème d'encodage dans le nom de l'organisation");
+  });
+
+  it("should prioritize the first validation error", () => {
+    mission.title = ""; // First error
+    mission.description = ""; // Second error
+    getModeration(mission as Mission);
+    expect(mission.statusComment).toBe("Titre manquant");
+  });
+});

--- a/process/src/jobs/import/utils/moderation.ts
+++ b/process/src/jobs/import/utils/moderation.ts
@@ -1,0 +1,42 @@
+import { COUNTRIES } from "../../../constants/countries";
+import { DOMAINS } from "../../../constants/domains";
+import { Mission } from "../../../types";
+
+export const getModeration = (mission: Mission) => {
+  let statusComment = "";
+  if (!mission.title || mission.title === " ") {
+    statusComment = "Titre manquant";
+  } else if (hasEncodageIssue(mission.title)) {
+    statusComment = "Problème d'encodage dans le titre";
+  } else if ((mission.title || "").split(" ").length === 1) {
+    statusComment = "Le titre est trop court (1 seul mot)";
+  } else if (!mission.clientId) {
+    statusComment = "ClientId manquant";
+  } else if (!mission.description) {
+    statusComment = "Description manquante";
+  } else if (hasEncodageIssue(mission.description)) {
+    statusComment = "Problème d'encodage dans la description";
+  } else if ((mission.description || "").length > 20000) {
+    mission.description = mission.description.substring(0, 20000);
+    statusComment = "La description est trop longue (plus de 20000 caractères)";
+  } else if (!mission.applicationUrl) {
+    statusComment = "URL de candidature manquant";
+  } else if (mission.country && !COUNTRIES.includes(mission.country)) {
+    statusComment = `Pays non valide : "${mission.country}"`;
+  } else if (mission.remote && !["no", "possible", "full"].includes(mission.remote)) {
+    statusComment = "Valeur remote non valide (no, possible ou full)";
+  } else if (typeof mission.places === "number" && mission.places <= 0) {
+    statusComment = "Nombre de places invalide (doit être supérieur à 0)";
+  } else if (mission.domain && !DOMAINS.includes(mission.domain)) {
+    statusComment = `Domaine non valide : "${mission.domain}"`;
+  } else if (hasEncodageIssue(mission.organizationName)) {
+    statusComment = "Problème d'encodage dans le nom de l'organisation";
+  }
+
+  mission.statusCode = statusComment ? "REFUSED" : "ACCEPTED";
+  mission.statusComment = statusComment || "";
+};
+
+const hasEncodageIssue = (str = "") => {
+  return str.indexOf("&#") !== -1;
+};


### PR DESCRIPTION
## Description

- Suppression de la restriction de 300 caractères minimum au moment de la modération. 
- Split de la fonction dans un fichier dédié + tests

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Ne-plus-appliquer-la-limite-de-300-caract-res-aux-missions-venant-des-partenaires-annonceurs-21c72a322d5080428296fe0b2b14a184?source=copy_link)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire