### PR TITLE
refactor(api): fill StatEvent.updated_at with created_at value

### DIFF
--- a/analytics/src/jobs/export-to-analytics-raw/config.ts
+++ b/analytics/src/jobs/export-to-analytics-raw/config.ts
@@ -8,7 +8,7 @@ export const exportDefinitions: ExportDefinition[] = [
       schema: "public",
       table: "StatEvent",
       cursor: {
-        field: "created_at",
+        field: "updated_at",
         idField: "id",
       },
       columns: [

--- a/api/scripts/fill-stat-event-updated-at.ts
+++ b/api/scripts/fill-stat-event-updated-at.ts
@@ -12,32 +12,45 @@ const parseBatchSize = () => {
   return 5000;
 };
 
+const parseLastId = () => {
+  const idx = process.argv.indexOf("--last-id");
+  return idx !== -1 && process.argv[idx + 1] ? process.argv[idx + 1] : null;
+};
+
 const BATCH_SIZE = parseBatchSize();
+const INITIAL_LAST_ID = parseLastId();
 
 async function backfill() {
   let total = 0;
+  let lastId: string | null = INITIAL_LAST_ID;
 
-  let rows = await prismaCore.statEvent.findMany({
-    where: { updated_at: null },
-    select: { id: true },
-    take: BATCH_SIZE,
-    orderBy: { created_at: "asc" },
-  });
+  while (true) {
+    const where = lastId ? { id: { gt: lastId } } : undefined;
 
-  while (rows.length > 0) {
-    const ids = rows.map((row) => row.id);
-
-    await prismaCore.$executeRawUnsafe(`UPDATE "StatEvent" SET updated_at = created_at WHERE id = ANY($1)`, ids);
-
-    total += rows.length;
-    console.log(`Set updated_at for ${total} rows…`);
-
-    rows = await prismaCore.statEvent.findMany({
-      where: { updated_at: null },
-      select: { id: true },
+    const batch = await prismaCore.statEvent.findMany({
+      where,
+      select: { id: true, created_at: true, updated_at: true },
+      orderBy: { id: "asc" },
       take: BATCH_SIZE,
-      orderBy: { created_at: "asc" },
     });
+
+    if (batch.length === 0) {
+      break;
+    }
+
+    const ids = batch.filter((row) => row.updated_at === null || row.updated_at < row.created_at).map((row) => row.id);
+
+    if (ids.length > 0) {
+      const placeholders = ids.map((_, index) => `$${index + 1}`).join(", ");
+      const sql = `UPDATE "StatEvent" SET updated_at = created_at WHERE id IN (${placeholders})`;
+      await prismaCore.$executeRawUnsafe(sql, ...ids);
+
+      total += ids.length;
+      console.log(`Set updated_at for ${total} rows [cursor: ${lastId}]`);
+    }
+
+    const last = batch[batch.length - 1];
+    lastId = last.id;
   }
 
   console.log(`Backfill completed. Total rows updated: ${total}`);


### PR DESCRIPTION
## Description

Pour gérer au mieux l'ingestion de `StatEvent` mettons la valeur de `created_at` dans `updated_at`

## Liens utiles

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [x] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
