### PR TITLE
fix(analytics): set job cmd as an env variable

### DIFF
--- a/analytics/Dockerfile.production
+++ b/analytics/Dockerfile.production
@@ -27,6 +27,5 @@ COPY --from=builder /app/db ./db
 
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh
-RUN chmod +x dist/jobs/run-job.js
 
-ENTRYPOINT ["sh", "-c", "/app/docker-entrypoint.sh \"$@\""]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/analytics/db/migrations/20251022122846_add_statEvent.sql
+++ b/analytics/db/migrations/20251022122846_add_statEvent.sql
@@ -3,16 +3,16 @@ CREATE TYPE "analytics_raw"."StatEventType" AS ENUM ('click', 'print', 'apply', 
 CREATE TYPE "analytics_raw"."StatSource" AS ENUM ('api', 'widget', 'campaign', 'seo', 'jstag', 'publisher');
 CREATE TYPE "analytics_raw"."StatEventStatus" AS ENUM ('PENDING', 'VALIDATED', 'CANCEL', 'CANCELED', 'REFUSED', 'CARRIED_OUT');
 
-CREATE TABLE "analytics_raw"."StatEvent" (
+CREATE TABLE IF NOT EXISTS "analytics_raw"."StatEvent" (
   "id" TEXT NOT NULL,
-  "type" "public"."StatEventType" NOT NULL,
+  "type" "analytics_raw"."StatEventType" NOT NULL,
   "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
   "click_id" TEXT,
   "referer" TEXT,
   "host" TEXT,
   "is_bot" BOOLEAN NOT NULL DEFAULT FALSE,
   "is_human" BOOLEAN NOT NULL DEFAULT FALSE,
-  "source" "public"."StatSource" NOT NULL,
+  "source" "analytics_raw"."StatSource" NOT NULL,
   "source_id" TEXT NOT NULL,
   "from_publisher_id" TEXT NOT NULL,
   "to_publisher_id" TEXT NOT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE "analytics_raw"."StatEvent" (
   "mission_client_id" TEXT,
   "tag" TEXT,
   "tags" TEXT[],
-  "status" "public"."StatEventStatus",
+  "status" "analytics_raw"."StatEventStatus",
   "custom_attributes" JSONB,
 
   CONSTRAINT "StatEvent_pkey" PRIMARY KEY ("id")

--- a/analytics/docker-entrypoint.sh
+++ b/analytics/docker-entrypoint.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 
+echo "🚀 Running DB migration..."
 npm run db:migrate
-exec "$@"
+
+if [ -n "${JOB_CMD:-}" ]; then
+  echo "🔧 Executing JOB_CMD: $JOB_CMD"
+  exec sh -lc "$JOB_CMD"
+fi

--- a/terraform/jobs-analytics.tf
+++ b/terraform/jobs-analytics.tf
@@ -16,7 +16,6 @@ resource "scaleway_job_definition" "analytics-stat-event" {
   cpu_limit    = 1000
   memory_limit = 2048
   image_uri    = local.image_analytics_uri
-  command      = "node dist/jobs/run-job.js export-to-analytics-raw StatEvent"
   timeout      = "120m"
 
   cron {
@@ -24,5 +23,7 @@ resource "scaleway_job_definition" "analytics-stat-event" {
     timezone = "Europe/Paris"
   }
 
-  env = local.common_analytics_env_vars
+  env = merge(local.common_analytics_env_vars, {
+    JOB_CMD = "node dist/jobs/run-job.js export-to-analytics-raw StatEvent"
+  })
 }


### PR DESCRIPTION
## Description

Tant que command est présent dans scaleway_job_definition, l’ENTRYPOINT est court-circuité. Voir la doc scalway https://www.scaleway.com/en/docs/serverless-jobs/concepts/#startup-command

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
