### PR TITLE
fix(analytics): publisher is_annonceur field

### DIFF
--- a/analytics/dbt/analytics/models/marts/publisher/__models.yml
+++ b/analytics/dbt/analytics/models/marts/publisher/__models.yml
@@ -26,7 +26,7 @@ models:
         description: Flag indiquant l'accès aux campagnes / emails.
         tests:
           - not_null
-      - name: annonceur
+      - name: is_annonceur
         description: Flag indiquant si le partenaire agit comme annonceur (receveur de candidatures).
         tests:
           - not_null


### PR DESCRIPTION
## Description

Typo dans la documentation sur le champs `is_annonceur` pour la table `Publisher`

```
2025-11-24 14:09:03.212 | WARNING  2025-11-24 13:09:03 +0000 — Field 'ANNONCEUR' not in     _models.py:110 | 
2025-11-24 14:08:57.897 | table 'ANALYTICS.PUBLISHER'
```

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
