### PR TITLE
fix(analytics): reduce dbt run complexity for apply table

### DIFF
--- a/analytics/dbt/analytics/models/marts/stat_event/mart_account.sql
+++ b/analytics/dbt/analytics/models/marts/stat_event/mart_account.sql
@@ -20,13 +20,6 @@ with src as (
       created_at
       > (select coalesce(max(a.created_at), '1900-01-01') from {{ this }} as a)
   {% endif %}
-),
-
-prepared as (
-  select
-    *,
-    md5(stat_event_id::text) as event_hash
-  from src
 )
 
 select
@@ -46,4 +39,4 @@ select
   view_id_raw,
   null::text as url,
   updated_at
-from prepared
+from src

--- a/analytics/dbt/analytics/models/marts/stat_event/mart_apply.sql
+++ b/analytics/dbt/analytics/models/marts/stat_event/mart_apply.sql
@@ -20,13 +20,6 @@ with src as (
       created_at
       > (select coalesce(max(a.created_at), '1900-01-01') from {{ this }} as a)
   {% endif %}
-),
-
-prepared as (
-  select
-    *,
-    md5(stat_event_id::text) as event_hash
-  from src
 )
 
 select
@@ -46,13 +39,5 @@ select
   view_id_raw,
   status,
   custom_attributes,
-  updated_at,
-  concat_ws(
-    '-',
-    substr(event_hash, 1, 8),
-    substr(event_hash, 9, 4),
-    substr(event_hash, 13, 4),
-    substr(event_hash, 17, 4),
-    substr(event_hash, 21, 12)
-  ) as id
-from prepared
+  updated_at
+from src

--- a/analytics/dbt/analytics/models/marts/stat_event/mart_click.sql
+++ b/analytics/dbt/analytics/models/marts/stat_event/mart_click.sql
@@ -20,13 +20,6 @@ with src as (
       created_at
       > (select coalesce(max(c.created_at), '1900-01-01') from {{ this }} as c)
   {% endif %}
-),
-
-prepared as (
-  select
-    *,
-    md5(stat_event_id::text) as event_hash
-  from src
 )
 
 select
@@ -46,13 +39,5 @@ select
   mission_id_raw,
   is_bot,
   is_human,
-  updated_at,
-  concat_ws(
-    '-',
-    substr(event_hash, 1, 8),
-    substr(event_hash, 9, 4),
-    substr(event_hash, 13, 4),
-    substr(event_hash, 17, 4),
-    substr(event_hash, 21, 12)
-  ) as id
-from prepared
+  updated_at
+from src

--- a/analytics/dbt/analytics/models/marts/stat_event/mart_impression.sql
+++ b/analytics/dbt/analytics/models/marts/stat_event/mart_impression.sql
@@ -19,13 +19,6 @@ with src as (
       created_at
       > (select coalesce(max(i.created_at), '1900-01-01') from {{ this }} as i)
   {% endif %}
-),
-
-prepared as (
-  select
-    *,
-    md5(stat_event_id::text) as event_hash
-  from src
 )
 
 select
@@ -40,13 +33,5 @@ select
   to_publisher_id,
   mission_id,
   mission_id_raw,
-  updated_at,
-  concat_ws(
-    '-',
-    substr(event_hash, 1, 8),
-    substr(event_hash, 9, 4),
-    substr(event_hash, 13, 4),
-    substr(event_hash, 17, 4),
-    substr(event_hash, 21, 12)
-  ) as id
-from prepared
+  updated_at
+from src

--- a/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__apply.sql
+++ b/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__apply.sql
@@ -34,7 +34,9 @@ widgets as (
 ),
 
 clicks as (
-  select stat_event_id from {{ ref('stg_stat_event__click') }}
+  select id as stat_event_id
+  from {{ ref('stg_stat_event') }}
+  where type = 'click'
 ),
 
 mission_map as (


### PR DESCRIPTION
## Description

* Les clics CTE extraient `stat_event_id` de `stg_stat_event__click`, ce qui entraîne l'affichage complet de la vue des clics lourds (avec les jointures de mission, l'analyse des référents, etc.) uniquement pour obtenir l'ID. 
* Remplacement par un scan direct de la table de base `(select id as stat_event_id from {{ ref(“stg_stat_event”) }} where type = “click”)`. Cela supprime un recalcul complet de la table par exécution.

Avant
```
 OK created sql incremental model public.mart_apply .................... [SELECT 42130 in 68.53s]
```

Après
```
 OK created sql incremental model public.mart_apply .................... [SELECT 42130 in 23.75s]
```

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
