### PR TITLE
Fix ESClient conflict on is-human endpoint

### DIFF
--- a/api/src/controllers/redirect.ts
+++ b/api/src/controllers/redirect.ts
@@ -643,12 +643,17 @@ router.get("/:statsId/confirm-human", cors({ origin: "*" }), async (req, res) =>
       index: STATS_INDEX,
       id: params.data.statsId,
       body: { doc: { isHuman: true } },
+      retry_on_conflict: 5,
     });
 
     return res.status(200).send({ ok: true });
   } catch (error: any) {
     if (error.statusCode === 404) {
       return res.status(404).send({ ok: false, code: NOT_FOUND });
+    }
+    // If another concurrent update already set the flag, treat as success
+    if (error.statusCode === 409 || error?.meta?.statusCode === 409) {
+      return res.status(200).send({ ok: true, alreadyUpdated: true });
     }
     captureException(error);
     return res.status(500).send({ ok: false, code: SERVER_ERROR });


### PR DESCRIPTION
## Description

Utilisation de `retry_on_conflict` dans le cas d'une tentative d'update simultanée de la stat. Voir erreur Sentry 👇 
https://discuss.elastic.co/t/why-is-retry-on-conflict-necessary/311177

## Liens utiles

- 📝 Erreur Sentry : [Lien vers l'issue](https://sentry.incubateur.net/organizations/betagouv/issues/192904/?project=227&referrer=issue-stream&stream_index=0)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire