### PR TITLE
fix(app): widget edition mission

### DIFF
--- a/app/src/scenes/widget/components/Settings.jsx
+++ b/app/src/scenes/widget/components/Settings.jsx
@@ -24,7 +24,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
     if (loading) return;
     const fetchMissions = async () => {
       try {
-        const publishers = publisher.publishers.map((p) => p.publisherId);
+        const publishers = publisher.publishers.map((p) => p.diffuseurPublisherId);
         if (publisher.isAnnonceur) publishers.push(publisher.id);
         const query = {
           publishers,


### PR DESCRIPTION
## Description

L'édition de widget ne fonctionnait plus suite à la migration de `Publisher`

<img width="1770" height="1153" alt="image" src="https://github.com/user-attachments/assets/0b9413ec-277a-4296-a87a-e182761e426b" />


## Liens utiles

Erreur Sentry : https://reserve-civique.slack.com/archives/C08QQT4702D/p1763982020497399

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire