### PR TITLE
feat(api): add Service Civique support for L'Etudiant

### DIFF
--- a/api/src/jobs/letudiant/__tests__/transformers.test.ts
+++ b/api/src/jobs/letudiant/__tests__/transformers.test.ts
@@ -98,6 +98,7 @@ describe("L'Etudiant Transformers", () => {
       const results = missionToPilotyJobs(mission, mockCompanyId, mockMandatoryData);
       const result = results[0];
       expect(result.contract_id).toBe(mockMandatoryData.contracts.volontariat);
+      expect(result.name).toBe(`Volontariat - ${mission.title}`);
     });
 
     it("should set localisation to 'organization City' for full remote missions", () => {

--- a/api/src/jobs/letudiant/config.ts
+++ b/api/src/jobs/letudiant/config.ts
@@ -4,7 +4,7 @@ export const DEFAULT_LIMIT = ENV === "production" ? 1000 : 1;
 // Don't want to republish missions in staging
 export const DAYS_AFTER_REPUBLISH = ENV === "production" ? 15 : 10000;
 
-export const WHITELISTED_PUBLISHERS_IDS = [PUBLISHER_IDS.JEVEUXAIDER];
+export const WHITELISTED_PUBLISHERS_IDS = [PUBLISHER_IDS.JEVEUXAIDER, PUBLISHER_IDS.SERVICE_CIVIQUE];
 
 // Used to sign every Piloty API requests
 export const MEDIA_PUBLIC_ID = "letudiant";

--- a/api/src/jobs/letudiant/transformers.ts
+++ b/api/src/jobs/letudiant/transformers.ts
@@ -30,7 +30,7 @@ export function missionToPilotyJobs(mission: Mission, companyId: string, mandato
     return {
       media_public_id: MEDIA_PUBLIC_ID,
       company_public_id: companyId,
-      name: mission.title,
+      name: mission.type === MissionType.VOLONTARIAT ? `Volontariat - ${mission.title}` : mission.title,
       contract_id: mission.type === MissionType.VOLONTARIAT ? mandatoryData.contracts.volontariat : mandatoryData.contracts.benevolat,
       job_category_id: mandatoryData.jobCategories[mission.domain] ?? mandatoryData.jobCategories["autre"],
       localisation: localisation || "France",


### PR DESCRIPTION
## Description

Ajout du support des missions de volontariat (Service Civique) pour l'Etudiant. 

Une soixantaine de missions ont été d'ores et déjà ajoutées en prod : 
https://jobs-stages.letudiant.fr/offres?contracts=6621507a9d6dc3b9e2ed7e66

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Activer-les-missions-de-Service-Civique-diffuser-sur-l-tudiant-21f72a322d508043a59bd776cecc5af7?source=copy_link)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire