### PR TITLE
refactor(analytics): ability to override batch size

### DIFF
--- a/analytics/README.md
+++ b/analytics/README.md
@@ -65,7 +65,8 @@ transform: (row) => {
 
 ## Dépendances requises
 
-- Variables d’environnement : `DATABASE_URL_CORE`, `DATABASE_URL_ANALYTICS`.
+- Variables d’environnement obligatoires : `DATABASE_URL_CORE`, `DATABASE_URL_ANALYTICS`.
+- Optionnel : `BATCH_SIZE`pour surcharger la taille des lots direction dans Scalway lors d'un `Run with option` lors d’un `Run job with options` sans modifier le code/config.
 
 ## Workflow type
 


### PR DESCRIPTION
## Description

* Possibilité de modifier le batch size sans avoir besoin de mettre à jour le code. Sur des grosses tables cela cela peut etre intéressant pour trouver le bon ration d'insertion
* Track le temps de traitement d'un lot batch pour comprendre les points de blocage en cas d'ingestion lente.


## Liens utiles



## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
