### PR TITLE
feat(stats): read public stats from materialized views

### DIFF
--- a/api/prisma/core/migrations/20251010120000_create_public_stats_materialized_views/migration.sql
+++ b/api/prisma/core/migrations/20251010120000_create_public_stats_materialized_views/migration.sql
@@ -1,0 +1,241 @@
+-- Create materialized views for public stats aggregates
+CREATE MATERIALIZED VIEW "PublicStatsGraphMonthly" AS
+WITH base AS (
+  SELECT
+    EXTRACT(YEAR FROM "created_at")::int AS year,
+    EXTRACT(MONTH FROM "created_at")::int AS month,
+    "mission_department_name" AS department,
+    CASE WHEN "to_publisher_name" = 'Service Civique' THEN 'volontariat' ELSE 'benevolat' END AS publisher_category,
+    CASE
+      WHEN "mission_organization_name" IS NOT NULL AND "mission_organization_name" <> '' THEN "mission_organization_name"
+      ELSE NULL
+    END AS organization_name,
+    "type"
+  FROM "public"."StatEvent"
+  WHERE "is_bot" IS NOT TRUE
+)
+SELECT
+  year,
+  month,
+  department,
+  FALSE AS is_all_department,
+  publisher_category,
+  SUM(CASE WHEN type = 'click' THEN 1 ELSE 0 END)::bigint AS click_count,
+  SUM(CASE WHEN type = 'apply' THEN 1 ELSE 0 END)::bigint AS apply_count,
+  COUNT(DISTINCT organization_name)::bigint AS organization_count
+FROM base
+GROUP BY year, month, department, publisher_category
+
+UNION ALL
+SELECT
+  year,
+  month,
+  department,
+  FALSE AS is_all_department,
+  'all' AS publisher_category,
+  SUM(CASE WHEN type = 'click' THEN 1 ELSE 0 END)::bigint AS click_count,
+  SUM(CASE WHEN type = 'apply' THEN 1 ELSE 0 END)::bigint AS apply_count,
+  COUNT(DISTINCT organization_name)::bigint AS organization_count
+FROM base
+GROUP BY year, month, department
+
+UNION ALL
+SELECT
+  year,
+  month,
+  NULL AS department,
+  TRUE AS is_all_department,
+  publisher_category,
+  SUM(CASE WHEN type = 'click' THEN 1 ELSE 0 END)::bigint AS click_count,
+  SUM(CASE WHEN type = 'apply' THEN 1 ELSE 0 END)::bigint AS apply_count,
+  COUNT(DISTINCT organization_name)::bigint AS organization_count
+FROM base
+GROUP BY year, month, publisher_category
+
+UNION ALL
+SELECT
+  year,
+  month,
+  NULL AS department,
+  TRUE AS is_all_department,
+  'all' AS publisher_category,
+  SUM(CASE WHEN type = 'click' THEN 1 ELSE 0 END)::bigint AS click_count,
+  SUM(CASE WHEN type = 'apply' THEN 1 ELSE 0 END)::bigint AS apply_count,
+  COUNT(DISTINCT organization_name)::bigint AS organization_count
+FROM base
+GROUP BY year, month;
+
+CREATE UNIQUE INDEX "PublicStatsGraphMonthly_unique_idx"
+  ON "PublicStatsGraphMonthly" ("year", "month", "publisher_category", "is_all_department", "department");
+
+CREATE MATERIALIZED VIEW "PublicStatsGraphYearlyOrganizations" AS
+WITH base AS (
+  SELECT
+    EXTRACT(YEAR FROM "created_at")::int AS year,
+    "mission_department_name" AS department,
+    CASE WHEN "to_publisher_name" = 'Service Civique' THEN 'volontariat' ELSE 'benevolat' END AS publisher_category,
+    CASE
+      WHEN "mission_organization_name" IS NOT NULL AND "mission_organization_name" <> '' THEN "mission_organization_name"
+      ELSE NULL
+    END AS organization_name
+  FROM "public"."StatEvent"
+  WHERE "is_bot" IS NOT TRUE
+)
+SELECT
+  year,
+  department,
+  FALSE AS is_all_department,
+  publisher_category,
+  COUNT(DISTINCT organization_name)::bigint AS organization_count
+FROM base
+GROUP BY year, department, publisher_category
+
+UNION ALL
+SELECT
+  year,
+  department,
+  FALSE AS is_all_department,
+  'all' AS publisher_category,
+  COUNT(DISTINCT organization_name)::bigint AS organization_count
+FROM base
+GROUP BY year, department
+
+UNION ALL
+SELECT
+  year,
+  NULL AS department,
+  TRUE AS is_all_department,
+  publisher_category,
+  COUNT(DISTINCT organization_name)::bigint AS organization_count
+FROM base
+GROUP BY year, publisher_category
+
+UNION ALL
+SELECT
+  year,
+  NULL AS department,
+  TRUE AS is_all_department,
+  'all' AS publisher_category,
+  COUNT(DISTINCT organization_name)::bigint AS organization_count
+FROM base
+GROUP BY year;
+
+CREATE UNIQUE INDEX "PublicStatsGraphYearlyOrganizations_unique_idx"
+  ON "PublicStatsGraphYearlyOrganizations" ("year", "publisher_category", "is_all_department", "department");
+
+CREATE MATERIALIZED VIEW "PublicStatsDomains" AS
+WITH base AS (
+  SELECT
+    EXTRACT(YEAR FROM "created_at")::int AS year,
+    "mission_department_name" AS department,
+    CASE WHEN "to_publisher_name" = 'Service Civique' THEN 'volontariat' ELSE 'benevolat' END AS publisher_category,
+    CASE
+      WHEN "mission_domain" IS NOT NULL AND "mission_domain" <> '' THEN "mission_domain"
+      ELSE NULL
+    END AS domain,
+    CASE
+      WHEN "mission_id" IS NOT NULL AND "mission_id" <> '' THEN "mission_id"
+      ELSE NULL
+    END AS mission_id,
+    "type"
+  FROM "public"."StatEvent"
+  WHERE "is_bot" IS NOT TRUE
+    AND "mission_domain" IS NOT NULL
+    AND "mission_domain" <> ''
+)
+SELECT
+  year,
+  department,
+  FALSE AS is_all_department,
+  publisher_category,
+  domain,
+  COUNT(DISTINCT mission_id)::bigint AS mission_count,
+  SUM(CASE WHEN type = 'click' THEN 1 ELSE 0 END)::bigint AS click_count,
+  SUM(CASE WHEN type = 'apply' THEN 1 ELSE 0 END)::bigint AS apply_count
+FROM base
+GROUP BY year, department, publisher_category, domain
+
+UNION ALL
+SELECT
+  year,
+  department,
+  FALSE AS is_all_department,
+  'all' AS publisher_category,
+  domain,
+  COUNT(DISTINCT mission_id)::bigint AS mission_count,
+  SUM(CASE WHEN type = 'click' THEN 1 ELSE 0 END)::bigint AS click_count,
+  SUM(CASE WHEN type = 'apply' THEN 1 ELSE 0 END)::bigint AS apply_count
+FROM base
+GROUP BY year, department, domain
+
+UNION ALL
+SELECT
+  year,
+  NULL AS department,
+  TRUE AS is_all_department,
+  publisher_category,
+  domain,
+  COUNT(DISTINCT mission_id)::bigint AS mission_count,
+  SUM(CASE WHEN type = 'click' THEN 1 ELSE 0 END)::bigint AS click_count,
+  SUM(CASE WHEN type = 'apply' THEN 1 ELSE 0 END)::bigint AS apply_count
+FROM base
+GROUP BY year, publisher_category, domain
+
+UNION ALL
+SELECT
+  year,
+  NULL AS department,
+  TRUE AS is_all_department,
+  'all' AS publisher_category,
+  domain,
+  COUNT(DISTINCT mission_id)::bigint AS mission_count,
+  SUM(CASE WHEN type = 'click' THEN 1 ELSE 0 END)::bigint AS click_count,
+  SUM(CASE WHEN type = 'apply' THEN 1 ELSE 0 END)::bigint AS apply_count
+FROM base
+GROUP BY year, domain;
+
+CREATE UNIQUE INDEX "PublicStatsDomains_unique_idx"
+  ON "PublicStatsDomains" ("year", "domain", "publisher_category", "is_all_department", "department");
+
+CREATE MATERIALIZED VIEW "PublicStatsDepartments" AS
+WITH base AS (
+  SELECT
+    EXTRACT(YEAR FROM "created_at")::int AS year,
+    CASE
+      WHEN "mission_postal_code" IS NOT NULL AND "mission_postal_code" <> '' THEN "mission_postal_code"
+      ELSE NULL
+    END AS postal_code,
+    CASE WHEN "to_publisher_name" = 'Service Civique' THEN 'volontariat' ELSE 'benevolat' END AS publisher_category,
+    CASE
+      WHEN "mission_id" IS NOT NULL AND "mission_id" <> '' THEN "mission_id"
+      ELSE NULL
+    END AS mission_id,
+    "type"
+  FROM "public"."StatEvent"
+  WHERE "is_bot" IS NOT TRUE
+    AND "mission_postal_code" IS NOT NULL
+    AND "mission_postal_code" <> ''
+)
+SELECT
+  year,
+  postal_code,
+  publisher_category,
+  COUNT(DISTINCT mission_id)::bigint AS mission_count,
+  SUM(CASE WHEN type = 'click' THEN 1 ELSE 0 END)::bigint AS click_count,
+  SUM(CASE WHEN type = 'apply' THEN 1 ELSE 0 END)::bigint AS apply_count
+FROM base
+GROUP BY year, postal_code, publisher_category
+
+UNION ALL
+SELECT
+  year,
+  postal_code,
+  'all' AS publisher_category,
+  COUNT(DISTINCT mission_id)::bigint AS mission_count,
+  SUM(CASE WHEN type = 'click' THEN 1 ELSE 0 END)::bigint AS click_count,
+  SUM(CASE WHEN type = 'apply' THEN 1 ELSE 0 END)::bigint AS apply_count
+FROM base
+GROUP BY year, postal_code;
+
+CREATE UNIQUE INDEX "PublicStatsDepartments_unique_idx"
+  ON "PublicStatsDepartments" ("year", "postal_code", "publisher_category");

--- a/api/src/jobs/update-stats-views/handler.ts
+++ b/api/src/jobs/update-stats-views/handler.ts
@@ -1,0 +1,42 @@
+import { prismaCore } from "../../db/postgres";
+import { captureException } from "../../error";
+import { BaseHandler } from "../base/handler";
+import { JobResult } from "../types";
+
+const VIEWS = [
+  "PublicStatsGraphMonthly",
+  "PublicStatsGraphYearlyOrganizations",
+  "PublicStatsDomains",
+  "PublicStatsDepartments",
+] as const;
+
+export interface UpdateStatsViewsJobResult extends JobResult {
+  refreshed: string[];
+}
+
+export class UpdateStatsViewsHandler implements BaseHandler<void, UpdateStatsViewsJobResult> {
+  name = "Mise à jour des vues materialized des stats publiques";
+
+  async handle(): Promise<UpdateStatsViewsJobResult> {
+    const refreshed: string[] = [];
+
+    for (const view of VIEWS) {
+      try {
+        await prismaCore.$executeRawUnsafe(`REFRESH MATERIALIZED VIEW CONCURRENTLY "${view}"`);
+        refreshed.push(view);
+      } catch (error) {
+        captureException(error, { extra: { view } });
+        throw error;
+      }
+    }
+
+    return {
+      success: true,
+      timestamp: new Date(),
+      message: `Vues mises à jour: ${refreshed.join(", ")}`,
+      refreshed,
+    };
+  }
+}
+
+export default UpdateStatsViewsHandler;


### PR DESCRIPTION
## Summary
- add materialized views that cache public stats aggregates with supporting indexes
- update the stats-public controller to read precomputed values from the new views
- add a recurring job to refresh the materialized views

## Testing
- npm run lint:api *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68d65e53a8348324b89baa872d63a021