### PR TITLE
Fix letudiant duplicate cities

### DIFF
--- a/api/src/jobs/letudiant/__tests__/transformers.test.ts
+++ b/api/src/jobs/letudiant/__tests__/transformers.test.ts
@@ -98,9 +98,10 @@ describe("L'Etudiant Transformers", () => {
       expect(result.contract_id).toBe(mockMandatoryData.contracts.volontariat);
     });
 
-    it("should set localisation to 'A distance' for full remote missions and set remote_policy_id", () => {
+    it("should set localisation to 'A distance' for full remote missions with no address", () => {
       const mission: Mission = {
         ...baseMission,
+        addresses: [],
         remote: "full",
       } as Mission;
 
@@ -110,13 +111,15 @@ describe("L'Etudiant Transformers", () => {
       expect(result.remote_policy_id).toBe(mockMandatoryData.remotePolicies.full);
     });
 
-    it("should return an empty array if no address is provided", () => {
+    it("should consider remote job if no address", () => {
       const mission: Mission = {
         ...baseMission,
         addresses: [],
       } as Mission;
       const results = missionToPilotyJobs(mission, mockCompanyId, mockMandatoryData);
-      expect(results).toHaveLength(0);
+      const result = results[0];
+      expect(result.localisation).toBe("A distance");
+      expect(result.remote_policy_id).toBe(mockMandatoryData.remotePolicies.full);
     });
 
     it("should return an array of jobs for each address", () => {
@@ -155,6 +158,45 @@ describe("L'Etudiant Transformers", () => {
       } as Mission;
       const results = missionToPilotyJobs(mission, mockCompanyId, mockMandatoryData);
       expect(results).toHaveLength(2);
+    });
+
+    it("should merge jobs when addresses are in the same city", () => {
+      const mission: Mission = {
+        ...baseMission,
+        addresses: [
+          {
+            city: "Lyon",
+            postalCode: "69000",
+            street: "123 rue de test",
+            country: "France",
+            departmentName: "Rhône",
+            departmentCode: "69",
+            region: "Auvergne-Rhône-Alpes",
+            geolocStatus: "ENRICHED_BY_PUBLISHER",
+            location: {
+              lat: 45.764,
+              lon: 4.835,
+            },
+          },
+          {
+            city: "Lyon",
+            postalCode: "69000",
+            street: "456 rue de test",
+            country: "France",
+            departmentName: "Rhône",
+            departmentCode: "69",
+            region: "Auvergne-Rhône-Alpes",
+            geolocStatus: "ENRICHED_BY_PUBLISHER",
+            location: {
+              lat: 45.764,
+              lon: 4.835,
+            },
+          },
+        ],
+      } as Mission;
+      const results = missionToPilotyJobs(mission, mockCompanyId, mockMandatoryData);
+      expect(results).toHaveLength(1);
+      expect(results[0].localisation).toBe("Lyon");
     });
 
     it("should set state to 'archived' if mission is deleted", () => {

--- a/api/src/jobs/letudiant/utils.ts
+++ b/api/src/jobs/letudiant/utils.ts
@@ -39,7 +39,6 @@ export async function getMissionsToSync(id?: string, limit = 10): Promise<Hydrat
   const republishingDate = new Date(Date.now() - DAYS_AFTER_REPUBLISH * 24 * 60 * 60 * 1000);
 
   const missions = await MissionModel.find({
-    "addresses.1": { $exists: true },
     deletedAt: null,
     statusCode: "ACCEPTED",
     publisherId: {
@@ -54,14 +53,14 @@ export async function getMissionsToSync(id?: string, limit = 10): Promise<Hydrat
     letudiantError: {
       $exists: false,
     },
-    // $or: [
-    //   // Updated since last sync
-    //   { $expr: { $lt: ["$letudiantUpdatedAt", "$updatedAt"] } },
-    //   // Deleted since last sync
-    //   { $expr: { $lt: ["$letudiantUpdatedAt", "$deletedAt"] } },
-    //   // Missions not synced for more than X days or not synced at all
-    //   { $or: [{ letudiantUpdatedAt: { $exists: false } }, { letudiantUpdatedAt: { $lt: republishingDate } }] },
-    // ],
+    $or: [
+      // Updated since last sync
+      { $expr: { $lt: ["$letudiantUpdatedAt", "$updatedAt"] } },
+      // Deleted since last sync
+      { $expr: { $lt: ["$letudiantUpdatedAt", "$deletedAt"] } },
+      // Missions not synced for more than X days or not synced at all
+      { $or: [{ letudiantUpdatedAt: { $exists: false } }, { letudiantUpdatedAt: { $lt: republishingDate } }] },
+    ],
   }).limit(limit);
 
   return missions;

--- a/api/src/jobs/letudiant/utils.ts
+++ b/api/src/jobs/letudiant/utils.ts
@@ -39,6 +39,7 @@ export async function getMissionsToSync(id?: string, limit = 10): Promise<Hydrat
   const republishingDate = new Date(Date.now() - DAYS_AFTER_REPUBLISH * 24 * 60 * 60 * 1000);
 
   const missions = await MissionModel.find({
+    "addresses.1": { $exists: true },
     deletedAt: null,
     statusCode: "ACCEPTED",
     publisherId: {
@@ -53,14 +54,14 @@ export async function getMissionsToSync(id?: string, limit = 10): Promise<Hydrat
     letudiantError: {
       $exists: false,
     },
-    $or: [
-      // Updated since last sync
-      { $expr: { $lt: ["$letudiantUpdatedAt", "$updatedAt"] } },
-      // Deleted since last sync
-      { $expr: { $lt: ["$letudiantUpdatedAt", "$deletedAt"] } },
-      // Missions not synced for more than X days or not synced at all
-      { $or: [{ letudiantUpdatedAt: { $exists: false } }, { letudiantUpdatedAt: { $lt: republishingDate } }] },
-    ],
+    // $or: [
+    //   // Updated since last sync
+    //   { $expr: { $lt: ["$letudiantUpdatedAt", "$updatedAt"] } },
+    //   // Deleted since last sync
+    //   { $expr: { $lt: ["$letudiantUpdatedAt", "$deletedAt"] } },
+    //   // Missions not synced for more than X days or not synced at all
+    //   { $or: [{ letudiantUpdatedAt: { $exists: false } }, { letudiantUpdatedAt: { $lt: republishingDate } }] },
+    // ],
   }).limit(limit);
 
   return missions;


### PR DESCRIPTION
## Description

Pour éviter les doublons de missions qui ont plusieurs adresses de la même ville, on les groupe désormais par ville.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire