### PR TITLE
feat: add StatEvent backfill script

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,9 @@
       "test": "vitest run",
       "test:watch": "vitest",
       "test:ci": "npm run prisma:generate && vitest run --pool=forks",
-      "job": "ts-node src/jobs/run-job.ts"
+      "job": "ts-node src/jobs/run-job.ts",
+      "backfill:stats": "ts-node src/scripts/es-to-pg-backfill.ts",
+      "verify:backfill": "ts-node src/scripts/verify-backfill.ts"
     },
     "dependencies": {
       "@elastic/elasticsearch": "7.17.14",

--- a/api/src/scripts/es-to-pg-backfill.ts
+++ b/api/src/scripts/es-to-pg-backfill.ts
@@ -2,13 +2,19 @@ import dotenv from "dotenv";
 import type { Stats } from "../types";
 import { Prisma } from "@prisma/client";
 
+const args = process.argv.slice(2);
+
+const envArgIndex = args.indexOf("--env");
+if (envArgIndex !== -1 && args[envArgIndex + 1]) {
+  dotenv.config({ path: args[envArgIndex + 1] });
+} else {
+  dotenv.config();
+}
+
 /**
  * Optionally override endpoints with:
  *   --es <elastic_url> --db <postgres_url>
  */
-dotenv.config();
-
-const args = process.argv.slice(2);
 
 const esArgIndex = args.indexOf("--es");
 if (esArgIndex !== -1 && args[esArgIndex + 1]) {

--- a/api/src/scripts/es-to-pg-backfill.ts
+++ b/api/src/scripts/es-to-pg-backfill.ts
@@ -1,30 +1,23 @@
-import fs from "fs";
-import path from "path";
 import dotenv from "dotenv";
 import type { Stats } from "../types";
 import { Prisma } from "@prisma/client";
 
+/**
+ * Optionally override endpoints with:
+ *   --es <elastic_url> --db <postgres_url>
+ */
+dotenv.config();
+
 const args = process.argv.slice(2);
-const envArgIndex = args.indexOf("--env");
-let envFile: string | undefined;
 
-if (envArgIndex !== -1 && args[envArgIndex + 1]) {
-  envFile = `.env.${args[envArgIndex + 1]}`;
+const esArgIndex = args.indexOf("--es");
+if (esArgIndex !== -1 && args[esArgIndex + 1]) {
+  process.env.ES_ENDPOINT = args[esArgIndex + 1];
 }
 
-if (!envFile) {
-  const defaultFile = path.resolve(__dirname, "..", "..", ".env.es-to-pg-backfill");
-  if (fs.existsSync(defaultFile)) {
-    envFile = ".env.es-to-pg-backfill";
-  }
-}
-
-if (envFile) {
-  const envPath = path.resolve(__dirname, "..", "..", envFile);
-  console.log(`Loading environment variables from ${envFile}`);
-  dotenv.config({ path: envPath });
-} else {
-  dotenv.config();
+const dbArgIndex = args.indexOf("--db");
+if (dbArgIndex !== -1 && args[dbArgIndex + 1]) {
+  process.env.DATABASE_URL_CORE = args[dbArgIndex + 1];
 }
 
 const esClient = require("../db/elastic").default;

--- a/api/src/scripts/es-to-pg-backfill.ts
+++ b/api/src/scripts/es-to-pg-backfill.ts
@@ -1,9 +1,36 @@
-import esClient from "../db/elastic";
-import { prismaCore } from "../db/postgres";
-import { STATS_INDEX } from "../config";
-import { captureException } from "../error";
-import { Stats } from "../types";
+import fs from "fs";
+import path from "path";
+import dotenv from "dotenv";
+import type { Stats } from "../types";
 import { Prisma } from "@prisma/client";
+
+const args = process.argv.slice(2);
+const envArgIndex = args.indexOf("--env");
+let envFile: string | undefined;
+
+if (envArgIndex !== -1 && args[envArgIndex + 1]) {
+  envFile = `.env.${args[envArgIndex + 1]}`;
+}
+
+if (!envFile) {
+  const defaultFile = path.resolve(__dirname, "..", "..", ".env.es-to-pg-backfill");
+  if (fs.existsSync(defaultFile)) {
+    envFile = ".env.es-to-pg-backfill";
+  }
+}
+
+if (envFile) {
+  const envPath = path.resolve(__dirname, "..", "..", envFile);
+  console.log(`Loading environment variables from ${envFile}`);
+  dotenv.config({ path: envPath });
+} else {
+  dotenv.config();
+}
+
+const esClient = require("../db/elastic").default;
+const { prismaCore } = require("../db/postgres");
+const { STATS_INDEX } = require("../config");
+const { captureException } = require("../error");
 
 const BATCH_SIZE = 1000;
 const BACKFILL_KEY = "stat_event_es_to_pg";

--- a/api/src/scripts/es-to-pg-backfill.ts
+++ b/api/src/scripts/es-to-pg-backfill.ts
@@ -73,8 +73,10 @@ const handler = async () => {
     let created = 0;
     let scrollId: string | null = null;
     const state = await getState();
+    // Use gte so that on resume we reprocess the last timestamp; duplicates are
+    // ignored by createMany with skipDuplicates.
     const query = state.lastCreatedAt
-      ? { range: { createdAt: { gt: state.lastCreatedAt } } }
+      ? { range: { createdAt: { gte: state.lastCreatedAt } } }
       : { match_all: {} };
 
     while (true) {

--- a/api/src/scripts/es-to-pg-backfill.ts
+++ b/api/src/scripts/es-to-pg-backfill.ts
@@ -1,0 +1,126 @@
+import esClient from "../db/elastic";
+import { prismaCore } from "../db/postgres";
+import { STATS_INDEX } from "../config";
+import { captureException } from "../error";
+import { Stats } from "../types";
+import { Prisma } from "@prisma/client";
+
+const BATCH_SIZE = 1000;
+const BACKFILL_KEY = "stat_event_es_to_pg";
+
+type BackfillState = {
+  lastCreatedAt?: string;
+};
+
+const getState = async (): Promise<BackfillState> => {
+  const rows = await prismaCore.$queryRaw<{ state: Prisma.JsonValue }[]>`
+    SELECT state FROM backfill_state WHERE id = ${BACKFILL_KEY}
+  `;
+  if (rows.length) {
+    const value = rows[0].state as any;
+    return value || {};
+  }
+  return {};
+};
+
+const saveState = async (state: BackfillState) => {
+  await prismaCore.$executeRaw`
+    INSERT INTO backfill_state(id, state)
+    VALUES (${BACKFILL_KEY}, ${state}::jsonb)
+    ON CONFLICT (id) DO UPDATE SET state = EXCLUDED.state
+  `;
+};
+
+const mapDoc = (doc: Stats) => ({
+  id: doc._id,
+  type: doc.type,
+  created_at: new Date(doc.createdAt),
+  click_user: doc.clickUser ?? null,
+  click_id: doc.clickId ?? null,
+  request_id: doc.requestId ?? null,
+  origin: doc.origin,
+  referer: doc.referer,
+  user_agent: doc.userAgent,
+  host: doc.host,
+  user: doc.user ?? null,
+  is_bot: doc.isBot,
+  is_human: doc.isHuman,
+  source: doc.source,
+  source_id: doc.sourceId,
+  source_name: doc.sourceName,
+  status: doc.status ?? "PENDING",
+  from_publisher_id: doc.fromPublisherId,
+  from_publisher_name: doc.fromPublisherName,
+  to_publisher_id: doc.toPublisherId,
+  to_publisher_name: doc.toPublisherName,
+  mission_id: doc.missionId ?? null,
+  mission_client_id: doc.missionClientId ?? null,
+  mission_domain: doc.missionDomain ?? null,
+  mission_title: doc.missionTitle ?? null,
+  mission_postal_code: doc.missionPostalCode ?? null,
+  mission_department_name: doc.missionDepartmentName ?? null,
+  mission_organization_id: doc.missionOrganizationId ?? null,
+  mission_organization_name: doc.missionOrganizationName ?? null,
+  mission_organization_client_id: doc.missionOrganizationClientId ?? null,
+  tag: doc.tag ?? null,
+  tags: doc.tags ?? [],
+});
+
+const handler = async () => {
+  try {
+    const start = new Date();
+    console.log(`[Backfill] Started at ${start.toISOString()}.`);
+    let created = 0;
+    let scrollId: string | null = null;
+    const state = await getState();
+    const query = state.lastCreatedAt
+      ? { range: { createdAt: { gt: state.lastCreatedAt } } }
+      : { match_all: {} };
+
+    while (true) {
+      let hits: { _id: string; _source: Stats }[] = [];
+
+      if (scrollId) {
+        const { body } = await esClient.scroll({
+          scroll: "5m",
+          scroll_id: scrollId,
+        });
+        scrollId = body._scroll_id;
+        hits = body.hits.hits;
+      } else {
+        const { body } = await esClient.search({
+          index: STATS_INDEX,
+          scroll: "5m",
+          size: BATCH_SIZE,
+          body: { query, sort: [{ createdAt: "asc" }] },
+        });
+        scrollId = body._scroll_id;
+        hits = body.hits.hits as { _id: string; _source: Stats }[];
+        console.log(`[Backfill] Total hits ${body.hits.total.value}, scrollId ${scrollId}`);
+      }
+
+      if (hits.length === 0) {
+        break;
+      }
+
+      const dataToCreate = hits.map((h) => mapDoc({ _id: h._id, ...h._source }));
+      if (dataToCreate.length) {
+        const res = await prismaCore.statEvent.createMany({ data: dataToCreate, skipDuplicates: true });
+        created += res.count;
+        console.log(`[Backfill] Created ${res.count} docs, ${created} so far.`);
+      }
+
+      const last = hits[hits.length - 1];
+      state.lastCreatedAt = last._source.createdAt as any;
+      await saveState(state);
+    }
+
+    console.log(`[Backfill] Ended at ${new Date().toISOString()} in ${(Date.now() - start.getTime()) / 1000}s.`);
+  } catch (error) {
+    captureException(error, "[Backfill] Error while syncing docs.");
+  } finally {
+    await prismaCore.$disconnect();
+  }
+};
+
+handler();

--- a/api/src/scripts/verify-backfill.ts
+++ b/api/src/scripts/verify-backfill.ts
@@ -1,0 +1,134 @@
+import dotenv from "dotenv";
+import { Prisma } from "@prisma/client";
+
+const args = process.argv.slice(2);
+
+const envArgIndex = args.indexOf("--env");
+if (envArgIndex !== -1 && args[envArgIndex + 1]) {
+  dotenv.config({ path: args[envArgIndex + 1] });
+} else {
+  dotenv.config();
+}
+
+const esArgIndex = args.indexOf("--es");
+if (esArgIndex !== -1 && args[esArgIndex + 1]) {
+  process.env.ES_ENDPOINT = args[esArgIndex + 1];
+}
+
+const dbArgIndex = args.indexOf("--db");
+if (dbArgIndex !== -1 && args[dbArgIndex + 1]) {
+  process.env.DATABASE_URL_CORE = args[dbArgIndex + 1];
+}
+
+const esClient = require("../db/elastic").default;
+const { prismaCore } = require("../db/postgres");
+const { STATS_INDEX } = require("../config");
+const { captureException } = require("../error");
+
+const BACKFILL_KEY = "stat_event_es_to_pg";
+
+type BackfillState = {
+  lastCreatedAt?: string;
+};
+
+const getState = async (): Promise<BackfillState> => {
+  const rows = await prismaCore.$queryRaw<{ state: Prisma.JsonValue }[]>`
+    SELECT state FROM backfill_state WHERE id = ${BACKFILL_KEY}
+  `;
+  return rows.length ? ((rows[0].state as any) || {}) : {};
+};
+
+const verifyCounts = async (start: Date, end: Date) => {
+  const esRes: any = await esClient.search({
+    index: STATS_INDEX,
+    size: 0,
+    body: {
+      query: { range: { createdAt: { gte: start, lt: end } } },
+      aggs: {
+        by_day: {
+          date_histogram: { field: "createdAt", calendar_interval: "day" },
+          aggs: {
+            by_type: { terms: { field: "type.keyword" } },
+          },
+        },
+      },
+    },
+  });
+
+  const esCounts: Record<string, Record<string, number>> = {};
+  for (const dayBucket of esRes.body.aggregations.by_day.buckets as any[]) {
+    const day = dayBucket.key_as_string.slice(0, 10);
+    esCounts[day] = {};
+    for (const typeBucket of dayBucket.by_type.buckets) {
+      esCounts[day][typeBucket.key] = typeBucket.doc_count;
+    }
+  }
+
+  const pgRows = await prismaCore.$queryRaw<{
+    day: Date;
+    type: string;
+    count: bigint;
+  }[]>`
+    SELECT date_trunc('day', created_at) as day, type, COUNT(*) as count
+    FROM stat_event
+    WHERE created_at >= ${start} AND created_at < ${end}
+    GROUP BY 1,2
+    ORDER BY 1,2
+  `;
+
+  const pgCounts: Record<string, Record<string, number>> = {};
+  for (const row of pgRows) {
+    const day = row.day.toISOString().slice(0, 10);
+    if (!pgCounts[day]) {
+      pgCounts[day] = {};
+    }
+    pgCounts[day][row.type] = Number(row.count);
+  }
+
+  const days = Array.from(new Set([...Object.keys(esCounts), ...Object.keys(pgCounts)])).sort();
+  for (const day of days) {
+    const types = new Set([
+      ...Object.keys(esCounts[day] || {}),
+      ...Object.keys(pgCounts[day] || {}),
+    ]);
+    for (const type of types) {
+      const esCount = esCounts[day]?.[type] ?? 0;
+      const pgCount = pgCounts[day]?.[type] ?? 0;
+      console.log(`${day} ${type} ES:${esCount} PG:${pgCount}`);
+    }
+  }
+};
+
+const spotCheckIds = async (start: Date, end: Date) => {
+  const { body }: any = await esClient.search({
+    index: STATS_INDEX,
+    size: 5,
+    body: { query: { range: { createdAt: { gte: start, lt: end } } } },
+  });
+  const hits = body.hits.hits as { _id: string }[];
+  for (const h of hits) {
+    const exists = await prismaCore.statEvent.count({ where: { id: h._id } });
+    console.log(`[SpotCheck] ${h._id} ${exists ? "found" : "missing"}`);
+  }
+};
+
+const handler = async () => {
+  try {
+    const state = await getState();
+    const end = state.lastCreatedAt ? new Date(state.lastCreatedAt) : new Date();
+    const start = new Date(end);
+    start.setDate(start.getDate() - 7);
+    console.log(
+      `[Verify] Comparing counts between ${start.toISOString()} and ${end.toISOString()}`,
+    );
+    await verifyCounts(start, end);
+    await spotCheckIds(start, end);
+  } catch (error) {
+    captureException(error, "[Verify] Error verifying backfill");
+  } finally {
+    await prismaCore.$disconnect();
+  }
+};
+
+handler();
+


### PR DESCRIPTION
## Summary
- add `es-to-pg-backfill` script to migrate stats events from Elasticsearch into `StatEvent`
- batch insert using Prisma with `createMany` and `skipDuplicates`
- persist progress in `backfill_state` table for resume

## Testing
- `npm test` *(fails: Cannot find module '../../../../db/analytics' imported from ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c421692760832482d1812c31f9a8d1