### PR TITLE
fix(analytics): fix duplicate terraform variable

### DIFF
--- a/terraform/jobs-analytics.tf
+++ b/terraform/jobs-analytics.tf
@@ -1,5 +1,5 @@
 locals {
-  common_env_vars = {
+  common_analytics_env_vars = {
     "ENV"                     = terraform.workspace
     "DATABASE_URL_CORE"       = local.secrets.DATABASE_URL_CORE
     "DATABASE_URL_ANALYTICS"  = local.secrets.DATABASE_URL_ANALYTICS
@@ -24,5 +24,5 @@ resource "scaleway_job_definition" "analytics-stat-event" {
     timezone = "Europe/Paris"
   }
 
-  env = local.common_env_vars
+  env = local.common_analytics_env_vars
 }


### PR DESCRIPTION
## Description

Fix cette erreur terraform

```
│ Error: Duplicate local value definition
│ 
│   on jobs.tf line 2, in locals:
│    2:   common_env_vars = {
│    3:     "ENV"                        = terraform.workspace
│    4:     "API_URL"                    = "https://${local.api_hostname}"
│    5:     "APP_URL"                    = "https://${local.app_hostname}"
│    6:     "BENEVOLAT_URL"              = "https://${local.benevolat_hostname}"
│    7:     "VOLONTARIAT_URL"            = "https://${local.volontariat_hostname}"
│    8:     "BUCKET_NAME"                = local.bucket_name
│    9:     "SLACK_JOBTEASER_CHANNEL_ID" = terraform.workspace == "production" ? "C080H9MH56W" : ""
│   10:   }
│ 
│ A local value named "common_env_vars" was already defined at
│ jobs-analytics.tf:2,3-8,4. Local value names must be unique within a
│ module.
```

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires
