### PR TITLE
refactor: use stat event repo in linkedin stats job

### DIFF
--- a/api/src/jobs/linkedin-stats/add-stats.ts
+++ b/api/src/jobs/linkedin-stats/add-stats.ts
@@ -1,9 +1,8 @@
-import { BulkOperationContainer } from "@elastic/elasticsearch/api/types";
-import { PUBLISHER_IDS, STATS_INDEX } from "../../config";
-import esClient from "../../db/elastic";
+import { PUBLISHER_IDS } from "../../config";
 import { captureException, captureMessage } from "../../error";
 import MissionModel from "../../models/mission";
 import { Stats } from "../../types";
+import statEventRepository from "../../repositories/stat-event";
 
 const ROWS = [
   "LinkedIn Job ID",
@@ -41,8 +40,6 @@ const ROWS = [
   "ATS Posting Method",
   "ATS Posting Method Detail",
 ];
-
-const BULK_SIZE = 1000;
 
 const getDate = (date: string, full: boolean = false) => {
   const s = date.split("-");
@@ -92,11 +89,8 @@ const parseRow = async (row: (string | number)[], from: Date, to: Date, sourceId
 
     let mission = await MissionModel.findOne({ _old_ids: { $in: [missionId] } });
     if (!mission) {
-      const response2 = await esClient.search({
-        index: STATS_INDEX,
-        body: { query: { term: { "missionId.keyword": missionId } }, size: 1 },
-      });
-      if (response2.body.hits.total.value === 0) {
+      const existingStat = await statEventRepository.findFirstByMissionId(missionId.toString());
+      if (!existingStat) {
         if (MISSION_NOT_FOUND[missionId.toString()]) {
           mission = await MissionModel.findById(MISSION_NOT_FOUND[missionId.toString()]);
           if (!mission) {
@@ -108,13 +102,9 @@ const parseRow = async (row: (string | number)[], from: Date, to: Date, sourceId
           return;
         }
       } else {
-        const stats = {
-          _id: response2.body.hits.hits[0]._id,
-          ...response2.body.hits.hits[0]._source,
-        } as Stats;
         mission = await MissionModel.findOne({
-          clientId: stats.missionClientId?.toString(),
-          publisherId: stats.toPublisherId,
+          clientId: existingStat.missionClientId?.toString(),
+          publisherId: existingStat.toPublisherId,
         });
         if (!mission) {
           if (MISSION_NOT_FOUND[missionId.toString()]) {
@@ -167,7 +157,6 @@ const parseRow = async (row: (string | number)[], from: Date, to: Date, sourceId
 };
 
 export const processData = async (data: (string | number)[][], from: Date, to: Date, sourceId: string) => {
-  const bulk = [] as (BulkOperationContainer | Stats)[];
   const result = {
     created: 0,
     failed: { data: [] as any[] },
@@ -187,23 +176,15 @@ export const processData = async (data: (string | number)[][], from: Date, to: D
       continue;
     }
 
-    res.forEach((print) => {
-      bulk.push({ index: { _index: STATS_INDEX } });
-      bulk.push(print);
-    });
-
-    if (bulk.length >= BULK_SIZE || i === data.length - 1) {
-      const { body } = await esClient.bulk({ refresh: true, body: bulk });
-      result.created += body.items.filter((e: any) => e.index._index === STATS_INDEX).length;
-      if (body.errors) {
-        const errors = body.items.filter((e: any) => e.index.error);
-        errors.forEach((e: any) => {
-          console.error(JSON.stringify(e, null, 2));
-        });
-        captureException(`ES bulk failed`, JSON.stringify(errors, null, 2));
-        result.failed.data.push(...errors);
+    for (const print of res) {
+      try {
+        await statEventRepository.createStatEvent(print);
+        result.created += 1;
+      } catch (error) {
+        console.error(`[Linkedin Stats] Failed to create stat`, error);
+        captureException(error, `[Linkedin Stats] Failed to create stat for mission ${print.missionId}`);
+        result.failed.data.push({ error: (error as Error)?.message, stat: print });
       }
-      bulk.length = 0;
     }
   }
   return result;


### PR DESCRIPTION
## Summary
- replace direct Elasticsearch lookup in the LinkedIn stats job with the stat-event repository
- write stats using the repository so the job honours the ES/PG feature flags

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da8aaae4c88324b31954282b813aef