### PR TITLE
Migrate moderation job to serverless

### DIFF
--- a/api/src/jobs/moderation/handler.ts
+++ b/api/src/jobs/moderation/handler.ts
@@ -1,0 +1,86 @@
+import { SLACK_CRON_CHANNEL_ID } from "../../config";
+import { captureException } from "../../error";
+import PublisherModel from "../../models/publisher";
+import { postMessage } from "../../services/slack";
+import { BaseHandler } from "../base/handler";
+import { JobResult } from "../types";
+import { createModerations, findMissions } from "./utils";
+
+export interface ModerationJobPayload {}
+
+export interface ModerationJobResult extends JobResult {
+  moderators?: {
+    name: string;
+    updated: number;
+    events: number;
+    refused: number;
+    pending: number;
+  }[];
+}
+
+/*
+Here the job is to update the moderation status of the jva partners.
+The issue here is that the moderation was built to be open to all partners, 
+but we know only JVA is using it.
+Would have been better to directly have a moderation_jva collection.
+*/
+export class ModerationHandler implements BaseHandler<ModerationJobPayload, ModerationJobResult> {
+  async handle(): Promise<ModerationJobResult> {
+    try {
+      const start = new Date();
+      console.log(`[Moderation] Starting at ${start.toISOString()}`);
+
+      const moderators = await PublisherModel.find({ moderator: true });
+      const result = [] as ModerationJobResult["moderators"];
+
+      for (let i = 0; i < moderators.length; i++) {
+        const moderator = moderators[i];
+
+        if (!moderator.publishers || !moderator.publishers.length) {
+          continue;
+        }
+
+        console.log(`[Moderation] Starting for ${moderator.name} (${moderator._id}), number ${i + 1}/${moderators.length}`);
+
+        const data = await findMissions(moderator);
+        console.log(`[Moderation] - ${moderator.name} ${data.length} found in pending moderation yet`);
+
+        if (!data.length) {
+          continue;
+        }
+
+        const res = await createModerations(data, moderator);
+        result?.push({
+          name: moderator.name,
+          updated: res.updated,
+          events: res.events,
+          refused: res.refused,
+          pending: res.pending,
+        });
+        console.log(`[Moderation] ${moderator.name} ${res.updated} missions updated`);
+        console.log(`[Moderation] ${moderator.name} ${res.events} events created`);
+
+        await postMessage(
+          {
+            title: `Moderation ${moderator.name} completed`,
+            text: `Mission updated: ${res.updated}, Events created: ${res.events}, Missions refused: ${res.refused}, Missions pending: ${res.pending}`,
+          },
+          SLACK_CRON_CHANNEL_ID
+        );
+      }
+      console.log(`[Moderation] Ended at ${new Date().toISOString()} in ${(Date.now() - start.getTime()) / 1000}s`);
+
+      return {
+        success: true,
+        timestamp: new Date(),
+        moderators: result,
+      };
+    } catch (err) {
+      captureException(err);
+      return {
+        success: false,
+        timestamp: new Date(),
+      };
+    }
+  }
+}

--- a/api/src/jobs/moderation/types.ts
+++ b/api/src/jobs/moderation/types.ts
@@ -1,0 +1,6 @@
+export interface ModerationUpdate {
+  status: string | null;
+  comment: string | null;
+  note: string | null;
+  date: Date | null;
+}

--- a/process/src/index.ts
+++ b/process/src/index.ts
@@ -24,7 +24,6 @@ import "./db/postgres";
 import { captureException } from "./error";
 import imports from "./jobs/import";
 import metabase from "./jobs/metabase";
-import moderation from "./jobs/moderation";
 import report from "./jobs/report";
 
 const app = express();
@@ -55,7 +54,6 @@ const missionJob = new CronJob(
     runnings.mission = true;
     try {
       await imports.handler();
-      await moderation.handler();
       Sentry.captureCheckIn({
         checkInId,
         monitorSlug: "mission-updates",

--- a/terraform/jobs.tf
+++ b/terraform/jobs.tf
@@ -161,3 +161,21 @@ resource "scaleway_job_definition" "brevo" {
 
   env = local.all_env_vars
 }
+
+# Job Definition for the 'moderation' task
+resource "scaleway_job_definition" "moderation" {
+  name         = "${terraform.workspace}-moderation"
+  project_id   = var.project_id
+  cpu_limit    = 1000
+  memory_limit = 2048
+  image_uri    = local.image_uri
+  command      = "node dist/jobs/run-job.js moderation"
+  timeout      = "15m"
+
+  cron {
+    schedule = "0 */3 * * *" # Every 3 hours
+    timezone = "Europe/Paris"
+  }
+
+  env = local.all_env_vars
+}


### PR DESCRIPTION
## Description

Migration du job "moderation". 

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Migrer-le-job-de-mod-ration-JVA-22d72a322d5080e6b01ae4ad1abd376f?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
