### PR TITLE
Simplify warning bot repository helpers

### DIFF
--- a/api/tests/mocks/elasticMock.ts
+++ b/api/tests/mocks/elasticMock.ts
@@ -3,6 +3,7 @@ import { vi } from "vitest";
 const elasticMock = {
   index: vi.fn().mockResolvedValue({}),
   update: vi.fn().mockResolvedValue({}),
+  updateByQuery: vi.fn().mockResolvedValue({}),
   get: vi.fn().mockResolvedValue({ body: { _source: {}, _id: "1" } }),
   count: vi.fn().mockResolvedValue({ body: { count: 0 } }),
   msearch: vi.fn().mockResolvedValue({

--- a/api/tests/mocks/pgMock.ts
+++ b/api/tests/mocks/pgMock.ts
@@ -4,6 +4,7 @@ const pgMock = {
   statEvent: {
     create: vi.fn(),
     update: vi.fn(),
+    updateMany: vi.fn(),
     findUnique: vi.fn(),
     findFirst: vi.fn(),
     findMany: vi.fn(),


### PR DESCRIPTION
## Summary
- localize the warning bot PostgreSQL aggregation mapping inside the helper
- always update Elasticsearch for warning bot isBot changes and only dual-write to Postgres when enabled
- refresh repository unit tests to cover the revised update flow

## Testing
- npm test -- src/repositories/__tests__/stat-event.test.ts (from the api directory)


------
https://chatgpt.com/codex/tasks/task_e_68da70e0f6188324ab1648ede483d7b8