### PR TITLE
Replace myorganization stats aggregation with stat-event repository

### DIFF
--- a/api/src/repositories/__tests__/stat-event.test.ts
+++ b/api/src/repositories/__tests__/stat-event.test.ts
@@ -170,9 +170,7 @@ describe("stat-event repository", () => {
   });
 
   it("aggregates click counts by publisher from postgres", async () => {
-    pgMock.statEvent.groupBy.mockResolvedValueOnce([
-      { from_publisher_id: "pub-1", _count: { _all: 5 } },
-    ]);
+    pgMock.statEvent.groupBy.mockResolvedValueOnce([{ from_publisher_id: "pub-1", _count: { _all: 5 } }]);
 
     initFeatureFlags("pg");
 
@@ -186,7 +184,7 @@ describe("stat-event repository", () => {
       by: ["from_publisher_id"],
       where: {
         type: "click",
-        is_bot: false,
+        is_bot: { not: true },
         mission_organization_client_id: "org-1",
         from_publisher_id: { in: ["pub-1", "pub-2"] },
         created_at: { gte: expect.any(Date) },

--- a/api/src/repositories/__tests__/stat-event.test.ts
+++ b/api/src/repositories/__tests__/stat-event.test.ts
@@ -141,6 +141,61 @@ describe("stat-event repository", () => {
     expect(elasticMock.search).not.toHaveBeenCalled();
     expect(res).toMatchObject({ click: 12, apply: 0 });
   });
+
+  it("aggregates click counts by publisher from elasticsearch", async () => {
+    elasticMock.search.mockResolvedValueOnce({
+      body: {
+        aggregations: {
+          fromPublisherId: {
+            buckets: [
+              { key: "pub-1", doc_count: 3 },
+              { key: "pub-2", doc_count: 0 },
+            ],
+          },
+        },
+      },
+    });
+
+    initFeatureFlags("es");
+
+    const res = await statEventRepository.countClicksByPublisherForOrganizationSince({
+      publisherIds: ["pub-1", "pub-2"],
+      organizationClientId: "org-1",
+      from: new Date(),
+    });
+
+    expect(elasticMock.search).toHaveBeenCalled();
+    expect(pgMock.statEvent.groupBy).not.toHaveBeenCalled();
+    expect(res).toMatchObject({ "pub-1": 3, "pub-2": 0 });
+  });
+
+  it("aggregates click counts by publisher from postgres", async () => {
+    pgMock.statEvent.groupBy.mockResolvedValueOnce([
+      { from_publisher_id: "pub-1", _count: { _all: 5 } },
+    ]);
+
+    initFeatureFlags("pg");
+
+    const res = await statEventRepository.countClicksByPublisherForOrganizationSince({
+      publisherIds: ["pub-1", "pub-2"],
+      organizationClientId: "org-1",
+      from: new Date(),
+    });
+
+    expect(pgMock.statEvent.groupBy).toHaveBeenCalledWith({
+      by: ["from_publisher_id"],
+      where: {
+        type: "click",
+        is_bot: false,
+        mission_organization_client_id: "org-1",
+        from_publisher_id: { in: ["pub-1", "pub-2"] },
+        created_at: { gte: expect.any(Date) },
+      },
+      _count: { _all: true },
+    });
+    expect(elasticMock.search).not.toHaveBeenCalled();
+    expect(res).toMatchObject({ "pub-1": 5 });
+  });
 });
 
 function initFeatureFlags(readFrom: "pg" | "es", dual = "false") {

--- a/api/src/repositories/stat-event.ts
+++ b/api/src/repositories/stat-event.ts
@@ -13,6 +13,12 @@ interface CountByTypeParams {
   types?: StatEventType[];
 }
 
+interface CountClicksByPublisherForOrganizationSinceParams {
+  publisherIds: string[];
+  organizationClientId: string;
+  from: Date;
+}
+
 const DEFAULT_TYPES: StatEventType[] = ["click", "print", "apply", "account"];
 
 function toPg(data: Partial<Stats>, options: { includeDefaults?: boolean } = {}) {
@@ -209,12 +215,73 @@ export async function countByTypeSince({ publisherId, from, types }: CountByType
   return counts;
 }
 
+export async function countClicksByPublisherForOrganizationSince({
+  publisherIds,
+  organizationClientId,
+  from,
+}: CountClicksByPublisherForOrganizationSinceParams) {
+  if (!publisherIds.length) {
+    return {} as Record<string, number>;
+  }
+
+  if (getReadStatsFrom() === "pg") {
+    const rows = (await prismaCore.statEvent.groupBy({
+      by: ["from_publisher_id"],
+      where: {
+        type: "click",
+        is_bot: false,
+        mission_organization_client_id: organizationClientId,
+        from_publisher_id: { in: publisherIds },
+        created_at: { gte: from },
+      },
+      _count: { _all: true },
+    })) as { from_publisher_id: string; _count: { _all: number } }[];
+
+    return rows.reduce((acc, row) => {
+      acc[row.from_publisher_id] = row._count._all;
+      return acc;
+    }, {} as Record<string, number>);
+  }
+
+  const response = await esClient.search({
+    index: STATS_INDEX,
+    body: {
+      query: {
+        bool: {
+          filter: [
+            { term: { "type.keyword": "click" } },
+            { terms: { "fromPublisherId.keyword": publisherIds } },
+            { term: { missionOrganizationClientId: organizationClientId } },
+            { range: { createdAt: { gte: from.toISOString() } } },
+          ],
+          must_not: [{ term: { isBot: true } }],
+        },
+      },
+      aggs: {
+        fromPublisherId: {
+          terms: { field: "fromPublisherId.keyword", size: publisherIds.length },
+        },
+      },
+      size: 0,
+    },
+  });
+
+  const buckets =
+    response.body.aggregations?.fromPublisherId?.buckets ?? ([] as { key: string; doc_count: number }[]);
+
+  return buckets.reduce((acc, bucket) => {
+    acc[bucket.key] = bucket.doc_count;
+    return acc;
+  }, {} as Record<string, number>);
+}
+
 const statEventRepository = {
   createStatEvent,
   updateStatEventById,
   getStatEventById,
   count,
   countByTypeSince,
+  countClicksByPublisherForOrganizationSince,
 };
 
 export default statEventRepository;

--- a/api/src/v0/myorganization/controller.ts
+++ b/api/src/v0/myorganization/controller.ts
@@ -2,8 +2,6 @@ import { NextFunction, Response, Router } from "express";
 import passport from "passport";
 import zod from "zod";
 
-import { STATS_INDEX } from "../../config";
-import esClient from "../../db/elastic";
 import { INVALID_BODY, INVALID_PARAMS } from "../../error";
 import MissionModel from "../../models/mission";
 import OrganizationExclusionModel from "../../models/organization-exclusion";
@@ -11,6 +9,7 @@ import PublisherModel from "../../models/publisher";
 import RequestModel from "../../models/request";
 import { Publisher } from "../../types";
 import { PublisherRequest } from "../../types/passport";
+import statEventRepository from "../../repositories/stat-event";
 import { buildPublisherData } from "./transformer";
 const router = Router();
 
@@ -66,38 +65,18 @@ router.get("/:organizationClientId", passport.authenticate(["apikey", "api"], { 
     const exclusionSet = new Set(organizationExclusions.map((o) => `${o.organizationClientId}:${o.excludedForPublisherId}`));
 
     const oneMonthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-    const aggs = await esClient.search({
-      index: STATS_INDEX,
-      body: {
-        query: {
-          bool: {
-            filter: [
-              { term: { "type.keyword": "click" } },
-              // Warning: publishers array may be quite large, so performance may be impacted
-              { terms: { "fromPublisherId.keyword": publishers.map((e) => e._id.toString()) } },
-              { term: { missionOrganizationClientId: params.data.organizationClientId } },
-              { range: { createdAt: { gte: oneMonthAgo.toISOString() } } },
-            ],
-            must_not: [{ term: { isBot: true } }],
-          },
-        },
-        aggs: {
-          fromPublisherId: {
-            terms: { field: "fromPublisherId.keyword", size: publishers.length },
-          },
-        },
-      },
+    const publisherIds = publishers.map((publisher) => publisher._id.toString());
+    const clicksByPublisher = await statEventRepository.countClicksByPublisherForOrganizationSince({
+      publisherIds,
+      organizationClientId: params.data.organizationClientId,
+      from: oneMonthAgo,
     });
-
-    // Build Map for clicks lookup
-    const clickMap = new Map<string, number>();
-    aggs.body.aggregations?.fromPublisherId?.buckets?.forEach((b: { key: string; doc_count: number }) => clickMap.set(b.key, b.doc_count));
 
     // Build response data
     const data = [] as any[];
     publishers.forEach((publisher) => {
       const isExcluded = exclusionSet.has(`${params.data.organizationClientId}:${publisher._id.toString()}`);
-      const clicks = clickMap.get(publisher._id.toString()) || 0;
+      const clicks = clicksByPublisher[publisher._id.toString()] || 0;
 
       data.push(buildPublisherData(publisher, clicks, isExcluded));
     });

--- a/api/tests/integration/api/v0/myorganization.test.ts
+++ b/api/tests/integration/api/v0/myorganization.test.ts
@@ -4,9 +4,8 @@ import OrganizationExclusionModel from "../../../../src/models/organization-excl
 import { Mission, MissionType, Publisher } from "../../../../src/types";
 import { createTestMission, createTestPublisher } from "../../../fixtures";
 import elasticMock from "../../../mocks/elasticMock";
+import pgMock from "../../../mocks/pgMock";
 import { createTestApp } from "../../../testApp";
-
-vi.mock("../../../src/es", () => ({ esClient: elasticMock }));
 
 describe("MyOrganization API Integration Tests", () => {
   const app = createTestApp();
@@ -20,6 +19,8 @@ describe("MyOrganization API Integration Tests", () => {
   beforeEach(async () => {
     elasticMock.search.mockReset();
     elasticMock.msearch.mockReset();
+    pgMock.statEvent.groupBy.mockReset();
+    process.env.READ_STATS_FROM = "es";
 
     publisher = await createTestPublisher();
     apiKey = publisher.apikey || "";
@@ -121,6 +122,24 @@ describe("MyOrganization API Integration Tests", () => {
       const partner2 = response.body.data.find((p: any) => p._id === publisher2._id.toString());
       expect(partner1.excluded).toBe(false);
       expect(partner2.excluded).toBe(true);
+    });
+
+    it("should retrieve clicks from postgres when feature flag is enabled", async () => {
+      process.env.READ_STATS_FROM = "pg";
+      pgMock.statEvent.groupBy.mockResolvedValueOnce([
+        { from_publisher_id: publisher1._id.toString(), _count: { _all: 4 } },
+      ]);
+
+      const response = await request(app).get(`/v0/myorganization/${orgId}`).set("x-api-key", apiKey);
+
+      expect(response.status).toBe(200);
+      expect(pgMock.statEvent.groupBy).toHaveBeenCalled();
+      expect(elasticMock.search).not.toHaveBeenCalled();
+
+      const partner1 = response.body.data.find((p: any) => p._id === publisher1._id.toString());
+      const partner2 = response.body.data.find((p: any) => p._id === publisher2._id.toString());
+      expect(partner1.clicks).toBe(4);
+      expect(partner2.clicks).toBe(0);
     });
   });
 

--- a/api/tests/mocks/pgMock.ts
+++ b/api/tests/mocks/pgMock.ts
@@ -7,6 +7,7 @@ const pgMock = {
     findUnique: vi.fn(),
     findFirst: vi.fn(),
     count: vi.fn(),
+    groupBy: vi.fn(),
   },
 };
 


### PR DESCRIPTION
## Summary
- add a stat-event repository helper to count click events by publisher for an organization with both ES and PG implementations
- update the v0 myorganization controller to rely on the repository instead of the raw Elasticsearch client
- extend integration and repository tests to cover the new repository helper in ES/PG modes and reset the pg mock

## Testing
- npx vitest run src/repositories/__tests__/stat-event.test.ts tests/integration/api/v0/myorganization.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d2a62126208324b5e7224f48ac66de