### PR TITLE
feat: add materialized views for stats-global endpoints

### DIFF
--- a/api/prisma/core/migrations/20250211090000_create_stats_global_materialized_views/migration.sql
+++ b/api/prisma/core/migrations/20250211090000_create_stats_global_materialized_views/migration.sql
@@ -1,0 +1,68 @@
+-- Create materialized views used by the stats-global endpoint
+CREATE MATERIALIZED VIEW "StatsGlobalEvents" AS
+SELECT
+  "id",
+  "created_at",
+  "type",
+  "source",
+  "from_publisher_id",
+  "from_publisher_name",
+  "to_publisher_id",
+  "to_publisher_name",
+  "mission_id"
+FROM "public"."StatEvent"
+WHERE "is_bot" IS NOT TRUE;
+
+CREATE UNIQUE INDEX "StatsGlobalEvents_id_unique_idx"
+  ON "StatsGlobalEvents" ("id");
+CREATE INDEX "StatsGlobalEvents_created_at_idx"
+  ON "StatsGlobalEvents" ("created_at");
+CREATE INDEX "StatsGlobalEvents_type_idx"
+  ON "StatsGlobalEvents" ("type");
+CREATE INDEX "StatsGlobalEvents_source_idx"
+  ON "StatsGlobalEvents" ("source");
+CREATE INDEX "StatsGlobalEvents_from_publisher_idx"
+  ON "StatsGlobalEvents" ("from_publisher_id");
+CREATE INDEX "StatsGlobalEvents_to_publisher_idx"
+  ON "StatsGlobalEvents" ("to_publisher_id");
+CREATE INDEX "StatsGlobalEvents_mission_idx"
+  ON "StatsGlobalEvents" ("mission_id");
+
+CREATE MATERIALIZED VIEW "StatsGlobalMissionActivity" AS
+SELECT
+  "mission_id",
+  "type",
+  "from_publisher_id",
+  "from_publisher_name",
+  "to_publisher_id",
+  "to_publisher_name",
+  MIN("created_at") AS "first_created_at",
+  MAX("created_at") AS "last_created_at"
+FROM "public"."StatEvent"
+WHERE "is_bot" IS NOT TRUE
+  AND "mission_id" IS NOT NULL
+GROUP BY
+  "mission_id",
+  "type",
+  "from_publisher_id",
+  "from_publisher_name",
+  "to_publisher_id",
+  "to_publisher_name";
+
+CREATE UNIQUE INDEX "StatsGlobalMissionActivity_unique_idx"
+  ON "StatsGlobalMissionActivity" (
+    "mission_id",
+    "type",
+    "from_publisher_id",
+    "to_publisher_id"
+  );
+CREATE INDEX "StatsGlobalMissionActivity_first_created_idx"
+  ON "StatsGlobalMissionActivity" ("first_created_at");
+CREATE INDEX "StatsGlobalMissionActivity_last_created_idx"
+  ON "StatsGlobalMissionActivity" ("last_created_at");
+CREATE INDEX "StatsGlobalMissionActivity_from_publisher_idx"
+  ON "StatsGlobalMissionActivity" ("from_publisher_id");
+CREATE INDEX "StatsGlobalMissionActivity_to_publisher_idx"
+  ON "StatsGlobalMissionActivity" ("to_publisher_id");
+CREATE INDEX "StatsGlobalMissionActivity_type_idx"
+  ON "StatsGlobalMissionActivity" ("type");

--- a/api/src/controllers/stats-global/helper.ts
+++ b/api/src/controllers/stats-global/helper.ts
@@ -163,7 +163,7 @@ async function countEvents(whereClause: Prisma.Sql): Promise<number> {
 async function countMissions(whereClause: Prisma.Sql): Promise<number> {
   const rows = await prismaCore.$queryRaw<Array<{ total: bigint }>>(
     Prisma.sql`
-      SELECT COUNT(*)::bigint AS total
+      SELECT COUNT(DISTINCT ${Prisma.raw('"mission_id"')})::bigint AS total
       FROM ${STATS_GLOBAL_MISSION_VIEW}
       ${whereClause}
     `
@@ -899,7 +899,7 @@ async function getMissionsStatsFromPg({ publisherId, from, to }: MissionsParams)
     Prisma.sql`
       SELECT
         ${Prisma.raw('"to_publisher_name"')} AS publisher_name,
-        COUNT(*)::bigint AS mission_count
+        COUNT(DISTINCT ${Prisma.raw('"mission_id"')})::bigint AS mission_count
       FROM ${STATS_GLOBAL_MISSION_VIEW}
       ${missionWhere}
       GROUP BY ${Prisma.raw('"to_publisher_name"')}

--- a/api/src/jobs/update-stats-views/handler.ts
+++ b/api/src/jobs/update-stats-views/handler.ts
@@ -8,6 +8,8 @@ const VIEWS = [
   "PublicStatsGraphYearlyOrganizations",
   "PublicStatsDomains",
   "PublicStatsDepartments",
+  "StatsGlobalEvents",
+  "StatsGlobalMissionActivity",
 ] as const;
 
 export interface UpdateStatsViewsJobResult extends JobResult {


### PR DESCRIPTION
## Summary
- add StatsGlobalEvents and StatsGlobalMissionActivity materialized views with the required indexes
- refactor the stats-global Postgres helpers to read from the new views instead of the base table
- refresh the new materialized views from the update-stats-views job

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d686ce88c4832482048add6adff4ae