### PR TITLE
fix(app): widget edit form

### DIFF
--- a/api/src/controllers/mission.ts
+++ b/api/src/controllers/mission.ts
@@ -32,6 +32,7 @@ const searchSchema = zod.object({
   lon: zod.coerce.number().min(-180).max(180).optional(),
   location: zod.string().optional(),
   distance: zod.string().optional(),
+  type: zod.array(zod.string()).optional(),
   rules: zod
     .array(
       zod.object({
@@ -92,6 +93,7 @@ const findFilters = (user: UserRequest["user"], body: zod.infer<typeof searchSch
     city: asArray(body.cities),
     departmentName: asArray(body.department),
     organizationIds: asArray(body.organizationIds),
+    type: body.type,
   };
 
   if (body.status) {

--- a/api/src/controllers/widget.ts
+++ b/api/src/controllers/widget.ts
@@ -158,7 +158,7 @@ router.post("/", passport.authenticate("admin", { session: false }), async (req:
 
         style: zod.enum(["carousel", "page"]).optional(),
         color: zod.string().optional(),
-        type: zod.enum(["benevolat", "volontariat"]).optional(),
+        type: zod.enum(["benevolat", "volontariat_service_civique", "volontariat_sapeurs_pompiers", "volontariat_reserve_operationnelle"]).optional(),
         active: zod.coerce.boolean().optional(),
         publishers: zod.array(zod.string()).optional(),
         jvaModeration: zod.coerce.boolean().optional(),
@@ -246,7 +246,7 @@ router.put("/:id", passport.authenticate("admin", { session: false }), async (re
 
         style: zod.enum(["carousel", "page"]).optional(),
         color: zod.string().optional(),
-        type: zod.enum(["benevolat", "volontariat"]).optional(),
+        type: zod.enum(["benevolat", "volontariat_service_civique", "volontariat_sapeurs_pompiers", "volontariat_reserve_operationnelle"]).optional(),
         active: zod.coerce.boolean().optional(),
         publishers: zod.array(zod.string()).optional(),
         jvaModeration: zod.coerce.boolean().optional(),

--- a/api/src/controllers/widget.ts
+++ b/api/src/controllers/widget.ts
@@ -158,7 +158,7 @@ router.post("/", passport.authenticate("admin", { session: false }), async (req:
 
         style: zod.enum(["carousel", "page"]).optional(),
         color: zod.string().optional(),
-        type: zod.enum(["benevolat", "volontariat_service_civique", "volontariat_sapeurs_pompiers", "volontariat_reserve_operationnelle"]).optional(),
+        type: zod.enum(["benevolat", "volontariat", "volontariat_sapeurs_pompiers", "volontariat_reserve_operationnelle"]).optional(),
         active: zod.coerce.boolean().optional(),
         publishers: zod.array(zod.string()).optional(),
         jvaModeration: zod.coerce.boolean().optional(),
@@ -246,7 +246,7 @@ router.put("/:id", passport.authenticate("admin", { session: false }), async (re
 
         style: zod.enum(["carousel", "page"]).optional(),
         color: zod.string().optional(),
-        type: zod.enum(["benevolat", "volontariat_service_civique", "volontariat_sapeurs_pompiers", "volontariat_reserve_operationnelle"]).optional(),
+        type: zod.enum(["benevolat", "volontariat", "volontariat_sapeurs_pompiers", "volontariat_reserve_operationnelle"]).optional(),
         active: zod.coerce.boolean().optional(),
         publishers: zod.array(zod.string()).optional(),
         jvaModeration: zod.coerce.boolean().optional(),

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -503,7 +503,7 @@ const buildAggregations = async (where: Prisma.MissionWhereInput): Promise<Missi
         key: row.key,
         doc_count: row.doc_count,
         label: publisher?.name,
-        mission_type: publisher?.missionType === "volontariat_service_civique" ? "volontariat" : "benevolat",
+        mission_type: publisher?.missionType ?? "benevolat",
       };
     })
     .filter((row) => isNonEmpty(row.key))

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -503,7 +503,10 @@ const buildAggregations = async (where: Prisma.MissionWhereInput): Promise<Missi
         key: row.key,
         doc_count: row.doc_count,
         label: publisher?.name,
-        mission_type: publisher?.missionType ?? "benevolat",
+        mission_type:
+          publisher?.missionType === "volontariat_service_civique"
+            ? "volontariat"
+            : (publisher?.missionType ?? "benevolat"),
       };
     })
     .filter((row) => isNonEmpty(row.key))

--- a/api/src/services/publisher.ts
+++ b/api/src/services/publisher.ts
@@ -16,7 +16,7 @@ import {
 import { normalizeCollection, normalizeOptionalString } from "@/utils";
 
 type PrismaPublisherWithRelation = Publisher & {
-  diffuseurs?: PublisherDiffusion[];
+  diffuseurs?: (PublisherDiffusion & { diffuseur?: Publisher })[];
   diffusionExclusionsFor?: PublisherDiffusionExclusion[];
   diffusionExclusionsBy?: PublisherDiffusionExclusion[];
 };
@@ -28,11 +28,12 @@ export class PublisherNotFoundError extends Error {
 }
 
 export const publisherService = (() => {
-  const defaultInclude = Object.freeze({ diffuseurs: true }) satisfies Prisma.PublisherInclude;
+  const defaultInclude = Object.freeze({ diffuseurs: { include: { diffuseur: true } } }) satisfies Prisma.PublisherInclude;
 
-  const toDiffusionRecord = (diffusion: PublisherDiffusion): PublisherDiffusionRecord => ({
+  const toDiffusionRecord = (diffusion: PublisherDiffusion & { diffuseur?: Publisher }): PublisherDiffusionRecord => ({
     id: diffusion.id,
     diffuseurPublisherId: diffusion.diffuseurPublisherId,
+    diffuseurPublisherName: diffusion.diffuseur?.name ?? null,
     annonceurPublisherId: diffusion.annonceurPublisherId,
     moderator: diffusion.moderator,
     missionType: (diffusion.missionType as PublisherMissionType) ?? null,

--- a/api/src/types/publisher.ts
+++ b/api/src/types/publisher.ts
@@ -21,6 +21,7 @@ export interface PublisherDiffusionInput {
 export interface PublisherDiffusionRecord {
   id: string;
   diffuseurPublisherId: string;
+  diffuseurPublisherName: string | null;
   annonceurPublisherId: string;
   moderator: boolean;
   missionType: PublisherMissionType | null;

--- a/api/src/types/widget.ts
+++ b/api/src/types/widget.ts
@@ -1,7 +1,7 @@
 import { PublisherDiffusionExclusionRecord } from "./publisher-diffusion-exclusion";
 
 export type WidgetStyle = "carousel" | "page";
-export type WidgetType = "benevolat" | "volontariat";
+export type WidgetType = "benevolat" | "volontariat_service_civique" | "volontariat_sapeurs_pompiers" | "volontariat_reserve_operationnelle";
 export type WidgetRuleCombinator = "and" | "or";
 
 export type WidgetLocation = {

--- a/api/src/types/widget.ts
+++ b/api/src/types/widget.ts
@@ -1,7 +1,7 @@
 import { PublisherDiffusionExclusionRecord } from "./publisher-diffusion-exclusion";
 
 export type WidgetStyle = "carousel" | "page";
-export type WidgetType = "benevolat" | "volontariat_service_civique" | "volontariat_sapeurs_pompiers" | "volontariat_reserve_operationnelle";
+export type WidgetType = "benevolat" | "volontariat" | "volontariat_sapeurs_pompiers" | "volontariat_reserve_operationnelle";
 export type WidgetRuleCombinator = "and" | "or";
 
 export type WidgetLocation = {

--- a/app/src/scenes/widget/Edit.jsx
+++ b/app/src/scenes/widget/Edit.jsx
@@ -7,6 +7,8 @@ import Toggle from "@/components/Toggle";
 import Settings from "@/scenes/widget/components/Settings";
 import api from "@/services/api";
 import { BENEVOLAT_URL, VOLONTARIAT_URL } from "@/services/config";
+
+const getWidgetUrl = (type) => (type === "benevolat" ? BENEVOLAT_URL : VOLONTARIAT_URL);
 import { captureError } from "@/services/error";
 
 const Edit = () => {
@@ -165,7 +167,7 @@ const Frame = ({ widget }) => {
   const handleLoad = (e) => {
     let height;
     const width = e.target.offsetWidth;
-    if (widget.type === "volontariat") {
+    if (widget.type !== "benevolat") {
       if (widget.style === "carousel") {
         if (width < 768) {
           height = "670px";
@@ -218,7 +220,7 @@ const Frame = ({ widget }) => {
         allowFullScreen
         allow="geolocation"
         onLoad={handleLoad}
-        src={`${widget.type === "volontariat" ? VOLONTARIAT_URL : BENEVOLAT_URL}?widget=${widget.id}&notrack=true`}
+        src={`${getWidgetUrl(widget.type)}?widget=${widget.id}&notrack=true`}
       />
     </div>
   );
@@ -229,7 +231,15 @@ const IFRAMES = {
     carousel: `<iframe id="engagement-widget" title="Widget Trouver une mission de bénévolat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${BENEVOLAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '780px': '686px'"></iframe>`,
     page: `<iframe id="engagement-widget" title="Widget Trouver une mission de bénévolat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${BENEVOLAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '3424px': this.offsetWidth < 1024 ? '1862px': '1314px'"></iframe>`,
   },
-  volontariat: {
+  volontariat_service_civique: {
+    carousel: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '670px': '600px'"></iframe>`,
+    page: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '2200px': this.offsetWidth < 1024 ? '1350px': '1050px'"></iframe>`,
+  },
+  volontariat_sapeurs_pompiers: {
+    carousel: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '670px': '600px'"></iframe>`,
+    page: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '2200px': this.offsetWidth < 1024 ? '1350px': '1050px'"></iframe>`,
+  },
+  volontariat_reserve_operationnelle: {
     carousel: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '670px': '600px'"></iframe>`,
     page: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '2200px': this.offsetWidth < 1024 ? '1350px': '1050px'"></iframe>`,
   },

--- a/app/src/scenes/widget/Edit.jsx
+++ b/app/src/scenes/widget/Edit.jsx
@@ -226,20 +226,14 @@ const Frame = ({ widget }) => {
   );
 };
 
+const getIframeKey = (type) => (type === "benevolat" ? "benevolat" : "volontariat");
+
 const IFRAMES = {
   benevolat: {
     carousel: `<iframe id="engagement-widget" title="Widget Trouver une mission de bénévolat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${BENEVOLAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '780px': '686px'"></iframe>`,
     page: `<iframe id="engagement-widget" title="Widget Trouver une mission de bénévolat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${BENEVOLAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '3424px': this.offsetWidth < 1024 ? '1862px': '1314px'"></iframe>`,
   },
   volontariat: {
-    carousel: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '670px': '600px'"></iframe>`,
-    page: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '2200px': this.offsetWidth < 1024 ? '1350px': '1050px'"></iframe>`,
-  },
-  volontariat_sapeurs_pompiers: {
-    carousel: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '670px': '600px'"></iframe>`,
-    page: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '2200px': this.offsetWidth < 1024 ? '1350px': '1050px'"></iframe>`,
-  },
-  volontariat_reserve_operationnelle: {
     carousel: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '670px': '600px'"></iframe>`,
     page: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '2200px': this.offsetWidth < 1024 ? '1350px': '1050px'"></iframe>`,
   },
@@ -254,7 +248,7 @@ const JVA_LOGO = `<div style="padding:10px; display:flex; justify-content:center
 
 const Code = ({ widget }) => {
   const handleCopy = () => {
-    navigator.clipboard.writeText(`${IFRAMES[widget.type][widget.style].replace("{{widgetId}}", widget.id)}${widget.type === "benevolat" ? `\n\n${JVA_LOGO}` : ""}`);
+    navigator.clipboard.writeText(`${IFRAMES[getIframeKey(widget.type)][widget.style].replace("{{widgetId}}", widget.id)}${widget.type === "benevolat" ? `\n\n${JVA_LOGO}` : ""}`);
     toast.success("Clé copiée");
   };
 
@@ -273,7 +267,7 @@ const Code = ({ widget }) => {
           className="border-blue-france-925 bg-blue-france-975 w-full rounded-none border px-4 py-2 text-base read-only:opacity-80"
           rows={widget.type === "benevolat" ? 11 : 4}
           readOnly
-          value={`${IFRAMES[widget.type][widget.style].replace("{{widgetId}}", widget.id)}${widget.type === "benevolat" ? `\n\n${JVA_LOGO}` : ""}`}
+          value={`${IFRAMES[getIframeKey(widget.type)][widget.style].replace("{{widgetId}}", widget.id)}${widget.type === "benevolat" ? `\n\n${JVA_LOGO}` : ""}`}
         />
       </div>
     </div>

--- a/app/src/scenes/widget/Edit.jsx
+++ b/app/src/scenes/widget/Edit.jsx
@@ -7,9 +7,9 @@ import Toggle from "@/components/Toggle";
 import Settings from "@/scenes/widget/components/Settings";
 import api from "@/services/api";
 import { BENEVOLAT_URL, VOLONTARIAT_URL } from "@/services/config";
+import { captureError } from "@/services/error";
 
 const getWidgetUrl = (type) => (type === "benevolat" ? BENEVOLAT_URL : VOLONTARIAT_URL);
-import { captureError } from "@/services/error";
 
 const Edit = () => {
   const navigate = useNavigate();
@@ -231,7 +231,7 @@ const IFRAMES = {
     carousel: `<iframe id="engagement-widget" title="Widget Trouver une mission de bénévolat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${BENEVOLAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '780px': '686px'"></iframe>`,
     page: `<iframe id="engagement-widget" title="Widget Trouver une mission de bénévolat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${BENEVOLAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '3424px': this.offsetWidth < 1024 ? '1862px': '1314px'"></iframe>`,
   },
-  volontariat_service_civique: {
+  volontariat: {
     carousel: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 768 ? '670px': '600px'"></iframe>`,
     page: `<iframe id="engagement-widget" title="Widget Trouver une mission de volontariat" border="0" frameborder="0" style="display:block; width:100%; transition: height 0.3s ease;" loading="lazy" allowfullscreen allow="geolocation" src="${VOLONTARIAT_URL}?widget={{widgetId}}" onload="this.style.height=this.offsetWidth < 640 ? '2200px': this.offsetWidth < 1024 ? '1350px': '1050px'"></iframe>`,
   },

--- a/app/src/scenes/widget/components/Settings.jsx
+++ b/app/src/scenes/widget/components/Settings.jsx
@@ -24,6 +24,11 @@ const toWidgetType = (missionType) => {
   return missionType || "benevolat";
 };
 
+const toMissionTypes = (widgetType) => {
+  if (widgetType === "volontariat") return ["volontariat_service_civique"];
+  return widgetType ? [widgetType] : undefined;
+};
+
 const Settings = ({ widget, values, onChange, loading }) => {
   const { publisher } = useStore();
   const [publishers, setPublishers] = useState([]);
@@ -60,7 +65,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
         try {
           const query = {
             publisherIds: values.publishers,
-            type: values.type ? [values.type] : undefined,
+            type: toMissionTypes(values.type),
             lat: values.location?.lat,
             lon: values.location?.lon,
             distance: values.distance,

--- a/app/src/scenes/widget/components/Settings.jsx
+++ b/app/src/scenes/widget/components/Settings.jsx
@@ -14,9 +14,14 @@ const JVA_ID = "5f5931496c7ea514150a818f";
 
 const MISSION_TYPE_LABELS = {
   benevolat: "Bénévolat",
-  volontariat_service_civique: "Service Civique",
+  volontariat: "Service Civique",
   volontariat_sapeurs_pompiers: "Sapeurs-pompiers",
   volontariat_reserve_operationnelle: "Réserve opérationnelle",
+};
+
+const toWidgetType = (missionType) => {
+  if (missionType === "volontariat_service_civique") return "volontariat";
+  return missionType || "benevolat";
 };
 
 const Settings = ({ widget, values, onChange, loading }) => {
@@ -28,8 +33,8 @@ const Settings = ({ widget, values, onChange, loading }) => {
 
   const availableTypes = useMemo(() => {
     const types = new Set();
-    publisher.publishers.forEach((p) => types.add(p.missionType || "benevolat"));
-    if (publisher.isAnnonceur && publisher.missionType) types.add(publisher.missionType);
+    publisher.publishers.forEach((p) => types.add(toWidgetType(p.missionType)));
+    if (publisher.isAnnonceur && publisher.missionType) types.add(toWidgetType(publisher.missionType));
     return Object.keys(MISSION_TYPE_LABELS).filter((t) => types.has(t));
   }, [publisher]);
 
@@ -38,10 +43,10 @@ const Settings = ({ widget, values, onChange, loading }) => {
     const items = publisher.publishers.map((p) => ({
       key: p.diffuseurPublisherId,
       label: p.diffuseurPublisherName,
-      mission_type: p.missionType || "benevolat",
+      mission_type: toWidgetType(p.missionType),
     }));
     if (publisher.isAnnonceur) {
-      items.push({ key: publisher.id, label: publisher.name, mission_type: publisher.missionType || "benevolat" });
+      items.push({ key: publisher.id, label: publisher.name, mission_type: toWidgetType(publisher.missionType) });
     }
     setPublishers(items);
   }, [loading, publisher]);

--- a/app/src/scenes/widget/components/Settings.jsx
+++ b/app/src/scenes/widget/components/Settings.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { BiSolidInfoSquare } from "react-icons/bi";
 
 import JvaLogoSvg from "@/assets/svg/jva-logo.svg";
@@ -11,7 +11,13 @@ import { captureError } from "@/services/error";
 import useStore from "@/services/store";
 
 const JVA_ID = "5f5931496c7ea514150a818f";
-const SC_ID = "5f99dbe75eb1ad767733b206";
+
+const MISSION_TYPE_LABELS = {
+  benevolat: "Bénévolat",
+  volontariat_service_civique: "Service Civique",
+  volontariat_sapeurs_pompiers: "Sapeurs-pompiers",
+  volontariat_reserve_operationnelle: "Réserve opérationnelle",
+};
 
 const Settings = ({ widget, values, onChange, loading }) => {
   const { publisher } = useStore();
@@ -20,41 +26,25 @@ const Settings = ({ widget, values, onChange, loading }) => {
   const [showAll, setShowAll] = useState(false);
   const [selectAll, setSelectAll] = useState(false);
 
-  useEffect(() => {
-    if (loading) {
-      return;
-    }
-    const fetchMissions = async () => {
-      try {
-        const publishers = publisher.publishers.map((p) => p.diffuseurPublisherId);
-        if (publisher.isAnnonceur) {
-          publishers.push(publisher.id);
-        }
-        const query = {
-          publishers,
-          lat: values.location?.lat,
-          lon: values.location?.lon,
-          distance: values.distance,
-          jvaModeration: values.jvaModeration,
-          status: "ACCEPTED",
-          size: 0,
-        };
+  const availableTypes = useMemo(() => {
+    const types = new Set();
+    publisher.publishers.forEach((p) => types.add(p.missionType || "benevolat"));
+    if (publisher.isAnnonceur && publisher.missionType) types.add(publisher.missionType);
+    return Object.keys(MISSION_TYPE_LABELS).filter((t) => types.has(t));
+  }, [publisher]);
 
-        const res = await api.post("/mission/search", query);
-        if (!res.ok) {
-          throw res;
-        }
-        const newPublishers = res.aggs.partners;
-        if (publisher.isAnnonceur && !newPublishers.some((p) => p.key === publisher.id)) {
-          newPublishers.push({ key: publisher.id, doc_count: 0, name: publisher.name, mission_type: publisher.missionType });
-        }
-        setPublishers(newPublishers);
-      } catch (error) {
-        captureError(error, { extra: { publisherId: publisher.id } });
-      }
-    };
-    fetchMissions();
-  }, [loading, publisher, values.location, values.distance, values.jvaModeration]);
+  useEffect(() => {
+    if (loading) return;
+    const items = publisher.publishers.map((p) => ({
+      key: p.diffuseurPublisherId,
+      label: p.diffuseurPublisherName,
+      mission_type: p.missionType || "benevolat",
+    }));
+    if (publisher.isAnnonceur) {
+      items.push({ key: publisher.id, label: publisher.name, mission_type: publisher.missionType || "benevolat" });
+    }
+    setPublishers(items);
+  }, [loading, publisher]);
 
   useEffect(() => {
     if (loading) {
@@ -64,7 +54,8 @@ const Settings = ({ widget, values, onChange, loading }) => {
       const fetchFilteredMissions = async () => {
         try {
           const query = {
-            publishers: values.publishers,
+            publisherIds: values.publishers,
+            type: values.type ? [values.type] : undefined,
             lat: values.location?.lat,
             lon: values.location?.lon,
             distance: values.distance,
@@ -86,7 +77,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
       fetchFilteredMissions();
     }, 1000);
     return () => clearTimeout(timeout);
-  }, [loading, values.publishers, values.location, values.distance, values.jvaModeration, values.rules]);
+  }, [loading, values.type, values.publishers, values.location, values.distance, values.jvaModeration, values.rules]);
 
   return (
     <div className="space-y-12 bg-white p-12 shadow-lg">
@@ -121,31 +112,19 @@ const Settings = ({ widget, values, onChange, loading }) => {
               Type de mission<span className="text-error ml-1">*</span>
             </label>
             <div className="flex items-center">
-              {publisher.publishers.filter((p) => p.publisherId !== SC_ID).length > 0 && (
+              {availableTypes.map((type) => (
                 <RadioInput
-                  id="type-benevolat"
+                  key={type}
+                  id={`type-${type}`}
                   name="type"
-                  value="benevolat"
-                  label="Bénévolat"
-                  checked={values.type === "benevolat"}
-                  onChange={() => onChange({ ...values, type: "benevolat", publishers: [] })}
+                  value={type}
+                  label={MISSION_TYPE_LABELS[type]}
+                  checked={values.type === type}
+                  onChange={() => onChange({ ...values, type, publishers: [] })}
                   className="flex-1"
                   size={24}
                 />
-              )}
-
-              {publisher.publishers.some((p) => p.publisherId === SC_ID) && (
-                <RadioInput
-                  id="type-volontariat"
-                  name="type"
-                  value="volontariat"
-                  label="Volontariat"
-                  checked={values.type === "volontariat"}
-                  onChange={() => onChange({ ...values, type: "volontariat", publishers: [SC_ID] })}
-                  className="flex-1"
-                  size={24}
-                />
-              )}
+              ))}
             </div>
           </div>
           <div />
@@ -188,29 +167,25 @@ const Settings = ({ widget, values, onChange, loading }) => {
             <span className="text-error ml-1">*</span>
           </label>
 
-          {values.type === "benevolat" && (
-            <div>
-              <button
-                className="text-blue-france underline"
-                onClick={() => {
-                  onChange({ ...values, publishers: selectAll ? [] : publishers.map((p) => p.key) });
-                  setSelectAll(!selectAll);
-                }}
-              >
-                {selectAll ? "Tout déselectionner" : "Tout sélectionner"}
-              </button>
-            </div>
-          )}
+          <div>
+            <button
+              className="text-blue-france cursor-pointer underline"
+              onClick={() => {
+                onChange({ ...values, publishers: selectAll ? [] : publishers.filter((p) => (p.mission_type || "benevolat") === values.type).map((p) => p.key) });
+                setSelectAll(!selectAll);
+              }}
+            >
+              {selectAll ? "Tout déselectionner" : "Tout sélectionner"}
+            </button>
+          </div>
 
-          {publishers.length === 0 ? (
-            <p className="text-text-mention text-sm">Aucun partenaire disponible</p>
-          ) : (
-            <div className={`grid grid-cols-3 gap-x-6 gap-y-3 ${values.type === "volontariat" ? "text-gray-625" : ""}`}>
-              {publishers
-                .filter((item) => (values.type === "benevolat" ? item.key !== SC_ID : item.key === SC_ID))
-                .sort((a, b) => b.doc_count - a.doc_count)
-                .slice(0, showAll ? publishers.length : 15)
-                .map((item, i) => (
+          {(() => {
+            const filteredPublishers = publishers.filter((item) => (item.mission_type || "benevolat") === values.type).sort((a, b) => b.doc_count - a.doc_count);
+            return filteredPublishers.length === 0 ? (
+              <p className="text-text-mention text-sm">Aucun partenaire disponible</p>
+            ) : (
+              <div className="grid grid-cols-3 gap-x-6 gap-y-3">
+                {filteredPublishers.slice(0, showAll ? filteredPublishers.length : 15).map((item, i) => (
                   <label
                     key={i}
                     className={`hover:border-blue-france flex cursor-pointer gap-4 rounded border p-4 ${values.publishers.includes(item.key) ? "border-blue-france" : "border-gray-300"}`}
@@ -221,8 +196,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
                         className="checkbox"
                         id={`${i}-publishers`}
                         name={`${i}-publishers`}
-                        disabled={values.type === "volontariat"}
-                        checked={values.publishers.includes(item.key) || values.type === "volontariat"}
+                        checked={values.publishers.includes(item.key)}
                         onChange={(e) =>
                           onChange({ ...values, publishers: e.target.checked ? [...values.publishers, item.key] : values.publishers.filter((id) => id !== item.key) })
                         }
@@ -231,11 +205,6 @@ const Settings = ({ widget, values, onChange, loading }) => {
 
                     <div className="flex flex-col truncate">
                       <span className={`line-clamp-2 truncate text-sm ${values.publishers.includes(item.key) ? "text-blue-france" : "text-black"}`}>{item.label}</span>
-                      <div className={`flex ${values.type === "volontariat" ? "text-gray-625" : "text-text-mention"}`}>
-                        <span className="text-xs">
-                          {item.doc_count.toLocaleString("fr")} {item.doc_count > 1 ? "missions" : "mission"}
-                        </span>
-                      </div>
                     </div>
 
                     {item.moderation && item.moderation.length > 0 && values.publishers.includes(item.key) && (
@@ -265,10 +234,11 @@ const Settings = ({ widget, values, onChange, loading }) => {
                     )}
                   </label>
                 ))}
-            </div>
-          )}
+              </div>
+            );
+          })()}
 
-          {publishers.length > 15 && values.type === "benevolat" && (
+          {publishers.filter((item) => (item.mission_type || "benevolat") === values.type).length > 15 && (
             <button className="border-blue-france text-blue-france mt-6 border p-2" onClick={() => setShowAll(!showAll)}>
               {showAll ? "Masquer les annonceurs" : "Afficher tous les annonceurs"}
             </button>


### PR DESCRIPTION
## Description

Refonte de la gestion des types de missions dans le formulaire d'édition de widget.

**Contexte** : La sélection du type de mission reposait sur un identifiant publisher hardcodé (`SC_ID`) pour détecter les missions "volontariat". L'API définit maintenant 4 types distincts via `MissionType` : `benevolat`, `volontariat_service_civique`, `volontariat_sapeurs_pompiers`, `volontariat_reserve_operationnelle`.

**Changements** :
- Un radio button par type de mission disponible (déterminé depuis `publisher.publishers[].missionType`)
- Suppression du `SC_ID` hardcodé — le filtrage se base désormais sur `missionType`
- Le nom du publisher diffuseur est maintenant inclus dans l'enregistrement de diffusion (champ `diffuseurPublisherName`), évitant tout appel API supplémentaire côté frontend
- La liste des partenaires est construite directement depuis `publisher.publishers` (store), sans requête mission/search
- Le compteur de missions est filtré par type sélectionné (`type: [values.type]` dans la recherche)
- Correction du bug `publishers` → `publisherIds` dans les requêtes de recherche de missions
- `WidgetType` étendu aux 4 types ; `Edit.jsx` mappe les 3 types volontariat sur `VOLONTARIAT_URL`

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Sous-le-soleil-32572a322d5080ce8503f1e05378a6f8?p=33672a322d508082beb2e3f242bb035d&pm=s)

## Type de changement

- [x] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Points d'attention** :
- `diffuseurPublisherName` est ajouté à `PublisherDiffusionRecord` — vérifier que les autres usages de ce type ne sont pas impactés
- Le champ `type` dans le search schema de mission est nouveau — compatible avec les appels existants (optionnel)
- Les widgets existants avec `type: "volontariat"` en base sont invalides avec le nouveau `WidgetType` — à migrer si nécessaire