### PR TITLE
fix(analytics): missing created_at on login history

### DIFF
--- a/analytics/dbt/analytics/models/marts/user/login_history.sql
+++ b/analytics/dbt/analytics/models/marts/user/login_history.sql
@@ -20,5 +20,6 @@ with base as (
 
 select
   user_id,
-  login_at
+  login_at,
+  created_at
 from base


### PR DESCRIPTION
## Description

Il manque le champs `created_at` pour faire la syncro incrémental du modèle `login_history`. 
```
08:08:23  Failure in model login_history (models/marts/user/login_history.sql)
08:08:23    Database Error in model login_history (models/marts/user/login_history.sql)
  column lh.created_at does not exist
  LINE 23:       select coalesce(max(lh.created_at), '1900-01-01')
```

Cela n'a pas été vu initialement car à la première synchro il n'était pas nécessaire c'était au 2ème run que l'erreur apparaissait. 

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
