### PR TITLE
refactor: use stat-event repo for mymission stats

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -46,7 +46,7 @@ import WarningBotController from "./controllers/warning-bot";
 import WidgetController from "./controllers/widget";
 import AssociationV0Controller from "./v0/association";
 import MissionV0Controller from "./v0/mission/controller";
-import MyMissionV0Controller from "./v0/mymission";
+import MyMissionV0Controller from "./v0/mymission/controller";
 import MyOrganizationV0Controller from "./v0/myorganization/controller";
 import OrganizationV0Controller from "./v0/organization";
 import PublisherV0Controller from "./v0/publisher";

--- a/api/src/v0/mymission/stats.ts
+++ b/api/src/v0/mymission/stats.ts
@@ -1,0 +1,188 @@
+import { STATS_INDEX } from "../../config";
+import esClient from "../../db/elastic";
+import { prismaCore } from "../../db/postgres";
+
+type MissionStatsDetails = {
+  key: string;
+  doc_count: number;
+  name?: string;
+  logo?: string;
+  url?: string;
+};
+
+type MissionStatsSummary = {
+  key: string;
+  doc_count: number;
+};
+
+export async function getMissionStatsWithDetails(missionId: string): Promise<{ clicks: MissionStatsDetails[]; applications: MissionStatsDetails[] }> {
+  if (getReadStatsFrom() === "pg") {
+    const [applications, clicks] = await Promise.all([
+      prismaCore.statEvent.groupBy({
+        by: ["from_publisher_id", "from_publisher_name"],
+        where: {
+          mission_id: missionId,
+          is_bot: false,
+          type: "apply",
+        },
+        _count: { _all: true },
+      }),
+      prismaCore.statEvent.groupBy({
+        by: ["from_publisher_id", "from_publisher_name"],
+        where: {
+          mission_id: missionId,
+          is_bot: false,
+          type: "click",
+        },
+        _count: { _all: true },
+      }),
+    ]);
+
+    const mapGroup = (group: { from_publisher_id: string | null; from_publisher_name: string | null; _count: { _all: number } }): MissionStatsDetails => ({
+      key: group.from_publisher_id ?? "",
+      name: group.from_publisher_name ?? undefined,
+      logo: undefined,
+      url: undefined,
+      doc_count: group._count._all,
+    });
+
+    return {
+      applications: applications.map(mapGroup),
+      clicks: clicks.map(mapGroup),
+    };
+  }
+
+  const query = {
+    query: {
+      bool: {
+        must_not: [{ term: { isBot: true } }],
+        must: [{ term: { "missionId.keyword": missionId } }],
+      },
+    },
+    aggs: {
+      apply: {
+        filter: { term: { type: "apply" } },
+        aggs: {
+          data: {
+            terms: { field: "fromPublisherId.keyword", size: 100 },
+            aggs: { hits: { top_hits: { size: 1 } } },
+          },
+        },
+      },
+      click: {
+        filter: { term: { type: "click" } },
+        aggs: {
+          data: {
+            terms: { field: "fromPublisherId.keyword", size: 100 },
+            aggs: { hits: { top_hits: { size: 1 } } },
+          },
+        },
+      },
+    },
+    size: 0,
+  };
+
+  const raw = await esClient.msearch({ body: [{ index: STATS_INDEX }, query] });
+  const response = raw.body.responses[0];
+  const applications = mapEsBuckets(response?.aggregations?.apply?.data?.buckets ?? []);
+  const clicks = mapEsBuckets(response?.aggregations?.click?.data?.buckets ?? []);
+  return { applications, clicks };
+}
+
+export async function getMissionStatsSummary(missionId: string): Promise<{ clicks: MissionStatsSummary[]; applications: MissionStatsSummary[] }> {
+  if (getReadStatsFrom() === "pg") {
+    const [clicks, applications] = await Promise.all([
+      prismaCore.statEvent.groupBy({
+        by: ["from_publisher_name"],
+        where: {
+          mission_id: missionId,
+          is_bot: false,
+          type: "click",
+        },
+        _count: { _all: true },
+      }),
+      prismaCore.statEvent.groupBy({
+        by: ["from_publisher_name"],
+        where: {
+          mission_id: missionId,
+          is_bot: false,
+          type: "apply",
+        },
+        _count: { _all: true },
+      }),
+    ]);
+
+    const mapGroup = (group: { from_publisher_name: string | null; _count: { _all: number } }): MissionStatsSummary => ({
+      key: group.from_publisher_name ?? "",
+      doc_count: group._count._all,
+    });
+
+    return {
+      clicks: clicks.map(mapGroup),
+      applications: applications.map(mapGroup),
+    };
+  }
+
+  const clicksQuery = {
+    query: {
+      bool: {
+        must_not: [{ term: { isBot: true } }],
+        must: [
+          { term: { "missionId.keyword": missionId } },
+          { term: { "type.keyword": "click" } },
+        ],
+      },
+    },
+    aggs: { mission: { terms: { field: "fromPublisherName.keyword" } } },
+    size: 0,
+  };
+
+  const applicationsQuery = {
+    query: {
+      bool: {
+        must_not: [{ term: { isBot: true } }],
+        must: [
+          { term: { "missionId.keyword": missionId } },
+          { term: { "type.keyword": "apply" } },
+        ],
+      },
+    },
+    aggs: { mission: { terms: { field: "fromPublisherName.keyword" } } },
+    size: 0,
+  };
+
+  const stats = await esClient.msearch({
+    body: [{ index: STATS_INDEX }, clicksQuery, { index: STATS_INDEX }, applicationsQuery],
+  });
+
+  const [clicksResponse, applicationsResponse] = stats.body.responses;
+
+  return {
+    clicks: mapEsMissionBuckets(clicksResponse?.aggregations?.mission?.buckets ?? []),
+    applications: mapEsMissionBuckets(applicationsResponse?.aggregations?.mission?.buckets ?? []),
+  };
+}
+
+function mapEsBuckets(buckets: any[]): MissionStatsDetails[] {
+  return buckets.map((bucket) => {
+    const topHit = bucket?.hits?.hits?.hits?.[0]?._source ?? {};
+    return {
+      key: bucket.key,
+      doc_count: bucket.doc_count,
+      logo: topHit.fromPublisherLogo,
+      name: topHit.fromPublisherName,
+      url: topHit.fromPublisherUrl,
+    };
+  });
+}
+
+function mapEsMissionBuckets(buckets: any[]): MissionStatsSummary[] {
+  return buckets.map((bucket) => ({
+    key: bucket.key,
+    doc_count: bucket.doc_count,
+  }));
+}
+
+function getReadStatsFrom(): "es" | "pg" {
+  return (process.env.READ_STATS_FROM as "es" | "pg") || "es";
+}

--- a/api/tests/integration/api/v0/mymission.test.ts
+++ b/api/tests/integration/api/v0/mymission.test.ts
@@ -1,7 +1,7 @@
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestMission, createTestPublisher } from "../../../fixtures";
-import elasticMock from "../../../mocks/elasticMock";
+import { elasticMock, pgMock } from "../../../mocks";
 import { createTestApp } from "../../../testApp";
 
 describe("MyMission API Integration Tests", () => {
@@ -19,6 +19,9 @@ describe("MyMission API Integration Tests", () => {
     mission2 = await createTestMission({ organizationClientId: orgId, publisherId: publisher._id.toString() });
 
     vi.clearAllMocks();
+    process.env.READ_STATS_FROM = "es";
+    process.env.WRITE_STATS_DUAL = "false";
+    pgMock.statEvent.groupBy.mockResolvedValue([]);
     elasticMock.msearch.mockResolvedValue({
       body: {
         responses: [
@@ -182,6 +185,39 @@ describe("MyMission API Integration Tests", () => {
       validateStatsStructure(mission.stats);
     });
 
+    it("should return mission details with stats from postgres", async () => {
+      process.env.READ_STATS_FROM = "pg";
+      pgMock.statEvent.groupBy.mockResolvedValueOnce([
+        {
+          from_publisher_id: "publisher1",
+          from_publisher_name: "Publisher 1",
+          _count: { _all: 2 },
+        },
+      ]);
+      pgMock.statEvent.groupBy.mockResolvedValueOnce([
+        {
+          from_publisher_id: "publisher2",
+          from_publisher_name: "Publisher 2",
+          _count: { _all: 4 },
+        },
+      ]);
+
+      const response = await request(app).get(`/v0/mymission/${mission1.clientId}`).set("x-api-key", apiKey);
+
+      expect(response.status).toBe(200);
+      expect(pgMock.statEvent.groupBy).toHaveBeenCalledTimes(2);
+      expect(response.body.data.stats.applications[0]).toMatchObject({
+        key: "publisher1",
+        doc_count: 2,
+        name: "Publisher 1",
+      });
+      expect(response.body.data.stats.clicks[0]).toMatchObject({
+        key: "publisher2",
+        doc_count: 4,
+        name: "Publisher 2",
+      });
+    });
+
     it("should return 400 for invalid parameters", async () => {
       const response = await request(app).get(`/v0/mymission/${mission1.clientId}`).set("x-api-key", apiKey).query({ someInvalidParam: "value" });
 
@@ -246,6 +282,25 @@ describe("MyMission API Integration Tests", () => {
       expect(response.body.data).toBeDefined();
 
       validateStatsStructure(response.body.data);
+    });
+
+    it("should return mission stats from postgres", async () => {
+      process.env.READ_STATS_FROM = "pg";
+      pgMock.statEvent.groupBy.mockResolvedValueOnce([
+        { from_publisher_name: "Publisher 1", _count: { _all: 5 } },
+      ]);
+      pgMock.statEvent.groupBy.mockResolvedValueOnce([
+        { from_publisher_name: "Publisher 2", _count: { _all: 3 } },
+      ]);
+
+      const response = await request(app).get(`/v0/mymission/${mission1.clientId}/stats`).set("x-api-key", apiKey);
+
+      expect(response.status).toBe(200);
+      expect(pgMock.statEvent.groupBy).toHaveBeenCalledTimes(2);
+      expect(response.body.data).toEqual({
+        clicks: [{ key: "Publisher 1", doc_count: 5 }],
+        applications: [{ key: "Publisher 2", doc_count: 3 }],
+      });
     });
 
     it("should return 400 for invalid parameters", async () => {

--- a/api/tests/mocks/pgMock.ts
+++ b/api/tests/mocks/pgMock.ts
@@ -7,6 +7,7 @@ const pgMock = {
     findUnique: vi.fn(),
     findFirst: vi.fn(),
     count: vi.fn(),
+    groupBy: vi.fn(),
   },
 };
 

--- a/api/tests/testApp.ts
+++ b/api/tests/testApp.ts
@@ -4,7 +4,7 @@ import cors from "cors";
 import express from "express";
 import passport from "../src/middlewares/passport";
 import MissionV0Controller from "../src/v0/mission/controller";
-import MyMissionV0Controller from "../src/v0/mymission";
+import MyMissionV0Controller from "../src/v0/mymission/controller";
 import MyOrganizationV0Controller from "../src/v0/myorganization/controller";
 
 // Create a test Express app with minimal configuration


### PR DESCRIPTION
## Summary
- add a dedicated mymission stats helper that reads from Postgres or Elasticsearch via feature flags
- refactor the v0/mymission controller to reuse the helper instead of calling Elasticsearch directly
- extend mocks and integration tests to exercise the Postgres code path and cover new groupBy usage
- reorganize the mymission API files under v0/mymission/controller.ts and v0/mymission/stats.ts per the preferred layout

## Testing
- (fails) cd api && npm test # existing suite fails because db/analytics module is unavailable in the test environment
- npx vitest run tests/integration/api/v0/mymission.test.ts
- npx eslint --ext .ts src/v0/mymission/controller.ts src/v0/mymission/stats.ts

------
https://chatgpt.com/codex/tasks/task_e_68d2a6a354608324909547ab75d9b332