### PR TITLE
fix(analytics): missing SLACK_CRON_CHANNEL_ID for terraform jobs

### DIFF
--- a/terraform/jobs-analytics.tf
+++ b/terraform/jobs-analytics.tf
@@ -5,6 +5,7 @@ locals {
     "DATABASE_URL_ANALYTICS"  = local.secrets.DATABASE_URL_ANALYTICS
     "SENTRY_DSN_JOBS"         = local.secrets.SENTRY_DSN_JOBS
     "SLACK_TOKEN"             = local.secrets.SLACK_TOKEN
+    "SLACK_CRON_CHANNEL_ID"   = local.secrets.SLACK_CRON_CHANNEL_ID
   }
 
   image_analytics_uri = "ghcr.io/${var.github_repository}/analytics:${terraform.workspace == "production" ? "production" : "staging"}${var.image_tag == "latest" ? "" : "-${var.image_tag}"}"


### PR DESCRIPTION
## Description

Il manque dans le `terraform` pour les serverless jobs le `SLACK_CRON_CHANNEL_ID` pour publier une message sur slack sur la bonne exécution du flow


## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
