### PR TITLE
Add missions to delete in letudiant job

### DIFF
--- a/api/src/jobs/letudiant/__tests__/transformers.test.ts
+++ b/api/src/jobs/letudiant/__tests__/transformers.test.ts
@@ -63,6 +63,7 @@ describe("L'Etudiant Transformers", () => {
       publisherId: "some_publisher_id",
       remote: "no",
       deletedAt: null,
+      statusCode: "ACCEPTED",
     };
 
     it("should correctly transform a mission for Benevolat", () => {
@@ -199,14 +200,52 @@ describe("L'Etudiant Transformers", () => {
       expect(results[0].localisation).toBe("Lyon");
     });
 
-    it("should set state to 'archived' if mission is deleted", () => {
+    it("should set state to 'archived' for not accepted mission", () => {
       const mission: Mission = {
         ...baseMission,
+        statusCode: "REJECTED",
+      } as Mission;
+      const results = missionToPilotyJobs(mission, mockCompanyId, mockMandatoryData);
+      expect(results[0].state).toBe("archived");
+    });
+
+    it("should set state to 'archived' for each job if mission is deleted", () => {
+      const mission: Mission = {
+        ...baseMission,
+        addresses: [
+          {
+            city: "Lyon",
+            postalCode: "69000",
+            street: "123 rue de test",
+            country: "France",
+            departmentName: "Rhône",
+            departmentCode: "69",
+            region: "Auvergne-Rhône-Alpes",
+            geolocStatus: "ENRICHED_BY_PUBLISHER",
+            location: {
+              lat: 45.764,
+              lon: 4.835,
+            },
+          },
+          {
+            city: "Marseille",
+            postalCode: "13000",
+            street: "456 rue de test",
+            country: "France",
+            departmentName: "Bouches-du-Rhône",
+            departmentCode: "13",
+            region: "Provence-Alpes-Côte d'Azur",
+            geolocStatus: "ENRICHED_BY_PUBLISHER",
+            location: {
+              lat: 43.296,
+              lon: 5.369,
+            },
+          },
+        ],
         deletedAt: new Date(),
       } as Mission;
       const results = missionToPilotyJobs(mission, mockCompanyId, mockMandatoryData);
-      const result = results[0];
-      expect(result.state).toBe("archived");
+      expect(results.every((job) => job.state === "archived")).toBe(true);
     });
 
     it("should use 'autre' job category if mission domain is null or not in mandatoryData", () => {

--- a/api/src/jobs/letudiant/handler.ts
+++ b/api/src/jobs/letudiant/handler.ts
@@ -21,6 +21,7 @@ export interface LetudiantJobResult extends JobResult {
     processed: number;
     created: number;
     updated: number;
+    deleted: number;
     skipped: number;
     error: number;
   };
@@ -43,6 +44,7 @@ export class LetudiantHandler implements BaseHandler<LetudiantJobPayload, Letudi
     const counter = {
       created: 0,
       updated: 0,
+      deleted: 0,
       skipped: 0,
       error: 0,
     };
@@ -76,7 +78,11 @@ export class LetudiantHandler implements BaseHandler<LetudiantJobPayload, Letudi
           if (letudiantPublicId) {
             console.log(`[LetudiantHandler] Updating job ${mission._id} - ${jobPayload.localisation} (${letudiantPublicId})`);
             pilotyJob = await pilotyClient.updateJob(letudiantPublicId, jobPayload);
-            counter.updated++;
+            if (jobPayload.state === "archived") {
+              counter.deleted++;
+            } else {
+              counter.updated++;
+            }
           } else {
             console.log(`[LetudiantHandler] Creating job ${mission._id} - ${jobPayload.localisation}`);
             pilotyJob = await pilotyClient.createJob(jobPayload);

--- a/api/src/jobs/letudiant/transformers.ts
+++ b/api/src/jobs/letudiant/transformers.ts
@@ -38,7 +38,7 @@ export function missionToPilotyJobs(mission: Mission, companyId: string, mandato
       description_job: decodeHtml(mission.descriptionHtml),
       application_method: "external_apply",
       application_url: getMissionTrackedApplicationUrl(mission, PUBLISHER_IDS.LETUDIANT),
-      state: mission.deletedAt ? "archived" : "published",
+      state: mission.deletedAt || mission.statusCode !== "ACCEPTED" ? "archived" : "published",
       remote_policy_id: localisation ? undefined : mandatoryData.remotePolicies.full,
       position_level: "employee",
       description_company: mission.organizationDescription || "",


### PR DESCRIPTION
## Description

Gestion des missions supprimées / modérées dans le job l'Etudiant. 
On synchro les missions qui auraient déjà été envoyées à l'Etudiant : 
- Supprimées (`deletedAt`)
- Modérées (`statusCode != "ACCEPTED"`)

Ces missions sont envoyées en `archived`

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Missions-supprim-es-sur-l-etudiant-24172a322d50807ca630c79a83012b5b?source=copy_link)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
