### PR TITLE
Init simple stat-event repository

### DIFF
--- a/api/src/repositories/__tests__/stat-event.test.ts
+++ b/api/src/repositories/__tests__/stat-event.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import statEventRepository from "../../../src/repositories/stat-event";
+import { Stats } from "../../../src/types";
+import { elasticMock, pgMock } from "../../../tests/mocks";
+
+const baseEvent: Partial<Stats> = {
+  type: "click",
+  createdAt: new Date(),
+  origin: "",
+  referer: "",
+  userAgent: "",
+  host: "",
+  isBot: false,
+  isHuman: true,
+  source: "publisher",
+  sourceId: "",
+  sourceName: "",
+  status: "PENDING",
+  toPublisherId: "",
+  toPublisherName: "",
+};
+
+describe("stat-event repository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("writes to postgres when reading from pg", async () => {
+    initFeatureFlags("pg");
+
+    await statEventRepository.createStatEvent(baseEvent as Stats);
+    expect(pgMock.statEvent.create).toHaveBeenCalled();
+    expect(elasticMock.index).not.toHaveBeenCalled();
+  });
+
+  it("dual writes when enabled", async () => {
+    initFeatureFlags("es", "true");
+    await statEventRepository.createStatEvent(baseEvent as Stats);
+    expect(elasticMock.index).toHaveBeenCalled();
+    expect(pgMock.statEvent.create).toHaveBeenCalled();
+  });
+
+  it("reads from elastic when configured", async () => {
+    elasticMock.get.mockResolvedValueOnce({ body: { _source: { foo: "bar" }, _id: "1" } });
+    initFeatureFlags("es");
+    const res = await statEventRepository.getStatEventById("1");
+    expect(elasticMock.get).toHaveBeenCalled();
+    expect(pgMock.statEvent.findUnique).not.toHaveBeenCalled();
+    expect(res).toEqual({ foo: "bar", _id: "1" });
+  });
+
+  it("reads from postgres when configured", async () => {
+    pgMock.statEvent.findUnique.mockResolvedValueOnce({
+      id: "1",
+      type: "click",
+      created_at: new Date(),
+      origin: "",
+      referer: "",
+      user_agent: "",
+      host: "",
+      is_bot: false,
+      is_human: true,
+      source: "publisher",
+      source_id: "",
+      source_name: "",
+      status: "PENDING",
+      to_publisher_id: "",
+      to_publisher_name: "",
+    });
+    initFeatureFlags("pg");
+    const res = await statEventRepository.getStatEventById("1");
+    expect(pgMock.statEvent.findUnique).toHaveBeenCalled();
+    expect(elasticMock.get).not.toHaveBeenCalled();
+    expect(res?._id).toBe("1");
+  });
+});
+
+function initFeatureFlags(readFrom: "pg" | "es", dual = "false") {
+  process.env.READ_STATS_FROM = readFrom;
+  process.env.WRITE_STATS_DUAL = dual;
+}

--- a/api/src/repositories/stat-event.ts
+++ b/api/src/repositories/stat-event.ts
@@ -1,0 +1,162 @@
+import { v4 as uuidv4 } from "uuid";
+
+import { STATS_INDEX } from "../config";
+import esClient from "../db/elastic";
+import { prismaCore } from "../db/postgres";
+import { Stats } from "../types";
+
+function toPg(data: Partial<Stats>) {
+  const mapped: any = {
+    type: data.type,
+    created_at: data.createdAt,
+    click_user: data.clickUser,
+    click_id: data.clickId,
+    request_id: data.requestId,
+    origin: data.origin,
+    referer: data.referer,
+    user_agent: data.userAgent,
+    host: data.host,
+    user: data.user,
+    is_bot: data.isBot,
+    is_human: data.isHuman ?? false,
+    source: data.source || "publisher",
+    source_id: data.sourceId || "",
+    source_name: data.sourceName || "",
+    status: data.status || "PENDING",
+    from_publisher_id: data.fromPublisherId || "",
+    from_publisher_name: data.fromPublisherName || "",
+    to_publisher_id: data.toPublisherId || "",
+    to_publisher_name: data.toPublisherName || "",
+    mission_id: data.missionId,
+    mission_client_id: data.missionClientId,
+    mission_domain: data.missionDomain,
+    mission_title: data.missionTitle,
+    mission_postal_code: data.missionPostalCode,
+    mission_department_name: data.missionDepartmentName,
+    mission_organization_id: data.missionOrganizationId,
+    mission_organization_name: data.missionOrganizationName,
+    mission_organization_client_id: data.missionOrganizationClientId,
+    tag: data.tag,
+    tags: data.tags,
+  };
+  Object.keys(mapped).forEach((key) => mapped[key] === undefined && delete mapped[key]);
+  return mapped;
+}
+
+// Map to Elasticsearch document by removing reserved/internal fields.
+function toEs(data: Partial<Stats>) {
+  const { _id, ...rest } = data as any;
+  return rest;
+}
+
+function fromPg(row: any): Stats {
+  return {
+    _id: row.id,
+    type: row.type,
+    createdAt: row.created_at,
+    clickUser: row.click_user ?? undefined,
+    clickId: row.click_id ?? undefined,
+    requestId: row.request_id ?? undefined,
+    origin: row.origin,
+    referer: row.referer,
+    userAgent: row.user_agent,
+    host: row.host,
+    user: row.user ?? undefined,
+    isBot: row.is_bot,
+    isHuman: row.is_human,
+    source: row.source,
+    sourceId: row.source_id,
+    sourceName: row.source_name,
+    status: row.status,
+    fromPublisherId: row.from_publisher_id,
+    fromPublisherName: row.from_publisher_name,
+    toPublisherId: row.to_publisher_id,
+    toPublisherName: row.to_publisher_name,
+    missionId: row.mission_id ?? undefined,
+    missionClientId: row.mission_client_id ?? undefined,
+    missionDomain: row.mission_domain ?? undefined,
+    missionTitle: row.mission_title ?? undefined,
+    missionPostalCode: row.mission_postal_code ?? undefined,
+    missionDepartmentName: row.mission_department_name ?? undefined,
+    missionOrganizationId: row.mission_organization_id ?? undefined,
+    missionOrganizationName: row.mission_organization_name ?? undefined,
+    missionOrganizationClientId: row.mission_organization_client_id ?? undefined,
+    tag: row.tag ?? undefined,
+    tags: row.tags ?? undefined,
+  } as Stats;
+}
+
+export async function createStatEvent(event: Stats): Promise<string> {
+  // Render id here to share it between es and pg
+  const id = event._id || uuidv4();
+  if (getReadStatsFrom() === "pg") {
+    await prismaCore.statEvent.create({ data: { id, ...toPg(event) } });
+    if (getWriteStatsDual()) {
+      await esClient.index({ index: STATS_INDEX, id, body: toEs(event) });
+    }
+    return id;
+  }
+  await esClient.index({ index: STATS_INDEX, id, body: toEs(event) });
+  if (getWriteStatsDual()) {
+    await prismaCore.statEvent.create({ data: { id, ...toPg(event) } });
+  }
+  return id;
+}
+
+export async function updateStatEventById(id: string, patch: Partial<Stats>) {
+  const data = toPg(patch);
+  if (getReadStatsFrom() === "pg") {
+    await prismaCore.statEvent.update({ where: { id }, data });
+    if (getWriteStatsDual()) {
+      await esClient.update({ index: STATS_INDEX, id, body: { doc: patch } });
+    }
+    return;
+  }
+  await esClient.update({ index: STATS_INDEX, id, body: { doc: patch } });
+  if (getWriteStatsDual()) {
+    try {
+      await prismaCore.statEvent.update({ where: { id }, data });
+    } catch (error) {
+      console.error(`[StatEvent] Error updating stat event ${id}:`, error);
+    }
+  }
+}
+
+export async function getStatEventById(id: string): Promise<Stats | null> {
+  if (getReadStatsFrom() === "pg") {
+    const pgRes = await prismaCore.statEvent.findUnique({ where: { id } });
+    return pgRes ? fromPg(pgRes) : null;
+  }
+  try {
+    const esRes = await esClient.get({ index: STATS_INDEX, id });
+    return { ...esRes.body._source, _id: esRes.body._id } as Stats;
+  } catch {
+    return null;
+  }
+}
+
+export async function count() {
+  if (getReadStatsFrom() === "pg") {
+    return prismaCore.statEvent.count();
+  }
+  const { body } = await esClient.count({ index: STATS_INDEX });
+  return body.count as number;
+}
+
+const statEventRepository = {
+  createStatEvent,
+  updateStatEventById,
+  getStatEventById,
+  count,
+};
+
+export default statEventRepository;
+
+// Helpers to evaluate feature flags
+function getReadStatsFrom(): "es" | "pg" {
+  return (process.env.READ_STATS_FROM as "es" | "pg") || "es";
+}
+
+function getWriteStatsDual(): boolean {
+  return process.env.WRITE_STATS_DUAL === "true";
+}

--- a/api/src/repositories/stat-event.ts
+++ b/api/src/repositories/stat-event.ts
@@ -5,7 +5,8 @@ import esClient from "../db/elastic";
 import { prismaCore } from "../db/postgres";
 import { Stats } from "../types";
 
-function toPg(data: Partial<Stats>) {
+function toPg(data: Partial<Stats>, options: { includeDefaults?: boolean } = {}) {
+  const { includeDefaults = true } = options;
   const mapped: any = {
     type: data.type,
     created_at: data.createdAt,
@@ -18,15 +19,21 @@ function toPg(data: Partial<Stats>) {
     host: data.host,
     user: data.user,
     is_bot: data.isBot,
-    is_human: data.isHuman ?? false,
-    source: data.source || "publisher",
-    source_id: data.sourceId || "",
-    source_name: data.sourceName || "",
-    status: data.status || "PENDING",
-    from_publisher_id: data.fromPublisherId || "",
-    from_publisher_name: data.fromPublisherName || "",
-    to_publisher_id: data.toPublisherId || "",
-    to_publisher_name: data.toPublisherName || "",
+    is_human: includeDefaults ? data.isHuman ?? false : data.isHuman,
+    source: includeDefaults ? data.source ?? "publisher" : data.source,
+    source_id: includeDefaults ? data.sourceId ?? "" : data.sourceId,
+    source_name: includeDefaults ? data.sourceName ?? "" : data.sourceName,
+    status: includeDefaults ? data.status ?? "PENDING" : data.status,
+    from_publisher_id: includeDefaults
+      ? data.fromPublisherId ?? ""
+      : data.fromPublisherId,
+    from_publisher_name: includeDefaults
+      ? data.fromPublisherName ?? ""
+      : data.fromPublisherName,
+    to_publisher_id: includeDefaults ? data.toPublisherId ?? "" : data.toPublisherId,
+    to_publisher_name: includeDefaults
+      ? data.toPublisherName ?? ""
+      : data.toPublisherName,
     mission_id: data.missionId,
     mission_client_id: data.missionClientId,
     mission_domain: data.missionDomain,
@@ -104,7 +111,7 @@ export async function createStatEvent(event: Stats): Promise<string> {
 }
 
 export async function updateStatEventById(id: string, patch: Partial<Stats>) {
-  const data = toPg(patch);
+  const data = toPg(patch, { includeDefaults: false });
   if (getReadStatsFrom() === "pg") {
     await prismaCore.statEvent.update({ where: { id }, data });
     if (getWriteStatsDual()) {

--- a/api/tests/mocks/elasticMock.ts
+++ b/api/tests/mocks/elasticMock.ts
@@ -1,6 +1,10 @@
 import { vi } from "vitest";
 
 const elasticMock = {
+  index: vi.fn().mockResolvedValue({}),
+  update: vi.fn().mockResolvedValue({}),
+  get: vi.fn().mockResolvedValue({ body: { _source: {}, _id: "1" } }),
+  count: vi.fn().mockResolvedValue({ body: { count: 0 } }),
   msearch: vi.fn().mockResolvedValue({
     body: {
       responses: [],

--- a/api/tests/mocks/index.ts
+++ b/api/tests/mocks/index.ts
@@ -1,5 +1,6 @@
 import dataSubventionMock from "./dataSubventionMock";
 import elasticMock from "./elasticMock";
+import pgMock from "./pgMock";
 import sentryMock from "./sentryMock";
 
-export { dataSubventionMock, elasticMock, sentryMock };
+export { dataSubventionMock, elasticMock, pgMock, sentryMock };

--- a/api/tests/mocks/pgMock.ts
+++ b/api/tests/mocks/pgMock.ts
@@ -1,0 +1,13 @@
+import { vi } from "vitest";
+
+const pgMock = {
+  statEvent: {
+    create: vi.fn(),
+    update: vi.fn(),
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    count: vi.fn(),
+  },
+};
+
+export default pgMock;

--- a/api/tests/setup.ts
+++ b/api/tests/setup.ts
@@ -1,7 +1,7 @@
 import { MongoMemoryServer } from "mongodb-memory-server";
 import mongoose from "mongoose";
 import { afterAll, beforeAll, beforeEach, vi } from "vitest";
-import { dataSubventionMock, elasticMock, sentryMock } from "./mocks";
+import { dataSubventionMock, elasticMock, pgMock, sentryMock } from "./mocks";
 
 process.env.JWT_SECRET = "test-jwt-secret";
 process.env.MONGODB_URI = "mongodb://localhost:27017/test";
@@ -9,6 +9,12 @@ process.env.NODE_ENV = "test";
 
 vi.mock("../src/db/elastic", () => ({
   default: elasticMock,
+}));
+
+vi.mock("../src/db/postgres", () => ({
+  prismaCore: pgMock,
+  prismaAnalytics: pgMock,
+  pgConnected: Promise.resolve(),
 }));
 
 vi.mock("@sentry/node", () => ({


### PR DESCRIPTION
## Description

Je suis parti trop loin dans #441 

On reprend les bases : 
- Un repository simple pour lire les données de stat sur PG / ES suivant les features flags 
- TU de ce module

Pas encore utilisé dans aucun contrôleur.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire