### PR TITLE
Implements Linkedin multi address with alternate locations

### DIFF
--- a/api/src/jobs/linkedin/__tests__/transformers.test.ts
+++ b/api/src/jobs/linkedin/__tests__/transformers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Mission } from "../../../types";
 import { missionToLinkedinJob } from "../transformers";
 
 // Mock constants with IDs but keep the rest of the config
@@ -28,20 +29,31 @@ vi.mock("../utils", () => ({
 
 const defaultCompany = "benevolt";
 
-const baseMission: any = {
-  _id: "60d5f1b4e6b3f3b4e8f1b0e1",
+const baseMission: Partial<Mission> = {
   title: "Développeur Web",
   description: "Ceci est une description de mission de plus de 100 caractères pour passer la validation initiale. Il faut que ce soit assez long pour que le test passe.",
   organizationName: "Mon asso",
-  city: "Paris",
-  postalCode: "75001",
-  region: "Île-de-France",
-  country: "FR",
-  startAt: new Date("2025-01-15").toISOString(),
-  createdAt: new Date("2025-01-01").toISOString(),
-  endAt: new Date("2025-06-30").toISOString(),
+  startAt: new Date("2025-01-15"),
+  createdAt: new Date("2025-01-01"),
+  endAt: new Date("2025-06-30"),
   domain: "environnement",
   remote: "no",
+  addresses: [
+    {
+      city: "Paris",
+      postalCode: "75001",
+      region: "Île-de-France",
+      country: "FR",
+      street: "123 rue de test",
+      departmentName: "Paris",
+      departmentCode: "75",
+      location: {
+        lat: 48.8566,
+        lon: 2.3522,
+      },
+      geolocStatus: "ENRICHED_BY_PUBLISHER",
+    },
+  ],
 };
 
 describe("missionToLinkedinJob", () => {
@@ -56,7 +68,7 @@ describe("missionToLinkedinJob", () => {
 
   it("should return a valid LinkedInJob for a valid mission", () => {
     vi.setSystemTime(new Date("2025-01-16")); // diffDays = 1, initialDescription = true
-    const job = missionToLinkedinJob(baseMission, defaultCompany);
+    const job = missionToLinkedinJob(baseMission as Mission, defaultCompany);
     expect(job).not.toBeNull();
     expect(job?.partnerJobId).toBe(String(baseMission._id));
     expect(job?.title).toBe(`Bénévolat - ${baseMission.title}`);
@@ -65,12 +77,13 @@ describe("missionToLinkedinJob", () => {
     expect(job?.description).not.toBeNull(); // Description will be tested in dedicated test
     expect(job?.company).toBe("Mon asso");
     expect(job?.companyId).toBe("12345");
-    expect(job?.location).toBe("Paris, France, Île-de-France");
-    expect(job?.country).toBe("FR");
-    expect(job?.city).toBe("Paris");
-    expect(job?.postalCode).toBe("75001");
-    expect(job?.listDate).toBe(new Date(baseMission.createdAt).toISOString());
-    expect(job?.expirationDate).toBe(new Date(baseMission.endAt).toISOString());
+    expect(job?.location).toBe("Paris, France");
+    // When location is provided, country and city are not mandatory
+    expect(job?.country).toBeUndefined();
+    expect(job?.city).toBeUndefined();
+    expect(job?.postalCode).toBeUndefined();
+    expect(job?.listDate).toBe(baseMission.createdAt?.toISOString());
+    expect(job?.expirationDate).toBe(baseMission.endAt?.toISOString());
     expect(job?.industryCodes).toEqual([{ industryCode: 2368 }]);
     expect(job?.workplaceTypes).toBe("On-site");
   });
@@ -88,20 +101,19 @@ describe("missionToLinkedinJob", () => {
     const requirements = ["Précision 1", "Précision 2"];
     const schedule = "un jour par semaine";
 
-    const job = missionToLinkedinJob(
-      {
-        ...baseMission,
-        descriptionHtml,
-        domain: "environnement",
-        requirements,
-        audience: ["seniors", "people_in_difficulty"],
-        schedule,
-        openToMinors: "no",
-      },
-      defaultCompany
-    );
+    const mission = {
+      ...baseMission,
+      descriptionHtml,
+      domain: "environnement",
+      requirements,
+      audience: ["seniors", "people_in_difficulty"],
+      schedule,
+      openToMinors: "no",
+    } as Mission;
 
-    const startDate = new Date(baseMission.startAt);
+    const job = missionToLinkedinJob(mission, defaultCompany);
+
+    const startDate = mission.startAt;
     const currentDate = new Date();
     const diffTime = Math.abs(currentDate.getTime() - startDate.getTime());
     const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
@@ -130,99 +142,134 @@ describe("missionToLinkedinJob", () => {
   });
 
   it("shouldnt include block title if openToMinors is yes", () => {
-    const mission = { ...baseMission, openToMinors: "yes" };
+    const mission = { ...baseMission, openToMinors: "yes" } as Mission;
     const job = missionToLinkedinJob(mission, defaultCompany);
     expect(job?.description).not.toContain("<b>Âge minimum : </b>");
   });
 
-  it("shouldnt include block title if audience is undefined", () => {
-    const mission = { ...baseMission, audience: undefined };
+  it("shouldnt include block title if audience is empty", () => {
+    const mission = { ...baseMission, audience: [] } as Mission;
     const job = missionToLinkedinJob(mission, defaultCompany);
     expect(job?.description).not.toContain("<b>Public accompagné durant la mission : </b>");
   });
 
-  it("shouldnt include block title if schedule is undefined", () => {
-    const mission = { ...baseMission, schedule: undefined };
+  it("shouldnt include block title if schedule is empty", () => {
+    const mission = { ...baseMission, schedule: "" } as Mission;
     const job = missionToLinkedinJob(mission, defaultCompany);
     expect(job?.description).not.toContain("<b>Durée de la mission : </b>");
   });
 
   it("shouldnt include block title if requirements is empty", () => {
-    const mission = { ...baseMission, requirements: [] };
+    const mission = { ...baseMission, requirements: [] } as Mission;
     const job = missionToLinkedinJob(mission, defaultCompany);
     expect(job?.description).not.toContain("<b>Pré-requis : </b>");
   });
 
   it("should use alternate description based on date difference", () => {
     vi.setSystemTime(new Date("2025-01-19")); // diffDays = 4, initialDescription = false
-    const job = missionToLinkedinJob(baseMission, defaultCompany);
+    const job = missionToLinkedinJob(baseMission as Mission, defaultCompany);
     expect(job?.description).toContain(`Ceci est une mission de bénévolat pour <b>${baseMission.organizationName}</b>`);
   });
 
-  it("should use return location to FR if not provided", () => {
-    const mission = { ...baseMission, city: undefined, country: undefined, region: undefined };
+  it("should use location fields when present and no address are provided", () => {
+    const mission = { ...baseMission, addresses: [], country: "FR", city: "Nantes", postalCode: "44000" } as Mission;
     const job = missionToLinkedinJob(mission, defaultCompany);
-    expect(job?.location).toBe("France");
+    expect(job?.country).toBe("FR");
+    expect(job?.city).toBe("Nantes");
+    expect(job?.postalCode).toBe("44000");
   });
 
-  it("should use country FR if not provided", () => {
-    const mission = { ...baseMission, country: undefined };
+  it("should use country to FR if address and no located fields are provided", () => {
+    const mission = { ...baseMission, addresses: [] } as Mission;
     const job = missionToLinkedinJob(mission, defaultCompany);
     expect(job?.country).toBe("FR");
   });
 
+  it("should return null if country is not valid", () => {
+    const mission = { ...baseMission, addresses: [], country: "invalid" } as Mission;
+    const job = missionToLinkedinJob(mission, defaultCompany);
+    expect(job).toBeNull();
+  });
+
+  it("should have alternate locations if mission has multiple addresses", () => {
+    const addresses = [
+      { ...baseMission.addresses?.[0], city: "Lyon", region: "Rhône-Alpes", country: "FR", postalCode: "69001" },
+      { ...baseMission.addresses?.[0], city: "Marseille", region: "Provence-Alpes-Côte d'Azur", country: "FR", postalCode: "13001" },
+    ];
+    const mission = { ...baseMission, addresses } as Mission;
+    const job = missionToLinkedinJob(mission, defaultCompany);
+    expect(job?.alternateLocations?.alternateLocation).toHaveLength(2);
+    expect(job?.alternateLocations?.alternateLocation).toContain("Lyon, France");
+    expect(job?.alternateLocations?.alternateLocation).toContain("Marseille, France");
+  });
+
+  it("should not have alternate locations if mission has only one address", () => {
+    const mission = { ...baseMission } as Mission;
+    const job = missionToLinkedinJob(mission, defaultCompany);
+    expect(job?.alternateLocations).toBeUndefined();
+  });
+
+  it("should limit alternate locations to 7", () => {
+    const addresses = Array.from({ length: 8 }, (_, i) => ({ ...baseMission.addresses?.[0], city: `City ${i}`, region: `Region ${i}`, country: "FR", postalCode: `12345${i}` }));
+    const mission = { ...baseMission, addresses } as Mission;
+    const job = missionToLinkedinJob(mission, defaultCompany);
+    expect(job?.alternateLocations?.alternateLocation).toHaveLength(7);
+    expect(job?.alternateLocations?.alternateLocation).toContain("City 0, France");
+    expect(job?.alternateLocations?.alternateLocation).toContain("City 1, France");
+    expect(job?.alternateLocations?.alternateLocation).toContain("City 2, France");
+    expect(job?.alternateLocations?.alternateLocation).toContain("City 3, France");
+    expect(job?.alternateLocations?.alternateLocation).toContain("City 4, France");
+    expect(job?.alternateLocations?.alternateLocation).toContain("City 5, France");
+    expect(job?.alternateLocations?.alternateLocation).toContain("City 6, France");
+  });
+
   it.each([["title"], ["description"], ["organizationName"]])("should return null if %s is missing", (field) => {
-    const mission = { ...baseMission, [field]: undefined };
+    const mission = { ...baseMission, [field]: undefined } as Mission;
     expect(missionToLinkedinJob(mission, defaultCompany)).toBeNull();
   });
 
   it("should use defaultCompany when organization is not in LINKEDIN_COMPANY_ID", () => {
-    const mission = { ...baseMission, organizationName: "Some Other Org" };
+    const mission = { ...baseMission, organizationName: "Some Other Org" } as Mission;
     const job = missionToLinkedinJob(mission, "benevolt");
     expect(job?.company).toBe("benevolt");
     expect(job?.companyId).toBeUndefined();
   });
 
   it("should use defaultCompany when organizationName is not in LINKEDIN_COMPANY_ID and default is not benevolt", () => {
-    const mission = { ...baseMission, organizationName: "Unknown Org" };
+    const mission = { ...baseMission, organizationName: "Unknown Org" } as Mission;
     const job = missionToLinkedinJob(mission, "some-default");
     expect(job?.company).toBe("some-default");
     expect(job?.companyId).toBeUndefined();
   });
 
   it("should correctly map remote status", () => {
-    let job = missionToLinkedinJob({ ...baseMission, remote: "full" }, defaultCompany);
+    let job = missionToLinkedinJob({ ...baseMission, remote: "full" } as Mission, defaultCompany);
     expect(job?.workplaceTypes).toBe("Remote");
-    job = missionToLinkedinJob({ ...baseMission, remote: "possible" }, defaultCompany);
+    job = missionToLinkedinJob({ ...baseMission, remote: "possible" } as Mission, defaultCompany);
     expect(job?.workplaceTypes).toBe("Hybrid");
-    job = missionToLinkedinJob({ ...baseMission, remote: "no" }, defaultCompany);
+    job = missionToLinkedinJob({ ...baseMission, remote: "no" } as Mission, defaultCompany);
     expect(job?.workplaceTypes).toBe("On-site");
   });
 
   it("should not have expirationDate if endAt is not provided", () => {
-    const mission = { ...baseMission, endAt: undefined };
+    const mission = { ...baseMission, endAt: null } as Mission;
     const job = missionToLinkedinJob(mission, defaultCompany);
     expect(job?.expirationDate).toBeUndefined();
   });
 
   it("should return null for description length > 25000", () => {
-    const mission = { ...baseMission, descriptionHtml: "a".repeat(25001) };
-    expect(missionToLinkedinJob(mission, defaultCompany)).toBeNull();
-  });
-
-  it("should return null for country code length > 2", () => {
-    const mission = { ...baseMission, country: "FRA" };
+    const mission = { ...baseMission, descriptionHtml: "a".repeat(25001) } as Mission;
     expect(missionToLinkedinJob(mission, defaultCompany)).toBeNull();
   });
 
   it("should map domain to industry code", () => {
-    const mission = { ...baseMission, domain: "sante" };
+    const mission = { ...baseMission, domain: "sante" } as Mission;
     const job = missionToLinkedinJob(mission, defaultCompany);
     expect(job?.industryCodes).toEqual([{ industryCode: 14 }]);
   });
 
   it("when domain is not in LINKEDIN_INDUSTRY_CODE, key should be undefined", () => {
-    const mission = { ...baseMission, domain: "unknown" };
+    const mission = { ...baseMission, domain: "unknown" } as Mission;
     const job = missionToLinkedinJob(mission, defaultCompany);
     expect(job?.industryCodes).toBeUndefined();
   });

--- a/api/src/jobs/linkedin/types.ts
+++ b/api/src/jobs/linkedin/types.ts
@@ -10,7 +10,7 @@ export interface LinkedInJob {
   publisherURL?: string;
   publisher?: string;
   expectedJobCount?: number;
-  alternateLocations?: string[];
+  alternateLocations?: { alternateLocation: string[] };
   city?: string;
   state?: string;
   country?: string;


### PR DESCRIPTION
## Description

Utilisation de la clé `alternateLocations` pour gérer les missions multi-adresses. 
Simplification de la gestion des localisations, par ordre de priorité : 
- `mission.addresses`
- `mission.country|city`
- Fallback vers "FR"

Annule et remplace #354 

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/G-n-raliser-l-augmentation-du-nombre-de-missions-diffus-es-chez-nos-diffuseurs-principaux-en-augment-1ea72a322d508046a2f4fb9fc1daffc7?d=64672a322d50834a98c683635557934c)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
