### PR TITLE
feat: add default mission logo

### DIFF
--- a/api/src/jobs/import-missions/types.ts
+++ b/api/src/jobs/import-missions/types.ts
@@ -64,7 +64,7 @@ export interface MissionXML {
 
   organizationSiren: string;
   organizationUrl: string;
-  organizationLogo: string;
+  organizationLogo?: string;
   organizationDescription: string;
   organizationClientId: string;
   organizationStatusJuridique: string;

--- a/api/src/jobs/import-missions/utils/mission.ts
+++ b/api/src/jobs/import-missions/utils/mission.ts
@@ -115,6 +115,8 @@ const parseArray = (value: string | { value: string[] | string } | undefined, in
 };
 
 const parseMission = (publisher: Publisher, missionXML: MissionXML, missionDB: Mission | null) => {
+  const organizationLogo = parseString(missionXML.organizationLogo);
+
   const mission = {
     title: he.decode(missionXML.title),
     type: publisher.missionType,
@@ -151,7 +153,7 @@ const parseMission = (publisher: Publisher, missionXML: MissionXML, missionDB: M
     organizationRNA: parseString(missionXML.organizationRNA) || parseString(missionXML.organizationRna) || "",
     organizationSiren: parseString(missionXML.organizationSiren) || missionXML.organizationSiren || "",
     organizationUrl: parseString(missionXML.organizationUrl),
-    organizationLogo: parseString(missionXML.organizationLogo || ""),
+    organizationLogo: organizationLogo || publisher.defaultMissionLogo || "",
     organizationDescription: parseString(missionXML.organizationDescription),
     organizationClientId: parseString(missionXML.organizationId),
     organizationStatusJuridique: parseString(missionXML.organizationStatusJuridique) || "",

--- a/api/src/models/publisher.ts
+++ b/api/src/models/publisher.ts
@@ -27,6 +27,7 @@ const schema = new Schema<Publisher>(
 
     documentation: { type: String },
     logo: { type: String },
+    defaultMissionLogo: { type: String },
     lead: { type: String },
     feed: { type: String },
     feedUsername: { type: String },

--- a/api/src/types/index.ts
+++ b/api/src/types/index.ts
@@ -405,6 +405,7 @@ export interface Publisher {
   url: string;
   email: string;
   logo: string;
+  defaultMissionLogo?: string;
   documentation: string;
   description: string;
 

--- a/api/tests/integration/jobs/import-missions/data/missing-logo-feed.xml
+++ b/api/tests/integration/jobs/import-missions/data/missing-logo-feed.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<source>
+  <publisher><![CDATA[Example Job Site]]></publisher>
+  <publisherurl><![CDATA[http://www.examplemissionsite.com]]></publisherurl>
+  <lastBuildDate><![CDATA[Fri, 10 March 2020 22:49:39 GMT]]></lastBuildDate>
+  <mission>
+    <title><![CDATA[Titre de la mission]]></title>
+    <clientId><![CDATA[32132143]]></clientId>
+    <description><![CDATA[Description de la mission]]></description>
+    <applicationUrl><![CDATA[https://www.urltomymission.org]]></applicationUrl>
+    <postedAt><![CDATA[01/01/2023]]></postedAt>
+    <startAt><![CDATA[01/01/2025]]></startAt>
+    <endAt><![CDATA[11/01/2025]]></endAt>
+    <addresses>
+      <address>
+        <street><![CDATA[46 Rue Saint-Antoine]]></street>
+        <postalCode><![CDATA[75004]]></postalCode>
+        <city><![CDATA[Paris]]></city>
+        <departmentCode><![CDATA[75]]></departmentCode>
+        <departmentName><![CDATA[Paris]]></departmentName>
+        <region><![CDATA[Île-de-France]]></region>
+        <country><![CDATA[France]]></country>
+        <location>
+          <lat><![CDATA[48.8541]]></lat>
+          <lon><![CDATA[2.3643]]></lon>
+        </location>
+      </address>
+    </addresses>
+    <schedule><![CDATA[1 demi-journée par semaine]]></schedule>
+    <places><![CDATA[2]]></places>
+    <activity><![CDATA[logistique]]></activity>
+    <remote><![CDATA[full]]></remote>
+    <domain><![CDATA[environnement]]></domain>
+    <tags><![CDATA[environnement,écologie]]></tags>
+    <image><![CDATA[https://monurl.com/1.jpg]]></image>
+    <audience><![CDATA[Tous]]></audience>
+    <softSkills><![CDATA[compétence 1,compétence 2]]></softSkills>
+    <romeSkills><![CDATA[Rome 1,Rome 2]]></romeSkills>
+    <requirements><![CDATA[Exigence 1,Exigence 2]]></requirements>
+    <reducedMobilityAccessible><![CDATA[yes]]></reducedMobilityAccessible>
+    <closeToTransport><![CDATA[yes]]></closeToTransport>
+    <openToMinors><![CDATA[yes]]></openToMinors>
+    <priority><![CDATA[haute]]></priority>
+    <metadata></metadata>
+    <organizationName><![CDATA[Mon asso]]></organizationName>
+    <organizationRNA><![CDATA[W922000733]]></organizationRNA>
+    <organizationSiren><![CDATA[332737394]]></organizationSiren>
+    <organizationUrl><![CDATA[https://www.organizationname.com]]></organizationUrl>
+    <organizationLogo></organizationLogo>
+    <organizationClientId><![CDATA[123312321]]></organizationClientId>
+    <organizationId><![CDATA[123312321]]></organizationId>
+    <organizationType><![CDATA[1901]]></organizationType>
+    <organizationFullAddress><![CDATA[55 Rue du Faubourg Saint-Honoré 75008 Paris]]></organizationFullAddress>
+    <organizationPostCode><![CDATA[75008]]></organizationPostCode>
+    <organizationCity><![CDATA[Paris]]></organizationCity>
+    <organizationBeneficiaries><![CDATA[Tous]]></organizationBeneficiaries>
+    <organizationReseaux><![CDATA[Réseau]]></organizationReseaux>
+    <organizationStatusJuridique><![CDATA[Association]]></organizationStatusJuridique>
+  </mission>
+</source>
+

--- a/api/tests/integration/jobs/import-missions/import-missions.handler.test.ts
+++ b/api/tests/integration/jobs/import-missions/import-missions.handler.test.ts
@@ -88,6 +88,19 @@ describe("Import missions job (integration test)", () => {
     expect(mission.title).toBe("Titre de la mission");
   });
 
+  it("uses publisher defaultMissionLogo when organizationLogo is missing", async () => {
+    const xml = await readFile(path.join(__dirname, "data/missing-logo-feed.xml"), "utf-8");
+    const defaultLogo = "https://example.com/default_logo.png";
+    const publisher = await createTestPublisher({ feed: "https://fixture-missing-logo", defaultMissionLogo: defaultLogo });
+    (global.fetch as any).mockResolvedValueOnce({ ok: true, text: async () => xml });
+
+    await handler.handle({ publisherId: publisher._id.toString() });
+
+    const missions = await MissionModel.find({ publisherId: publisher._id.toString() });
+    expect(missions.length).toBeGreaterThan(0);
+    expect(missions[0].organizationLogo).toBe(defaultLogo);
+  });
+
   it("If feed is empty for the first time, missions related to publisher should not be deleted", async () => {
     const publisher = await createTestPublisher({ feed: "https://empty-feed" });
     await createTestMission({ publisherId: publisher._id.toString(), clientId: "client-old" });


### PR DESCRIPTION
## Summary
- add defaultMissionLogo field to Publisher
- use publisher defaultMissionLogo during mission import when organizationLogo missing
- test default mission logo fallback

## Testing
- `cd api && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68baa940d544832496746962a25d3e72