### PR TITLE
fix(app): block current day selection in date range picker

### DIFF
--- a/app/src/components/DateRangePicker.jsx
+++ b/app/src/components/DateRangePicker.jsx
@@ -3,7 +3,7 @@ import fr from "date-fns/locale/fr";
 import { useEffect, useState } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
-import { RiArrowDownSLine, RiArrowLeftSLine, RiArrowRightSLine } from "react-icons/ri";
+import { RiArrowDownSLine, RiArrowLeftSLine, RiArrowRightSLine, RiInformationLine } from "react-icons/ri";
 
 const NOW = new Date();
 const YESTERDAY = new Date(NOW.getFullYear(), NOW.getMonth(), NOW.getDate() - 1);
@@ -69,7 +69,7 @@ export const DateInput = ({ value, onChange }) => {
       <PopoverPanel
         transition
         anchor="bottom"
-        className="border-grey-border divide-grey-border mt-1 origin-top divide-y border bg-white p-10 shadow-lg transition duration-200 ease-out focus:outline-none data-closed:scale-95 data-closed:opacity-0"
+        className="border-grey-border divide-grey-border mt-1 origin-top divide-y border bg-white px-8 pt-6 pb-4 shadow-lg transition duration-200 ease-out focus:outline-none data-closed:scale-95 data-closed:opacity-0"
       >
         <div className="flex gap-6">
           <ul className="m-0 flex w-44 list-none flex-col p-0 text-base" role="list" aria-label="Périodes disponibles">
@@ -138,7 +138,7 @@ export const DateInput = ({ value, onChange }) => {
             onChange={handleChange}
             startDate={from}
             endDate={to}
-            maxDate={NOW}
+            maxDate={YESTERDAY}
             locale={fr}
             selectsRange
             inline
@@ -146,6 +146,10 @@ export const DateInput = ({ value, onChange }) => {
             calendarContainer={DatePickerContainer}
           />
         </div>
+        <p className="text-grey-text flex items-center gap-1 pt-4 text-sm">
+          <RiInformationLine className="shrink-0" aria-hidden="true" />
+          Les données du jour en cours ne sont pas encore disponibles.
+        </p>
       </PopoverPanel>
     </Popover>
   );

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -315,7 +315,6 @@ select {
   border-radius: 0 !important;
   border: none;
   color: #000091;
-  padding-top: 6px;
   color: var(--color-blue-france);
 }
 .react-datepicker__day:not(.react-datepicker__day--disabled):hover {

--- a/app/src/scenes/admin-stats/Announcer.jsx
+++ b/app/src/scenes/admin-stats/Announcer.jsx
@@ -13,7 +13,7 @@ const Announcer = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [filters, setFilters] = useState({
     from: searchParams.has("from") ? new Date(searchParams.get("from")) : new Date(new Date().getFullYear() - 1, new Date().getMonth(), new Date().getDate()),
-    to: searchParams.has("to") ? new Date(searchParams.get("to")) : new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() + 1, 0, 0, 0, -1),
+    to: searchParams.has("to") ? new Date(searchParams.get("to")) : new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate(), 0, 0, 0, -1),
     type: searchParams.get("type") || "",
     publisher: searchParams.get("announcer") || "",
   });

--- a/app/src/scenes/admin-stats/Apercu.jsx
+++ b/app/src/scenes/admin-stats/Apercu.jsx
@@ -17,8 +17,9 @@ const toEndOfDay = (date) => new Date(date.getFullYear(), date.getMonth(), date.
 
 const buildDefaultFilters = (searchParams) => {
   const now = new Date();
+  const yesterday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1);
   const defaultFrom = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
-  const defaultTo = toEndOfDay(now);
+  const defaultTo = toEndOfDay(yesterday);
 
   const fromValue = searchParams.get("from");
   const toValue = searchParams.get("to");

--- a/app/src/scenes/admin-stats/Broacaster.jsx
+++ b/app/src/scenes/admin-stats/Broacaster.jsx
@@ -13,7 +13,7 @@ const Broacaster = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [filters, setFilters] = useState({
     from: searchParams.has("from") ? new Date(searchParams.get("from")) : new Date(new Date().getFullYear() - 1, new Date().getMonth(), new Date().getDate()),
-    to: searchParams.has("to") ? new Date(searchParams.get("to")) : new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() + 1, 0, 0, 0, -1),
+    to: searchParams.has("to") ? new Date(searchParams.get("to")) : new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate(), 0, 0, 0, -1),
     type: searchParams.get("type") || "",
     publisher: searchParams.get("broadcaster") || "",
     source: searchParams.get("source") || "",

--- a/app/src/scenes/performance/index.jsx
+++ b/app/src/scenes/performance/index.jsx
@@ -14,7 +14,7 @@ const Performance = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [filters, setFilters] = useState({
     from: searchParams.has("from") ? new Date(searchParams.get("from")) : new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() - 30),
-    to: searchParams.has("to") ? new Date(searchParams.get("to")) : new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() + 1, 0, 0, 0, -1),
+    to: searchParams.has("to") ? new Date(searchParams.get("to")) : new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate(), 0, 0, 0, -1),
   });
   const location = useLocation();
   const isTabbed = flux === "from";


### PR DESCRIPTION
## Description

Bloque la sélection de la date du jour dans le date picker, car les données du jour en cours ne sont pas disponibles (le recalcul Metabase a lieu une fois par jour).

**Changements** :
- `maxDate` du calendrier passé de aujourd'hui à hier
- Ajout d'un message d'information dans le popover du date picker

<img width="781" height="424" alt="Screenshot 2026-04-02 at 17 50 17" src="https://github.com/user-attachments/assets/897ea6c7-c4bb-4b2b-8a2e-76654ba9dffd" />

- Mise à jour des filtres par défaut dans toutes les pages (performance, admin-stats) pour que la date de fin soit hier au lieu d'aujourd'hui

**Pages impactées** :
- `DateRangePicker` (composant partagé)
- `performance/index.jsx`
- `admin-stats/Announcer.jsx`
- `admin-stats/Broacaster.jsx`
- `admin-stats/Apercu.jsx`

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Emp-cher-la-s-lection-de-la-date-du-jour-dans-le-datepicker-32572a322d5080448c6defc72ff79d1c?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Aucune migration DB. Les presets de dates (7 jours, 30 jours, etc.) utilisaient déjà hier comme date de fin — seul le calendrier et les filtres par défaut des pages permettaient de sélectionner aujourd'hui.