### PR TITLE
fix(api): backfill moderationEvent without mongoID

### DIFF
--- a/api/scripts/mongo-backfill/backfill-moderation-event.ts
+++ b/api/scripts/mongo-backfill/backfill-moderation-event.ts
@@ -165,7 +165,6 @@ const normalizeModerationEvent = (doc: MongoModerationEventDocument): Normalized
   };
 
   const create: Prisma.ModerationEventCreateInput = {
-    id: record.id,
     missionId: record.missionId,
     moderatorId: record.moderatorId,
     userId: record.userId,


### PR DESCRIPTION
## Description

Comme `moderationEvent` est en bout de chaine on peut se permettre de ne pas garder des IDs mongo, donc enlever les ID dans le script de backfill pour laisser postgres générer des `uuid`

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
