### PR TITLE
fix(api): mission not found in redirect

### DIFF
--- a/api/src/controllers/redirect.ts
+++ b/api/src/controllers/redirect.ts
@@ -97,7 +97,7 @@ router.get("/apply", cors({ origin: "*" }), async (req: Request, res: Response) 
     }
 
     if (query.data.mission) {
-      mission = await missionService.findMissionByClientAndPublisher(query.data.mission, click.toPublisherId || query.data.publisher);
+      mission = await missionService.findMissionByClientAndPublisher(query.data.mission, click.toPublisherId || query.data.publisher || "");
       if (!mission) {
         captureException(new Error(`[Apply] Mission not found`), { extra: { missionId: query.data.mission, publisherId: click.toPublisherId || query.data.publisher } });
       }
@@ -231,7 +231,7 @@ router.get("/account", cors({ origin: "*" }), async (req: Request, res: Response
     }
 
     if (query.data.mission) {
-      mission = await missionService.findMissionByClientAndPublisher(query.data.mission, click.toPublisherId || query.data.publisher);
+      mission = await missionService.findMissionByClientAndPublisher(query.data.mission, click.toPublisherId || query.data.publisher || "");
       if (!mission) {
         captureException(new Error(`[Account] Mission not found`), { extra: { missionId: query.data.mission, publisherId: click.toPublisherId || query.data.publisher } });
       }

--- a/api/src/controllers/redirect.ts
+++ b/api/src/controllers/redirect.ts
@@ -97,9 +97,9 @@ router.get("/apply", cors({ origin: "*" }), async (req: Request, res: Response) 
     }
 
     if (query.data.mission) {
-      mission = await missionService.findMissionByClientAndPublisher(query.data.mission, query.data.publisher || click.toPublisherId);
+      mission = await missionService.findMissionByClientAndPublisher(query.data.mission, click.toPublisherId || query.data.publisher);
       if (!mission) {
-        captureException(new Error(`[Apply] Mission not found`), { extra: { missionId: query.data.mission } });
+        captureException(new Error(`[Apply] Mission not found`), { extra: { missionId: query.data.mission, publisherId: click.toPublisherId || query.data.publisher } });
       }
     }
 
@@ -231,9 +231,9 @@ router.get("/account", cors({ origin: "*" }), async (req: Request, res: Response
     }
 
     if (query.data.mission) {
-      mission = await missionService.findMissionByClientAndPublisher(query.data.mission, query.data.publisher || click.toPublisherId);
+      mission = await missionService.findMissionByClientAndPublisher(query.data.mission, click.toPublisherId || query.data.publisher);
       if (!mission) {
-        captureException(new Error(`[Account] Mission not found`), { extra: { missionId: query.data.mission } });
+        captureException(new Error(`[Account] Mission not found`), { extra: { missionId: query.data.mission, publisherId: click.toPublisherId || query.data.publisher } });
       }
     }
 


### PR DESCRIPTION
## Description

Corrige une erreur de lookup de mission dans les endpoints `/r/apply` et `/r/account` : en cas de diffusion croisée (publisher A affiche des missions de publisher B), le paramètre\`publisher` dans l'URL de tracking correspond au **from** publisher (l'embedder du widget), pas au propriétaire de la mission. La requête `findMissionByClientAndPublisher` échouait donc alors que la mission existait bien en base.

**Changements :**
- Priorité inversée : `click.toPublisherId || query.data.publisher` au lieu de `query.data.publisher || click.toPublisherId`
- `publisherId` ajouté dans l'extra Sentry pour faciliter le debug futur

**Impact :**
- Pas de perte de candidatures (l'apply était quand même créé via les données du click)
- Données mission désormais récupérées depuis la DB plutôt que depuis le snapshot du click

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Erreur-Sentry-mission-not-found-33372a322d50802598d5e4d7a0ed6fae?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire