### PR TITLE
feat: add Postgres-backed stat event repository with read/write flags

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -17,6 +17,8 @@ export const DB_ENDPOINT = process.env.DB_ENDPOINT;
 export const MISSION_INDEX = "mission";
 export const ASSOS_INDEX = "association";
 export const STATS_INDEX = "stats";
+export const READ_STATS_FROM = (process.env.READ_STATS_FROM as "es" | "pg") || "es";
+export const WRITE_STATS_DUAL = process.env.WRITE_STATS_DUAL === "true";
 
 export const SENDINBLUE_APIKEY = process.env.SENDINBLUE_APIKEY;
 

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -17,6 +17,8 @@ export const DB_ENDPOINT = process.env.DB_ENDPOINT;
 export const MISSION_INDEX = "mission";
 export const ASSOS_INDEX = "association";
 export const STATS_INDEX = "stats";
+
+// ES to PG migration: feature flags
 export const READ_STATS_FROM = (process.env.READ_STATS_FROM as "es" | "pg") || "es";
 export const WRITE_STATS_DUAL = process.env.WRITE_STATS_DUAL === "true";
 

--- a/api/src/controllers/redirect.ts
+++ b/api/src/controllers/redirect.ts
@@ -4,13 +4,13 @@ import zod from "zod";
 
 import { HydratedDocument } from "mongoose";
 import { JVA_URL, PUBLISHER_IDS } from "../config";
-import statEventRepository from "../repositories/stat-event";
 import { INVALID_PARAMS, INVALID_QUERY, NOT_FOUND, SERVER_ERROR, captureException, captureMessage } from "../error";
 import CampaignModel from "../models/campaign";
 import MissionModel from "../models/mission";
 import PublisherModel from "../models/publisher";
 import StatsBotModel from "../models/stats-bot";
 import WidgetModel from "../models/widget";
+import statEventRepository from "../repositories/stat-event";
 import { Mission, Stats } from "../types";
 import { identify, slugify } from "../utils";
 

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -1,0 +1,2 @@
+// Prisma analytics client stub for tests
+export {};

--- a/api/src/db/analytics.ts
+++ b/api/src/db/analytics.ts
@@ -1,2 +1,0 @@
-// Prisma analytics client stub for tests
-export {};

--- a/api/src/repositories/stat-event.ts
+++ b/api/src/repositories/stat-event.ts
@@ -1,0 +1,179 @@
+import { v4 as uuidv4 } from "uuid";
+
+import { READ_STATS_FROM, STATS_INDEX, WRITE_STATS_DUAL } from "../config";
+import esClient from "../db/elastic";
+import { prismaCore } from "../db/postgres";
+import { Stats } from "../types";
+
+function toPg(data: Partial<Stats>) {
+  const mapped: any = {
+    type: data.type,
+    created_at: data.createdAt,
+    click_user: data.clickUser,
+    click_id: data.clickId,
+    request_id: data.requestId,
+    origin: data.origin,
+    referer: data.referer,
+    user_agent: data.userAgent,
+    host: data.host,
+    user: data.user,
+    is_bot: data.isBot,
+    is_human: data.isHuman ?? false,
+    source: data.source || "publisher",
+    source_id: data.sourceId || "",
+    source_name: data.sourceName || "",
+    status: data.status || "PENDING",
+    from_publisher_id: data.fromPublisherId || "",
+    from_publisher_name: data.fromPublisherName || "",
+    to_publisher_id: data.toPublisherId || "",
+    to_publisher_name: data.toPublisherName || "",
+    mission_id: data.missionId,
+    mission_client_id: data.missionClientId,
+    mission_domain: data.missionDomain,
+    mission_title: data.missionTitle,
+    mission_postal_code: data.missionPostalCode,
+    mission_department_name: data.missionDepartmentName,
+    mission_organization_id: data.missionOrganizationId,
+    mission_organization_name: data.missionOrganizationName,
+    mission_organization_client_id: data.missionOrganizationClientId,
+    tag: data.tag,
+    tags: data.tags,
+  };
+  Object.keys(mapped).forEach((key) => mapped[key] === undefined && delete mapped[key]);
+  return mapped;
+}
+
+function fromPg(row: any): Stats {
+  return {
+    _id: row.id,
+    type: row.type,
+    createdAt: row.created_at,
+    clickUser: row.click_user ?? undefined,
+    clickId: row.click_id ?? undefined,
+    requestId: row.request_id ?? undefined,
+    origin: row.origin,
+    referer: row.referer,
+    userAgent: row.user_agent,
+    host: row.host,
+    user: row.user ?? undefined,
+    isBot: row.is_bot,
+    isHuman: row.is_human,
+    source: row.source,
+    sourceId: row.source_id,
+    sourceName: row.source_name,
+    status: row.status,
+    fromPublisherId: row.from_publisher_id,
+    fromPublisherName: row.from_publisher_name,
+    toPublisherId: row.to_publisher_id,
+    toPublisherName: row.to_publisher_name,
+    missionId: row.mission_id ?? undefined,
+    missionClientId: row.mission_client_id ?? undefined,
+    missionDomain: row.mission_domain ?? undefined,
+    missionTitle: row.mission_title ?? undefined,
+    missionPostalCode: row.mission_postal_code ?? undefined,
+    missionDepartmentName: row.mission_department_name ?? undefined,
+    missionOrganizationId: row.mission_organization_id ?? undefined,
+    missionOrganizationName: row.mission_organization_name ?? undefined,
+    missionOrganizationClientId: row.mission_organization_client_id ?? undefined,
+    tag: row.tag ?? undefined,
+    tags: row.tags ?? undefined,
+  } as Stats;
+}
+
+export async function createStatEvent(event: Stats): Promise<string> {
+  const id = event._id || uuidv4();
+  if (READ_STATS_FROM === "pg") {
+    await prismaCore.statEvent.create({ data: { id, ...toPg(event) } });
+    if (WRITE_STATS_DUAL) {
+      await esClient.index({ index: STATS_INDEX, id, body: event });
+    }
+    return id;
+  }
+  await esClient.index({ index: STATS_INDEX, id, body: event });
+  if (WRITE_STATS_DUAL) {
+    await prismaCore.statEvent.create({ data: { id, ...toPg(event) } });
+  }
+  return id;
+}
+
+export async function updateStatEventById(id: string, patch: Partial<Stats>) {
+  const data = toPg(patch);
+  if (READ_STATS_FROM === "pg") {
+    await prismaCore.statEvent.update({ where: { id }, data });
+    if (WRITE_STATS_DUAL) {
+      await esClient.update({ index: STATS_INDEX, id, body: { doc: patch } });
+    }
+    return;
+  }
+  await esClient.update({ index: STATS_INDEX, id, body: { doc: patch } });
+  if (WRITE_STATS_DUAL) {
+    await prismaCore.statEvent.update({ where: { id }, data });
+  }
+}
+
+export async function getStatEventById(id: string): Promise<Stats | null> {
+  if (READ_STATS_FROM === "pg") {
+    const pgRes = await prismaCore.statEvent.findUnique({ where: { id } });
+    return pgRes ? fromPg(pgRes) : null;
+  }
+  try {
+    const esRes = await esClient.get({ index: STATS_INDEX, id });
+    return { ...esRes.body._source, _id: esRes.body._id } as Stats;
+  } catch {
+    return null;
+  }
+}
+
+export async function findRecentByTypeAndClickId(
+  type: string,
+  clickId: string,
+  minutes: number,
+): Promise<Stats | null> {
+  if (READ_STATS_FROM === "pg") {
+    const from = new Date(Date.now() - minutes * 60 * 1000);
+    const pgRes = await prismaCore.statEvent.findFirst({
+      where: { type, click_id: clickId, created_at: { gte: from } },
+      orderBy: { created_at: "desc" },
+    });
+    return pgRes ? fromPg(pgRes) : null;
+  }
+  const { body } = await esClient.search({
+    index: STATS_INDEX,
+    body: {
+      query: {
+        bool: {
+          must: [
+            { term: { "type.keyword": type } },
+            { term: { "clickId.keyword": clickId } },
+            { range: { createdAt: { gte: `now-${minutes}m/m`, lte: "now/m" } } },
+          ],
+        },
+      },
+    },
+    size: 1,
+  });
+  if (body.hits.total.value) {
+    const hit = body.hits.hits[0];
+    return { ...hit._source, _id: hit._id } as Stats;
+  }
+  return null;
+}
+
+export async function count() {
+  if (READ_STATS_FROM === "pg") {
+    return prismaCore.statEvent.count();
+  }
+  const { body } = await esClient.count({ index: STATS_INDEX });
+  return body.count as number;
+}
+
+const statEventRepository = {
+  createStatEvent,
+  updateStatEventById,
+  getStatEventById,
+  findRecentByTypeAndClickId,
+  count,
+};
+
+export default statEventRepository;
+

--- a/api/tests/mocks/elasticMock.ts
+++ b/api/tests/mocks/elasticMock.ts
@@ -1,6 +1,10 @@
 import { vi } from "vitest";
 
 const elasticMock = {
+  index: vi.fn().mockResolvedValue({}),
+  update: vi.fn().mockResolvedValue({}),
+  get: vi.fn().mockResolvedValue({ body: { _source: {}, _id: "1" } }),
+  count: vi.fn().mockResolvedValue({ body: { count: 0 } }),
   msearch: vi.fn().mockResolvedValue({
     body: {
       responses: [],

--- a/api/tests/mocks/index.ts
+++ b/api/tests/mocks/index.ts
@@ -1,5 +1,6 @@
 import dataSubventionMock from "./dataSubventionMock";
 import elasticMock from "./elasticMock";
+import pgMock from "./pgMock";
 import sentryMock from "./sentryMock";
 
-export { dataSubventionMock, elasticMock, sentryMock };
+export { dataSubventionMock, elasticMock, pgMock, sentryMock };

--- a/api/tests/mocks/pgMock.ts
+++ b/api/tests/mocks/pgMock.ts
@@ -1,0 +1,13 @@
+import { vi } from "vitest";
+
+const pgMock = {
+  statEvent: {
+    create: vi.fn(),
+    update: vi.fn(),
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    count: vi.fn(),
+  },
+};
+
+export default pgMock;

--- a/api/tests/setup.ts
+++ b/api/tests/setup.ts
@@ -1,7 +1,7 @@
 import { MongoMemoryServer } from "mongodb-memory-server";
 import mongoose from "mongoose";
 import { afterAll, beforeAll, beforeEach, vi } from "vitest";
-import { dataSubventionMock, elasticMock, sentryMock } from "./mocks";
+import { dataSubventionMock, elasticMock, pgMock, sentryMock } from "./mocks";
 
 process.env.JWT_SECRET = "test-jwt-secret";
 process.env.MONGODB_URI = "mongodb://localhost:27017/test";
@@ -9,6 +9,31 @@ process.env.NODE_ENV = "test";
 
 vi.mock("../src/db/elastic", () => ({
   default: elasticMock,
+}));
+
+vi.mock("../src/db/postgres", () => ({
+  prismaCore: pgMock,
+  prismaAnalytics: pgMock,
+  pgConnected: Promise.resolve(),
+}));
+
+vi.mock("../src/db/analytics", () => ({
+  MissionHistoryEventType: {
+    Created: "Created",
+    Deleted: "Deleted",
+    UpdatedStartDate: "UpdatedStartDate",
+    UpdatedEndDate: "UpdatedEndDate",
+    UpdatedDescription: "UpdatedDescription",
+    UpdatedActivityDomain: "UpdatedActivityDomain",
+    UpdatedPlaces: "UpdatedPlaces",
+    UpdatedJVAModerationStatus: "UpdatedJVAModerationStatus",
+    UpdatedApiEngModerationStatus: "UpdatedApiEngModerationStatus",
+    UpdatedOther: "UpdatedOther",
+  },
+  MissionType: {
+    benevolat: "benevolat",
+    volontariat_service_civique: "volontariat_service_civique",
+  },
 }));
 
 vi.mock("@sentry/node", () => ({

--- a/api/tests/unit/repositories/stat-event.test.ts
+++ b/api/tests/unit/repositories/stat-event.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { elasticMock, pgMock } from "../../mocks";
+import { Stats } from "../../../src/types";
+
+async function loadRepo(readFrom: string, dual = "false") {
+  vi.resetModules();
+  process.env.READ_STATS_FROM = readFrom;
+  process.env.WRITE_STATS_DUAL = dual;
+  return await import("../../../src/repositories/stat-event");
+}
+
+const baseEvent: Stats = {
+  type: "click",
+  createdAt: new Date(),
+  origin: "", // required fields for toPg
+  referer: "",
+  userAgent: "",
+  host: "",
+  isBot: false,
+  isHuman: true,
+  source: "publisher",
+  sourceId: "",
+  sourceName: "",
+  status: "PENDING",
+  toPublisherId: "",
+  toPublisherName: "",
+};
+
+describe("stat-event repository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("writes to postgres when reading from pg", async () => {
+    const repo = await loadRepo("pg");
+    await repo.createStatEvent(baseEvent);
+    expect(pgMock.statEvent.create).toHaveBeenCalled();
+    expect(elasticMock.index).not.toHaveBeenCalled();
+  });
+
+  it("dual writes when enabled", async () => {
+    const repo = await loadRepo("es", "true");
+    await repo.createStatEvent(baseEvent);
+    expect(elasticMock.index).toHaveBeenCalled();
+    expect(pgMock.statEvent.create).toHaveBeenCalled();
+  });
+
+  it("reads from elastic when configured", async () => {
+    elasticMock.get.mockResolvedValueOnce({ body: { _source: { foo: "bar" }, _id: "1" } });
+    const repo = await loadRepo("es");
+    const res = await repo.getStatEventById("1");
+    expect(elasticMock.get).toHaveBeenCalled();
+    expect(pgMock.statEvent.findUnique).not.toHaveBeenCalled();
+    expect(res).toEqual({ foo: "bar", _id: "1" });
+  });
+
+  it("reads from postgres when configured", async () => {
+    pgMock.statEvent.findUnique.mockResolvedValueOnce({
+      id: "1",
+      type: "click",
+      created_at: new Date(),
+      origin: "",
+      referer: "",
+      user_agent: "",
+      host: "",
+      is_bot: false,
+      is_human: true,
+      source: "publisher",
+      source_id: "",
+      source_name: "",
+      status: "PENDING",
+      to_publisher_id: "",
+      to_publisher_name: "",
+    });
+    const repo = await loadRepo("pg");
+    const res = await repo.getStatEventById("1");
+    expect(pgMock.statEvent.findUnique).toHaveBeenCalled();
+    expect(elasticMock.get).not.toHaveBeenCalled();
+    expect(res?._id).toBe("1");
+  });
+});
+


### PR DESCRIPTION
## Summary
- simplify stat-event repository to exported functions driven by READ_STATS_FROM and WRITE_STATS_DUAL
- add Vitest unit tests with Postgres and ElasticSearch mocks
- include stubbed Prisma analytics module for test environment

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3ece9aa1c8324a6c98052318094c1