### PR TITLE
refactor: migrate stats search to stat-event repository

### DIFF
--- a/api/src/controllers/stats.ts
+++ b/api/src/controllers/stats.ts
@@ -2,11 +2,9 @@ import { NextFunction, Response, Router } from "express";
 import passport from "passport";
 import zod from "zod";
 
-import { STATS_INDEX } from "../config";
-import esClient from "../db/elastic";
 import { INVALID_BODY } from "../error";
-import { EsQuery } from "../types";
 import { UserRequest } from "../types/passport";
+import statEventRepository from "../repositories/stat-event";
 
 const router = Router();
 
@@ -35,39 +33,16 @@ router.post("/search", passport.authenticate("user", { session: false }), async 
       });
     }
 
-    const where = {
-      bool: { must: [], must_not: [{ term: { isBot: true } }], should: [], filter: [] },
-    } as EsQuery;
-
-    if (body.data.fromPublisherId) {
-      where.bool.filter.push({ term: { fromPublisherId: body.data.fromPublisherId } });
-    }
-    if (body.data.toPublisherId) {
-      where.bool.filter.push({ term: { toPublisherId: body.data.toPublisherId } });
-    }
-    if (body.data.type) {
-      where.bool.filter.push({ term: { type: body.data.type.toString() } });
-    }
-    if (body.data.sourceId) {
-      where.bool.filter.push({ term: { sourceId: body.data.sourceId } });
-    }
-
-    const response = await esClient.search({
-      index: STATS_INDEX,
-      body: {
-        track_total_hits: true,
-        query: where,
-        sort: [{ createdAt: { order: "desc" } }],
-        size: body.data.size,
-        from: body.data.skip,
-      },
+    const { data: events, total } = await statEventRepository.searchStatEvents({
+      fromPublisherId: body.data.fromPublisherId,
+      toPublisherId: body.data.toPublisherId,
+      type: body.data.type,
+      sourceId: body.data.sourceId,
+      size: body.data.size,
+      skip: body.data.skip,
     });
-    if (response.statusCode !== 200) {
-      next(response.body.error);
-    }
 
-    const data = response.body.hits.hits.map((h: any) => ({ ...h._source, id: h._id }));
-    const total = response.body.hits.total.value;
+    const data = events.map(({ _id, ...rest }) => ({ ...rest, id: _id }));
     return res.status(200).send({ ok: true, data, total });
   } catch (error) {
     next(error);

--- a/api/tests/mocks/pgMock.ts
+++ b/api/tests/mocks/pgMock.ts
@@ -6,6 +6,7 @@ const pgMock = {
     update: vi.fn(),
     findUnique: vi.fn(),
     findFirst: vi.fn(),
+    findMany: vi.fn(),
     count: vi.fn(),
     groupBy: vi.fn(),
   },


### PR DESCRIPTION
## Summary
- add a repository search function that supports both PG and ES for stat events
- update the stats controller to reuse the repository instead of the elastic client directly
- expand automated coverage and mocks for the new repository entry point

## Testing
- npm run lint -- src/controllers/stats.ts src/repositories/stat-event.ts
- npm run test -- src/repositories/__tests__/stat-event.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6a1aab2c88324a018cc4067481771