### PR TITLE
fix(ci): always run dbt metabase sync

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -28,22 +28,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  detect-changes:
-    name: Detect analytics changes
-    runs-on: ubuntu-latest
-    outputs:
-      analytics: ${{ steps.filter.outputs.analytics }}
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            analytics:
-              - 'analytics/**'
-
   test:
-    needs: detect-changes
     uses: ./.github/workflows/tests.yml
     permissions:
       contents: read
@@ -69,7 +54,5 @@ jobs:
   dbt-metabase-sync:
     needs:
       - deploy
-      - detect-changes
-    if: ${{ needs.detect-changes.outputs.analytics == 'true' }}
     uses: ./.github/workflows/dbt-metabase-sync.yml
     secrets: inherit


### PR DESCRIPTION
## Description

Le detect change tient en compte uniquement le commit qui trigger le CI, dans notre flow de mise en production comme on rebase staging vers master le dernier commit n'est pas forcément des changements dans le dossier analytics alors que le reste des commits peut potentiellement contenir des changement nécessitant de lancer le `dbt-metabase-sync`. 

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
