### PR TITLE
Add referer to click in postgres

### DIFF
--- a/process/prisma/migrations/20250709091913_add_referrer/migration.sql
+++ b/process/prisma/migrations/20250709091913_add_referrer/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `host` on the `Click` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Click" DROP COLUMN "host",
+ADD COLUMN     "domain_origin" TEXT,
+ADD COLUMN     "url_origin" TEXT;

--- a/process/prisma/migrations/20250709124300_change_click_url_origin/migration.sql
+++ b/process/prisma/migrations/20250709124300_change_click_url_origin/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `domain_origin` on the `Click` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Click" DROP COLUMN "domain_origin";

--- a/process/prisma/schema.prisma
+++ b/process/prisma/schema.prisma
@@ -120,7 +120,7 @@ model Click {
   campaign_id     String?
   widget_id       String?
   source          SourceType?
-  host            String?
+  url_origin      String?
   from_partner_id String?
   to_partner_id   String?
   tag             String?

--- a/process/src/jobs/metabase/click.ts
+++ b/process/src/jobs/metabase/click.ts
@@ -8,6 +8,18 @@ import { Stats } from "../../types";
 
 const BATCH_SIZE = 5000;
 
+const getReferer = (doc: Stats) => {
+  if (!doc.referer) {
+    return null;
+  }
+  try {
+    const url = new URL(doc.referer);
+    return url.href;
+  } catch (error) {
+    return null;
+  }
+};
+
 const buildData = async (
   doc: Stats,
   partners: { [key: string]: string },
@@ -65,7 +77,7 @@ const buildData = async (
     mission_id: missionId ? missionId : null,
     mission_old_id: doc.missionId ? doc.missionId : null,
     created_at: new Date(doc.createdAt),
-    host: doc.host,
+    url_origin: getReferer(doc),
     tag: doc.tag,
     tags: doc.tags,
     source: !doc.source || doc.source === "publisher" ? "api" : doc.source,


### PR DESCRIPTION
## Description

Ajout du champs `url_origin` dans Postgres qui contient la valeur contenu dans referer

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/G-rer-la-comptabilisation-des-stats-manant-des-liens-SPV-sur-Service-public-fr-20972a322d508024a866c0753d006f80?source=copy_link)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
