### PR TITLE
Handle Prisma migration failures by cancelling Scaleway deployment

### DIFF
--- a/api/Dockerfile.production
+++ b/api/Dockerfile.production
@@ -24,6 +24,11 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY package*.json ./
 
 RUN npm ci --omit=dev

--- a/api/docker-entrypoint.sh
+++ b/api/docker-entrypoint.sh
@@ -1,4 +1,43 @@
 #!/bin/sh
+set -eu
 
-npm run prisma:migrate:deploy
-exec node /app/dist/index.js 
+cancel_scaleway_deployment() {
+  if [ -z "${SCW_DEPLOYMENT_ID:-}" ] || [ -z "${SCW_SECRET_KEY:-}" ]; then
+    echo "Scaleway deployment cancellation skipped: missing SCW_DEPLOYMENT_ID or SCW_SECRET_KEY" >&2
+    return
+  fi
+
+  REGION="${SCW_REGION:-fr-par}"
+  API_URL="${SCW_API_URL:-https://api.scaleway.com}"
+  DEPLOYMENT_ENDPOINT="${API_URL%/}/containers/v1beta1/regions/${REGION}/deployments/${SCW_DEPLOYMENT_ID}/cancel"
+
+  echo "Attempting to cancel Scaleway deployment ${SCW_DEPLOYMENT_ID}..." >&2
+
+  HTTP_CODE=$(curl -sS -o /tmp/scw-cancel-response -w "%{http_code}" \
+    -X POST "${DEPLOYMENT_ENDPOINT}" \
+    -H "Content-Type: application/json" \
+    -H "X-Auth-Token: ${SCW_SECRET_KEY}") || HTTP_CODE="000"
+
+  if [ "${HTTP_CODE}" != "204" ]; then
+    echo "Failed to cancel Scaleway deployment. HTTP status: ${HTTP_CODE}" >&2
+    cat /tmp/scw-cancel-response >&2 || true
+  else
+    echo "Scaleway deployment cancelled." >&2
+  fi
+
+  rm -f /tmp/scw-cancel-response
+}
+
+run_migrations() {
+  echo "Running Prisma migrations..."
+  if npm run prisma:migrate:deploy; then
+    echo "Prisma migrations executed successfully."
+  else
+    echo "Prisma migrations failed." >&2
+    cancel_scaleway_deployment
+    exit 1
+  fi
+}
+
+run_migrations
+exec node /app/dist/index.js


### PR DESCRIPTION
## Summary
- add error handling to the API entrypoint so failed Prisma migrations cancel the active Scaleway deployment and stop boot
- install curl in the production image to allow the cancellation request to be sent safely before the app starts

## Testing
- npm --prefix api run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5245806848324a7b6408a814c09d2