### PR TITLE
fix(api): add deterministic sort for my mission list

### DIFF
--- a/api/src/v0/mymission.ts
+++ b/api/src/v0/mymission.ts
@@ -54,7 +54,11 @@ router.get("/", passport.authenticate(["apikey", "api"], { session: false }), as
     const where = { deleted: false, publisherId: user._id.toString() };
 
     const total = await MissionModel.countDocuments(where);
-    const data = await MissionModel.find(where).limit(query.data.limit).skip(query.data.skip).lean();
+    const data = await MissionModel.find(where)
+      .sort({ createdAt: -1 })
+      .skip(query.data.skip)
+      .limit(query.data.limit)
+      .lean();
 
     res.locals = { total };
     return res.status(200).send({


### PR DESCRIPTION
## Summary
- ensure consistent ordering when listing MyMission entries to avoid pagination issues

## Testing
- `npm run lint:api`
- `npm --prefix api test` *(fails: DownloadError: Download failed for url "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.14.tgz")*


------
https://chatgpt.com/codex/tasks/task_e_68bad163454c8324aee0f99e02e4d152