### PR TITLE
fix(api): simplify OR search on organization model

### DIFF
--- a/api/src/services/organization.ts
+++ b/api/src/services/organization.ts
@@ -56,7 +56,6 @@ const buildSearchWhere = (params: OrganizationSearchParams): Prisma.Organization
         const textConditions: Prisma.OrganizationWhereInput[] = [
           { title: { contains: query, mode: "insensitive" } },
           { shortTitle: { contains: query, mode: "insensitive" } },
-          { object: { contains: query, mode: "insensitive" } },
           { rna: { contains: query, mode: "insensitive" } },
           { siret: { contains: query, mode: "insensitive" } },
           { siren: { contains: query, mode: "insensitive" } },


### PR DESCRIPTION
## Description

Même avec l'amélioration des indexes pour la search (https://github.com/betagouv/api-engagement/pull/554) sur la table `Organization` on avait toujours des queries très lentes sur la base de données à cause du champs `object` qui contient trop de texte donc le search `ILIKE` est trop couteux.

Avec `object` ~5secs
```
SELECT *
FROM "public"."organization"
WHERE (
    "public"."organization"."title" ILIKE '%TOUS.%' OR
    "public"."organization"."short_title" ILIKE '%TOUS.%' OR
    "public"."organization"."object" ILIKE '%TOUS.%' OR
    "public"."organization"."rna" ILIKE '%TOUS.%' OR
    "public"."organization"."siret" ILIKE '%TOUS.%' OR
    "public"."organization"."siren" ILIKE '%TOUS.%' OR
    "public"."organization"."names" @> '{tous}')
ORDER BY "public"."organization"."updated_at" DESC LIMIT 25 OFFSET 0
```

Sans `object` ~700ms
```
SELECT *
FROM "public"."organization"
WHERE (
    "public"."organization"."title" ILIKE '%TOUS.%' OR
    "public"."organization"."short_title" ILIKE '%TOUS.%' OR
    "public"."organization"."rna" ILIKE '%TOUS.%' OR
    "public"."organization"."siret" ILIKE '%TOUS.%' OR
    "public"."organization"."siren" ILIKE '%TOUS.%' OR
    "public"."organization"."names" @> '{tous}')
ORDER BY "public"."organization"."updated_at" DESC LIMIT 25 OFFSET 0
```

## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Timeout-sur-le-connection-pool-Prisma-2af72a322d5080c7aef0f1e91955c6e3?source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
