### PR TITLE
fix(analytics): no backfill for updatedAt keep it nullable

### DIFF
--- a/analytics/db/migrations/20251031134922_add_updated_at_to_stat_event.sql
+++ b/analytics/db/migrations/20251031134922_add_updated_at_to_stat_event.sql
@@ -1,7 +1,5 @@
 -- migrate:up
-ALTER TABLE "analytics_raw"."StatEvent" ADD COLUMN     "updated_at" TIMESTAMP(3);
-UPDATE "analytics_raw"."StatEvent" SET "updated_at" = "created_at" WHERE "updated_at" IS NULL;
-ALTER TABLE "analytics_raw"."StatEvent" ALTER COLUMN "updated_at" SET NOT NULL;
+ALTER TABLE "analytics_raw"."StatEvent" ADD COLUMN "updated_at" TIMESTAMP(3);
 
 -- migrate:down
 ALTER TABLE "analytics_raw"."StatEvent" DROP COLUMN "updated_at";

--- a/api/prisma/core/migrations/20251031130829_add_updated_at_to_stat_event/migration.sql
+++ b/api/prisma/core/migrations/20251031130829_add_updated_at_to_stat_event/migration.sql
@@ -1,17 +1,2 @@
-/*
-  Warnings:
-
-  - Added the required column `updated_at` to the `StatEvent` table without a default value. This is not possible if the table is not empty.
-    - First add required column `updated_at` to the `StatEvent` without not null
-    - Backfill `updated_at` with `created_at` column
-    - Alter column to set not null parameter to `updated_at
-
-*/
 -- AlterTable
 ALTER TABLE "public"."StatEvent" ADD COLUMN     "updated_at" TIMESTAMP(3);
-
--- Backfill
-UPDATE "public"."StatEvent" SET "updated_at" = "created_at" WHERE "updated_at" IS NULL;
-
--- AlterTable to set NOT NULL
-ALTER TABLE "public"."StatEvent" ALTER COLUMN "updated_at" SET NOT NULL;

--- a/api/prisma/core/schema.core.prisma
+++ b/api/prisma/core/schema.core.prisma
@@ -83,7 +83,7 @@ model StatEvent {
   es_id             String?         @unique
   type              StatEventType
   created_at        DateTime        @default(now())
-  updated_at        DateTime        @updatedAt
+  updated_at        DateTime?       @updatedAt
   click_user        String?
   click_id          String?
   request_id        String?


### PR DESCRIPTION
## Description

Le backfill du `updatedAt` a mis à genou la base de données en staging. Rendant une partie de l'API en 504. Pour éviter ce problème en production on va rendre ce champs `null` il sera mis à jour sur les prochains insert / update dans la table `StatEvent`.

<img width="522" height="396" alt="Capture d’écran 2025-10-31 à 16 21 50" src="https://github.com/user-attachments/assets/cc82d4e5-52d3-4881-9918-8db78e0341be" />

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
