### PR TITLE
Enable multi addresses for Linkedin

### DIFF
--- a/api/src/jobs/linkedin/__tests__/transformers.test.ts
+++ b/api/src/jobs/linkedin/__tests__/transformers.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { missionToLinkedinJob } from "../transformers";
+import { Mission } from "../../../types";
+import { missionToLinkedinJobs } from "../transformers";
 
 // Mock constants with IDs but keep the rest of the config
 vi.mock("../config", async () => {
@@ -23,23 +24,34 @@ vi.mock("../../../utils/mission", () => ({
 
 const defaultCompany = "benevolt";
 
-const baseMission: any = {
-  _id: "60d5f1b4e6b3f3b4e8f1b0e1",
+const baseMission: Partial<Mission> = {
   title: "Développeur Web",
   description: "Ceci est une description de mission de plus de 100 caractères pour passer la validation initiale. Il faut que ce soit assez long pour que le test passe.",
   organizationName: "Mon asso",
-  city: "Paris",
-  postalCode: "75001",
-  region: "Île-de-France",
-  country: "FR",
-  startAt: new Date("2025-01-15").toISOString(),
-  createdAt: new Date("2025-01-01").toISOString(),
-  endAt: new Date("2025-06-30").toISOString(),
+  addresses: [
+    {
+      city: "Paris",
+      postalCode: "75001",
+      region: "Île-de-France",
+      country: "FR",
+      street: "123 rue de test",
+      departmentName: "Paris",
+      departmentCode: "75",
+      location: {
+        lat: 48.8566,
+        lon: 2.3522,
+      },
+      geolocStatus: "ENRICHED_BY_PUBLISHER",
+    },
+  ],
+  startAt: new Date("2025-01-15"),
+  createdAt: new Date("2025-01-01"),
+  endAt: new Date("2025-06-30"),
   domain: "environnement",
   remote: "no",
 };
 
-describe("missionToLinkedinJob", () => {
+describe("missionToLinkedinJobs", () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -50,24 +62,25 @@ describe("missionToLinkedinJob", () => {
 
   it("should return a valid LinkedInJob for a valid mission", () => {
     vi.setSystemTime(new Date("2025-01-16")); // diffDays = 1, initialDescription = true
-    const job = missionToLinkedinJob(baseMission, defaultCompany);
+    const jobs = missionToLinkedinJobs(baseMission as Mission, defaultCompany);
+    const job = jobs[0];
     expect(job).not.toBeNull();
-    expect(job?.partnerJobId).toBe(String(baseMission._id));
-    expect(job?.title).toBe(`Bénévolat - ${baseMission.title}`);
-    expect(job?.jobtype).toBe("VOLUNTEER");
-    expect(job?.applyUrl).toBe(`https://api.api-engagement.beta.gouv.fr/r/${baseMission._id}/test-linkedin-id`);
-    expect(job?.description).not.toBeNull(); // Description will be tested in dedicated test
-    expect(job?.company).toBe("Mon asso");
-    expect(job?.companyId).toBe("12345");
-    expect(job?.location).toBe("Paris, France, Île-de-France");
-    expect(job?.country).toBe("FR");
-    expect(job?.city).toBe("Paris");
-    expect(job?.postalCode).toBe("75001");
-    expect(job?.listDate).toBe(new Date(baseMission.createdAt).toISOString());
-    expect(job?.expirationDate).toBe(new Date(baseMission.endAt).toISOString());
-    expect(job?.industry).toBe("environnement");
-    expect(job?.industryCodes).toEqual([{ industryCode: 2368 }]);
-    expect(job?.workplaceTypes).toBe("On-site");
+    expect(job.partnerJobId).toBe(String(baseMission._id));
+    expect(job.title).toBe(`Bénévolat - ${baseMission.title}`);
+    expect(job.jobtype).toBe("VOLUNTEER");
+    expect(job.applyUrl).toBe(`https://api.api-engagement.beta.gouv.fr/r/${baseMission._id}/test-linkedin-id`);
+    expect(job.description).not.toBeNull(); // Description will be tested in dedicated test
+    expect(job.company).toBe("Mon asso");
+    expect(job.companyId).toBe("12345");
+    expect(job.location).toBe("Paris, France, Île-de-France");
+    expect(job.country).toBe("FR");
+    expect(job.city).toBe("Paris");
+    expect(job.postalCode).toBe("75001");
+    expect(job.listDate).toBe(baseMission.createdAt?.toISOString());
+    expect(job.expirationDate).toBe(baseMission.endAt?.toISOString());
+    expect(job.industry).toBe("environnement");
+    expect(job.industryCodes).toEqual([{ industryCode: 2368 }]);
+    expect(job.workplaceTypes).toBe("On-site");
   });
 
   it("should format description with correct data", () => {
@@ -82,23 +95,23 @@ describe("missionToLinkedinJob", () => {
     const organizationName = "Mon asso";
     const domain = "environnement";
     const requirements = ["Précision 1", "Précision 2"];
-    const audience = "Jeunes";
+    const audience = ["Jeunes"];
     const schedule = "un jour par semaine";
 
-    const job = missionToLinkedinJob(
-      {
-        ...baseMission,
-        descriptionHtml,
-        domain,
-        requirements,
-        audience,
-        schedule,
-        openToMinors: "no",
-      },
-      defaultCompany
-    );
+    const mission = {
+      ...baseMission,
+      descriptionHtml,
+      domain,
+      requirements,
+      audience,
+      schedule,
+      openToMinors: "no",
+    } as Mission;
 
-    const startDate = new Date(baseMission.startAt);
+    const jobs = missionToLinkedinJobs(mission, defaultCompany);
+    const job = jobs[0];
+
+    const startDate = mission.startAt;
     const currentDate = new Date();
     const diffTime = Math.abs(currentDate.getTime() - startDate.getTime());
     const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
@@ -115,7 +128,7 @@ describe("missionToLinkedinJob", () => {
         <li>${requirements[1]}</li>
       </ol>
       <p><b>Public accompagné durant la mission : </b></p>
-      <p>${audience}</p>
+      <p>${audience.join(", ")}</p>
       <p><b>Durée de la mission : </b></p>
       <p>${schedule}</p>
       <p><b>Âge minimum : </b></p>
@@ -130,100 +143,128 @@ describe("missionToLinkedinJob", () => {
   });
 
   it("shouldnt include block title if openToMinors is yes", () => {
-    const mission = { ...baseMission, openToMinors: "yes" };
-    const job = missionToLinkedinJob(mission, defaultCompany);
-    expect(job?.description).not.toContain("<b>Âge minimum : </b>");
+    const mission = { ...baseMission, openToMinors: "yes" } as Mission;
+    const jobs = missionToLinkedinJobs(mission, defaultCompany);
+    expect(jobs[0].description).not.toContain("<b>Âge minimum : </b>");
   });
 
-  it("shouldnt include block title if audience is undefined", () => {
-    const mission = { ...baseMission, audience: undefined };
-    const job = missionToLinkedinJob(mission, defaultCompany);
-    expect(job?.description).not.toContain("<b>Public accompagné durant la mission : </b>");
+  it("shouldnt include block title if audience is empty", () => {
+    const mission = { ...baseMission, audience: [] } as Mission;
+    const jobs = missionToLinkedinJobs(mission, defaultCompany);
+    expect(jobs[0].description).not.toContain("<b>Public accompagné durant la mission : </b>");
   });
 
   it("shouldnt include block title if schedule is undefined", () => {
-    const mission = { ...baseMission, schedule: undefined };
-    const job = missionToLinkedinJob(mission, defaultCompany);
-    expect(job?.description).not.toContain("<b>Durée de la mission : </b>");
+    const mission = { ...baseMission, schedule: "" } as Mission;
+    const jobs = missionToLinkedinJobs(mission, defaultCompany);
+    expect(jobs[0].description).not.toContain("<b>Durée de la mission : </b>");
   });
 
   it("shouldnt include block title if requirements is empty", () => {
-    const mission = { ...baseMission, requirements: [] };
-    const job = missionToLinkedinJob(mission, defaultCompany);
-    expect(job?.description).not.toContain("<b>Pré-requis : </b>");
+    const mission = { ...baseMission, requirements: [] } as Mission;
+    const jobs = missionToLinkedinJobs(mission, defaultCompany);
+    expect(jobs[0].description).not.toContain("<b>Pré-requis : </b>");
   });
 
   it("should use alternate description based on date difference", () => {
     vi.setSystemTime(new Date("2025-01-19")); // diffDays = 4, initialDescription = false
-    const job = missionToLinkedinJob(baseMission, defaultCompany);
-    expect(job?.description).toContain(`Ceci est une mission de bénévolat pour <b>${baseMission.organizationName}</b>`);
-  });
-
-  it("should use return location to FR if not provided", () => {
-    const mission = { ...baseMission, city: undefined, country: undefined, region: undefined };
-    const job = missionToLinkedinJob(mission, defaultCompany);
-    expect(job?.location).toBe("France");
+    const jobs = missionToLinkedinJobs(baseMission as Mission, defaultCompany);
+    expect(jobs[0].description).toContain(`Ceci est une mission de bénévolat pour <b>${baseMission.organizationName}</b>`);
   });
 
   it("should use country FR if not provided", () => {
-    const mission = { ...baseMission, country: undefined };
-    const job = missionToLinkedinJob(mission, defaultCompany);
-    expect(job?.country).toBe("FR");
+    const mission = { ...baseMission } as Mission;
+    mission.addresses[0].country = "";
+    const jobs = missionToLinkedinJobs(mission, defaultCompany);
+    expect(jobs[0].country).toBe("FR");
   });
 
-  it.each([["title"], ["description"], ["organizationName"]])("should return null if %s is missing", (field) => {
-    const mission = { ...baseMission, [field]: undefined };
-    expect(missionToLinkedinJob(mission, defaultCompany)).toBeNull();
+  it.each([["title"], ["description"], ["organizationName"]])("should return empty array if %s is missing", (field) => {
+    const mission = { ...baseMission, title: "" } as Mission;
+    expect(missionToLinkedinJobs(mission, defaultCompany)).toHaveLength(0);
   });
 
   it("should use defaultCompany when organization is not in LINKEDIN_COMPANY_ID", () => {
-    const mission = { ...baseMission, organizationName: "Some Other Org" };
-    const job = missionToLinkedinJob(mission, "benevolt");
-    expect(job?.company).toBe("benevolt");
-    expect(job?.companyId).toBeUndefined();
+    const mission = { ...baseMission, organizationName: "Some Other Org" } as Mission;
+    const jobs = missionToLinkedinJobs(mission, "benevolt");
+    expect(jobs[0].company).toBe("benevolt");
+    expect(jobs[0].companyId).toBeUndefined();
   });
 
   it("should use defaultCompany when organizationName is not in LINKEDIN_COMPANY_ID and default is not benevolt", () => {
-    const mission = { ...baseMission, organizationName: "Unknown Org" };
-    const job = missionToLinkedinJob(mission, "some-default");
-    expect(job?.company).toBe("some-default");
-    expect(job?.companyId).toBeUndefined();
+    const mission = { ...baseMission, organizationName: "Unknown Org" } as Mission;
+    const jobs = missionToLinkedinJobs(mission, "some-default");
+    expect(jobs[0].company).toBe("some-default");
+    expect(jobs[0].companyId).toBeUndefined();
   });
 
   it("should correctly map remote status", () => {
-    let job = missionToLinkedinJob({ ...baseMission, remote: "full" }, defaultCompany);
-    expect(job?.workplaceTypes).toBe("Remote");
-    job = missionToLinkedinJob({ ...baseMission, remote: "possible" }, defaultCompany);
-    expect(job?.workplaceTypes).toBe("Hybrid");
-    job = missionToLinkedinJob({ ...baseMission, remote: "no" }, defaultCompany);
-    expect(job?.workplaceTypes).toBe("On-site");
+    let jobs = missionToLinkedinJobs({ ...baseMission, remote: "full" } as Mission, defaultCompany);
+    expect(jobs[0].workplaceTypes).toBe("Remote");
+    jobs = missionToLinkedinJobs({ ...baseMission, remote: "possible" } as Mission, defaultCompany);
+    expect(jobs[0].workplaceTypes).toBe("Hybrid");
+    jobs = missionToLinkedinJobs({ ...baseMission, remote: "no" } as Mission, defaultCompany);
+    expect(jobs[0].workplaceTypes).toBe("On-site");
   });
 
   it("should not have expirationDate if endAt is not provided", () => {
-    const mission = { ...baseMission, endAt: undefined };
-    const job = missionToLinkedinJob(mission, defaultCompany);
-    expect(job?.expirationDate).toBeUndefined();
-  });
-
-  it("should return null for description length > 25000", () => {
-    const mission = { ...baseMission, descriptionHtml: "a".repeat(25001) };
-    expect(missionToLinkedinJob(mission, defaultCompany)).toBeNull();
-  });
-
-  it("should return null for country code length > 2", () => {
-    const mission = { ...baseMission, country: "FRA" };
-    expect(missionToLinkedinJob(mission, defaultCompany)).toBeNull();
+    const mission = { ...baseMission, endAt: null } as Mission;
+    const jobs = missionToLinkedinJobs(mission, defaultCompany);
+    expect(jobs[0].expirationDate).toBeUndefined();
   });
 
   it("should map domain to industry code", () => {
-    const mission = { ...baseMission, domain: "sante" };
-    const job = missionToLinkedinJob(mission, defaultCompany);
-    expect(job?.industryCodes).toEqual([{ industryCode: 14 }]);
+    const mission = { ...baseMission, domain: "sante" } as Mission;
+    const jobs = missionToLinkedinJobs(mission, defaultCompany);
+    expect(jobs[0].industryCodes).toEqual([{ industryCode: 14 }]);
   });
 
   it("when domain is not in LINKEDIN_INDUSTRY_CODE, key should be undefined", () => {
-    const mission = { ...baseMission, domain: "unknown" };
-    const job = missionToLinkedinJob(mission, defaultCompany);
-    expect(job?.industryCodes).toBeUndefined();
+    const mission = { ...baseMission, domain: "unknown" } as Mission;
+    const jobs = missionToLinkedinJobs(mission, defaultCompany);
+    expect(jobs[0].industryCodes).toBeUndefined();
+  });
+
+  it("should return empty array for description length > 25000", () => {
+    const mission = { ...baseMission, descriptionHtml: "a".repeat(25001) } as Mission;
+    const jobs = missionToLinkedinJobs(mission, defaultCompany);
+    expect(jobs).toHaveLength(0);
+  });
+
+  it("should return empty array for country code length > 2", () => {
+    const mission = { ...baseMission } as Mission;
+    mission.addresses[0].country = "FRA";
+    const jobs = missionToLinkedinJobs(mission, defaultCompany);
+    expect(jobs).toHaveLength(0);
+  });
+
+  it("should return array of jobs when mission has multiple addresses", () => {
+    const mission = { ...baseMission } as Mission;
+    const address = mission.addresses[0];
+    address.city = "Lyon";
+    address.country = "FR";
+    address.region = "Auvergne-Rhône-Alpes";
+    address.postalCode = "69001";
+    mission.addresses.push(address);
+    const jobs = missionToLinkedinJobs(mission, defaultCompany);
+    expect(jobs).toHaveLength(2);
+  });
+
+  it("should return empty array when mission has no addresses", () => {
+    const mission = { ...baseMission, addresses: [] } as Mission;
+    const jobs = missionToLinkedinJobs(mission, defaultCompany);
+    expect(jobs).toHaveLength(0);
+  });
+
+  it("should return array with single job when multiAddresses is false", () => {
+    const mission = { ...baseMission } as Mission;
+    const address = mission.addresses[0];
+    address.city = "Lyon";
+    address.country = "FR";
+    address.region = "Auvergne-Rhône-Alpes";
+    address.postalCode = "69001";
+    mission.addresses.push(address);
+    const jobs = missionToLinkedinJobs(mission, defaultCompany, false);
+    expect(jobs).toHaveLength(1);
   });
 });

--- a/api/src/jobs/linkedin/config.ts
+++ b/api/src/jobs/linkedin/config.ts
@@ -1,8 +1,10 @@
 import { BUCKET_NAME, PUBLISHER_IDS } from "../../config";
 
 export const LINKEDIN_XML_URL = `https://${BUCKET_NAME}.s3.fr-par.scw.cloud/xml/linkedin`;
-
 export const LINKEDIN_PUBLISHER_ID = PUBLISHER_IDS.LINKEDIN;
+// Limit number of multi addresses jobs for testing purpose
+// TODO: remove this limit
+export const MAX_MULTI_ADDRESSES_JOBS = 10;
 
 export const PARTNERS_IDS = [
   PUBLISHER_IDS.LINKEDIN,

--- a/api/src/jobs/linkedin/config.ts
+++ b/api/src/jobs/linkedin/config.ts
@@ -2,10 +2,21 @@ import { BUCKET_NAME, PUBLISHER_IDS } from "../../config";
 
 export const LINKEDIN_XML_URL = `https://${BUCKET_NAME}.s3.fr-par.scw.cloud/xml/linkedin`;
 export const LINKEDIN_PUBLISHER_ID = PUBLISHER_IDS.LINKEDIN;
-// Limit number of multi addresses jobs for testing purpose
-// TODO: remove this limit
-export const MAX_MULTI_ADDRESSES_JOBS = 10;
-
+// Mission with multiple addresses for testing purpose
+// TODO: remove later
+export const MULTI_ADDRESSES_MISSIONS = [
+  "5f6b4c1e596993ec582ffd10",
+  "5f776377d06bc5f77de70dfb",
+  "5fb9a9e6096468000815c811",
+  "6703bbb373fbd982c101234a",
+  "60a72a9093b62c074927103c",
+  "60ee5a6bb225b20748696c00",
+  "612074a3bfcfe7060e7b9361",
+  "6703bb4273fbd982c1011c3d",
+  "61778ba7d0947a074f8b68ef",
+  "61a1b0d001adda076753ea03",
+  "61b2e1290e690d075ebd57d5",
+];
 export const PARTNERS_IDS = [
   PUBLISHER_IDS.LINKEDIN,
   PUBLISHER_IDS.BENEVOLT,

--- a/api/src/jobs/linkedin/transformers.ts
+++ b/api/src/jobs/linkedin/transformers.ts
@@ -5,102 +5,111 @@ import { LinkedInJob } from "./types";
 
 /**
  * Format mission to Linkedin Job
+ * Returns multiple jobs if mission has multiple addresses
+ * NB: when multiAddresses is set to false, only the first address is used. Param will be removed in the future.
+ *
  * Doc: https://learn.microsoft.com/en-us/linkedin/talent/job-postings/xml-feeds-development-guide?view=li-lts-2025-04
  *
  * @param mission - Mission to format
  * @param defaultCompany - Default company to use if organizationName is not in LINKEDIN_COMPANY_ID
- * @returns LinkedInJob | null
+ * @param multiAddresses - Whether to generate multiple jobs for single mission with multiple addresses
+ * @returns LinkedInJob[] | null
  */
-export function missionToLinkedinJob(mission: Mission, defaultCompany: string): LinkedInJob | null {
+export function missionToLinkedinJobs(mission: Mission, defaultCompany: string, multiAddresses: boolean = true): LinkedInJob[] {
   if (!mission.country) {
     mission.country = "FR";
   }
   if (!mission.title) {
-    return null;
+    return [];
   }
   if (!mission.description) {
-    return null;
+    return [];
   }
   if (!mission.organizationName) {
-    return null;
+    return [];
   }
 
-  const job = {
-    jobtype: "VOLUNTEER",
-    partnerJobId: String(mission._id),
-    applyUrl: getMissionTrackedApplicationUrl(mission, LINKEDIN_PUBLISHER_ID),
-    title: `Bénévolat - ${mission.title}`,
-    description: (() => {
-      const blocks: string[] = [];
-      const startDate = new Date(mission.startAt);
-      const currentDate = new Date();
-      const diffTime = Math.abs(currentDate.getTime() - startDate.getTime());
-      const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+  const jobs = [];
 
-      blocks.push("<p><b>Type de mission : </b><br>");
+  for (const address of mission.addresses) {
+    const job = {
+      jobtype: "VOLUNTEER",
+      partnerJobId: String(mission._id),
+      applyUrl: getMissionTrackedApplicationUrl(mission, LINKEDIN_PUBLISHER_ID),
+      title: `Bénévolat - ${mission.title}`,
+      description: (() => {
+        const blocks: string[] = [];
+        const startDate = new Date(mission.startAt);
+        const currentDate = new Date();
+        const diffTime = Math.abs(currentDate.getTime() - startDate.getTime());
+        const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
 
-      // Switch main title based on diffDays to alternate on 3 days basis
-      if (diffDays % 6 < 3) {
-        blocks.push(`<p><b>${mission.organizationName}</b> vous propose une mission de bénévolat</p>`);
-      } else {
-        blocks.push(`<p>Ceci est une mission de bénévolat pour <b>${mission.organizationName}</b></p>`);
-      }
+        blocks.push("<p><b>Type de mission : </b><br>");
 
-      if (mission.domain) {
-        blocks.push("<p><b>Domaine d'activité</b></p>");
-        blocks.push(`<p>${mission.domain}</p>`);
-      }
+        // Switch main title based on diffDays to alternate on 3 days basis
+        if (diffDays % 6 < 3) {
+          blocks.push(`<p><b>${mission.organizationName}</b> vous propose une mission de bénévolat</p>`);
+        } else {
+          blocks.push(`<p>Ceci est une mission de bénévolat pour <b>${mission.organizationName}</b></p>`);
+        }
 
-      if (mission.descriptionHtml) {
-        blocks.push(mission.descriptionHtml);
-      }
+        if (mission.domain) {
+          blocks.push("<p><b>Domaine d'activité</b></p>");
+          blocks.push(`<p>${mission.domain}</p>`);
+        }
 
-      if (Array.isArray(mission.requirements) && mission.requirements.length > 0) {
-        blocks.push("<p><b>Pré-requis : </b></p>");
-        blocks.push("<ol>");
-        mission.requirements.forEach((req) => {
-          blocks.push(`  <li>${req}</li>`);
-        });
-        blocks.push("</ol>");
-      }
+        if (mission.descriptionHtml) {
+          blocks.push(mission.descriptionHtml);
+        }
 
-      if (mission.audience) {
-        blocks.push("<p><b>Public accompagné durant la mission : </b></p>");
-        blocks.push(`<p>${mission.audience}</p>`);
-      }
+        if (Array.isArray(mission.requirements) && mission.requirements.length > 0) {
+          blocks.push("<p><b>Pré-requis : </b></p>");
+          blocks.push("<ol>");
+          mission.requirements.forEach((req) => {
+            blocks.push(`  <li>${req}</li>`);
+          });
+          blocks.push("</ol>");
+        }
 
-      if (mission.schedule) {
-        blocks.push("<p><b>Durée de la mission : </b></p>");
-        blocks.push(`<p>${mission.schedule}</p>`);
-      }
+        if (mission.audience && mission.audience.length > 0) {
+          blocks.push("<p><b>Public accompagné durant la mission : </b></p>");
+          blocks.push(`<p>${mission.audience}</p>`);
+        }
 
-      if (mission.openToMinors === "no") {
-        blocks.push("<p><b>Âge minimum : </b></p>");
-        blocks.push(`<p>18 ans minimum.</p>`);
-      }
-      return blocks.join("\n");
-    })(),
-    company: LINKEDIN_COMPANY_ID[mission.organizationName] ? mission.organizationName : defaultCompany,
-    location: `${mission.city ? `${mission.city}, ` : ""}${mission.country === "FR" ? "France" : mission.country}${mission.region ? `, ${mission.region}` : ""}`,
-    country: mission.country,
-    city: mission.city,
-    postalCode: mission.postalCode,
-    listDate: new Date(mission.createdAt).toISOString(),
-    industry: mission.domain,
-    industryCodes: LINKEDIN_INDUSTRY_CODE[mission.domain] ? [{ industryCode: LINKEDIN_INDUSTRY_CODE[mission.domain] }] : undefined,
-    workplaceTypes: mission.remote === "no" ? "On-site" : mission.remote === "full" ? "Remote" : "Hybrid",
-  } as LinkedInJob;
-  if (mission.endAt) {
-    job.expirationDate = new Date(mission.endAt).toISOString();
+        if (mission.schedule) {
+          blocks.push("<p><b>Durée de la mission : </b></p>");
+          blocks.push(`<p>${mission.schedule}</p>`);
+        }
+
+        if (mission.openToMinors === "no") {
+          blocks.push("<p><b>Âge minimum : </b></p>");
+          blocks.push(`<p>18 ans minimum.</p>`);
+        }
+        return blocks.join("\n");
+      })(),
+      company: LINKEDIN_COMPANY_ID[mission.organizationName] ? mission.organizationName : defaultCompany,
+      location: `${address.city ? `${address.city}, ` : ""}${address.country === "FR" ? "France" : address.country}${address.region ? `, ${address.region}` : ""}`,
+      country: address.country || "FR",
+      city: address.city,
+      postalCode: address.postalCode,
+      listDate: new Date(mission.createdAt).toISOString(),
+      industry: mission.domain,
+      industryCodes: LINKEDIN_INDUSTRY_CODE[mission.domain] ? [{ industryCode: LINKEDIN_INDUSTRY_CODE[mission.domain] }] : undefined,
+      workplaceTypes: mission.remote === "no" ? "On-site" : mission.remote === "full" ? "Remote" : "Hybrid",
+    } as LinkedInJob;
+    if (mission.endAt) {
+      job.expirationDate = new Date(mission.endAt).toISOString();
+    }
+    job.companyId = LINKEDIN_COMPANY_ID[job.company];
+
+    if (!job.description || job.description.length < 100 || job.description.length > 25000) {
+      continue;
+    }
+    if (!job.country || job.country.length > 2) {
+      continue;
+    }
+    jobs.push(job);
   }
-  job.companyId = LINKEDIN_COMPANY_ID[job.company];
 
-  if (!job.description || job.description.length < 100 || job.description.length > 25000) {
-    return null;
-  }
-  if (!job.country || job.country.length > 2) {
-    return null;
-  }
-
-  return job;
+  return multiAddresses ? jobs : [jobs[0] || []];
 }


### PR DESCRIPTION
## Description

Premier test du multi-adresses pour le flux Linkedin : 
- On créé une mission par adresse uniquement pour 10 missions whitelistées
- Les autres missions ne sont pas impactées

Prochaines étapes : 
- Voir quel impact cela a sur les 10 missions en question.
- Enlever la restriction si tout va bien.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/G-n-raliser-l-augmentation-du-nombre-de-missions-diffus-es-chez-nos-diffuseurs-principaux-en-augment-1ea72a322d508046a2f4fb9fc1daffc7?source=copy_link)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
