### PR TITLE
fix(analytics): wrong conflict resolution on tf jobs

### DIFF
--- a/terraform/jobs-analytics.tf
+++ b/terraform/jobs-analytics.tf
@@ -158,24 +158,6 @@ resource "scaleway_job_definition" "analytics-publisher-diffusion-exclusion" {
   })
 }
 
-resource "scaleway_job_definition" "analytics-publisher-diffusion-exclusion" {
-  name         = "analytics-${terraform.workspace}-publisher-diffusion-exclusion"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
-
-  cron {
-    schedule = "0 3 * * *" # Every day at 3:00 AM
-    timezone = "Europe/Paris"
-  }
-
-  env = merge(local.common_analytics_env_vars, {
-    JOB_CMD = "node dist/jobs/run-job.js export-to-analytics-raw publisher_diffusion_exclusion"
-  })
-}
-
 resource "scaleway_job_definition" "analytics-user" {
   name         = "analytics-${terraform.workspace}-user"
   project_id   = var.project_id


### PR DESCRIPTION
## Description

Mauvaise résolution de conflit sur le job terraform `analytics-publisher-diffusion-exclusion` qui est dupliqué

```
│ Error: Duplicate resource "scaleway_job_definition" configuration
│ 
│   on jobs-analytics.tf line 161:
│  161: resource "scaleway_job_definition" "analytics-publisher-diffusion-exclusion" {
```

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
