### PR TITLE
feat(app): add sapeurs pompier in publisher's mission type

### DIFF
--- a/api/prisma/core/migrations/20251202122656_add_volontariat_sapeur_pompier_mission_type/migration.sql
+++ b/api/prisma/core/migrations/20251202122656_add_volontariat_sapeur_pompier_mission_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "public"."MissionType" ADD VALUE 'volontariat_sapeurs_pompiers';

--- a/api/prisma/core/schema.core.prisma
+++ b/api/prisma/core/schema.core.prisma
@@ -45,6 +45,7 @@ enum ReportDataTemplate {
 enum MissionType {
   benevolat
   volontariat_service_civique
+  volontariat_sapeurs_pompiers
 }
 
 enum MissionEventType {

--- a/api/scripts/update-sdis-publisher.ts
+++ b/api/scripts/update-sdis-publisher.ts
@@ -1,0 +1,31 @@
+/**
+ * Script that updates the publisher with "SDIS" in the name to have the mission type "volontariat_sapeurs_pompiers".
+ */
+import { prismaCore } from "../src/db/postgres";
+import { PublisherMissionType } from "../src/types/publisher";
+
+async function run() {
+  const count = await prismaCore.publisher.count({
+    where: { name: { contains: "SDIS", mode: "insensitive" } },
+  });
+
+  console.log(`Found ${count} publishers`);
+
+  const res = await prismaCore.publisher.updateMany({
+    where: { name: { contains: "SDIS", mode: "insensitive" } },
+    data: { missionType: PublisherMissionType.VOLONTARIAT_SAPEURS_POMPIERS },
+  });
+
+  console.log(`Updated ${res.count} publishers`);
+
+  const sapeursPompiersPublishers = await prismaCore.publisher.count({
+    where: { missionType: PublisherMissionType.VOLONTARIAT_SAPEURS_POMPIERS },
+  });
+
+  console.log(`Found ${sapeursPompiersPublishers} publishers with mission type "volontariat_sapeurs_pompiers"`);
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/api/src/controllers/publisher.ts
+++ b/api/src/controllers/publisher.ts
@@ -10,7 +10,7 @@ import { publisherDiffusionExclusionService } from "../services/publisher-diffus
 import { OBJECT_ACL, putObject } from "../services/s3";
 import { userService } from "../services/user";
 import { UserRequest } from "../types/passport";
-import type { PublisherDiffusionInput, PublisherRoleFilter } from "../types/publisher";
+import { PublisherMissionType, type PublisherDiffusionInput, type PublisherRoleFilter } from "../types/publisher";
 
 const upload = multer();
 const router = Router();
@@ -18,7 +18,7 @@ const router = Router();
 const nullableString = zod.string().nullish();
 const publisherDiffusionSchema = zod.object({
   publisherId: zod.string().min(1),
-  missionType: zod.string().nullable().optional(),
+  missionType: zod.enum(PublisherMissionType).nullable().optional(),
   moderator: zod.boolean().optional(),
 });
 
@@ -27,7 +27,7 @@ type PublisherDiffusionBody = zod.infer<typeof publisherDiffusionSchema>;
 const mapPublishersForService = (publishers?: PublisherDiffusionBody[]): PublisherDiffusionInput[] | undefined =>
   publishers?.map(({ publisherId, missionType, moderator }) => ({
     publisherId,
-    missionType: missionType ?? null,
+    missionType: (missionType as PublisherMissionType) ?? null,
     moderator: moderator ?? false,
   }));
 
@@ -42,7 +42,7 @@ router.post("/search", passport.authenticate(["user", "admin"], { session: false
         ids: zod.array(zod.string()).optional(),
         role: zod.string().optional(),
         sendReport: zod.boolean().optional(),
-        missionType: zod.string().optional(),
+        missionType: zod.enum(PublisherMissionType).nullable().optional(),
       })
       .safeParse(req.body);
 
@@ -172,7 +172,7 @@ router.post("/", passport.authenticate("admin", { session: false }), async (req:
         sendReport: zod.boolean().default(false),
         sendReportTo: zod.array(zod.string()).default([]),
         isAnnonceur: zod.boolean().default(false),
-        missionType: zod.string().nullable().default(null),
+        missionType: zod.enum(PublisherMissionType).nullable().default(null),
         hasApiRights: zod.boolean().default(false),
         hasWidgetRights: zod.boolean().default(false),
         hasCampaignRights: zod.boolean().default(false),
@@ -311,7 +311,7 @@ router.put("/:id", passport.authenticate("admin", { session: false }), async (re
         sendReport: zod.boolean().optional(),
         sendReportTo: zod.array(zod.string()).optional(),
         isAnnonceur: zod.boolean().optional(),
-        missionType: zod.string().nullable().optional(),
+        missionType: zod.enum(PublisherMissionType).nullable().optional(),
         hasApiRights: zod.boolean().optional(),
         hasWidgetRights: zod.boolean().optional(),
         hasCampaignRights: zod.boolean().optional(),

--- a/api/src/services/publisher.ts
+++ b/api/src/services/publisher.ts
@@ -3,7 +3,15 @@ import { v4 as uuid } from "uuid";
 
 import { MissionType, Prisma, Publisher, PublisherDiffusion } from "../db/core";
 import { publisherRepository } from "../repositories/publisher";
-import { PublisherCreateInput, PublisherDiffusionInput, PublisherDiffusionRecord, PublisherRecord, PublisherSearchParams, PublisherUpdatePatch } from "../types/publisher";
+import {
+  PublisherCreateInput,
+  PublisherDiffusionInput,
+  PublisherDiffusionRecord,
+  PublisherMissionType,
+  PublisherRecord,
+  PublisherSearchParams,
+  PublisherUpdatePatch,
+} from "../types/publisher";
 import { normalizeCollection, normalizeOptionalString } from "../utils";
 
 type PublisherWithDiffusion = Publisher & { diffuseurs?: PublisherDiffusion[] };
@@ -23,7 +31,7 @@ export const publisherService = (() => {
     diffuseurPublisherId: diffusion.diffuseurPublisherId,
     annonceurPublisherId: diffusion.annonceurPublisherId,
     moderator: diffusion.moderator,
-    missionType: diffusion.missionType ?? null,
+    missionType: (diffusion.missionType as PublisherMissionType) ?? null,
     createdAt: diffusion.createdAt,
     updatedAt: diffusion.updatedAt,
   });
@@ -46,7 +54,7 @@ export const publisherService = (() => {
     feedPassword: publisher.feedPassword ?? null,
     apikey: publisher.apikey ?? null,
     description: publisher.description ?? "",
-    missionType: publisher.missionType ?? null,
+    missionType: (publisher.missionType as PublisherMissionType) ?? null,
     isAnnonceur: publisher.isAnnonceur,
     hasApiRights: publisher.hasApiRights,
     hasWidgetRights: publisher.hasWidgetRights,
@@ -173,7 +181,7 @@ export const publisherService = (() => {
       feedPassword: normalizeOptionalString(input.feedPassword),
       apikey: normalizeOptionalString(input.apikey),
       description: normalizeOptionalString(input.description) ?? "",
-      missionType: (normalizeOptionalString(input.missionType) as MissionType) ?? null,
+      missionType: (normalizeOptionalString(input.missionType) as PublisherMissionType) ?? null,
       isAnnonceur: input.isAnnonceur ?? false,
       hasApiRights: input.hasApiRights ?? false,
       hasWidgetRights: input.hasWidgetRights ?? false,

--- a/api/src/types/publisher.ts
+++ b/api/src/types/publisher.ts
@@ -1,12 +1,18 @@
 export type PublisherRoleFilter = "annonceur" | "diffuseur" | "api" | "widget" | "campaign";
 
+export enum PublisherMissionType {
+  VOLONTARIAT_SERVICE_CIVIQUE = "volontariat_service_civique",
+  BENEVOLAT = "benevolat",
+  VOLONTARIAT_SAPEURS_POMPIERS = "volontariat_sapeurs_pompiers",
+}
+
 export interface PublisherDiffusionInput {
   diffuseurPublisherId?: string;
   publisherId?: string;
   diffuseurPublisherName?: string;
   publisherName?: string;
   moderator?: boolean;
-  missionType?: string | null;
+  missionType?: PublisherMissionType | null;
 }
 
 export interface PublisherDiffusionRecord {
@@ -14,7 +20,7 @@ export interface PublisherDiffusionRecord {
   diffuseurPublisherId: string;
   annonceurPublisherId: string;
   moderator: boolean;
-  missionType: string | null;
+  missionType: PublisherMissionType | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -37,7 +43,7 @@ export interface PublisherRecord {
   feedPassword: string | null;
   apikey: string | null;
   description: string;
-  missionType: string | null;
+  missionType: PublisherMissionType | null;
   isAnnonceur: boolean;
   hasApiRights: boolean;
   hasWidgetRights: boolean;
@@ -57,7 +63,7 @@ export interface PublisherSearchParams {
   ids?: string[];
   role?: PublisherRoleFilter;
   sendReport?: boolean;
-  missionType?: string | null;
+  missionType?: PublisherMissionType | null;
   includeDeleted?: boolean;
   accessiblePublisherIds?: string[];
 }
@@ -78,7 +84,7 @@ export interface PublisherCreateInput {
   feedUsername?: string | null;
   feedPassword?: string | null;
   apikey?: string | null;
-  missionType?: string | null;
+  missionType?: PublisherMissionType | null;
   isAnnonceur?: boolean;
   hasApiRights?: boolean;
   hasWidgetRights?: boolean;

--- a/app/src/constants/index.js
+++ b/app/src/constants/index.js
@@ -194,6 +194,7 @@ export const PUBLISHER_CATEGORIES = {
 };
 
 export const MISSION_TYPES = {
-  VOLONTARIAT: { slug: "volontariat_service_civique", label: "Volontariat (Service Civique)" },
+  VOLONTARIAT_SERVICE_CIVIQUE: { slug: "volontariat_service_civique", label: "Volontariat (Service Civique)" },
   BENEVOLAT: { slug: "benevolat", label: "Bénévolat" },
+  VOLONTARIAT_SAPERS_POMPIERS: { slug: "volontariat_sapeurs_pompiers", label: "Volontariat (Sapeurs-Pompiers)" },
 };

--- a/app/src/scenes/admin-account/Publishers.jsx
+++ b/app/src/scenes/admin-account/Publishers.jsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 
 import Loader from "../../components/Loader";
 import Table from "../../components/Table";
+import { MISSION_TYPES } from "../../constants";
 import api from "../../services/api";
 import { captureError } from "../../services/error";
 import exportCSV from "../../services/utils";
@@ -167,8 +168,11 @@ const Publishers = () => {
             onChange={(e) => setFilters({ ...filters, missionType: e.target.value })}
           >
             <option value="">Type de mission</option>
-            <option value="benevolat">Missions de bénévolat</option>
-            <option value="volontariat_service_civique">Missions de volontariat</option>
+            {Object.values(MISSION_TYPES).map((mission) => (
+              <option key={mission.slug} value={mission.slug}>
+                {mission.label}
+              </option>
+            ))}
           </select>
         </div>
         {loading ? (

--- a/app/src/utils/publisher.js
+++ b/app/src/utils/publisher.js
@@ -52,4 +52,4 @@ export const withLegacyPublisher = (publisher = {}) => {
 
 export const withLegacyPublishers = (items = []) => items.map((publisher) => withLegacyPublisher(publisher));
 
-export { sanitizeNullableString, formatPublishersForApi };
+export { formatPublishersForApi, sanitizeNullableString };


### PR DESCRIPTION
## Description

Add volontariat_sapeurs_pompier to the publisher mission type field

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Rajouter-le-type-Volontariat-Sapeur-Pompiers-c-t-Annonceur-2bc72a322d5080208d3cdac5aca83c9c?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
