### PR TITLE
fix: handle zero coordinates in distance calc

### DIFF
--- a/api/src/utils/__tests__/geo.test.ts
+++ b/api/src/utils/__tests__/geo.test.ts
@@ -53,5 +53,10 @@ describe("Geo Utils", () => {
       const distance = getDistanceFromLatLonInKm(lat, lon, lat, lon);
       expect(distance).toBe(0);
     });
+
+    it("should handle zero values for coordinates", () => {
+      const distance = getDistanceFromLatLonInKm(0, 0, 0, 0);
+      expect(distance).toBe(0);
+    });
   });
 });

--- a/api/src/utils/geo.ts
+++ b/api/src/utils/geo.ts
@@ -32,7 +32,12 @@ export const getDistanceKm = (value: string): number => {
 export const getDistanceFromLatLonInKm = (lat1?: number, lon1?: number, lat2?: number, lon2?: number): number | undefined => {
   const degreesToRadians = (degrees: number) => degrees * (Math.PI / 180);
 
-  if (!lat1 || !lon1 || !lat2 || !lon2) {
+  if (
+    lat1 === undefined ||
+    lon1 === undefined ||
+    lat2 === undefined ||
+    lon2 === undefined
+  ) {
     return undefined;
   }
   const r = EARTH_RADIUS; // Radius of the Earth in kilometers


### PR DESCRIPTION
## Summary
- avoid treating 0 latitude or longitude as missing when computing distance
- add regression test for zero-coordinate case

## Testing
- `npx vitest run src/utils/__tests__/geo.test.ts`
- `npm run lint` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68baa42f3bec8324bd90bb38ea832980