### PR TITLE
fix(analytics): select the right publisher id

### DIFF
--- a/analytics/dbt/analytics/models/staging/kpi/stg_kpi__mission_daily.sql
+++ b/analytics/dbt/analytics/models/staging/kpi/stg_kpi__mission_daily.sql
@@ -12,7 +12,7 @@ with mission_source as (
     coalesce(m.places, 0) as places,
     upper(coalesce(m.places_status, 'ATTRIBUTED_BY_API')) as places_status
   from {{ source('public', 'Mission') }} as m
-  left join {{ ref('publisher') }} as p on m.partner_id = p.id
+  left join {{ ref('dim_publisher') }} as p on m.partner_id = p.id
 ),
 
 missions as (


### PR DESCRIPTION
## Description

Au niveau des données dans la table `publisher` nous avons l'id du champs dans la base `core` alors que `Mission` à un `partner_id` qui est l'id au niveau de la base `analytics`. On utilise donc la dimension `dim_publisher` qui permet d'avoir la possibilité de choisir l'id qui nous intéresse `id` (analytics) ou `publisher_id_raw` (core).

Cette situation est temporaire le temps de la migration car la vision est d'avoir des ID iso entre `core` et `analytics` pour simplifier la gestion et la debug.

## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Migrer-les-questions-Metabase-KPI-vers-le-nouveau-mod-le-2bc72a322d5080ae8e84ec125bda4728?source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire