### PR TITLE
refactor(api): remove loginAt field from user

### DIFF
--- a/api/prisma/core/migrations/20251201150726_drop_user_login_at/migration.sql
+++ b/api/prisma/core/migrations/20251201150726_drop_user_login_at/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `login_at` on the `user` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."user" DROP COLUMN "login_at";

--- a/api/prisma/core/schema.core.prisma
+++ b/api/prisma/core/schema.core.prisma
@@ -119,23 +119,22 @@ model Email {
 }
 
 model User {
-  id                      String     @id @default(uuid())
-  firstname               String     @map("first_name")
-  lastname                String?    @map("last_name")
-  email                   String     @unique
+  id                      String    @id @default(uuid())
+  firstname               String    @map("first_name")
+  lastname                String?   @map("last_name")
+  email                   String    @unique
   password                String?
-  role                    UserRole   @default(user)
-  invitationToken         String?    @map("invitation_token")
-  invitationExpiresAt     DateTime?  @map("invitation_expires_at")
-  invitationCompletedAt   DateTime?  @map("invitation_completed_at")
-  lastActivityAt          DateTime?  @map("last_activity_at")
-  loginAt                 DateTime[] @default([]) @map("login_at")
-  forgotPasswordToken     String?    @map("forgot_password_token")
-  forgotPasswordExpiresAt DateTime?  @map("forgot_password_expires_at")
-  deletedAt               DateTime?  @map("deleted_at")
-  brevoContactId          Int?       @map("brevo_contact_id")
-  createdAt               DateTime   @default(now()) @map("created_at")
-  updatedAt               DateTime   @updatedAt @map("updated_at")
+  role                    UserRole  @default(user)
+  invitationToken         String?   @map("invitation_token")
+  invitationExpiresAt     DateTime? @map("invitation_expires_at")
+  invitationCompletedAt   DateTime? @map("invitation_completed_at")
+  lastActivityAt          DateTime? @map("last_activity_at")
+  forgotPasswordToken     String?   @map("forgot_password_token")
+  forgotPasswordExpiresAt DateTime? @map("forgot_password_expires_at")
+  deletedAt               DateTime? @map("deleted_at")
+  brevoContactId          Int?      @map("brevo_contact_id")
+  createdAt               DateTime  @default(now()) @map("created_at")
+  updatedAt               DateTime  @updatedAt @map("updated_at")
 
   userPublishers UserPublisher[]
   loginHistory   LoginHistory[]


### PR DESCRIPTION
## Description

Maintenant qu'on a migré le tableau `loginAt` dans une nouvelle table `login_history` on peut supprimer ce champs de la table `user` qui n'est plus utilisé

## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Kill-job-global-metabase-2ae72a322d50803e9073ec901528635d?source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire
