### PR TITLE
feat(analytics): new pipeline for publisher diffusion exclusion

### DIFF
--- a/analytics/db/migrations/20251127141243_add_publisher_diffusion_exclusion_schema.sql
+++ b/analytics/db/migrations/20251127141243_add_publisher_diffusion_exclusion_schema.sql
@@ -1,0 +1,13 @@
+-- migrate:up
+CREATE TABLE IF NOT EXISTS "analytics_raw"."publisher_diffusion_exclusion" (
+  "id" TEXT PRIMARY KEY,
+  "excluded_by_annonceur_id" TEXT NOT NULL,
+  "excluded_for_diffuseur_id" TEXT NOT NULL,
+  "organization_client_id" TEXT,
+  "organization_name" TEXT,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- migrate:down
+DROP TABLE IF EXISTS "analytics_raw"."publisher_diffusion_exclusion";

--- a/analytics/dbt/analytics/models/marts/publisher/__models.yml
+++ b/analytics/dbt/analytics/models/marts/publisher/__models.yml
@@ -78,3 +78,47 @@ models:
         description: Horodatage de dernière mise à jour.
         tests:
           - not_null
+  - name: publisher_diffusion_exclusion
+    description: >
+      Table de faits légère listant les exclusions de diffusion entre partenaires, enrichie des libellés annonceur et
+      diffuseur pour faciliter les analyses Metabase.
+    columns:
+      - name: id
+        description: Identifiant unique de la règle d'exclusion.
+        tests:
+          - not_null
+          - unique
+      - name: excluded_by_annonceur_id
+        description: Identifiant du partenaire annonceur à l'origine du blocage.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('publisher')
+                field: id
+      - name: excluded_by_annonceur_name
+        description: Nom du partenaire annonceur (nullable si inconnu).
+      - name: excluded_by_annonceur_deleted_at
+        description: Timestamp de suppression logique de l'annonceur (nullable).
+      - name: excluded_for_diffuseur_id
+        description: Identifiant du partenaire diffuseur ciblé.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('publisher')
+                field: id
+      - name: excluded_for_diffuseur_name
+        description: Nom du partenaire diffuseur (nullable si inconnu).
+      - name: excluded_for_diffuseur_deleted_at
+        description: Timestamp de suppression logique du diffuseur (nullable).
+      - name: organization_client_id
+        description: Identifiant client de l'organisation exclue (nullable).
+      - name: organization_name
+        description: Nom libre de l'organisation exclue (nullable).
+      - name: created_at
+        description: Horodatage de création de la règle.
+      - name: updated_at
+        description: Horodatage de dernière mise à jour, utilisé comme curseur d'export.
+        tests:
+          - not_null

--- a/analytics/dbt/analytics/models/marts/publisher/publisher_diffusion_exclusion.sql
+++ b/analytics/dbt/analytics/models/marts/publisher/publisher_diffusion_exclusion.sql
@@ -1,0 +1,19 @@
+select
+  pde.id,
+  pde.excluded_by_annonceur_id,
+  annonceur.name as excluded_by_annonceur_name,
+  annonceur.deleted_at as excluded_by_annonceur_deleted_at,
+  pde.excluded_for_diffuseur_id,
+  diffuseur.name as excluded_for_diffuseur_name,
+  diffuseur.deleted_at as excluded_for_diffuseur_deleted_at,
+  pde.organization_client_id,
+  pde.organization_name,
+  pde.created_at,
+  pde.updated_at
+from {{ ref('stg_publisher_diffusion_exclusion') }} as pde
+left join
+  {{ ref('stg_publisher') }} as annonceur
+  on pde.excluded_by_annonceur_id = annonceur.id
+left join
+  {{ ref('stg_publisher') }} as diffuseur
+  on pde.excluded_for_diffuseur_id = diffuseur.id

--- a/analytics/dbt/analytics/models/raw.yml
+++ b/analytics/dbt/analytics/models/raw.yml
@@ -278,3 +278,23 @@ sources:
             description: Horodatage de fin de l'import, utilisé comme curseur temporel pour l'incrémentalité.
           - name: status
             description: Statut global retourné par le job (`SUCCESS`, `FAILED`, etc.).
+      - name: publisher_diffusion_exclusion
+        description: >-
+          Exclusions de diffusion configurées entre partenaires (annonceur -> diffuseur) telles que synchronisées depuis
+          la base opérationnelle. Chaque ligne correspond à une règle interdisant à un diffuseur de relayer des missions
+          pour un annonceur donné.
+        columns:
+          - name: id
+            description: Identifiant unique de la règle d'exclusion.
+          - name: excluded_by_annonceur_id
+            description: Identifiant du partenaire annonceur qui crée l'exclusion.
+          - name: excluded_for_diffuseur_id
+            description: Identifiant du partenaire diffuseur visé par l'exclusion.
+          - name: organization_client_id
+            description: Identifiant métier de l'organisation concernée par l'exclusion (nullable).
+          - name: organization_name
+            description: Libellé texte de l'organisation exclue (nullable).
+          - name: created_at
+            description: Timestamp de création de la règle côté application source.
+          - name: updated_at
+            description: Timestamp de dernière mise à jour, utilisé comme curseur d'export incrémental.

--- a/analytics/dbt/analytics/models/staging/publisher/__models.yml
+++ b/analytics/dbt/analytics/models/staging/publisher/__models.yml
@@ -29,3 +29,33 @@ models:
         description: Timestamp de dernière mise à jour (curseur d'incrément).
         tests:
           - not_null
+  - name: stg_publisher_diffusion_exclusion
+    description: >
+      Staging des exclusions de diffusion entre partenaires, exportées depuis `analytics_raw.publisher_diffusion_exclusion`.
+      Chaque ligne décrit la relation annonceur/diffuseur et l'éventuelle organisation ciblée.
+    columns:
+      - name: id
+        description: Identifiant unique de la règle d'exclusion.
+        tests:
+          - not_null
+          - unique
+      - name: excluded_by_annonceur_id
+        description: Identifiant du partenaire annonceur à l'origine de l'exclusion.
+        tests:
+          - not_null
+      - name: excluded_for_diffuseur_id
+        description: Identifiant du partenaire diffuseur concerné.
+        tests:
+          - not_null
+      - name: organization_client_id
+        description: Identifiant client de l'organisation ciblée (nullable).
+      - name: organization_name
+        description: Libellé libre de l'organisation ciblée (nullable).
+      - name: created_at
+        description: Horodatage de création de la règle dans la base source.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Horodatage de dernière mise à jour, utilisé comme curseur d'incrément.
+        tests:
+          - not_null

--- a/analytics/dbt/analytics/models/staging/publisher/stg_publisher_diffusion_exclusion.sql
+++ b/analytics/dbt/analytics/models/staging/publisher/stg_publisher_diffusion_exclusion.sql
@@ -1,0 +1,9 @@
+select
+  id,
+  excluded_by_annonceur_id,
+  excluded_for_diffuseur_id,
+  organization_client_id,
+  organization_name,
+  created_at::timestamp as created_at,
+  updated_at::timestamp as updated_at
+from {{ source('analytics_raw', 'publisher_diffusion_exclusion') }}

--- a/analytics/src/jobs/export-to-analytics-raw/config.ts
+++ b/analytics/src/jobs/export-to-analytics-raw/config.ts
@@ -259,4 +259,20 @@ export const exportDefinitions: ExportDefinition[] = [
       conflictColumns: ["id"],
     },
   },
+  {
+    key: "publisher_diffusion_exclusion",
+    batchSize: 2000,
+    source: {
+      table: "publisher_diffusion_exclusion",
+      cursor: {
+        field: "updated_at",
+        idField: "id",
+      },
+      columns: ["id", "excluded_by_annonceur_id", "excluded_for_diffuseur_id", "organization_client_id", "organization_name", "created_at", "updated_at"],
+    },
+    destination: {
+      table: "publisher_diffusion_exclusion",
+      conflictColumns: ["id"],
+    },
+  },
 ];

--- a/terraform/jobs-analytics.tf
+++ b/terraform/jobs-analytics.tf
@@ -140,6 +140,24 @@ resource "scaleway_job_definition" "analytics-import" {
   })
 }
 
+resource "scaleway_job_definition" "analytics-publisher-diffusion-exclusion" {
+  name         = "analytics-${terraform.workspace}-publisher-diffusion-exclusion"
+  project_id   = var.project_id
+  cpu_limit    = 1000
+  memory_limit = 2048
+  image_uri    = local.image_analytics_uri
+  timeout      = "120m"
+
+  cron {
+    schedule = "0 3 * * *" # Every day at 3:00 AM
+    timezone = "Europe/Paris"
+  }
+
+  env = merge(local.common_analytics_env_vars, {
+    JOB_CMD = "node dist/jobs/run-job.js export-to-analytics-raw publisher_diffusion_exclusion"
+  })
+}
+
 
 resource "scaleway_job_definition" "analytics-dbt-run" {
   name         = "analytics-${terraform.workspace}-dbt-run"


### PR DESCRIPTION
## Description

Nouveau pipeline pour les `publisher_diffusion_exclusion`, il y a plusieurs dashboard metabase qui utlisent `Organization-exclusion` donc dans un premier temps on va garder l'ancien pipeline et on fera la bascule coté metabase progressivement avant de totalement l'enlever.

On anticipe la jointure dans le modèle `dbt` vers `publisher` qui est tout le temps présent lorsque l'on interroge la table `Organization-exclusion` dans `metabase` pour gagner en performance avec un modèle pre-compute

## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Kill-job-global-metabase-2ae72a322d50803e9073ec901528635d?v=1f872a322d5080a38ab2000ce606db06&source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire
