### PR TITLE
Add integration tests for redirect controller endpoints

### DIFF
--- a/api/tests/integration/api/redirect/mission.test.ts
+++ b/api/tests/integration/api/redirect/mission.test.ts
@@ -1,0 +1,202 @@
+import { Types } from "mongoose";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PUBLISHER_IDS, STATS_INDEX } from "../../../../src/config";
+import MissionModel from "../../../../src/models/mission";
+import PublisherModel from "../../../../src/models/publisher";
+import StatsBotModel from "../../../../src/models/stats-bot";
+import * as utils from "../../../../src/utils";
+import { elasticMock } from "../../../mocks";
+import { createTestApp } from "../../../testApp";
+
+const app = createTestApp();
+
+describe("RedirectController /:missionId/:publisherId", () => {
+  beforeEach(async () => {
+    await MissionModel.deleteMany({});
+    await PublisherModel.deleteMany({});
+
+    elasticMock.index.mockReset();
+    elasticMock.update.mockReset();
+    elasticMock.index.mockResolvedValue({ body: { _id: "default-click-id" } });
+    elasticMock.update.mockResolvedValue({});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await MissionModel.deleteMany({});
+    await PublisherModel.deleteMany({});
+  });
+
+  it("redirects to Service Civique when params are invalid", async () => {
+    const response = await request(app).get(`/r/${new Types.ObjectId().toString()}/invalid`);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe("https://www.service-civique.gouv.fr/");
+    expect(elasticMock.index).not.toHaveBeenCalled();
+  });
+
+  it("redirects to Service Civique when mission is not found and identity is missing", async () => {
+    vi.spyOn(utils, "identify").mockReturnValue(null);
+
+    const missionId = new Types.ObjectId().toString();
+    const publisherId = new Types.ObjectId().toString();
+    const response = await request(app).get(`/r/${missionId}/${publisherId}`);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe("https://www.service-civique.gouv.fr/");
+    expect(elasticMock.index).not.toHaveBeenCalled();
+  });
+
+  it("redirects to mission application URL when identity is missing but mission exists", async () => {
+    const mission = await MissionModel.create({
+      applicationUrl: "https://mission.example.com/apply",
+      clientId: "mission-client-id",
+      lastSyncAt: new Date(),
+      publisherId: new Types.ObjectId().toString(),
+      publisherName: "Mission Publisher",
+      title: "Mission Title",
+    });
+
+    vi.spyOn(utils, "identify").mockReturnValue(null);
+
+    const response = await request(app).get(`/r/${mission._id.toString()}/${new Types.ObjectId().toString()}`);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe("https://mission.example.com/apply");
+    expect(elasticMock.index).not.toHaveBeenCalled();
+  });
+
+  it("records click stats and appends tracking parameters when identity and publisher exist", async () => {
+    const fromPublisher = await PublisherModel.create({
+      name: "From Publisher",
+    });
+
+    const mission = await MissionModel.create({
+      applicationUrl: "https://mission.example.com/apply",
+      clientId: "mission-client-id",
+      domain: "mission.example.com",
+      title: "Mission Title",
+      postalCode: "75001",
+      departmentName: "Paris",
+      organizationName: "Mission Org",
+      organizationId: "mission-org-id",
+      organizationClientId: "mission-org-client-id",
+      lastSyncAt: new Date(),
+      publisherId: new Types.ObjectId().toString(),
+      publisherName: "Mission Publisher",
+    });
+
+    const identity = {
+      user: "mission-user",
+      referer: "https://referrer.example.com",
+      userAgent: "Mozilla/5.0",
+    };
+
+    vi.spyOn(utils, "identify").mockReturnValue(identity);
+    const statsBotFindOneSpy = vi.spyOn(StatsBotModel, "findOne").mockResolvedValue({ user: identity.user } as any);
+    elasticMock.index.mockResolvedValueOnce({ body: { _id: "mission-click-id" } });
+
+    const response = await request(app)
+      .get(`/r/${mission._id.toString()}/${fromPublisher._id.toString()}`)
+      .set("Host", "redirect.test")
+      .set("Origin", "https://app.example.com")
+      .query({ tags: "foo,bar" });
+
+    expect(response.status).toBe(302);
+    const redirectUrl = new URL(response.headers.location);
+    expect(`${redirectUrl.origin}${redirectUrl.pathname}`).toBe("https://mission.example.com/apply");
+    expect(redirectUrl.searchParams.get("apiengagement_id")).toBe("mission-click-id");
+    expect(redirectUrl.searchParams.get("utm_source")).toBe("api_engagement");
+    expect(redirectUrl.searchParams.get("utm_medium")).toBe("api");
+    expect(redirectUrl.searchParams.get("utm_campaign")).toBe("from-publisher");
+
+    expect(elasticMock.index).toHaveBeenCalled();
+    const [indexCall] = elasticMock.index.mock.calls;
+    expect(indexCall[0].index).toBe(STATS_INDEX);
+    const indexedBody = indexCall[0].body as any;
+    expect(indexedBody).toMatchObject({
+      type: "click",
+      user: identity.user,
+      referer: identity.referer,
+      userAgent: identity.userAgent,
+      host: "redirect.test",
+      origin: "https://app.example.com",
+      source: "publisher",
+      sourceName: fromPublisher.name,
+      missionId: mission._id.toString(),
+      missionClientId: mission.clientId,
+      missionDomain: mission.domain,
+      missionTitle: mission.title,
+      missionPostalCode: mission.postalCode,
+      missionDepartmentName: mission.departmentName,
+      missionOrganizationName: mission.organizationName,
+      missionOrganizationId: mission.organizationId,
+      missionOrganizationClientId: mission.organizationClientId,
+      toPublisherId: mission.publisherId,
+      toPublisherName: mission.publisherName,
+      fromPublisherId: fromPublisher._id.toString(),
+      fromPublisherName: fromPublisher.name,
+      isBot: false,
+      tags: ["foo", "bar"],
+    });
+    expect(indexedBody.sourceId?.toString()).toBe(fromPublisher._id.toString());
+
+    expect(statsBotFindOneSpy).toHaveBeenCalledWith({ user: identity.user });
+    expect(elasticMock.update).toHaveBeenCalledWith({
+      index: STATS_INDEX,
+      id: "mission-click-id",
+      body: { doc: { isBot: true } },
+    });
+  });
+
+  it("uses mtm tracking parameters for Service Civique missions", async () => {
+    const fromPublisher = await PublisherModel.create({
+      name: "From Publisher",
+    });
+
+    const originalServicePublisherId = PUBLISHER_IDS.SERVICE_CIVIQUE;
+    const servicePublisherId = originalServicePublisherId || new Types.ObjectId().toString();
+    if (!originalServicePublisherId) {
+      PUBLISHER_IDS.SERVICE_CIVIQUE = servicePublisherId;
+    }
+
+    try {
+      const mission = await MissionModel.create({
+        applicationUrl: "https://mission.example.com/apply",
+        clientId: "mission-client-id",
+        lastSyncAt: new Date(),
+        publisherId: servicePublisherId,
+        publisherName: "Service Civique",
+        title: "Mission Title",
+      });
+
+      const identity = {
+        user: "mission-user",
+        referer: "https://referrer.example.com",
+        userAgent: "Mozilla/5.0",
+      };
+
+      vi.spyOn(utils, "identify").mockReturnValue(identity);
+      vi.spyOn(StatsBotModel, "findOne").mockResolvedValue(null);
+      elasticMock.index.mockResolvedValueOnce({ body: { _id: "mission-click-id" } });
+
+      const response = await request(app)
+        .get(`/r/${mission._id.toString()}/${fromPublisher._id.toString()}`)
+        .query({ tags: "foo" });
+
+      expect(response.status).toBe(302);
+      const redirectUrl = new URL(response.headers.location);
+      expect(`${redirectUrl.origin}${redirectUrl.pathname}`).toBe("https://mission.example.com/apply");
+      expect(redirectUrl.searchParams.get("apiengagement_id")).toBe("mission-click-id");
+      expect(redirectUrl.searchParams.get("mtm_source")).toBe("api_engagement");
+      expect(redirectUrl.searchParams.get("mtm_medium")).toBe("api");
+      expect(redirectUrl.searchParams.get("mtm_campaign")).toBe("from-publisher");
+    } finally {
+      if (!originalServicePublisherId) {
+        PUBLISHER_IDS.SERVICE_CIVIQUE = originalServicePublisherId;
+      }
+    }
+  });
+});

--- a/api/tests/integration/api/redirect/print.test.ts
+++ b/api/tests/integration/api/redirect/print.test.ts
@@ -1,0 +1,237 @@
+import { Types } from "mongoose";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { STATS_INDEX } from "../../../../src/config";
+import { INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "../../../../src/error";
+import MissionModel from "../../../../src/models/mission";
+import PublisherModel from "../../../../src/models/publisher";
+import StatsBotModel from "../../../../src/models/stats-bot";
+import WidgetModel from "../../../../src/models/widget";
+import * as utils from "../../../../src/utils";
+import { elasticMock } from "../../../mocks";
+import { createTestApp } from "../../../testApp";
+
+const app = createTestApp();
+
+describe("RedirectController /impression/:missionId/:publisherId", () => {
+  beforeEach(async () => {
+    await MissionModel.deleteMany({});
+    await PublisherModel.deleteMany({});
+    await WidgetModel.deleteMany({});
+
+    elasticMock.index.mockReset();
+    elasticMock.index.mockResolvedValue({ body: { _id: "default-print-id" } });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await MissionModel.deleteMany({});
+    await PublisherModel.deleteMany({});
+    await WidgetModel.deleteMany({});
+  });
+
+  it("returns 204 when identity is missing", async () => {
+    vi.spyOn(utils, "identify").mockReturnValue(null);
+
+    const response = await request(app).get(`/r/impression/${new Types.ObjectId().toString()}/${new Types.ObjectId().toString()}`);
+
+    expect(response.status).toBe(204);
+    expect(elasticMock.index).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when params are invalid", async () => {
+    const identity = { user: "user", referer: "https://ref", userAgent: "Mozilla" };
+    vi.spyOn(utils, "identify").mockReturnValue(identity);
+
+    const response = await request(app).get(`/r/impression/${new Types.ObjectId().toString()}/invalid`);
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ ok: false, code: INVALID_PARAMS });
+    expect(elasticMock.index).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when query is invalid", async () => {
+    const identity = { user: "user", referer: "https://ref", userAgent: "Mozilla" };
+    vi.spyOn(utils, "identify").mockReturnValue(identity);
+
+    const mission = await MissionModel.create({
+      applicationUrl: "https://mission.example.com/apply",
+      clientId: "mission-client-id",
+      lastSyncAt: new Date(),
+      publisherId: new Types.ObjectId().toString(),
+      publisherName: "Mission Publisher",
+      title: "Mission Title",
+    });
+
+    const publisher = await PublisherModel.create({
+      name: "From Publisher",
+    });
+
+    const response = await request(app)
+      .get(`/r/impression/${mission._id.toString()}/${publisher._id.toString()}`)
+      .query({ sourceId: "not-a-valid-object-id" });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ ok: false, code: INVALID_QUERY });
+  });
+
+  it("returns 404 when mission is not found", async () => {
+    const identity = { user: "user", referer: "https://ref", userAgent: "Mozilla" };
+    vi.spyOn(utils, "identify").mockReturnValue(identity);
+
+    const response = await request(app).get(`/r/impression/${new Types.ObjectId().toString()}/${new Types.ObjectId().toString()}`);
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({ ok: false, code: NOT_FOUND });
+  });
+
+  it("returns 404 when publisher is not found", async () => {
+    const identity = { user: "user", referer: "https://ref", userAgent: "Mozilla" };
+    vi.spyOn(utils, "identify").mockReturnValue(identity);
+
+    const mission = await MissionModel.create({
+      applicationUrl: "https://mission.example.com/apply",
+      clientId: "mission-client-id",
+      lastSyncAt: new Date(),
+      publisherId: new Types.ObjectId().toString(),
+      publisherName: "Mission Publisher",
+      title: "Mission Title",
+    });
+
+    const response = await request(app).get(`/r/impression/${mission._id.toString()}/${new Types.ObjectId().toString()}`);
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({ ok: false, code: NOT_FOUND });
+  });
+
+  it("records print stats with widget source when all data is present", async () => {
+    const mission = await MissionModel.create({
+      applicationUrl: "https://mission.example.com/apply",
+      clientId: "mission-client-id",
+      domain: "mission.example.com",
+      title: "Mission Title",
+      postalCode: "75001",
+      departmentName: "Paris",
+      organizationName: "Mission Org",
+      organizationId: "mission-org-id",
+      organizationClientId: "mission-org-client-id",
+      lastSyncAt: new Date(),
+      publisherId: new Types.ObjectId().toString(),
+      publisherName: "Mission Publisher",
+    });
+
+    const publisher = await PublisherModel.create({
+      name: "From Publisher",
+    });
+
+    const widget = await WidgetModel.create({
+      name: "Widget Name",
+      fromPublisherId: new Types.ObjectId().toString(),
+      fromPublisherName: "Widget Source Publisher",
+    });
+
+    const identity = {
+      user: "print-user",
+      referer: "https://referrer.example.com",
+      userAgent: "Mozilla/5.0",
+    };
+
+    vi.spyOn(utils, "identify").mockReturnValue(identity);
+    const statsBotFindOneSpy = vi.spyOn(StatsBotModel, "findOne").mockResolvedValue({ user: identity.user } as any);
+    elasticMock.index.mockResolvedValueOnce({ body: { _id: "print-id" } });
+
+    const requestId = new Types.ObjectId().toString();
+    const response = await request(app)
+      .get(`/r/impression/${mission._id.toString()}/${publisher._id.toString()}`)
+      .set("Host", "redirect.test")
+      .set("Origin", "https://app.example.com")
+      .query({ tracker: "tag", sourceId: widget._id.toString(), requestId });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.data).toMatchObject({
+      _id: "print-id",
+      type: "print",
+      tag: "tag",
+      source: "widget",
+      sourceId: widget._id.toString(),
+      sourceName: widget.name,
+      missionId: mission._id.toString(),
+      missionClientId: mission.clientId,
+      missionDomain: mission.domain,
+      missionTitle: mission.title,
+      missionPostalCode: mission.postalCode,
+      missionDepartmentName: mission.departmentName,
+      missionOrganizationName: mission.organizationName,
+      missionOrganizationId: mission.organizationId,
+      missionOrganizationClientId: mission.organizationClientId,
+      toPublisherId: mission.publisherId,
+      toPublisherName: mission.publisherName,
+      fromPublisherId: publisher._id.toString(),
+      fromPublisherName: publisher.name,
+      isBot: true,
+    });
+
+    expect(elasticMock.index).toHaveBeenCalledWith({
+      index: STATS_INDEX,
+      body: expect.objectContaining({
+        type: "print",
+        host: "redirect.test",
+        origin: "https://app.example.com",
+        referer: identity.referer,
+        userAgent: identity.userAgent,
+        user: identity.user,
+        requestId,
+        tag: "tag",
+        source: "widget",
+        sourceId: widget._id.toString(),
+        sourceName: widget.name,
+        missionId: mission._id.toString(),
+        missionClientId: mission.clientId,
+        toPublisherId: mission.publisherId,
+        toPublisherName: mission.publisherName,
+        fromPublisherId: publisher._id.toString(),
+        fromPublisherName: publisher.name,
+        isBot: true,
+      }),
+    });
+
+    expect(statsBotFindOneSpy).toHaveBeenCalledWith({ user: identity.user });
+  });
+
+  it("returns 200 and records print stats when query has only tracker", async () => {
+    const mission = await MissionModel.create({
+      applicationUrl: "https://mission.example.com/apply",
+      clientId: "mission-client-id",
+      lastSyncAt: new Date(),
+      publisherId: new Types.ObjectId().toString(),
+      publisherName: "Mission Publisher",
+      title: "Mission Title",
+    });
+
+    const publisher = await PublisherModel.create({
+      name: "From Publisher",
+    });
+
+    const identity = {
+      user: "print-user",
+      referer: "https://referrer.example.com",
+      userAgent: "Mozilla/5.0",
+    };
+
+    vi.spyOn(utils, "identify").mockReturnValue(identity);
+    vi.spyOn(StatsBotModel, "findOne").mockResolvedValue(null);
+    elasticMock.index.mockResolvedValueOnce({ body: { _id: "print-id" } });
+
+    const response = await request(app)
+      .get(`/r/impression/${mission._id.toString()}/${publisher._id.toString()}`)
+      .query({ tracker: "tag" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.data.source).toBe("jstag");
+    expect(response.body.data.isBot).toBe(false);
+    expect(response.body.data.sourceId).toBeUndefined();
+  });
+});

--- a/api/tests/integration/api/redirect/widget.test.ts
+++ b/api/tests/integration/api/redirect/widget.test.ts
@@ -1,0 +1,198 @@
+import { Types } from "mongoose";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { JVA_URL, PUBLISHER_IDS, STATS_INDEX } from "../../../../src/config";
+import MissionModel from "../../../../src/models/mission";
+import StatsBotModel from "../../../../src/models/stats-bot";
+import WidgetModel from "../../../../src/models/widget";
+import * as utils from "../../../../src/utils";
+import { elasticMock } from "../../../mocks";
+import { createTestApp } from "../../../testApp";
+
+const app = createTestApp();
+
+describe("RedirectController /widget/:id", () => {
+  beforeEach(async () => {
+    await MissionModel.deleteMany({});
+    await WidgetModel.deleteMany({});
+
+    elasticMock.index.mockReset();
+    elasticMock.update.mockReset();
+
+    elasticMock.index.mockResolvedValue({ body: { _id: "default-widget-click" } });
+    elasticMock.update.mockResolvedValue({});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await MissionModel.deleteMany({});
+    await WidgetModel.deleteMany({});
+  });
+
+  it("redirects to JVA when mission is not found and identity is missing", async () => {
+    vi.spyOn(utils, "identify").mockReturnValue(null);
+
+    const missionId = new Types.ObjectId().toString();
+    const response = await request(app).get(`/r/widget/${missionId}`);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe(JVA_URL);
+    expect(elasticMock.index).not.toHaveBeenCalled();
+  });
+
+  it("redirects to mission application URL when identity is missing but mission exists", async () => {
+    const mission = await MissionModel.create({
+      applicationUrl: "https://mission.example.com/apply",
+      clientId: "mission-client-id",
+      lastSyncAt: new Date(),
+      publisherId: new Types.ObjectId().toString(),
+      publisherName: "Mission Publisher",
+      title: "Mission Title",
+    });
+
+    vi.spyOn(utils, "identify").mockReturnValue(null);
+
+    const response = await request(app).get(`/r/widget/${mission._id.toString()}`);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe("https://mission.example.com/apply");
+    expect(elasticMock.index).not.toHaveBeenCalled();
+  });
+
+  it("records click stats and appends tracking parameters when widget and identity are present", async () => {
+    const mission = await MissionModel.create({
+      applicationUrl: "https://mission.example.com/apply",
+      clientId: "mission-client-id",
+      domain: "mission.example.com",
+      title: "Mission Title",
+      postalCode: "75001",
+      departmentName: "Paris",
+      organizationName: "Mission Org",
+      organizationId: "mission-org-id",
+      organizationClientId: "mission-org-client-id",
+      lastSyncAt: new Date(),
+      publisherId: new Types.ObjectId().toString(),
+      publisherName: "Mission Publisher",
+    });
+
+    const widget = await WidgetModel.create({
+      name: "Widget Name",
+      fromPublisherId: new Types.ObjectId().toString(),
+      fromPublisherName: "From Publisher",
+    });
+
+    const identity = {
+      user: "widget-user",
+      referer: "https://referrer.example.com",
+      userAgent: "Mozilla/5.0",
+    };
+
+    vi.spyOn(utils, "identify").mockReturnValue(identity);
+    const statsBotFindOneSpy = vi.spyOn(StatsBotModel, "findOne").mockResolvedValue({ user: identity.user } as any);
+    elasticMock.index.mockResolvedValueOnce({ body: { _id: "widget-click-id" } });
+
+    const requestId = new Types.ObjectId().toString();
+    const response = await request(app)
+      .get(`/r/widget/${mission._id.toString()}`)
+      .set("Host", "redirect.test")
+      .set("Origin", "https://app.example.com")
+      .query({ widgetId: widget._id.toString(), requestId });
+
+    expect(response.status).toBe(302);
+    const redirectUrl = new URL(response.headers.location);
+    expect(`${redirectUrl.origin}${redirectUrl.pathname}`).toBe("https://mission.example.com/apply");
+    expect(redirectUrl.searchParams.get("apiengagement_id")).toBe("widget-click-id");
+    expect(redirectUrl.searchParams.get("utm_source")).toBe("api_engagement");
+    expect(redirectUrl.searchParams.get("utm_medium")).toBe("widget");
+    expect(redirectUrl.searchParams.get("utm_campaign")).toBe("widget-name");
+
+    expect(elasticMock.index).toHaveBeenCalledWith({
+      index: STATS_INDEX,
+      body: expect.objectContaining({
+        type: "click",
+        user: identity.user,
+        referer: identity.referer,
+        userAgent: identity.userAgent,
+        host: "redirect.test",
+        origin: "https://app.example.com",
+        requestId,
+        source: "widget",
+        sourceId: widget._id.toString(),
+        sourceName: widget.name,
+        missionId: mission._id.toString(),
+        missionClientId: mission.clientId,
+        missionDomain: mission.domain,
+        missionTitle: mission.title,
+        missionPostalCode: mission.postalCode,
+        missionDepartmentName: mission.departmentName,
+        missionOrganizationName: mission.organizationName,
+        missionOrganizationId: mission.organizationId,
+        missionOrganizationClientId: mission.organizationClientId,
+        toPublisherId: mission.publisherId,
+        toPublisherName: mission.publisherName,
+        fromPublisherId: widget.fromPublisherId,
+        fromPublisherName: widget.fromPublisherName,
+        isBot: false,
+      }),
+    });
+
+    expect(statsBotFindOneSpy).toHaveBeenCalledWith({ user: identity.user });
+    expect(elasticMock.update).toHaveBeenCalledWith({
+      index: STATS_INDEX,
+      id: "widget-click-id",
+      body: { doc: { isBot: true } },
+    });
+  });
+
+  it("uses mtm tracking parameters when mission publisher is service civique", async () => {
+    const originalServicePublisherId = PUBLISHER_IDS.SERVICE_CIVIQUE;
+    const servicePublisherId = originalServicePublisherId || new Types.ObjectId().toString();
+    if (!originalServicePublisherId) {
+      PUBLISHER_IDS.SERVICE_CIVIQUE = servicePublisherId;
+    }
+
+    try {
+      const mission = await MissionModel.create({
+        applicationUrl: "https://mission.example.com/apply",
+        clientId: "mission-client-id",
+        lastSyncAt: new Date(),
+        publisherId: servicePublisherId,
+        publisherName: "Service Civique",
+        title: "Mission Title",
+      });
+
+      const widget = await WidgetModel.create({
+        name: "Widget Special",
+        fromPublisherId: new Types.ObjectId().toString(),
+        fromPublisherName: "From Publisher",
+      });
+
+      const identity = {
+        user: "widget-user",
+        referer: "https://referrer.example.com",
+        userAgent: "Mozilla/5.0",
+      };
+
+      vi.spyOn(utils, "identify").mockReturnValue(identity);
+      vi.spyOn(StatsBotModel, "findOne").mockResolvedValue(null);
+      elasticMock.index.mockResolvedValueOnce({ body: { _id: "widget-click-id" } });
+
+      const response = await request(app)
+        .get(`/r/widget/${mission._id.toString()}`)
+        .query({ widgetId: widget._id.toString() });
+
+      expect(response.status).toBe(302);
+      const redirectUrl = new URL(response.headers.location);
+      expect(`${redirectUrl.origin}${redirectUrl.pathname}`).toBe("https://mission.example.com/apply");
+      expect(redirectUrl.searchParams.get("apiengagement_id")).toBe("widget-click-id");
+      expect(redirectUrl.searchParams.get("mtm_source")).toBe("api_engagement");
+      expect(redirectUrl.searchParams.get("mtm_medium")).toBe("widget");
+      expect(redirectUrl.searchParams.get("mtm_campaign")).toBe("widget-special");
+    } finally {
+      if (!originalServicePublisherId) {
+        PUBLISHER_IDS.SERVICE_CIVIQUE = originalServicePublisherId;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add integration coverage for the redirect mission, widget, and print endpoints
- assert tracking parameters and stats payloads when identities are present
- cover failure cases such as invalid parameters, missing identity, and missing resources

## Testing
- npm run test -- tests/integration/api/redirect/widget.test.ts tests/integration/api/redirect/print.test.ts tests/integration/api/redirect/mission.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dcf6ec2584832483e9f6b44c4c9876