### PR TITLE
chore(jobs): optimize StatsGlobalMissionActivity MV and refresh views job

### DIFF
--- a/api/prisma/core/migrations/20251021000000_update_global_stats_view/migration.sql
+++ b/api/prisma/core/migrations/20251021000000_update_global_stats_view/migration.sql
@@ -1,0 +1,45 @@
+-- 1) Drop indexes et vue
+DROP INDEX IF EXISTS "StatsGlobalMissionActivity_unique_idx";
+DROP INDEX IF EXISTS "StatsGlobalMissionActivity_first_created_idx";
+DROP INDEX IF EXISTS "StatsGlobalMissionActivity_last_created_idx";
+DROP INDEX IF EXISTS "StatsGlobalMissionActivity_from_publisher_idx";
+DROP INDEX IF EXISTS "StatsGlobalMissionActivity_to_publisher_idx";
+DROP INDEX IF EXISTS "StatsGlobalMissionActivity_type_idx";
+DROP MATERIALIZED VIEW IF EXISTS "StatsGlobalMissionActivity";
+
+-- 2) Recréer la vue en groupant UNIQUEMENT par IDs + filtrage des strings vides
+CREATE MATERIALIZED VIEW "StatsGlobalMissionActivity" AS
+SELECT
+  "mission_id",
+  "type",
+  "from_publisher_id",
+  MIN("from_publisher_name") AS "from_publisher_name",
+  "to_publisher_id",
+  MIN("to_publisher_name") AS "to_publisher_name",
+  MIN("created_at") AS "first_created_at",
+  MAX("created_at") AS "last_created_at"
+FROM "public"."StatEvent"
+WHERE "is_bot" IS NOT TRUE
+  AND "mission_id" IS NOT NULL
+  AND TRIM("mission_id") <> ''
+  AND TRIM("from_publisher_id") <> ''
+  AND TRIM("to_publisher_id") <> ''
+GROUP BY
+  "mission_id",
+  "type",
+  "from_publisher_id",
+  "to_publisher_id";
+
+-- 3) Recréer les indexes
+CREATE UNIQUE INDEX "StatsGlobalMissionActivity_unique_idx"
+  ON "StatsGlobalMissionActivity" ("mission_id", "type", "from_publisher_id", "to_publisher_id");
+CREATE INDEX "StatsGlobalMissionActivity_first_created_idx"
+  ON "StatsGlobalMissionActivity" ("first_created_at");
+CREATE INDEX "StatsGlobalMissionActivity_last_created_idx"
+  ON "StatsGlobalMissionActivity" ("last_created_at");
+CREATE INDEX "StatsGlobalMissionActivity_from_publisher_idx"
+  ON "StatsGlobalMissionActivity" ("from_publisher_id");
+CREATE INDEX "StatsGlobalMissionActivity_to_publisher_idx"
+  ON "StatsGlobalMissionActivity" ("to_publisher_id");
+CREATE INDEX "StatsGlobalMissionActivity_type_idx"
+  ON "StatsGlobalMissionActivity" ("type");

--- a/api/src/jobs/update-stats-views/handler.ts
+++ b/api/src/jobs/update-stats-views/handler.ts
@@ -13,32 +13,87 @@ const VIEWS = [
   "StatsGlobalMissionActivity",
 ] as const;
 
+type ViewRefreshed = {
+  view: string;
+  duration: number;
+};
+
 export interface UpdateStatsViewsJobResult extends JobResult {
-  refreshed: string[];
+  refreshed: ViewRefreshed[];
+  errors: string[];
 }
 
-export class UpdateStatsViewsHandler implements BaseHandler<void, UpdateStatsViewsJobResult> {
+export type UpdateStatsViewsPayload = {
+  views?: string[];
+};
+
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000; // 1s, exponential backoff
+
+export class UpdateStatsViewsHandler implements BaseHandler<UpdateStatsViewsPayload | undefined, UpdateStatsViewsJobResult> {
   name = "Mise à jour des vues materialized des stats publiques";
 
-  async handle(): Promise<UpdateStatsViewsJobResult> {
-    const refreshed: string[] = [];
+  async handle(payload?: UpdateStatsViewsPayload): Promise<UpdateStatsViewsJobResult> {
+    const refreshed: ViewRefreshed[] = [];
+    const errors: string[] = [];
 
-    for (const view of VIEWS) {
+    // Determine which views to refresh
+    const allowed = new Set<string>(VIEWS as readonly string[]);
+    const requested = payload?.views && payload.views.length > 0 ? payload.views : (VIEWS as readonly string[]);
+    const viewsToRefresh = requested.filter((v) => allowed.has(v));
+
+    for (const view of viewsToRefresh) {
       try {
-        await prismaCore.$executeRawUnsafe(`REFRESH MATERIALIZED VIEW CONCURRENTLY "${view}"`);
-        refreshed.push(view);
+        const startedAt = new Date();
+        console.log(`Refreshing view ${view}...`);
+
+        // Retry loop for transient failures (e.g., 57P01 admin shutdown)
+        for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+          try {
+            await prismaCore.$executeRawUnsafe(`REFRESH MATERIALIZED VIEW CONCURRENTLY "${view}"`);
+            const duration = (new Date().getTime() - startedAt.getTime()) / 1000;
+            console.log(`View ${view} refreshed in ${duration}s`);
+            refreshed.push({ view, duration });
+            break;
+          } catch (err: any) {
+            const code = err?.meta?.code || err?.code;
+            const message = err?.meta?.message || err?.message;
+            const attemptMsg = `Attempt ${attempt}/${MAX_RETRIES} failed for ${view}${code ? ` (code ${code})` : ""}${message ? `: ${message}` : ""}`;
+            console.warn(attemptMsg);
+
+            if (attempt >= MAX_RETRIES) {
+              captureException(err, { extra: { view, attempts: attempt } });
+              errors.push(view);
+              break;
+            }
+
+            // Backoff before retrying
+            const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+            await this.sleep(delay);
+          }
+        }
       } catch (error) {
         captureException(error, { extra: { view } });
-        throw error;
+        errors.push(view);
       }
+    }
+
+    let message = `Materialized views Postgres mises à jour: ${refreshed.map((v) => `${v.view} (${v.duration}s)`).join(", ")}`;
+    if (errors.length > 0) {
+      message += `\nErreur(s) lors de la mise à jour des vues materialisées: ${errors.join(", ")}`;
     }
 
     return {
       success: true,
       timestamp: new Date(),
-      message: `Vues mises à jour: ${refreshed.join(", ")}`,
+      message,
       refreshed,
+      errors,
     };
+  }
+
+  private sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 }
 


### PR DESCRIPTION
## Description

Pendant la phase de test de la migration ES -> PG, j'ai remarqué que les vues n'étaient pas bien refresh. 
- Migration pour supprimer / recréer la vue `StatsGlobalMissionActivity` qui n'était pas correcte. 
- Optimisation du job de refresh des différentes vues.

J'en ai profité pour créer un [ticket](https://www.notion.so/jeveuxaider/Optimisations-Materialized-views-28e72a322d508065a684f90f819f59c4?source=copy_link) pour essayer de rationaliser les différentes vues, mais pas bloquant pour la migration. 

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [x] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire