### PR TITLE
refactor(analytics): migration to publisher mart

### DIFF
--- a/analytics/dbt/analytics/models/marts/stat_event/__models.yml
+++ b/analytics/dbt/analytics/models/marts/stat_event/__models.yml
@@ -27,7 +27,7 @@ models:
           - not_null
           - relationships:
               arguments:
-                to: source('public', 'Partner')
+                to: ref('publisher')
                 field: id
       - name: to_publisher_id
         description: UUID du partenaire annonceur.
@@ -35,7 +35,7 @@ models:
           - not_null
           - relationships:
               arguments:
-                to: source('public', 'Partner')
+                to: ref('publisher')
                 field: id
       - name: click_id
         description: Référence vers la table `Click` lorsqu’un clic est associé.
@@ -84,7 +84,7 @@ models:
           - not_null
           - relationships:
               arguments:
-                to: source('public', 'Partner')
+                to: ref('publisher')
                 field: id
       - name: to_publisher_id
         description: UUID du partenaire annonceur.
@@ -92,7 +92,7 @@ models:
           - not_null
           - relationships:
               arguments:
-                to: source('public', 'Partner')
+                to: ref('publisher')
                 field: id
       - name: custom_attributes
         description: Champs JSON contenant les attributs personnalisés.
@@ -125,7 +125,7 @@ models:
           - not_null
           - relationships:
               arguments:
-                to: source('public', 'Partner')
+                to: ref('publisher')
                 field: id
       - name: to_publisher_id
         description: UUID du partenaire annonceur.
@@ -133,7 +133,7 @@ models:
           - not_null
           - relationships:
               arguments:
-                to: source('public', 'Partner')
+                to: ref('publisher')
                 field: id
       - name: source
         description: Origine normalisée du clic (`SourceType`).
@@ -168,7 +168,7 @@ models:
           - not_null
           - relationships:
               arguments:
-                to: source('public', 'Partner')
+                to: ref('publisher')
                 field: id
       - name: to_publisher_id
         description: UUID du partenaire annonceur.
@@ -176,7 +176,7 @@ models:
           - not_null
           - relationships:
               arguments:
-                to: source('public', 'Partner')
+                to: ref('publisher')
                 field: id
       - name: source
         description: Origine normalisée de l’impression (`SourceType`).

--- a/analytics/dbt/analytics/models/staging/dim/__models.yml
+++ b/analytics/dbt/analytics/models/staging/dim/__models.yml
@@ -3,19 +3,16 @@ version: 2
 models:
   - name: dim_publisher
     description: >
-      Vue légère sur la table `Partner` (schema public) qui expose uniquement
-      les identifiants nécessaires aux lookups analytics.
+      Vue légère sur le staging `stg_publisher` (snapshot `analytics_raw.publisher`) exposant
+      les identifiants nécessaires aux lookups analytics et quelques métadonnées.
     columns:
       - name: id
-        description: Identifiant UUID du publisher dans l’entrepôt analytics.
+        description: Identifiant du publisher synchronisé (UUID stocké en texte).
         tests:
           - not_null
           - unique
-      - name: publisher_id_raw
-        description: Identifiant partenaire utilisé dans `stat_event` de la base core.
-        tests:
-          - not_null
-          - unique
+      - name: name
+        description: Nom du publisher (utile pour retrouver Service Civique, etc.).
 
   - name: dim_mission
     description: >
@@ -31,8 +28,8 @@ models:
         description: Identifiant mission utilisé dans `stat_event` de la base core.
       - name: client_id
         description: Identifiant client de la mission (clé métier utilisée par `stat_event`).
-      - name: publisher_id_raw
-        description: Identifiant partenaire utilisé dans `stat_event` de la base core.
+      - name: publisher_id
+        description: Identifiant `Partner.id` associé à la mission (UUID stocké en texte).
 
   - name: dim_campaign
     description: >

--- a/analytics/dbt/analytics/models/staging/dim/dim_mission.sql
+++ b/analytics/dbt/analytics/models/staging/dim/dim_mission.sql
@@ -3,9 +3,8 @@ with base as (
     m.id,
     nullif(m.old_id, '') as mission_id_raw,
     nullif(m.client_id, '') as client_id,
-    nullif(p.old_id, '') as publisher_id_raw
+    nullif(m.partner_id::text, '') as publisher_id
   from {{ source('public', 'Mission') }} as m
-  left join {{ source('public', 'Partner') }} as p on m.partner_id = p.id
 )
 
 select * from base

--- a/analytics/dbt/analytics/models/staging/dim/dim_publisher.sql
+++ b/analytics/dbt/analytics/models/staging/dim/dim_publisher.sql
@@ -1,5 +1,4 @@
 select
   id,
-  old_id as publisher_id_raw,
   name
-from {{ source('public', 'Partner') }}
+from {{ ref('stg_publisher') }}

--- a/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__account.sql
+++ b/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__account.sql
@@ -3,9 +3,9 @@ with events as (
     e.*,
     nullif(e.mission_id, '') as mission_id_raw,
     nullif(e.mission_client_id, '') as mission_client_id_raw,
-    nullif(e.to_publisher_id, '') as to_publisher_id_raw,
-    nullif(e.from_publisher_id, '') as from_publisher_id_raw,
-    nullif(e.source_id, '') as source_id_raw,
+    nullif(e.to_publisher_id, '') as to_publisher_id_clean,
+    nullif(e.from_publisher_id, '') as from_publisher_id_clean,
+    nullif(e.source_id, '') as source_id_clean,
     nullif(e.click_id, '') as click_id_raw
   from {{ ref('stg_stat_event') }} as e
   where e.type = 'account'
@@ -14,7 +14,7 @@ with events as (
 publishers as (
   select
     id,
-    publisher_id_raw
+    name
   from {{ ref('dim_publisher') }}
 ),
 
@@ -53,12 +53,12 @@ select
   e.updated_at,
   e.host,
   e.tag,
-  p_from.id as from_publisher_id,
-  p_to.id as to_publisher_id,
   mm.mission_id,
   clk.stat_event_id as click_id,
   e.click_id_raw as view_id_raw,
   mm.resolved_mission_id_raw,
+  coalesce(p_from.id, e.from_publisher_id_clean) as from_publisher_id,
+  coalesce(p_to.id, e.to_publisher_id_clean) as to_publisher_id,
   case
     when coalesce(e.source, 'publisher') in ('publisher', 'api') then 'api'
     else e.source
@@ -66,23 +66,23 @@ select
   case
     when e.source = 'campaign' then c_source.id
     when e.source = 'widget' then w_source.id
-    when e.source = 'publisher' then p_source.id
+    when e.source = 'publisher' then coalesce(p_source.id, e.source_id_clean)
   end as source_id,
   case when e.source = 'campaign' then c_source.id end as campaign_id,
   case when e.source = 'widget' then w_source.id end as widget_id
 from events as e
 left join
   publishers as p_from
-  on e.from_publisher_id_raw = p_from.publisher_id_raw
-left join publishers as p_to on e.to_publisher_id_raw = p_to.publisher_id_raw
+  on e.from_publisher_id_clean = p_from.id
+left join publishers as p_to on e.to_publisher_id_clean = p_to.id
 left join mission_map as mm on e.id = mm.stat_event_id
 left join
   publishers as p_source
-  on e.source = 'publisher' and e.source_id_raw = p_source.publisher_id_raw
+  on e.source = 'publisher' and e.source_id_clean = p_source.id
 left join
   campaigns as c_source
-  on e.source = 'campaign' and e.source_id_raw = c_source.campaign_id_raw
+  on e.source = 'campaign' and e.source_id_clean = c_source.campaign_id_raw
 left join
   widgets as w_source
-  on e.source = 'widget' and e.source_id_raw = w_source.widget_id_raw
+  on e.source = 'widget' and e.source_id_clean = w_source.widget_id_raw
 left join clicks as clk on e.click_id_raw = clk.stat_event_id

--- a/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__apply.sql
+++ b/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__apply.sql
@@ -3,9 +3,9 @@ with events as (
     e.*,
     nullif(e.mission_id, '') as mission_id_raw,
     nullif(e.mission_client_id, '') as mission_client_id_raw,
-    nullif(e.to_publisher_id, '') as to_publisher_id_raw,
-    nullif(e.from_publisher_id, '') as from_publisher_id_raw,
-    nullif(e.source_id, '') as source_id_raw,
+    nullif(e.to_publisher_id, '') as to_publisher_id_clean,
+    nullif(e.from_publisher_id, '') as from_publisher_id_clean,
+    nullif(e.source_id, '') as source_id_clean,
     nullif(e.click_id, '') as click_id_raw,
     nullif(e.status, '') as status_raw
   from {{ ref('stg_stat_event') }} as e
@@ -15,7 +15,7 @@ with events as (
 publishers as (
   select
     id,
-    publisher_id_raw
+    name
   from {{ ref('dim_publisher') }}
 ),
 
@@ -54,14 +54,14 @@ select
   e.updated_at,
   e.host,
   e.tag,
-  p_from.id as from_publisher_id,
-  p_to.id as to_publisher_id,
   mm.mission_id,
   clk.stat_event_id as click_id,
   e.click_id_raw as view_id_raw,
   e.status_raw as status,
   e.custom_attributes,
   mm.resolved_mission_id_raw,
+  coalesce(p_from.id, e.from_publisher_id_clean) as from_publisher_id,
+  coalesce(p_to.id, e.to_publisher_id_clean) as to_publisher_id,
   case
     when coalesce(e.source, 'publisher') in ('publisher', 'api') then 'api'
     else e.source
@@ -69,23 +69,23 @@ select
   case
     when e.source = 'campaign' then c_source.id
     when e.source = 'widget' then w_source.id
-    when e.source = 'publisher' then p_source.id
+    when e.source = 'publisher' then coalesce(p_source.id, e.source_id_clean)
   end as source_id,
   case when e.source = 'campaign' then c_source.id end as campaign_id,
   case when e.source = 'widget' then w_source.id end as widget_id
 from events as e
 left join
   publishers as p_from
-  on e.from_publisher_id_raw = p_from.publisher_id_raw
-left join publishers as p_to on e.to_publisher_id_raw = p_to.publisher_id_raw
+  on e.from_publisher_id_clean = p_from.id
+left join publishers as p_to on e.to_publisher_id_clean = p_to.id
 left join mission_map as mm on e.id = mm.stat_event_id
 left join
   publishers as p_source
-  on e.source = 'publisher' and e.source_id_raw = p_source.publisher_id_raw
+  on e.source = 'publisher' and e.source_id_clean = p_source.id
 left join
   campaigns as c_source
-  on e.source = 'campaign' and e.source_id_raw = c_source.campaign_id_raw
+  on e.source = 'campaign' and e.source_id_clean = c_source.campaign_id_raw
 left join
   widgets as w_source
-  on e.source = 'widget' and e.source_id_raw = w_source.widget_id_raw
+  on e.source = 'widget' and e.source_id_clean = w_source.widget_id_raw
 left join clicks as clk on e.click_id_raw = clk.stat_event_id

--- a/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__click.sql
+++ b/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__click.sql
@@ -3,9 +3,9 @@ with events as (
     e.*,
     nullif(e.mission_id, '') as mission_id_raw,
     nullif(e.mission_client_id, '') as mission_client_id_raw,
-    nullif(e.to_publisher_id, '') as to_publisher_id_raw,
-    nullif(e.from_publisher_id, '') as from_publisher_id_raw,
-    nullif(e.source_id, '') as source_id_raw
+    nullif(e.to_publisher_id, '') as to_publisher_id_clean,
+    nullif(e.from_publisher_id, '') as from_publisher_id_clean,
+    nullif(e.source_id, '') as source_id_clean
   from {{ ref('stg_stat_event') }} as e
   where e.type = 'click'
 ),
@@ -13,7 +13,7 @@ with events as (
 publishers as (
   select
     id,
-    publisher_id_raw
+    name
   from {{ ref('dim_publisher') }}
 ),
 
@@ -45,34 +45,41 @@ select
   e.created_at,
   e.updated_at,
   e.tag,
-  p_from.id as from_publisher_id,
-  p_to.id as to_publisher_id,
   mm.mission_id,
   e.is_bot,
   e.is_human,
   e.referer as url_origin,
   e.click_id,
   mm.resolved_mission_id_raw as mission_id_raw,
+  coalesce(p_from.id, e.from_publisher_id_clean) as from_publisher_id,
+  coalesce(p_to.id, e.to_publisher_id_clean) as to_publisher_id,
   coalesce(e.tags, array[]::text []) as tags,
   case
     when coalesce(e.source, 'publisher') in ('publisher', 'api') then 'api'
     else e.source
   end as source,
-  coalesce(p_source.id, c_source.id, w_source.id) as source_id,
+  coalesce(
+    case
+      when e.source = 'publisher'
+        then coalesce(p_source.id, e.source_id_clean)
+    end,
+    c_source.id,
+    w_source.id
+  ) as source_id,
   case when e.source = 'campaign' then c_source.id end as campaign_id,
   case when e.source = 'widget' then w_source.id end as widget_id
 from events as e
 left join
   publishers as p_from
-  on e.from_publisher_id_raw = p_from.publisher_id_raw
-left join publishers as p_to on e.to_publisher_id_raw = p_to.publisher_id_raw
+  on e.from_publisher_id_clean = p_from.id
+left join publishers as p_to on e.to_publisher_id_clean = p_to.id
 left join mission_map as mm on e.id = mm.stat_event_id
 left join
   publishers as p_source
-  on e.source = 'publisher' and e.source_id_raw = p_source.publisher_id_raw
+  on e.source = 'publisher' and e.source_id_clean = p_source.id
 left join
   campaigns as c_source
-  on e.source = 'campaign' and e.source_id_raw = c_source.campaign_id_raw
+  on e.source = 'campaign' and e.source_id_clean = c_source.campaign_id_raw
 left join
   widgets as w_source
-  on e.source = 'widget' and e.source_id_raw = w_source.widget_id_raw
+  on e.source = 'widget' and e.source_id_clean = w_source.widget_id_raw

--- a/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__mission_map.sql
+++ b/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__mission_map.sql
@@ -6,7 +6,7 @@ with events as (
     e.mission_id as mission_id_raw_source,
     nullif(e.mission_id, '') as mission_id_raw,
     nullif(e.mission_client_id, '') as mission_client_id_raw,
-    nullif(e.to_publisher_id, '') as to_publisher_id_raw
+    nullif(e.to_publisher_id, '') as to_publisher_id
   from {{ ref('stg_stat_event') }} as e
 ),
 
@@ -15,7 +15,7 @@ missions as (
     id,
     mission_id_raw,
     client_id,
-    publisher_id_raw
+    publisher_id
   from {{ ref('dim_mission') }}
 ),
 
@@ -42,7 +42,7 @@ mission_client_partner as (
       e.mission_id_raw is null
       and e.mission_client_id_raw is not null
       and e.mission_client_id_raw = m.client_id
-      and e.to_publisher_id_raw = m.publisher_id_raw
+      and e.to_publisher_id = m.publisher_id
 ),
 
 mission_lookup as (

--- a/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__print.sql
+++ b/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__print.sql
@@ -3,9 +3,9 @@ with events as (
     e.*,
     nullif(e.mission_id, '') as mission_id_raw,
     nullif(e.mission_client_id, '') as mission_client_id_raw,
-    nullif(e.to_publisher_id, '') as to_publisher_id_raw,
-    nullif(e.from_publisher_id, '') as from_publisher_id_raw,
-    nullif(e.source_id, '') as source_id_raw
+    nullif(e.to_publisher_id, '') as to_publisher_id_clean,
+    nullif(e.from_publisher_id, '') as from_publisher_id_clean,
+    nullif(e.source_id, '') as source_id_clean
   from {{ ref('stg_stat_event') }} as e
   where e.type = 'print'
 ),
@@ -13,7 +13,7 @@ with events as (
 publishers as (
   select
     id,
-    publisher_id_raw
+    name
   from {{ ref('dim_publisher') }}
 ),
 
@@ -45,10 +45,10 @@ select
   e.created_at,
   e.updated_at,
   e.host,
-  p_from.id as from_publisher_id,
-  p_to.id as to_publisher_id,
   mm.mission_id,
   mm.resolved_mission_id_raw as mission_id_raw,
+  coalesce(p_from.id, e.from_publisher_id_clean) as from_publisher_id,
+  coalesce(p_to.id, e.to_publisher_id_clean) as to_publisher_id,
   case
     when
       coalesce(e.source, 'publisher') in ('publisher', 'api', 'jstag')
@@ -58,22 +58,22 @@ select
   case
     when e.source = 'campaign' then c_source.id
     when e.source = 'widget' then w_source.id
-    when e.source = 'publisher' then p_source.id
+    when e.source = 'publisher' then coalesce(p_source.id, e.source_id_clean)
   end as source_id,
   case when e.source = 'campaign' then c_source.id end as campaign_id,
   case when e.source = 'widget' then w_source.id end as widget_id
 from events as e
 left join
   publishers as p_from
-  on e.from_publisher_id_raw = p_from.publisher_id_raw
-left join publishers as p_to on e.to_publisher_id_raw = p_to.publisher_id_raw
+  on e.from_publisher_id_clean = p_from.id
+left join publishers as p_to on e.to_publisher_id_clean = p_to.id
 left join mission_map as mm on e.id = mm.stat_event_id
 left join
   publishers as p_source
-  on e.source = 'publisher' and e.source_id_raw = p_source.publisher_id_raw
+  on e.source = 'publisher' and e.source_id_clean = p_source.id
 left join
   campaigns as c_source
-  on e.source = 'campaign' and e.source_id_raw = c_source.campaign_id_raw
+  on e.source = 'campaign' and e.source_id_clean = c_source.campaign_id_raw
 left join
   widgets as w_source
-  on e.source = 'widget' and e.source_id_raw = w_source.widget_id_raw
+  on e.source = 'widget' and e.source_id_clean = w_source.widget_id_raw


### PR DESCRIPTION
## Description

Dans la logique de migration et l'unification des ID entre `core` et `analytics`, il est nécessaire d'effectuer cette migration afin d'utiliser les `id` publisher venant du modèle `analytics.publisher` et plus depuis `public.partner` qui a vocation à disparaitre prochainement.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x\ Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

/!\ Cela va demander de migrer tous les dashboard utilisant des jointres entre les tables `StatEvent` et `Partner` pour l'effectuer sur la table `publisher`. Il risque d'y avoir des incohérences de données le temps de la migration. Voici un aperçu des dashboard important impactés: https://www.notion.so/jeveuxaider/2bf72a322d508058b615e1e7090b3b96?v=2bf72a322d5080ada271000c77ace653&source=copy_link
