### PR TITLE
fix(app): improve responsive design for small viewports (RGAA 10.11)

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -253,7 +253,13 @@ const ProtectedLayout = () => {
       <Header />
       <Nav />
 
-      <main id="main-content" role="main" tabIndex={-1} aria-labelledby={hasActiveTab ? activeTabId : undefined} className="mx-auto mb-14 w-full max-w-[1200px] flex-1 px-4 pt-14 sm:w-4/5 sm:px-0">
+      <main
+        id="main-content"
+        role="main"
+        tabIndex={-1}
+        aria-labelledby={hasActiveTab ? activeTabId : undefined}
+        className="mx-auto mb-14 w-full max-w-[1200px] flex-1 px-0 pt-14 sm:w-4/5 sm:px-4"
+      >
         <Outlet />
       </main>
       <Footer />

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -128,7 +128,7 @@ const AuthLayout = () => {
         <div className="flex-1">
           <Outlet />
         </div>
-        <div className="h-full w-1/2">
+        <div className="hidden h-full w-1/2 md:block">
           <img src={image} alt="" aria-hidden="true" />
         </div>
       </main>
@@ -253,7 +253,7 @@ const ProtectedLayout = () => {
       <Header />
       <Nav />
 
-      <main id="main-content" role="main" tabIndex={-1} aria-labelledby={hasActiveTab ? activeTabId : undefined} className="mx-auto mb-14 w-4/5 max-w-[1200px] flex-1 pt-14">
+      <main id="main-content" role="main" tabIndex={-1} aria-labelledby={hasActiveTab ? activeTabId : undefined} className="mx-auto mb-14 w-full max-w-[1200px] flex-1 px-4 pt-14 sm:w-4/5 sm:px-0">
         <Outlet />
       </main>
       <Footer />

--- a/app/src/components/DateRangePicker.jsx
+++ b/app/src/components/DateRangePicker.jsx
@@ -59,10 +59,10 @@ const DateRangePicker = ({ value, onChange }) => {
   };
 
   return (
-    <div className="flex flex-col gap-4 lg:flex-row">
+    <div className="flex flex-col gap-4">
       <fieldset className="m-0 border-0 p-0">
         <legend className="sr-only">Période</legend>
-        <div className="border-grey-border flex w-fit items-center gap-x-2 rounded-sm border" role="radiogroup">
+        <div className="border-grey-border flex flex-col items-stretch gap-2 rounded-sm border sm:w-fit sm:flex-row sm:items-center sm:gap-x-2" role="radiogroup">
           {RANGES.map((range, i) => {
             const isSelected = selectedIndex === i;
             return (
@@ -72,7 +72,7 @@ const DateRangePicker = ({ value, onChange }) => {
                 role="radio"
                 aria-checked={isSelected}
                 tabIndex={isSelected || (selectedIndex === -1 && i === 0) ? 0 : -1}
-                className={`focus cursor-pointer rounded-sm px-4 py-2 text-sm ${isSelected ? "border-blue-france text-blue-france -my-px border-2" : ""} hover:bg-gray-100`}
+                className={`focus cursor-pointer rounded-sm px-4 py-2 text-sm whitespace-nowrap ${isSelected ? "border-blue-france text-blue-france -my-px border" : ""} hover:bg-gray-100`}
                 onClick={() => onChange(range)}
                 onKeyDown={(e) => handleKeyDown(e, i)}
               >
@@ -88,8 +88,19 @@ const DateRangePicker = ({ value, onChange }) => {
   );
 };
 
+const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(typeof window !== "undefined" && window.innerWidth < 640);
+  useEffect(() => {
+    const handler = () => setIsMobile(window.innerWidth < 640);
+    window.addEventListener("resize", handler);
+    return () => window.removeEventListener("resize", handler);
+  }, []);
+  return isMobile;
+};
+
 export const DateInput = ({ value, onChange }) => {
   const id = useId();
+  const isMobile = useIsMobile();
   const [from, setFrom] = useState(value.from);
   const [to, setTo] = useState(value.to);
   const [fromText, setFromText] = useState(formatDateFr(value.from));
@@ -211,10 +222,23 @@ export const DateInput = ({ value, onChange }) => {
         role="dialog"
         aria-modal="true"
         aria-label="Sélection de période"
-        className={`border-grey-border divide-grey-border absolute right-0 z-50 mt-1 divide-y border bg-white px-8 pt-6 pb-4 shadow-lg ${show ? "block" : "hidden"}`}
+        className={`border-grey-border fixed inset-0 z-50 overflow-y-auto border bg-white px-4 pt-4 pb-4 shadow-lg sm:absolute sm:inset-auto sm:right-0 sm:mt-1 sm:overflow-visible sm:px-8 sm:pt-6 ${show ? "block" : "hidden"}`}
       >
-        <div className="flex gap-6">
-          <ul className="m-0 flex w-44 list-none flex-col p-0 text-base" role="list" aria-label="Périodes disponibles">
+        <div className="mb-4 flex justify-end sm:hidden">
+          <button
+            type="button"
+            className="tertiary-btn"
+            onClick={() => {
+              setShow(false);
+              buttonRef.current?.focus();
+            }}
+            aria-label="Fermer le calendrier"
+          >
+            Fermer
+          </button>
+        </div>
+        <div className="flex flex-col gap-6 sm:flex-row">
+          <ul className="m-0 flex list-none flex-col p-0 text-base sm:w-44" role="list" aria-label="Périodes disponibles">
             <li>
               <button
                 className="hover:bg-gray-975 w-full cursor-pointer p-3 text-left text-base"
@@ -280,7 +304,7 @@ export const DateInput = ({ value, onChange }) => {
 
           <AccessibleCalendar>
             <DatePicker
-              renderCustomHeader={DatePickerHeader}
+              renderCustomHeader={(props) => <DatePickerHeader {...props} isMobile={isMobile} />}
               onChange={handleCalendarChange}
               startDate={from}
               endDate={to}
@@ -288,7 +312,7 @@ export const DateInput = ({ value, onChange }) => {
               locale={fr}
               selectsRange
               inline
-              monthsShown={2}
+              monthsShown={isMobile ? 1 : 2}
               calendarContainer={DatePickerContainer}
               ariaLabelPrefix="Choisir"
             />
@@ -320,9 +344,9 @@ const DatePickerContainer = ({ children }) => (
   </div>
 );
 
-const DatePickerHeader = ({ monthDate, customHeaderCount, decreaseMonth, increaseMonth }) => (
+const DatePickerHeader = ({ monthDate, customHeaderCount, decreaseMonth, increaseMonth, isMobile }) => (
   <div className="flex items-center justify-between gap-8 pb-4">
-    <button aria-label="Mois précédent" className="hover:bg-gray-975" style={customHeaderCount === 1 ? { visibility: "hidden" } : null} onClick={decreaseMonth}>
+    <button aria-label="Mois précédent" className="hover:bg-gray-975" style={!isMobile && customHeaderCount === 1 ? { visibility: "hidden" } : null} onClick={decreaseMonth}>
       <RiArrowLeftSLine className="text-blue-france text-[32px]" aria-hidden="true" />
     </button>
     <span className="text-base font-bold">
@@ -331,7 +355,7 @@ const DatePickerHeader = ({ monthDate, customHeaderCount, decreaseMonth, increas
         year: "numeric",
       })}
     </span>
-    <button aria-label="Mois suivant" className="hover:bg-gray-975" style={customHeaderCount === 0 ? { visibility: "hidden" } : null} onClick={increaseMonth}>
+    <button aria-label="Mois suivant" className="hover:bg-gray-975" style={!isMobile && customHeaderCount === 0 ? { visibility: "hidden" } : null} onClick={increaseMonth}>
       <RiArrowRightSLine className="text-blue-france text-[32px]" aria-hidden="true" />
     </button>
   </div>

--- a/app/src/components/Footer.jsx
+++ b/app/src/components/Footer.jsx
@@ -7,10 +7,10 @@ import marianneBanner from "@/assets/svg/marianne-banner.svg";
 const Footer = () => {
   return (
     <footer role="contentinfo" className="border-blue-france flex w-full flex-col justify-center border-t-2 bg-white">
-      <div className="mx-auto w-full max-w-7xl">
-        <div className="mt-10 flex items-center justify-between">
-          <Link className="hover:bg-gray-975 flex items-center p-2" to="/">
-            <div className="my-2 h-full w-24">
+      <div className="mx-auto w-full max-w-7xl px-4">
+        <div className="mt-10 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <Link className="hover:bg-gray-975 flex items-center gap-4 p-2" to="/">
+            <div className="my-2 h-full w-24 shrink-0">
               <div className="flex flex-col items-start">
                 <img src={marianneBanner} alt="" aria-hidden="true" className="mb-1 w-10" />
                 <p className="text-xs leading-3 font-bold text-black uppercase">
@@ -31,26 +31,26 @@ const Footer = () => {
               L'API vous permet de faciliter l'engagement en simplifiant la démarche de recherche d'une mission de bénévolat ou de volontariat
             </p>
 
-            <ul role="list" aria-label="Liens gouvernementaux" className="text-grey-default flex items-center text-sm font-bold">
-              <li className="mr-6">
+            <ul role="list" aria-label="Liens gouvernementaux" className="text-grey-default flex flex-wrap items-center gap-x-6 gap-y-2 text-sm font-bold">
+              <li>
                 <a href="https://www.legifrance.gouv.fr/" target="_blank" rel="noopener external" className="link-external">
                   legifrance.gouv.fr
                   <RiExternalLinkLine className="ml-1" aria-hidden="true" />
                 </a>
               </li>
-              <li className="mr-6">
+              <li>
                 <a href="https://www.gouvernement.fr/" target="_blank" rel="noopener external" className="link-external">
                   gouvernement.fr
                   <RiExternalLinkLine className="ml-1" aria-hidden="true" />
                 </a>
               </li>
-              <li className="mr-6">
+              <li>
                 <a href="https://www.service-public.fr/" target="_blank" rel="noopener external" className="link-external">
                   service-public.fr
                   <RiExternalLinkLine className="ml-1" aria-hidden="true" />
                 </a>
               </li>
-              <li className="mr-6">
+              <li>
                 <a href="https://www.data.gouv.fr/fr/" target="_blank" rel="noopener external" className="link-external">
                   data.gouv.fr
                   <RiExternalLinkLine className="ml-1" aria-hidden="true" />
@@ -63,7 +63,7 @@ const Footer = () => {
         <ul
           role="list"
           aria-label="Liens de pied de page"
-          className="divide-text-mention border-grey-border text-text-mention mt-10 flex items-center divide-x border-t py-4 text-xs"
+          className="divide-text-mention border-grey-border text-text-mention mt-10 flex flex-wrap items-center divide-x border-t py-4 text-xs"
         >
           <li>
             <a href="https://api-engagement.beta.gouv.fr/accessibilite/" className="pr-3 hover:underline">
@@ -101,7 +101,7 @@ const Footer = () => {
             </Link>
           </li>
         </ul>
-        <p className="text-text-mention flex items-center py-4 text-xs">
+        <p className="text-text-mention flex flex-wrap items-center py-4 text-xs">
           Sauf mention explicite de propriété intellectuelle détenue par des tiers, les contenus de ce site sont proposés sous
           <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" target="_blank" className="ml-1 flex items-center hover:underline">
             licence etalab-2.0

--- a/app/src/components/Header.jsx
+++ b/app/src/components/Header.jsx
@@ -18,8 +18,8 @@ const Header = () => {
   const { user } = useStore();
   return (
     <header role="banner" className="border-b-grey-border flex w-full justify-center border-b bg-white">
-      <div className="flex w-full max-w-7xl flex-wrap items-center justify-between gap-4 px-4 py-3">
-        <Link className="hover:bg-gray-975 flex items-center gap-4 p-4" to={user ? "/" : "/login"}>
+      <div className="flex w-full max-w-7xl flex-wrap items-center justify-between gap-4 px-4 py-1 sm:py-3">
+        <Link className="hover:bg-gray-975 flex items-center gap-4 p-2 sm:p-4" to={user ? "/" : "/login"}>
           <div className="flex h-24 items-center justify-center">
             <div className="flex flex-col items-start">
               <img src={marianneBanner} alt="" aria-hidden="true" className="mb-1 w-10" />
@@ -31,8 +31,8 @@ const Header = () => {
               <img src={deviseSrc} alt="" aria-hidden="true" className="mt-1 h-7" />
             </div>
           </div>
-          <LogoSvg alt="" className="w-8" />
-          <div>
+          <LogoSvg alt="" className="hidden w-8 sm:block" aria-hidden="true" />
+          <div className="hidden sm:block">
             <h1 className="text-xl font-bold">API Engagement</h1>
             <p className="text-sm">Plateforme de partage de missions de bénévolat et de volontariat</p>
           </div>

--- a/app/src/components/Header.jsx
+++ b/app/src/components/Header.jsx
@@ -18,7 +18,7 @@ const Header = () => {
   const { user } = useStore();
   return (
     <header role="banner" className="border-b-grey-border flex w-full justify-center border-b bg-white">
-      <div className="flex w-full max-w-7xl flex-wrap items-center justify-between gap-4 py-3">
+      <div className="flex w-full max-w-7xl flex-wrap items-center justify-between gap-4 px-4 py-3">
         <Link className="hover:bg-gray-975 flex items-center gap-4 p-4" to={user ? "/" : "/login"}>
           <div className="flex h-24 items-center justify-center">
             <div className="flex flex-col items-start">
@@ -38,12 +38,11 @@ const Header = () => {
           </div>
         </Link>
         <nav role="navigation" aria-label="Navigation d'en-tête" className="text-blue-france flex items-center gap-3 text-sm">
-          <div className="tertiary-bis-btn flex items-center">
+          <a href="https://doc.api-engagement.beta.gouv.fr/" target="_blank" className="text-blue-france flex items-center">
             <RiBookletLine className="mr-2" aria-hidden="true" />
-            <a href="https://doc.api-engagement.beta.gouv.fr/" target="_blank">
-              Documentation
-            </a>
-          </div>
+            <span className="hidden sm:block">Documentation</span>
+          </a>
+
           {!user ? (
             <Link to="/login" className="tertiary-btn flex items-center">
               <RiUserLine className="mr-2" aria-hidden="true" />
@@ -347,16 +346,16 @@ const AccountMenu = () => {
         <div className="bg-blue-france flex h-8 w-8 items-center justify-center rounded-full">
           <RiUserLine className="text-white" aria-hidden="true" />
         </div>
-        <div className="mx-4 text-left">
+        <div className="mx-4 hidden text-left sm:block">
           <p className="text-blue-france">{user.firstname}</p>
           <p className="text-text-mention text-sm">{user.publishers.length ? (user.role === "admin" ? "Administrateur" : "Utilisateur") : publisher.name}</p>
         </div>
-        <RiArrowDownSLine className={`text-base transition-transform duration-200 ${show ? "rotate-180" : ""}`} aria-hidden="true" />
+        <RiArrowDownSLine className={`hidden text-base transition-transform duration-200 sm:block ${show ? "rotate-180" : ""}`} aria-hidden="true" />
       </button>
 
       <div
         inert={!show ? true : undefined}
-        className={`border-grey-border absolute right-0 z-10 w-56 border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
+        className={`border-grey-border absolute left-1/2 z-10 w-[calc(100vw-2rem)] -translate-x-1/2 border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out sm:right-0 sm:left-auto sm:w-56 ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
       >
         <ul className="m-0 flex list-none flex-col p-0">
           <li>

--- a/app/src/components/Nav.jsx
+++ b/app/src/components/Nav.jsx
@@ -216,7 +216,7 @@ const FluxMenu = ({ value, onChange }) => {
 
       <div
         inert={!isOpen ? true : undefined}
-        className={`border-grey-border absolute left-0 z-10 mt-2 w-[calc(100vw-2rem)] border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out sm:w-64 ${isOpen ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
+        className={`border-grey-border absolute left-0 z-10 mt-2 w-[calc(100vw-2rem)] w-full border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out sm:w-64 ${isOpen ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
       >
         <ul className="m-0 flex list-none flex-col p-0" role="listbox">
           {FLUX_OPTIONS.map((option, index) => (
@@ -370,7 +370,7 @@ const PublisherMenu = ({ options, value, onChange }) => {
         aria-modal="true"
         aria-labelledby="publisher-search"
         inert={!show ? true : undefined}
-        className={`border-grey-border absolute right-0 z-50 w-[calc(100vw-2rem)] border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out focus:outline-none sm:w-80 ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
+        className={`border-grey-border absolute right-0 z-50 w-[calc(100vw-2rem)] w-full border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out focus:outline-none sm:w-80 ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
       >
         <div role="search" className="border-grey-border focus flex items-center gap-2 border-b p-3">
           <RiSearchLine aria-hidden="true" />
@@ -489,7 +489,7 @@ const AdminMenu = () => {
       </button>
       <div
         inert={!show ? true : undefined}
-        className={`border-grey-border absolute right-0 z-10 w-[calc(100vw-2rem)] border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out sm:w-80 ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
+        className={`border-grey-border absolute right-0 z-10 w-[calc(100vw-2rem)] w-full border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out sm:w-80 ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
       >
         <ul className="m-0 flex list-none flex-col p-0">
           {ADMIN_MENU_ITEMS.map((item, index) => {

--- a/app/src/components/Nav.jsx
+++ b/app/src/components/Nav.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { RiArrowDownSFill, RiArrowDownSLine, RiArrowLeftRightLine, RiCheckLine, RiSearchLine } from "react-icons/ri";
+import { RiArrowDownSFill, RiArrowDownSLine, RiArrowLeftRightLine, RiCheckLine, RiMenuLine, RiCloseLine, RiSearchLine } from "react-icons/ri";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import api from "@/services/api";
@@ -95,16 +95,30 @@ const Nav = () => {
         ]),
   ];
 
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
     <div className="w-full bg-white shadow-lg">
       <nav role="navigation" aria-label="Navigation principale" className="mx-auto min-h-14 w-full max-w-312 px-4">
-        <ul className="m-0 flex w-full list-none flex-col items-center justify-between gap-x-6 gap-y-2 p-0 lg:flex-row" role="list" aria-label="Menu principal">
-          <li className="flex flex-col items-center gap-4 lg:flex-row lg:gap-6">
+        <div className="flex items-center justify-between lg:hidden">
+          <span className="py-3 text-sm font-semibold">{menuItems.find((item) => item.isActive)?.label || "Menu"}</span>
+          <button
+            className="focus flex items-center rounded-sm p-2 hover:bg-gray-100"
+            aria-expanded={menuOpen}
+            aria-label={menuOpen ? "Fermer le menu" : "Ouvrir le menu"}
+            onClick={() => setMenuOpen(!menuOpen)}
+          >
+            {menuOpen ? <RiCloseLine className="text-xl" aria-hidden="true" /> : <RiMenuLine className="text-xl" aria-hidden="true" />}
+          </button>
+        </div>
+
+        <ul className={`m-0 w-full list-none flex-col items-start justify-between gap-x-6 gap-y-2 p-0 pb-4 lg:flex lg:flex-row lg:items-center lg:pb-0 ${menuOpen ? "flex" : "hidden lg:flex"}`} role="list" aria-label="Menu principal">
+          <li className="flex w-full flex-col items-start gap-4 lg:w-auto lg:flex-row lg:items-center lg:gap-6">
             {publisher.isAnnonceur && (publisher.hasApiRights || publisher.hasWidgetRights || publisher.hasCampaignRights) && <FluxMenu value={flux} onChange={handleFluxChange} />}
-            <ul className="m-0 flex list-none flex-col items-center gap-4 p-0 lg:flex-row lg:gap-6">
+            <ul className="m-0 flex w-full list-none flex-col items-start gap-2 p-0 lg:w-auto lg:flex-row lg:items-center lg:gap-6">
               {menuItems.map((item) => (
                 <li key={item.key}>
-                  <Link to={item.to} aria-current={item.isActive} className="nav-item">
+                  <Link to={item.to} aria-current={item.isActive} className="nav-item" onClick={() => setMenuOpen(false)}>
                     {item.label}
                   </Link>
                 </li>
@@ -112,7 +126,7 @@ const Nav = () => {
             </ul>
           </li>
 
-          <li className="flex flex-col items-center gap-4 lg:flex-row lg:gap-6">
+          <li className="flex w-full flex-col items-start gap-4 lg:w-auto lg:flex-row lg:items-center lg:gap-6">
             {publishers.length > 1 && <PublisherMenu options={publishers} value={publisher} onChange={handleChangePublisher} />}
             {user.role === "admin" && <AdminMenu />}
           </li>

--- a/app/src/components/Nav.jsx
+++ b/app/src/components/Nav.jsx
@@ -97,7 +97,7 @@ const Nav = () => {
 
   return (
     <div className="w-full bg-white shadow-lg">
-      <nav role="navigation" aria-label="Navigation principale" className="mx-auto min-h-14 w-full max-w-312">
+      <nav role="navigation" aria-label="Navigation principale" className="mx-auto min-h-14 w-full max-w-312 px-4">
         <ul className="m-0 flex w-full list-none flex-col items-center justify-between gap-x-6 gap-y-2 p-0 lg:flex-row" role="list" aria-label="Menu principal">
           <li className="flex flex-col items-center gap-4 lg:flex-row lg:gap-6">
             {publisher.isAnnonceur && (publisher.hasApiRights || publisher.hasWidgetRights || publisher.hasCampaignRights) && <FluxMenu value={flux} onChange={handleFluxChange} />}
@@ -203,7 +203,7 @@ const FluxMenu = ({ value, onChange }) => {
     <div className="relative" ref={ref} onBlur={handleFocusOut}>
       <button
         ref={buttonRef}
-        className="bg-blue-france hover:bg-blue-france-hover active:bg-blue-france-hover focus flex w-44 cursor-pointer items-center justify-between rounded-full px-4 py-2 text-sm text-white"
+        className="bg-blue-france hover:bg-blue-france-hover active:bg-blue-france-hover focus flex w-full cursor-pointer items-center justify-between rounded-full px-4 py-2 text-sm text-white sm:w-44"
         aria-expanded={isOpen}
         aria-haspopup="true"
         type="button"
@@ -216,7 +216,7 @@ const FluxMenu = ({ value, onChange }) => {
 
       <div
         inert={!isOpen ? true : undefined}
-        className={`border-grey-border absolute left-0 z-10 mt-2 w-64 border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out ${isOpen ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
+        className={`border-grey-border absolute left-0 z-10 mt-2 w-[calc(100vw-2rem)] border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out sm:w-64 ${isOpen ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
       >
         <ul className="m-0 flex list-none flex-col p-0" role="listbox">
           {FLUX_OPTIONS.map((option, index) => (
@@ -370,7 +370,7 @@ const PublisherMenu = ({ options, value, onChange }) => {
         aria-modal="true"
         aria-labelledby="publisher-search"
         inert={!show ? true : undefined}
-        className={`border-grey-border absolute right-0 z-50 w-80 border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out focus:outline-none ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
+        className={`border-grey-border absolute right-0 z-50 w-[calc(100vw-2rem)] border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out focus:outline-none sm:w-80 ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
       >
         <div role="search" className="border-grey-border focus flex items-center gap-2 border-b p-3">
           <RiSearchLine aria-hidden="true" />
@@ -489,7 +489,7 @@ const AdminMenu = () => {
       </button>
       <div
         inert={!show ? true : undefined}
-        className={`border-grey-border absolute right-0 z-10 w-80 border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
+        className={`border-grey-border absolute right-0 z-10 w-[calc(100vw-2rem)] border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out sm:w-80 ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
       >
         <ul className="m-0 flex list-none flex-col p-0">
           {ADMIN_MENU_ITEMS.map((item, index) => {

--- a/app/src/components/Tabs.jsx
+++ b/app/src/components/Tabs.jsx
@@ -16,7 +16,7 @@ const TAB_VARIANTS = {
 
 export const Tab = ({ tab, panelId, isFocusable, onKeyDown, setRef, variant = "primary", className = "" }) => {
   const variantClasses = TAB_VARIANTS[variant] || TAB_VARIANTS.primary;
-  const tabClassName = `${variantClasses.base} ${tab.isActive ? variantClasses.active : variantClasses.inactive} ${className}`.trim();
+  const tabClassName = `whitespace-nowrap ${variantClasses.base} ${tab.isActive ? variantClasses.active : variantClasses.inactive} ${className}`.trim();
   const sharedProps = {
     id: tab.id,
     role: "tab",
@@ -104,7 +104,7 @@ const Tabs = ({ tabs, ariaLabel, panelId, className = "", variant = "primary", t
   };
 
   return (
-    <div role="tablist" aria-label={ariaLabel} className={className}>
+    <div role="tablist" aria-label={ariaLabel} className={`flex flex-nowrap overflow-x-auto ${className}`}>
       {tabs.map((tab, index) => (
         <Tab
           key={tab.key}

--- a/app/src/scenes/account/index.jsx
+++ b/app/src/scenes/account/index.jsx
@@ -56,8 +56,8 @@ const Account = () => {
       <title>API Engagement - Mon compte</title>
       <h1 className="text-4xl font-bold">Mon compte</h1>
 
-      <form onSubmit={handleSubmit} className="bg-white p-12 shadow-lg">
-        <div className="mb-6 flex justify-between">
+      <form onSubmit={handleSubmit} className="bg-white p-4 shadow-lg sm:p-12">
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
           <h2 className="text-3xl font-bold">Vos informations</h2>
           <button
             type="button"
@@ -71,7 +71,7 @@ const Account = () => {
             Se deconnecter
           </button>
         </div>
-        <div className="grid grid-cols-2 gap-x-10 gap-y-5">
+        <div className="grid grid-cols-1 gap-x-10 gap-y-5 sm:grid-cols-2">
           <div className="flex flex-col">
             <label className="mb-2 text-sm" htmlFor="firstname">
               Prénom
@@ -103,14 +103,14 @@ const Account = () => {
               onChange={(e) => setValues({ ...values, lastname: e.target.value })}
             />
           </div>
-          <div className="col-span-2 flex flex-col">
+          <div className="flex flex-col sm:col-span-2">
             <label className="mb-2 text-sm" htmlFor="email">
               E-mail
             </label>
             <input id="email" className="input mb-2 border-b-black" name="email" readOnly value={values.email} />
           </div>
 
-          <div className="col-span-2 flex justify-end gap-4">
+          <div className="flex flex-wrap justify-end gap-4 sm:col-span-2">
             <ResetPasswordModal />
 
             <button type="submit" className="primary-btn" disabled={!isChanged() || isErrors()}>

--- a/app/src/scenes/admin-account/Publishers.jsx
+++ b/app/src/scenes/admin-account/Publishers.jsx
@@ -128,15 +128,15 @@ const Publishers = () => {
   };
 
   return (
-    <div className="space-y-12 p-12">
+    <div className="space-y-12 p-4 sm:p-12">
       <title>API Engagement - Partenaires - Administration</title>
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 className="text-3xl font-bold">Liste des partenaires</h2>
           <p className="mt-2">Liste de comptes annonceurs et diffuseurs de l'API</p>
         </div>
 
-        <div className="flex">
+        <div className="flex shrink-0">
           <button className="tertiary-bis-btn flex items-center" onClick={handleExport}>
             {exporting ? <Loader /> : <RiFileDownloadLine className="mr-2" aria-hidden="true" />}
             Exporter
@@ -147,8 +147,8 @@ const Publishers = () => {
         </div>
       </div>
 
-      <div className="border-grey-border border p-6">
-        <div role="search" className="mb-6 flex items-center gap-4">
+      <div className="border-grey-border overflow-x-auto border p-4 sm:p-6">
+        <div role="search" className="mb-6 flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center">
           <p className="font-semibold">{`${publishers.length} partenaire${publishers.length > 1 ? "s" : ""}`}</p>
           <label htmlFor="publisher-name" className="sr-only">
             Rechercher par nom
@@ -156,7 +156,7 @@ const Publishers = () => {
           <input
             id="publisher-name"
             name="publisher-name"
-            className="input flex-1"
+            className="input min-w-0 flex-1"
             placeholder="Chercher par nom"
             value={filters.name}
             onChange={(e) => setFilters({ ...filters, name: e.target.value })}
@@ -165,7 +165,7 @@ const Publishers = () => {
           <label htmlFor="publisher-role" className="sr-only">
             Filtrer par rôle
           </label>
-          <select id="publisher-role" name="publisher-role" className="input w-[20%]" value={filters.role} onChange={(e) => setFilters({ ...filters, role: e.target.value })}>
+          <select id="publisher-role" name="publisher-role" className="input w-full sm:w-[20%]" value={filters.role} onChange={(e) => setFilters({ ...filters, role: e.target.value })}>
             <option value="">Tous les rôles</option>
             <option value="annonceur">Tous les annonceurs</option>
             <option value="diffuseur">Tous les diffuseurs</option>
@@ -177,7 +177,7 @@ const Publishers = () => {
             Filtrer par rapport d'impact
           </label>
           <select
-            className="input w-[20%] truncate"
+            className="input w-full truncate sm:w-[20%]"
             id="publisher-send-report"
             value={filters.sendReport.toString()}
             onChange={(e) => setFilters({ ...filters, sendReport: e.target.value })}
@@ -190,7 +190,7 @@ const Publishers = () => {
             Filtrer par type de mission
           </label>
           <select
-            className="input w-[20%] truncate"
+            className="input w-full truncate sm:w-[20%]"
             id="publisher-mission-type"
             value={filters.missionType}
             onChange={(e) => setFilters({ ...filters, missionType: e.target.value })}
@@ -203,6 +203,7 @@ const Publishers = () => {
             ))}
           </select>
         </div>
+        <div className="min-w-[700px]">
         <Table caption="Liste des partenaires" header={TABLE_HEADER} total={publishers.length} loading={loading} page={page} pageSize={PAGE_SIZE} onPageChange={setPage}>
           {publishers.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE).map((item, i) => (
             <tr key={item.id} className={`${i % 2 === 0 ? "bg-table-even" : "bg-table-odd"} table-row h-20`}>
@@ -226,6 +227,7 @@ const Publishers = () => {
             </tr>
           ))}
         </Table>
+        </div>
       </div>
     </div>
   );

--- a/app/src/scenes/admin-account/Users.jsx
+++ b/app/src/scenes/admin-account/Users.jsx
@@ -61,7 +61,7 @@ const Users = () => {
   }, []);
 
   return (
-    <div className="space-y-12 p-12">
+    <div className="space-y-12 p-4 sm:p-12">
       <title>API Engagement - Utilisateurs - Administration</title>
       <div className="flex items-center justify-between">
         <div>
@@ -70,16 +70,17 @@ const Users = () => {
         </div>
       </div>
 
-      <div className="border-grey-border border p-6">
-        <div role="search" className="mb-6 flex items-center gap-4">
+      <div className="border-grey-border overflow-x-auto border p-4 sm:p-6">
+        <div role="search" className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center">
           <label htmlFor="user-search" className="sr-only">
             Rechercher par nom ou par email
           </label>
           <input id="user-search" name="user-search" className="input flex-1" placeholder="Chercher par nom ou par email" onChange={(e) => setSearch(e.target.value)} />
-          <Link to="/user/new" className="primary-btn flex items-center">
+          <Link to="/user/new" className="primary-btn flex shrink-0 items-center">
             Nouvel utilisateur <HiOutlinePlus className="ml-2" aria-hidden="true" />
           </Link>
         </div>
+        <div className="min-w-[700px]">
         <Table caption="Liste des utilisateurs" header={TABLE_HEADER} total={filteredUsers.length} loading={loading} page={page} pageSize={PAGE_SIZE} onPageChange={setPage} auto>
           {filteredUsers.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE).map((item, i) => (
             <tr key={item.id} className={`${i % 2 === 0 ? "bg-table-even" : "bg-table-odd"} table-row`}>
@@ -129,6 +130,7 @@ const Users = () => {
             </tr>
           ))}
         </Table>
+        </div>
       </div>
     </div>
   );

--- a/app/src/scenes/admin-mission/index.jsx
+++ b/app/src/scenes/admin-mission/index.jsx
@@ -133,11 +133,11 @@ const AdminMission = () => {
   };
 
   return (
-    <div className="space-y-12 bg-white p-12 shadow-lg">
+    <div className="space-y-12 bg-white p-4 shadow-lg sm:p-12">
       <title>API Engagement - Missions - Administration</title>
       <div className="space-y-4">
-        <SearchInput className="w-96" value={filters.search} onChange={(search) => setFilters({ ...filters, search })} placeholder="Rechercher par mot-clé" />
-        <div className="flex items-center gap-4">
+        <SearchInput className="w-full sm:w-96" value={filters.search} onChange={(search) => setFilters({ ...filters, search })} placeholder="Rechercher par mot-clé" />
+        <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center">
           <Select
             options={options.status.map((e) => ({ value: e.key, label: STATUS_PLR[e.key], count: e.doc_count }))}
             value={filters.status}
@@ -171,7 +171,7 @@ const AdminMission = () => {
             options={options.partners}
           />
         </div>
-        <div className="flex items-center gap-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-center">
           <Select
             options={options.cities.map((e) => ({ value: e.key === "" ? "none" : e.key, label: e.key === "" ? "Non renseignée" : e.key, count: e.doc_count }))}
             value={filters.city}
@@ -195,10 +195,10 @@ const AdminMission = () => {
       </div>
 
       <div className="space-y-6">
-        <div className="flex items-center justify-between gap-4">
-          <div className="max-w-[60%] flex-1 space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="min-w-0 flex-1 space-y-2">
             <h2 className="text-2xl font-bold">{total.toLocaleString("fr")} missions partagées</h2>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <p className="text-text-mention text-base">Dernière synchronisation le {lastImport ? new Date(lastImport.startedAt).toLocaleDateString("fr") : "N/A"}</p>
               {lastImport && new Date(lastImport.startedAt) > new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() - 1) ? (
                 <RiCheckboxCircleFill role="img" aria-label="OK" className="text-success text-base" />
@@ -207,7 +207,7 @@ const AdminMission = () => {
               )}
             </div>
           </div>
-          <button className="tertiary-btn flex items-center" onClick={handleExport}>
+          <button className="tertiary-btn flex shrink-0 items-center" onClick={handleExport}>
             {exporting ? <Loader /> : <RiFileDownloadLine className="mr-2" aria-hidden="true" />}
             Exporter
           </button>

--- a/app/src/scenes/admin-organization/List.jsx
+++ b/app/src/scenes/admin-organization/List.jsx
@@ -47,7 +47,7 @@ const List = () => {
   }, [filters]);
 
   return (
-    <div className="space-y-12 bg-white p-12 shadow-lg">
+    <div className="space-y-12 bg-white p-4 shadow-lg sm:p-12">
       <title>API Engagement - RNA - Administration</title>
       <div className="flex flex-wrap items-center justify-between gap-4">
         <h2 className="text-2xl font-semibold">{total.toLocaleString("fr")} d'associations référencées</h2>
@@ -60,7 +60,8 @@ const List = () => {
         />
       </div>
 
-      <div className="border-grey-border border p-6">
+      <div className="border-grey-border overflow-x-auto border p-4 sm:p-6">
+        <div className="min-w-[600px]">
         <Table
           caption="Liste des organisations"
           header={[{ title: "Titre de l'organisation", width: "40%" }, { title: "RNA" }, { title: "SIRET" }, { title: "Créée le" }, { title: "Statut" }]}
@@ -101,6 +102,7 @@ const List = () => {
             );
           })}
         </Table>
+        </div>
       </div>
     </div>
   );

--- a/app/src/scenes/admin-organization/View.jsx
+++ b/app/src/scenes/admin-organization/View.jsx
@@ -37,7 +37,7 @@ const View = () => {
       <title>{`API Engagement - Organisation - ${data.title}`}</title>
       <div className="mb-10">
         <h1 className="leading-normal">{data.title}</h1>
-        <div className="mt-4 flex justify-between">
+        <div className="mt-4 flex flex-wrap justify-between gap-4">
           {data.status === "ACTIVE" ? (
             <div className="flex items-center gap-2">
               <p>Active</p>
@@ -64,27 +64,27 @@ const View = () => {
         </div>
       </div>
 
-      <div className="bg-white p-12 shadow-lg">
-        <div className="flex justify-between">
+      <div className="bg-white p-4 shadow-lg sm:p-12">
+        <div className="flex flex-wrap justify-between gap-4">
           <p>
             RNA: <b>{data.rna}</b>
           </p>
           <p>Assocation créée le {data.createdAt ? new Date(data.createdAt).toLocaleDateString("fr") : "N/A"}</p>
         </div>
-        <div className="mb-6 flex justify-between">
+        <div className="mb-6 flex flex-wrap justify-between gap-4">
           <p>
             SIRET: <b>{data.siret || "N/A"}</b>
           </p>
           <p>Dernière modification le {data.updatedAt ? new Date(data.updatedAt).toLocaleDateString("fr") : "N/A"}</p>
         </div>
 
-        <div className="border-grey-border flex gap-4 border p-6">
+        <div className="border-grey-border flex flex-col gap-4 border p-4 sm:flex-row sm:p-6">
           <div className="flex-1">
             <p className="text-xl font-semibold">Object de l'organisme</p>
             <p className="mt-4">{data.object}</p>
           </div>
-          <div className="w-px bg-gray-900" />
-          <div className="w-1/3">
+          <div className="hidden w-px bg-gray-900 sm:block" />
+          <div className="border-t border-gray-900 pt-4 sm:w-1/3 sm:border-t-0 sm:pt-0">
             <p className="text-xl font-semibold">Adresse complète</p>
             <p className="mt-4">
               Numero: <b>{data.addressNumber}</b>

--- a/app/src/scenes/admin-report/index.jsx
+++ b/app/src/scenes/admin-report/index.jsx
@@ -57,15 +57,15 @@ const AdminReport = () => {
   }, [filters]);
 
   return (
-    <div className="space-y-12 bg-white p-12 shadow-lg">
+    <div className="space-y-12 bg-white p-4 shadow-lg sm:p-12">
       <title>API Engagement - Rapports d'impacts - Administration</title>
       <div className="flex items-center justify-between">
         <h2 className="flex-1 text-2xl font-semibold">{total.toLocaleString("fr")} rapports d'impacts</h2>
       </div>
 
-      <div className="border-grey-border space-y-6 border p-6">
+      <div className="border-grey-border space-y-6 overflow-x-auto border p-4 sm:p-6">
         <p className="font-bold">Filtrer les resultats</p>
-        <div className="flex items-center gap-4 border-b border-b-gray-900 pb-6">
+        <div className="flex flex-col gap-4 border-b border-b-gray-900 pb-6 sm:flex-row sm:flex-wrap sm:items-center">
           <Combobox
             id="publisher-id"
             options={options.publishers.sort((a, b) => b.count - a.count).map((e) => ({ value: e._id, label: e.name, count: e.count }))}
@@ -137,27 +137,23 @@ const AdminReport = () => {
 
               <td className="p-4">
                 <div className="flex items-center gap-4">
-                  <div className="grid flex-1 grid-cols-2 gap-2">
-                    {item.data?.receive !== undefined && item.data?.receive.general !== undefined && <p className="text-xs"> Pas de statistiques disponibles</p>}
+                  <div className="flex min-w-[200px] flex-1 flex-col gap-1">
+                    {item.data?.receive !== undefined && item.data?.receive.general !== undefined && <p className="text-xs">Pas de statistiques disponibles</p>}
                     {item.data?.receive !== undefined && (
                       <>
-                        <label className="text-xs">Redirections reçues</label>
-                        <span className="text-xs font-bold">{(item.data.receive.general?.traffic || item.data.receive.click || 0).toLocaleString("fr")}</span>
-                        <label className="text-xs">Candidatures reçues</label>
-                        <span className="text-xs font-bold">{(item.data.receive.general?.apply || item.data.receive.apply || 0).toLocaleString("fr")}</span>
+                        <p className="text-xs">Redirections reçues : <span className="font-bold">{(item.data.receive.general?.traffic || item.data.receive.click || 0).toLocaleString("fr")}</span></p>
+                        <p className="text-xs">Candidatures reçues : <span className="font-bold">{(item.data.receive.general?.apply || item.data.receive.apply || 0).toLocaleString("fr")}</span></p>
                       </>
                     )}
                     {item.data?.send !== undefined && (
                       <>
-                        <label className="text-xs">Redirections envoyées</label>
-                        <span className="text-xs font-bold">{(item.data.send.general?.traffic || item.data.send.click || 0).toLocaleString("fr")}</span>
-                        <label className="text-xs">Candidatures envoyées</label>
-                        <span className="text-xs font-bold">{(item.data.send.general?.apply || item.data.send.apply || 0).toLocaleString("fr")}</span>
+                        <p className="text-xs">Redirections envoyées : <span className="font-bold">{(item.data.send.general?.traffic || item.data.send.click || 0).toLocaleString("fr")}</span></p>
+                        <p className="text-xs">Candidatures envoyées : <span className="font-bold">{(item.data.send.general?.apply || item.data.send.apply || 0).toLocaleString("fr")}</span></p>
                       </>
                     )}
                   </div>
                   {item.url !== null && (
-                    <a className="border-blue-france text-blue-france border p-2" href={item.url} target="_blank" rel="noreferrer">
+                    <a className="border-blue-france text-blue-france shrink-0 border p-2" href={item.url} target="_blank" rel="noreferrer">
                       <RiDownload2Line className="text-blue-france" role="img" aria-label="Télécharger le rapport" />
                     </a>
                   )}

--- a/app/src/scenes/admin-stats/Annonceur.jsx
+++ b/app/src/scenes/admin-stats/Annonceur.jsx
@@ -9,7 +9,7 @@ import { captureError } from "@/services/error";
 import useStore from "@/services/store";
 import { withLegacyPublishers } from "@/utils/publisher";
 
-const Announcer = () => {
+const Annonceur = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [filters, setFilters] = useState({
     from: searchParams.has("from") ? new Date(searchParams.get("from")) : new Date(new Date().getFullYear() - 1, new Date().getMonth(), new Date().getDate()),
@@ -84,18 +84,18 @@ const Announcer = () => {
   };
 
   return (
-    <div className="space-y-12 p-12">
+    <div className="space-y-12 p-4 sm:p-12">
       <title>Annonceurs - Statistiques - Administration - API Engagement</title>
       <div className="flex justify-between">
         <h2 className="text-2xl font-bold">Annonceurs</h2>
       </div>
       <div className="box-border flex">
-        <div className="flex w-full justify-between gap-2">
+        <div className="flex w-full flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-between">
           <DateInput value={{ from: filters.from, to: filters.to }} onChange={(v) => setFilters({ ...filters, from: v.from, to: v.to })} />
           <label htmlFor="announcer" className="sr-only">
             Partenaire annonceur
           </label>
-          <select id="announcer" className="select min-w-[27.5em]" value={filters.publisher} onChange={(e) => setFilters({ ...filters, publisher: e.target.value })}>
+          <select id="announcer" className="select w-full sm:min-w-[27.5em]" value={filters.publisher} onChange={(e) => setFilters({ ...filters, publisher: e.target.value })}>
             <option value="">Partenaires</option>
             {partners.map((partner) => (
               <option key={partner.value} value={partner.value}>
@@ -106,7 +106,7 @@ const Announcer = () => {
           <label htmlFor="mission-type" className="sr-only">
             Type de mission
           </label>
-          <select id="mission-type" className="select min-w-[27.5em]" value={filters.type} onChange={(e) => setFilters({ ...filters, type: e.target.value })}>
+          <select id="mission-type" className="select w-full sm:min-w-[27.5em]" value={filters.type} onChange={(e) => setFilters({ ...filters, type: e.target.value })}>
             <option value="">Type de mission</option>
             {MISSION_TYPE_OPTIONS.map((missionType) => (
               <option key={missionType.value} value={missionType.value}>
@@ -143,4 +143,4 @@ const Announcer = () => {
   );
 };
 
-export default Announcer;
+export default Annonceur;

--- a/app/src/scenes/admin-stats/Apercu.jsx
+++ b/app/src/scenes/admin-stats/Apercu.jsx
@@ -36,7 +36,7 @@ const buildDefaultFilters = (searchParams) => {
 
 const Filters = ({ filters, onChange, idPrefix, showLabel = true }) => {
   return (
-    <div className="flex items-end gap-4">
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
       <div className="flex-1 space-y-2">
         {showLabel ? <label className="text-gray-425 text-sm font-semibold uppercase">Période</label> : null}
         <DateRangePicker value={filters} onChange={(value) => onChange({ ...filters, ...value })} />
@@ -44,7 +44,7 @@ const Filters = ({ filters, onChange, idPrefix, showLabel = true }) => {
       <label htmlFor={`${idPrefix}-mission-type`} className="sr-only">
         Type de mission
       </label>
-      <select id={`${idPrefix}-mission-type`} className="select w-80" value={filters.type} onChange={(event) => onChange({ ...filters, type: event.target.value })}>
+      <select id={`${idPrefix}-mission-type`} className="select w-full sm:w-80" value={filters.type} onChange={(event) => onChange({ ...filters, type: event.target.value })}>
         <option value="">Tous les types de missions</option>
         {MISSION_TYPE_OPTIONS.map((missionType) => (
           <option key={missionType.value} value={missionType.value}>
@@ -70,25 +70,27 @@ const ChartBlock = ({ title, subtitle, cardId, filters, type = "stacked", chartP
   }
 
   return (
-    <div className="border border-gray-900 p-4">
-      <div className="mb-4 flex flex-col gap-1 lg:flex-row lg:items-center lg:justify-between">
-        <h3 className="text-lg font-bold">{title}</h3>
-        {subtitle ? <p className="text-sm text-[#666]">{subtitle}</p> : null}
+    <div className="overflow-x-auto border border-gray-900 p-4">
+      <div className="min-w-[600px]">
+        <div className="mb-4 flex flex-col gap-1 lg:flex-row lg:items-center lg:justify-between">
+          <h3 className="text-lg font-bold">{title}</h3>
+          {subtitle ? <p className="text-sm text-[#666]">{subtitle}</p> : null}
+        </div>
+        {cardId ? (
+          <AnalyticsCard
+            cardId={cardId}
+            filters={filters}
+            type={type}
+            variables={variables}
+            chartProps={chartProps}
+            adapterOptions={adapterOptions}
+            showLegend={showLegend}
+            loaderHeight={loaderHeight}
+          />
+        ) : (
+          <ChartFallback title={title} />
+        )}
       </div>
-      {cardId ? (
-        <AnalyticsCard
-          cardId={cardId}
-          filters={filters}
-          type={type}
-          variables={variables}
-          chartProps={chartProps}
-          adapterOptions={adapterOptions}
-          showLegend={showLegend}
-          loaderHeight={loaderHeight}
-        />
-      ) : (
-        <ChartFallback title={title} />
-      )}
     </div>
   );
 };
@@ -209,25 +211,27 @@ const TrafficByAnnouncerChart = ({ filters, cardId, title, subtitle }) => {
   const { histogram, keys } = buildHistogram(rows);
 
   return (
-    <div className="border border-gray-900 p-4">
-      <div className="mb-4 flex flex-col gap-1 lg:flex-row lg:items-center lg:justify-between">
-        <h3 className="text-lg font-bold">{title}</h3>
-        <p className="text-sm text-[#666]">{subtitle}</p>
+    <div className="overflow-x-auto border border-gray-900 p-4">
+      <div className="min-w-[600px]">
+        <div className="mb-4 flex flex-col gap-1 lg:flex-row lg:items-center lg:justify-between">
+          <h3 className="text-lg font-bold">{title}</h3>
+          <p className="text-sm text-[#666]">{subtitle}</p>
+        </div>
+        {loading ? (
+          <div className="flex h-[420px] items-center justify-center">
+            <Loader />
+          </div>
+        ) : !histogram.length ? (
+          <div className="flex h-[248px] w-full flex-col items-center justify-center border border-dashed border-gray-900 bg-[#f6f6f6]">
+            <img src={EmptySVG} alt="" aria-hidden="true" className="h-16 w-16" />
+            <p className="text-base text-[#666]">Aucune donnée disponible pour la période</p>
+          </div>
+        ) : (
+          <div className="h-[420px] w-full">
+            <StackedBarchart data={histogram} dataKey={keys} />
+          </div>
+        )}
       </div>
-      {loading ? (
-        <div className="flex h-[420px] items-center justify-center">
-          <Loader />
-        </div>
-      ) : !histogram.length ? (
-        <div className="flex h-[248px] w-full flex-col items-center justify-center border border-dashed border-gray-900 bg-[#f6f6f6]">
-          <img src={EmptySVG} alt="" aria-hidden="true" className="h-16 w-16" />
-          <p className="text-base text-[#666]">Aucune donnée disponible pour la période</p>
-        </div>
-      ) : (
-        <div className="h-[420px] w-full">
-          <StackedBarchart data={histogram} dataKey={keys} />
-        </div>
-      )}
     </div>
   );
 };
@@ -355,11 +359,11 @@ const Apercu = () => {
   }, [filterSection]);
 
   return (
-    <div className="space-y-12 p-12">
+    <div className="space-y-12 p-4 sm:p-12">
       <title>Aperçu - Statistiques - Administration - API Engagement</title>
 
       {stickyVisible ? (
-        <div className="fixed top-0 left-0 z-50 w-full bg-white px-48 py-4 shadow-lg">
+        <div className="fixed top-0 left-0 z-50 w-full bg-white px-4 py-4 shadow-lg sm:px-48">
           <Filters filters={filters} onChange={setFilters} idPrefix="sticky" showLabel={false} />
         </div>
       ) : null}

--- a/app/src/scenes/admin-stats/Diffuseur.jsx
+++ b/app/src/scenes/admin-stats/Diffuseur.jsx
@@ -9,7 +9,7 @@ import { captureError } from "@/services/error";
 import useStore from "@/services/store";
 import { withLegacyPublishers } from "@/utils/publisher";
 
-const Broacaster = () => {
+const Diffuseur = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [filters, setFilters] = useState({
     from: searchParams.has("from") ? new Date(searchParams.get("from")) : new Date(new Date().getFullYear() - 1, new Date().getMonth(), new Date().getDate()),
@@ -98,18 +98,18 @@ const Broacaster = () => {
   };
 
   return (
-    <div className="space-y-12 p-12">
+    <div className="space-y-12 p-4 sm:p-12">
       <title>Diffuseurs - Statistiques - Administration - API Engagement</title>
       <div className="flex justify-between">
         <h2 className="text-2xl font-bold">Diffuseurs</h2>
       </div>
       <div className="box-border flex bg-white">
-        <div className="flex justify-between gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-between">
           <DateInput value={{ from: filters.from, to: filters.to }} onChange={(v) => setFilters({ ...filters, from: v.from, to: v.to })} />
           <label htmlFor="broadcaster" className="sr-only">
             Partenaire diffuseur
           </label>
-          <select id="broadcaster" className="select w-[18em]" value={filters.publisher} onChange={(e) => setFilters({ ...filters, publisher: e.target.value })}>
+          <select id="broadcaster" className="select w-full sm:w-[18em]" value={filters.publisher} onChange={(e) => setFilters({ ...filters, publisher: e.target.value })}>
             <option value="">Partenaires</option>
             {partners.map((partner) => (
               <option key={partner.value} value={partner.value}>
@@ -120,7 +120,7 @@ const Broacaster = () => {
           <label htmlFor="mission-type" className="sr-only">
             Type de mission
           </label>
-          <select className="select w-[18em]" id="mission-type" value={filters.type} onChange={(e) => setFilters({ ...filters, type: e.target.value })}>
+          <select className="select w-full sm:w-[18em]" id="mission-type" value={filters.type} onChange={(e) => setFilters({ ...filters, type: e.target.value })}>
             <option className="text-sm" value="">
               Type de mission
             </option>
@@ -133,7 +133,7 @@ const Broacaster = () => {
           <label htmlFor="source" className="sr-only">
             Moyen de diffusion
           </label>
-          <select className="select w-[18em]" id="source" value={filters.source} onChange={(e) => setFilters({ ...filters, source: e.target.value })}>
+          <select className="select w-full sm:w-[18em]" id="source" value={filters.source} onChange={(e) => setFilters({ ...filters, source: e.target.value })}>
             <option className="text-sm" value="">
               Moyen de diffusion
             </option>
@@ -143,34 +143,36 @@ const Broacaster = () => {
           </select>
         </div>
       </div>
-      <div>
-        <AnalyticsCard
-          cardId={METABASE_CARD_ID.ADMIN_STATS_PARTNERS_TABLE}
-          type="table"
-          filters={filters}
-          variables={{
-            role: "diffuseur",
-            ...(filters.publisher ? { publisher_id: filters.publisher } : {}),
-            ...(filters.type ? { mission_type: filters.type } : {}),
-            ...(filters.source ? { source: filters.source } : {}),
-          }}
-          tableProps={{
-            page: tableSettings.page,
-            pageSize: 20,
-            sortBy: tableSettings.sortBy,
-            onPageChange: (page) => setTableSettings((prev) => ({ ...prev, page })),
-            onSort: (key) =>
-              setTableSettings((prev) => ({
-                ...prev,
-                page: 1,
-                sortBy: prev.sortBy === key ? `-${key}` : key,
-              })),
-          }}
-          formatCell={formatTableCell}
-        />
+      <div className="overflow-x-auto">
+        <div className="min-w-[600px]">
+          <AnalyticsCard
+            cardId={METABASE_CARD_ID.ADMIN_STATS_PARTNERS_TABLE}
+            type="table"
+            filters={filters}
+            variables={{
+              role: "diffuseur",
+              ...(filters.publisher ? { publisher_id: filters.publisher } : {}),
+              ...(filters.type ? { mission_type: filters.type } : {}),
+              ...(filters.source ? { source: filters.source } : {}),
+            }}
+            tableProps={{
+              page: tableSettings.page,
+              pageSize: 20,
+              sortBy: tableSettings.sortBy,
+              onPageChange: (page) => setTableSettings((prev) => ({ ...prev, page })),
+              onSort: (key) =>
+                setTableSettings((prev) => ({
+                  ...prev,
+                  page: 1,
+                  sortBy: prev.sortBy === key ? `-${key}` : key,
+                })),
+            }}
+            formatCell={formatTableCell}
+          />
+        </div>
       </div>
     </div>
   );
 };
 
-export default Broacaster;
+export default Diffuseur;

--- a/app/src/scenes/admin-stats/index.jsx
+++ b/app/src/scenes/admin-stats/index.jsx
@@ -1,51 +1,41 @@
-import { useEffect, useState } from "react";
-import { Link, Route, Routes, useLocation } from "react-router-dom";
+import { Route, Routes, useLocation } from "react-router-dom";
 
-import Announcer from "./Announcer";
+import Tabs from "@/components/Tabs";
+import Annonceur from "./Annonceur";
 import Apercu from "./Apercu";
-import Broacaster from "./Broacaster";
+import Diffuseur from "./Diffuseur";
 
-const Index = () => (
-  <div className="space-y-12">
-    <h1 className="text-4xl font-bold">Statistiques</h1>
-
-    <div>
-      <nav className="flex items-center space-x-4 pl-4 font-semibold text-black">
-        <Tab title="Aperçu" route="" />
-        <Tab title="Diffuseurs" route="diffuseur" />
-        <Tab title="Annonceurs" route="annonceur" />
-      </nav>
-
-      <section className="bg-white shadow-lg">
-        <Routes>
-          <Route index element={<Apercu />} />
-          <Route path="diffuseur" element={<Broacaster />} />
-          <Route path="annonceur" element={<Announcer />} />
-        </Routes>
-      </section>
-    </div>
-  </div>
-);
-
-const Tab = ({ title, route = "" }) => {
-  const [active, setActive] = useState(false);
+const Index = () => {
   const location = useLocation();
+  const currentRoute = location.pathname.split("/admin-stats")[1]?.replace("/", "") || "";
 
-  useEffect(() => {
-    const current = location.pathname.split("/admin-stats")[1];
-    setActive(route === current.replace("/", ""));
-  }, [location]);
+  const tabs = [
+    { key: "apercu", label: "Aperçu", route: "", isActive: currentRoute === "" },
+    { key: "diffuseur", label: "Diffuseurs", route: "diffuseur", isActive: currentRoute === "diffuseur" },
+    { key: "annonceur", label: "Annonceurs", route: "annonceur", isActive: currentRoute === "annonceur" },
+  ].map((tab) => ({
+    ...tab,
+    id: `admin-stats-tab-${tab.key}`,
+    to: `/admin-stats/${tab.route}`,
+  }));
+
+  const activeTab = tabs.find((tab) => tab.isActive) || tabs[0];
 
   return (
-    <Link to={`/admin-stats/${route}`}>
-      <div
-        className={`${
-          active ? "border-blue-france text-blue-france hover:bg-gray-975 border-t-2 bg-white" : "bg-blue-france-925 hover:bg-blue-france-925-hover border-0"
-        } flex translate-y-px cursor-pointer items-center border-x border-x-gray-900 px-4 py-2`}
-      >
-        <p>{title}</p>
+    <div className="space-y-12">
+      <h1 className="text-4xl font-bold">Statistiques</h1>
+
+      <div>
+        <Tabs tabs={tabs} ariaLabel="Statistiques" panelId="admin-stats-panel" className="flex items-center gap-4 pl-4 font-semibold text-black" variant="primary" />
+        <section id="admin-stats-panel" role="tabpanel" aria-labelledby={activeTab?.id} className="bg-white shadow-lg">
+          <Routes>
+            <Route index element={<Apercu />} />
+            <Route path="diffuseur" element={<Diffuseur />} />
+            <Route path="annonceur" element={<Annonceur />} />
+          </Routes>
+        </section>
       </div>
-    </Link>
+    </div>
   );
 };
 

--- a/app/src/scenes/admin-warning/index.jsx
+++ b/app/src/scenes/admin-warning/index.jsx
@@ -169,7 +169,7 @@ const Index = () => {
       <div className="space-y-10">
         <h1 className="text-4xl font-bold">État du service</h1>
 
-        <div className="flex items-center gap-8 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-4 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:gap-8 sm:p-6">
           <img className="h-18 w-18" src={APILogo} alt="" aria-hidden="true" />
           <div>
             {state.success / state.imports < 0.9 ? (
@@ -188,13 +188,13 @@ const Index = () => {
             <p className="text-xl">Dernière mise à jour des flux réalisée le {`${buildDate(state.last)}`}</p>
           </div>
         </div>
-        <div className="space-y-12 bg-white p-12 shadow-lg">
+        <div className="space-y-12 bg-white p-4 shadow-lg sm:p-12">
           <h2 className="mb-6 text-xl font-bold text-black">
             {Object.keys(currentWarningsByPublishers).length > 1
               ? `${Object.keys(currentWarningsByPublishers).length} partenaires rencontrent un problème`
               : `${Object.keys(currentWarningsByPublishers).length} partenaire rencontre un problème`}
           </h2>
-          <div className="grid grid-cols-4 gap-10">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 sm:gap-10">
             {Object.values(currentWarningsByPublishers).map((p, i) => (
               <div className="border-grey-border flex h-40 flex-col items-center border" key={i}>
                 <div className="text-text-mention mt-2 text-center text-xs">{p.name}</div>
@@ -218,7 +218,7 @@ const Index = () => {
       <Bots />
       <div className="mb-6 space-y-6">
         <h2 className="text-2xl font-bold">Alertes en cours</h2>
-        <div className="flex w-2/3 items-center justify-start gap-4">
+        <div className="flex w-full flex-col gap-4 sm:w-2/3 sm:flex-row sm:flex-wrap sm:items-center">
           <Select
             options={publishers.map((e) => ({ value: e.id, label: e.name }))}
             value={currentFilters.publisher}
@@ -265,8 +265,8 @@ const Index = () => {
                 {currentWarningsByDays[d].map((w, i) => {
                   const label = WARNINGS[w.type] || WARNINGS.OTHER_WARNING;
                   return (
-                    <div className="flex items-center gap-8 bg-white p-6 shadow-sm" key={i} id={slugify(`${w.type}-${w.publisherName}`)}>
-                      {w.publisherLogo ? <img className="h-20 w-36 object-contain" src={w.publisherLogo} alt="" aria-hidden="true" /> : <div className="bg-grey-200 h-20 w-36" />}
+                    <div className="flex flex-col gap-4 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:gap-8 sm:p-6" key={i} id={slugify(`${w.type}-${w.publisherName}`)}>
+                      {w.publisherLogo ? <img className="h-20 w-36 shrink-0 object-contain" src={w.publisherLogo} alt="" aria-hidden="true" /> : <div className="bg-grey-200 h-20 w-36 shrink-0" />}
                       <div className="flex flex-col justify-between">
                         <div className="mb-2">
                           <span className="bg-yellow-tournesol-950 text-yellow-tournesol-200 truncate rounded p-1 text-center text-xs font-semibold uppercase">{label.name}</span>
@@ -287,7 +287,7 @@ const Index = () => {
       </div>
       <div className="space-y-6">
         <h2 className="text-2xl font-bold">Historiques des alertes passées</h2>
-        <div className="flex w-2/3 items-center justify-start gap-4">
+        <div className="flex w-full flex-col gap-4 sm:w-2/3 sm:flex-row sm:flex-wrap sm:items-center">
           <Select
             options={publishers.map((e) => ({ value: e.id, label: e.name }))}
             value={archivedFilters.publisher}
@@ -334,8 +334,8 @@ const Index = () => {
                 {archivedWarningsByDays[d].map((w, i) => {
                   const label = WARNINGS[w.type] || WARNINGS.OTHER_WARNING;
                   return (
-                    <div className="flex items-center gap-8 bg-white p-6 shadow-sm" key={i}>
-                      {w.publisherLogo ? <img className="h-20 w-36 object-contain" src={w.publisherLogo} alt="" aria-hidden="true" /> : <div className="bg-grey-200 h-20 w-36" />}
+                    <div className="flex flex-col gap-4 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:gap-8 sm:p-6" key={i}>
+                      {w.publisherLogo ? <img className="h-20 w-36 shrink-0 object-contain" src={w.publisherLogo} alt="" aria-hidden="true" /> : <div className="bg-grey-200 h-20 w-36 shrink-0" />}
 
                       <div className="flex flex-col justify-between">
                         <div className="mb-2">

--- a/app/src/scenes/auth/ForgotPassword.jsx
+++ b/app/src/scenes/auth/ForgotPassword.jsx
@@ -31,7 +31,7 @@ const Forgot = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex h-full flex-col bg-white px-32 py-10">
+    <form onSubmit={handleSubmit} className="flex h-full flex-col bg-white px-4 py-10 sm:px-32">
       <title>API Engagement - Mot de passe oublié</title>
       <h1 className="font-light">Mot de passe oublié</h1>
       <h2 className="text-4xl font-bold">Récupérez votre mot de passe</h2>

--- a/app/src/scenes/auth/Login.jsx
+++ b/app/src/scenes/auth/Login.jsx
@@ -56,7 +56,7 @@ const Login = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex h-full flex-col bg-white px-32 py-10">
+    <form onSubmit={handleSubmit} className="flex h-full flex-col bg-white px-4 py-10 sm:px-32">
       <title>API Engagement - Connexion</title>
       <h1 className="font-light">Connexion</h1>
       <h2 className="text-4xl font-bold">Accedez à votre espace</h2>

--- a/app/src/scenes/auth/ResetPassword.jsx
+++ b/app/src/scenes/auth/ResetPassword.jsx
@@ -35,7 +35,7 @@ const ResetPassword = () => {
   }, [token]);
 
   return (
-    <div className="h-full w-full bg-white px-32 py-10">
+    <div className="h-full w-full bg-white px-4 py-10 sm:px-32">
       <title>API Engagement - Réinitialisation du mot de passe</title>
       {error === "invalide" ? (
         <ErrorAlert>

--- a/app/src/scenes/auth/Signup.jsx
+++ b/app/src/scenes/auth/Signup.jsx
@@ -36,7 +36,7 @@ const Signup = () => {
   };
 
   return (
-    <div className="h-full w-full bg-white px-32 py-10">
+    <div className="h-full w-full bg-white px-4 py-10 sm:px-32">
       <title>API Engagement - Inscription</title>
       {error === "invalide" ? (
         <ErrorAlert>

--- a/app/src/scenes/broadcast/Api.jsx
+++ b/app/src/scenes/broadcast/Api.jsx
@@ -1,6 +1,6 @@
+import { toast } from "@/services/toast";
 import { useEffect, useState } from "react";
 import { RiBookletFill, RiFileCopyFill } from "react-icons/ri";
-import { toast } from "@/services/toast";
 
 import api from "@/services/api";
 import { captureError } from "@/services/error";
@@ -48,7 +48,7 @@ const Api = () => {
   if (!publisher) return <p className="p-3">Chargement...</p>;
 
   return (
-    <div className="space-y-12 p-12">
+    <div className="space-y-12 p-4 sm:p-12">
       <title>API Engagement - Flux par API - Diffuser des missions</title>
       <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="space-y-2">
@@ -61,14 +61,14 @@ const Api = () => {
           Documentation
         </a>
       </div>
-      <div className="border-grey-border border p-6">
-        <div className="border-b-gray-925 flex flex-wrap items-center gap-4 border-b pb-6">
+      <div className="border-grey-border border p-4 sm:p-6">
+        <div className="border-b-gray-925 flex flex-col gap-4 border-b pb-6">
           <label htmlFor="apikey" className="font-semibold">
             Votre clé API
           </label>
-          <div className="flex min-w-[200px] flex-1 items-center gap-4">
-            <input id="apikey" className="input flex-1" name="apikey" readOnly value={publisher.apikey || ""} />
-            <button className="secondary-btn flex h-10 w-10 items-center justify-center p-0" onClick={handleCopy}>
+          <div className="flex items-center gap-4">
+            <input id="apikey" className="input min-w-0 flex-1" name="apikey" readOnly value={publisher.apikey || ""} />
+            <button className="secondary-btn flex h-10 w-10 shrink-0 items-center justify-center p-0" onClick={handleCopy}>
               <RiFileCopyFill aria-hidden="true" />
               <span className="sr-only">Copier la clé API</span>
             </button>
@@ -91,7 +91,7 @@ const Api = () => {
         </div>
         <div className="flex flex-col gap-4 pt-6">
           <div className="flex items-center justify-between gap-4">
-            <p className="w-1/4 font-semibold">Exemple d'appel</p>
+            <p className="font-semibold sm:w-1/4">Exemple d'appel</p>
           </div>
           <textarea
             className="border-blue-france-925 bg-blue-france-975 w-full rounded-none border px-4 py-2 font-mono text-sm read-only:opacity-80"

--- a/app/src/scenes/broadcast/Campaigns.jsx
+++ b/app/src/scenes/broadcast/Campaigns.jsx
@@ -91,7 +91,7 @@ const Campaigns = () => {
   }
 
   return (
-    <div className="space-y-12 p-12">
+    <div className="space-y-12 p-4 sm:p-12">
       <title>API Engagement - Campagnes - Diffuser des missions</title>
       <div className="flex flex-col items-center justify-between gap-4 lg:flex-row lg:gap-32">
         <div role="search" className="flex flex-1 flex-col items-center gap-4 lg:flex-row lg:gap-4">
@@ -172,9 +172,7 @@ const Campaigns = () => {
                     {item.name}
                   </Link>
                 </td>
-                <td className={`px-4 py-3 ${!item.active ? "opacity-50" : "opacity-100"}`}>
-                  {item.toPublisherName}
-                </td>
+                <td className={`px-4 py-3 ${!item.active ? "opacity-50" : "opacity-100"}`}>{item.toPublisherName}</td>
                 <td className={`px-4 py-3 ${!item.active ? "opacity-50" : "opacity-100"}`}>{new Date(item.createdAt).toLocaleDateString("fr")}</td>
                 <td className="px-4 py-3">
                   <div className="flex w-fit gap-2 text-lg">

--- a/app/src/scenes/broadcast/Widgets.jsx
+++ b/app/src/scenes/broadcast/Widgets.jsx
@@ -59,7 +59,7 @@ const Widgets = () => {
   };
 
   return (
-    <div className="space-y-6 p-12">
+    <div className="space-y-6 p-4 sm:p-12">
       <title>API Engagement - Widgets - Diffuser des missions</title>
       <div className="mb-10 flex flex-col items-center justify-between gap-4 lg:flex-row lg:gap-4">
         <div role="search" className="flex flex-1 flex-col items-center gap-4 lg:flex-row lg:gap-4">

--- a/app/src/scenes/broadcast/moderation/components/Filters.jsx
+++ b/app/src/scenes/broadcast/moderation/components/Filters.jsx
@@ -66,8 +66,8 @@ const Filters = ({ filters, onChange, reload }) => {
           <h2 className="text-xl font-semibold text-black">Modération manuelle</h2>
         </div>
       </div>
-      <div className="mb-4 flex w-full justify-start">
-        <SearchInput value={filters.search} onChange={(e) => onChange({ ...filters, search: e })} placeholder="Rechercher" className="w-[40%]" />
+      <div className="mt-4 mb-4 flex w-full justify-start sm:mt-0">
+        <SearchInput value={filters.search} onChange={(e) => onChange({ ...filters, search: e })} placeholder="Rechercher" className="w-full sm:w-[40%]" />
       </div>
       <div className="grid grid-cols-1 gap-4 pb-4 md:grid-cols-2 lg:grid-cols-4">
         <Select

--- a/app/src/scenes/broadcast/moderation/components/Header.jsx
+++ b/app/src/scenes/broadcast/moderation/components/Header.jsx
@@ -22,8 +22,8 @@ const Header = ({ total, data, size, sort, selected, onSize, onSort, onSelect, o
 
   if (selected.length > 0) {
     return (
-      <div ref={headerRef} className={`sticky top-0 z-10 bg-white ${isSticky ? "px-12 shadow-md" : "mx-12"}`}>
-        <div className="flex items-center justify-between gap-4 py-4">
+      <div ref={headerRef} className={`sticky top-0 z-10 bg-white ${isSticky ? "px-4 shadow-md sm:px-12" : "mx-4 sm:mx-12"}`}>
+        <div className="flex flex-wrap items-center justify-between gap-4 py-4">
           {isSticky ? (
             <div>
               <button
@@ -54,10 +54,10 @@ const Header = ({ total, data, size, sort, selected, onSize, onSort, onSelect, o
   }
 
   return (
-    <div className="mx-12 flex items-center justify-between gap-4 py-4">
+    <div className="mx-4 flex flex-wrap items-center justify-between gap-4 py-4 sm:mx-12">
       <h2 className="text-xl font-semibold">{total.toLocaleString("fr")} missions diffusables</h2>
 
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <label htmlFor="missions-per-page" className="text-text-mention text-xs">
           Missions affichées par page
         </label>

--- a/app/src/scenes/broadcast/moderation/index.jsx
+++ b/app/src/scenes/broadcast/moderation/index.jsx
@@ -145,7 +145,7 @@ const Moderation = () => {
   }
 
   return (
-    <div className="space-y-12 py-12">
+    <div className="space-y-12 py-4 sm:py-12">
       <title>API Engagement - Modération - Diffuser des missions</title>
       <MissionModal
         onChange={(updates) => {
@@ -153,9 +153,9 @@ const Moderation = () => {
           fetchHistory();
         }}
       />
-      <div className="mx-12 flex items-start justify-between">
+      <div className="mx-4 flex flex-col gap-4 sm:mx-12 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-center gap-4">
-          <img src={ModerationAutoIcon} className="h-14 w-14" alt="" aria-hidden="true" />
+          <img src={ModerationAutoIcon} className="h-14 w-14 shrink-0" alt="" aria-hidden="true" />
           <h2 className="text-xl font-semibold text-black">Modération automatique</h2>
         </div>
 
@@ -169,12 +169,12 @@ const Moderation = () => {
           </div>
         </div>
       </div>
-      <div className="px-12">
+      <div className="px-4 sm:px-12">
         <div className="h-px w-full bg-gray-900" />
       </div>
 
       <Filters filters={filters} onChange={(next) => setFilters({ ...filters, ...next, page: 1 })} searchParams={searchParams} reload={reloadFilters} />
-      <div className="px-12">
+      <div className="px-4 sm:px-12">
         <div className="h-px w-full bg-gray-900" />
       </div>
       <Header
@@ -196,7 +196,7 @@ const Moderation = () => {
         }}
       />
 
-      <div className="mx-12">
+      <div className="mx-4 overflow-x-auto sm:mx-12">
         <Table
           caption="Missions en modération"
           header={[

--- a/app/src/scenes/campaign/Edit.jsx
+++ b/app/src/scenes/campaign/Edit.jsx
@@ -168,7 +168,7 @@ const Edit = () => {
           Retour
         </Link>
 
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h1 className="text-4xl font-bold">Modifier une campagne</h1>
             <p className="text-text-mention mt-2 text-base">Créée le {new Date(campaign.createdAt).toLocaleDateString("fr")}</p>
@@ -185,7 +185,7 @@ const Edit = () => {
           </div>
         </div>
 
-        <div className="flex flex-col gap-8 bg-white p-10 shadow-lg">
+        <div className="flex flex-col gap-8 bg-white p-4 shadow-lg sm:p-10">
           <div>
             <h2 className="mb-2 text-3xl font-bold">Paramètres</h2>
             <p className="text-text-mention text-xs">

--- a/app/src/scenes/campaign/components/Information.jsx
+++ b/app/src/scenes/campaign/components/Information.jsx
@@ -59,7 +59,7 @@ const Information = ({ values, onChange, errors, onErrorChange }) => {
 
   return (
     <>
-      <div className="flex gap-8">
+      <div className="flex flex-col gap-8 sm:flex-row">
         <div className="flex flex-1 flex-col gap-2">
           <label className="text-sm" htmlFor="name">
             Nom de la campagne<span className="text-error ml-1">*</span>
@@ -93,7 +93,7 @@ const Information = ({ values, onChange, errors, onErrorChange }) => {
           />
         </div>
       </div>
-      <div className="flex gap-8">
+      <div className="flex flex-col gap-8 sm:flex-row">
         <div className="flex flex-1 flex-col gap-2">
           <label className="text-sm" htmlFor="type">
             Type de campagne<span className="text-error ml-1">*</span>

--- a/app/src/scenes/campaign/components/Trackers.jsx
+++ b/app/src/scenes/campaign/components/Trackers.jsx
@@ -40,7 +40,8 @@ const Trackers = ({ values, onChange }) => {
         <label className="ml-2 text-base">Ajouter des paramètres pour le suivi statistique</label>
       </div>
       {values.trackers && values.trackers.length > 0 && (
-        <div className="border-grey-border border p-8">
+        <div className="border-grey-border overflow-x-auto border p-4 sm:p-8">
+          <div className="min-w-[500px]">
           <div className="mb-2 flex items-center gap-4">
             <label className="flex-1 text-base">Nom du paramètre</label>
             <label className="flex-1 text-base">Valeur du paramètre</label>
@@ -62,6 +63,7 @@ const Trackers = ({ values, onChange }) => {
           <button type="button" className="secondary-btn mt-4" onClick={() => onChange({ ...values, trackers: [...values.trackers, { key: "", value: "" }] })}>
             Ajouter un paramètre
           </button>
+          </div>
         </div>
       )}
     </>

--- a/app/src/scenes/cgu/index.jsx
+++ b/app/src/scenes/cgu/index.jsx
@@ -3,10 +3,10 @@ const Index = () => {
   return (
     <>
       <title>API Engagement - Conditions Générales d’Utilisation</title>
-      <div className="mx-auto my-14 w-4/5 max-w-[1200px] flex-1 space-y-10">
+      <div className="mx-auto my-14 w-full max-w-[1200px] flex-1 space-y-10 px-4 sm:w-4/5 sm:px-0">
         <h1 className="mb-2 text-4xl font-bold">Conditions Générales d’Utilisation</h1>
 
-        <div className="space-y-10 border bg-white px-24 py-12 text-base">
+        <div className="space-y-10 border bg-white px-4 py-12 text-base sm:px-24">
           <p>En vigueur à partir du 20/03/2025</p>
           <div className="space-y-6">
             <h2 className="text-lg font-bold">Article 1 - Champ d’application</h2>

--- a/app/src/scenes/mission/View.jsx
+++ b/app/src/scenes/mission/View.jsx
@@ -38,14 +38,14 @@ const View = () => {
       <title>{`API Engagement - ${mission.title}`}</title>
       <div className="space-y-6">
         <h1 className="text-4xl leading-normal font-bold">{mission.title}</h1>
-        <div className="flex justify-between">
+        <div className="flex flex-wrap justify-between gap-4">
           <p>
             Pour l'association{" "}
             <a href={mission.organizationUrl} target="_blank" className="link">
               {mission.organizationName}
             </a>
           </p>
-          <div className="text-text-mention flex items-center gap-2 text-base">
+          <div className="text-text-mention flex flex-wrap items-center gap-2 text-base">
             <HiLocationMarker className="ml-2" aria-hidden="true" />
             <span>{mission.country}</span>
             {mission.departmentName && (
@@ -64,14 +64,14 @@ const View = () => {
         </div>
       </div>
 
-      <div className="space-y-12 bg-white p-12">
-        <div className="flex justify-between">
+      <div className="space-y-12 bg-white p-4 sm:p-12">
+        <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
           <div>
             <h2 className="text-3xl font-bold">
               <span className="text-text-mention font-normal">Mission provenant de </span>
               {mission.publisherName}
-              <span className="ml-2 text-lg font-normal">#{mission._id}</span>
             </h2>
+            <p className="break-all text-lg font-normal">#{mission._id}</p>
             <p className="mt-2">Mise à jour le {new Date(mission.lastSyncAt).toLocaleString().replace(" ", " à ")}</p>
           </div>
 
@@ -81,32 +81,36 @@ const View = () => {
           </a>
         </div>
 
-        <div className="border-grey-border flex gap-4 border p-6">
-          <div>
+        <div className="border-grey-border flex flex-col gap-4 border p-4 sm:flex-row sm:p-6">
+          <div className="flex-1">
             <p className="text-xl font-semibold">Presentation de la mission</p>
             <div className="mt-2 max-h-96 overflow-y-scroll text-xs leading-relaxed" dangerouslySetInnerHTML={{ __html: `<p>${mission.description.replace(/\n/g, "</p><p>")}</p>` }} />
           </div>
-          <div className="w-px bg-gray-900" />
-          <div>
-            <div className="mb-4 flex items-center">
+          <div className="hidden w-px bg-gray-900 sm:block" />
+          <div className="border-t border-gray-900 pt-4 sm:border-t-0 sm:pt-0">
+            <div className="mb-4 space-y-2">
               <p className="text-xl font-semibold">Domaine de la mission</p>
-              <span className="ml-3 rounded-full bg-gray-950 px-3 py-2">{mission.domain}</span>
+              <span className="inline-block rounded-full bg-gray-950 px-3 py-2">{mission.domain}</span>
             </div>
-            <div className="mb-4 flex items-center">
+            <div className="mb-4 space-y-2">
               <p className="text-text-mention text-xs font-semibold uppercase">Activités</p>
-              {(mission.activities || []).map((activity, index) => (
-                <span key={index} className="ml-3 rounded bg-purple-300 px-3 py-1 text-xs font-semibold text-purple-950 uppercase">
-                  {activity}
-                </span>
-              ))}
+              <div className="flex flex-wrap gap-2">
+                {(mission.activities || []).map((activity, index) => (
+                  <span key={index} className="rounded bg-purple-300 px-3 py-1 text-xs font-semibold text-purple-950 uppercase">
+                    {activity}
+                  </span>
+                ))}
+              </div>
             </div>
-            <div className="flex flex-wrap items-center">
+            <div className="space-y-2">
               <p className="text-text-mention text-xs font-semibold uppercase">Compétences</p>
-              {(mission.softSkills || []).map((skill, index) => (
-                <span key={index} className="bg-yellow-tournesol-950 text-yellow-tournesol-200 my-1 ml-3 rounded px-3 py-1 text-xs font-semibold uppercase">
-                  {skill}
-                </span>
-              ))}
+              <div className="flex flex-wrap gap-2">
+                {(mission.softSkills || []).map((skill, index) => (
+                  <span key={index} className="bg-yellow-tournesol-950 text-yellow-tournesol-200 rounded px-3 py-1 text-xs font-semibold uppercase">
+                    {skill}
+                  </span>
+                ))}
+              </div>
             </div>
           </div>
         </div>

--- a/app/src/scenes/my-missions/Flux.jsx
+++ b/app/src/scenes/my-missions/Flux.jsx
@@ -127,7 +127,7 @@ const Flux = ({ moderated }) => {
   };
 
   return (
-    <div className="space-y-12 p-12">
+    <div className="space-y-12 p-4 sm:p-12">
       <title>API Engagement - Missions partagées - Vos Missions</title>
       {moderated && !hideAlert && (
         <InfoAlert onClose={() => setHideAlert(true)}>
@@ -138,7 +138,7 @@ const Flux = ({ moderated }) => {
         </InfoAlert>
       )}
       <div className="flex flex-col gap-6">
-        <SearchInput className="w-96" value={filters.search} onChange={(search) => setFilters({ ...filters, search })} placeholder="Rechercher par mot-clé" />
+        <SearchInput className="w-full sm:w-96" value={filters.search} onChange={(search) => setFilters({ ...filters, search })} placeholder="Rechercher par mot-clé" />
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
           <Select
             options={options.status.map((e) => ({ value: e.key, label: STATUS_PLR[e.key], count: e.doc_count }))}
@@ -187,23 +187,23 @@ const Flux = ({ moderated }) => {
       </div>
 
       <div className="flex flex-col gap-6">
-        <div className="flex items-center justify-between gap-4">
-          <div className="max-w-[60%] flex-1 space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="min-w-0 flex-1 space-y-2">
             <h2 className="text-2xl font-bold">{total.toLocaleString("fr")} missions partagées</h2>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <p className="text-text-mention text-base">Dernière synchronisation le {lastImport ? new Date(lastImport.startedAt).toLocaleDateString("fr") : "N/A"}</p>
               {lastImport && new Date(lastImport.startedAt) > new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() - 1) ? (
-                <RiCheckboxCircleFill role="img" aria-label="OK" className="text-success text-base" />
+                <RiCheckboxCircleFill role="img" aria-label="OK" className="text-success shrink-0 text-base" />
               ) : (
-                <ErrorIconSvg role="img" aria-label="Erreur" className="fill-error h-4 w-4" />
+                <ErrorIconSvg role="img" aria-label="Erreur" className="fill-error h-4 w-4 shrink-0" />
               )}
-              <Link to="/settings" className="link">
+              <Link to="/settings" className="link whitespace-nowrap">
                 Paraméter mon flux de missions
               </Link>
             </div>
           </div>
 
-          <button className="tertiary-btn" onClick={handleExport}>
+          <button className="tertiary-btn shrink-0" onClick={handleExport}>
             {exporting ? <Loader /> : <RiFileDownloadLine className="mr-2" aria-hidden="true" />}
             Exporter
           </button>

--- a/app/src/scenes/my-missions/Moderation.jsx
+++ b/app/src/scenes/my-missions/Moderation.jsx
@@ -125,9 +125,9 @@ const Moderation = () => {
   }
 
   return (
-    <div className="space-y-12 p-12">
+    <div className="space-y-12 p-4 sm:p-12">
       <title>API Engagement - Modération - Vos Missions</title>
-      <div className="mb-8 flex items-end justify-between gap-4">
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h2 className="text-3xl font-bold">Modération de JeVeuxAider.gouv.fr</h2>
           <p className="text-text-mention text-sm">
@@ -137,13 +137,13 @@ const Moderation = () => {
             </a>
           </p>
         </div>
-        <img className="w-2/5" src={JvaLogoPng} alt="" aria-hidden="true" />
+        <img className="hidden w-2/5 sm:block" src={JvaLogoPng} alt="" aria-hidden="true" />
       </div>
 
       <div className="border-b border-b-gray-900 pb-8">
-        <SearchInput value={filters.search} onChange={(search) => setFilters({ ...filters, search })} className="w-96" placeholder="Rechercher par mot-clé" />
+        <SearchInput value={filters.search} onChange={(search) => setFilters({ ...filters, search })} className="w-full sm:w-96" placeholder="Rechercher par mot-clé" />
 
-        <div className="mt-4 flex flex-1 items-center gap-4">
+        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
           <Select
             options={options.status.map((e) => ({ value: e.key === "" ? "none" : e.key, label: e.key === "" ? "Non renseigné" : STATUS[e.key], count: e.doc_count }))}
             value={filters.status}
@@ -221,13 +221,13 @@ const Moderation = () => {
         </div>
       )}
 
-      <div className="grid grid-cols-3 gap-5">
+      <div className="grid grid-cols-1 gap-5 lg:grid-cols-3">
         <div className="border-grey-border border p-4">
           <div className="flex items-start">
             <h3 className="flex-1 text-lg font-bold">Répartition des missions par statut</h3>
           </div>
           <div className="p-4">
-            <Pie data={stats.status} backgroundColor={colors} legendPosition="right" />
+            <Pie data={stats.status} backgroundColor={colors} legendPosition="bottom" />
           </div>
         </div>
         <div className="border-grey-border col-span-2 border p-4">
@@ -263,7 +263,7 @@ const Moderation = () => {
         </div>
       </div>
 
-      <div className="border-grey-border border p-6">
+      <div className="border-grey-border overflow-x-auto border p-4 sm:p-6">
         <Table
           caption="Missions en modération"
           header={MISSIONS_TABLE_HEADER}

--- a/app/src/scenes/my-missions/index.jsx
+++ b/app/src/scenes/my-missions/index.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import { Link, Route, Routes, useLocation } from "react-router-dom";
+import { Route, Routes, useLocation } from "react-router-dom";
 
+import Tabs from "@/components/Tabs";
 import api from "@/services/api";
 import { captureError } from "@/services/error";
 import useStore from "@/services/store";
@@ -11,6 +12,9 @@ const MyMissions = () => {
   const { publisher } = useStore();
   const publisherId = publisher?.id;
   const [moderated, setModerated] = useState(false);
+  const location = useLocation();
+
+  const currentRoute = location.pathname.split("/my-missions")[1]?.replace("/", "") || "";
 
   useEffect(() => {
     const fetchData = async () => {
@@ -25,16 +29,35 @@ const MyMissions = () => {
     fetchData();
   }, [publisher.id]);
 
+  const tabs = [
+    {
+      key: "missions",
+      label: "Missions partagées",
+      to: `/${publisherId}/my-missions`,
+      isActive: currentRoute === "" || currentRoute === "my-missions",
+    },
+    ...(moderated
+      ? [
+          {
+            key: "moderation",
+            label: "Modération",
+            to: `/${publisherId}/my-missions/moderated-mission`,
+            isActive: currentRoute === "moderated-mission",
+          },
+        ]
+      : []),
+  ].map((tab) => ({
+    ...tab,
+    id: `my-missions-tab-${tab.key}`,
+  }));
+
   return (
     <div className="space-y-12">
       <h1 className="text-4xl font-bold">Vos missions partagées</h1>
 
       <div>
-        <div className="flex items-center space-x-4 pl-4 font-semibold text-black">
-          <Tab route="" title="Mission partagées" publisherId={publisherId} />
-          {moderated && <Tab route="moderated-mission" title="Modération" publisherId={publisherId} />}
-        </div>
-        <section className="bg-white shadow-lg">
+        <Tabs tabs={tabs} ariaLabel="Vos missions" panelId="my-missions-panel" className="flex items-center gap-4 pl-4 font-semibold text-black" variant="primary" />
+        <section id="my-missions-panel" className="bg-white shadow-lg">
           <Routes>
             <Route path="/" element={<Flux moderated={moderated} />} />
             <Route path="/moderated-mission" element={<Moderation />} />
@@ -42,28 +65,6 @@ const MyMissions = () => {
         </section>
       </div>
     </div>
-  );
-};
-
-const Tab = ({ title, route = "", actives = [route], publisherId }) => {
-  const [active, setActive] = useState(false);
-  const location = useLocation();
-
-  useEffect(() => {
-    const current = location.pathname.split("/my-missions")[1].split("/")[1] || "";
-    setActive(actives.includes(current));
-  }, [location]);
-
-  return (
-    <Link to={`/${publisherId}/my-missions/${route}`}>
-      <div
-        className={`${
-          active ? "border-blue-france text-blue-france hover:bg-gray-975 border-t-2 bg-white" : "bg-blue-france-925 hover:bg-blue-france-925-hover border-0"
-        } border-x-grey-border flex translate-y-px cursor-pointer items-center border-x px-4 py-2`}
-      >
-        <p>{title}</p>
-      </div>
-    </Link>
   );
 };
 

--- a/app/src/scenes/performance/AnalyticsCard.jsx
+++ b/app/src/scenes/performance/AnalyticsCard.jsx
@@ -57,7 +57,11 @@ const AnalyticsCard = ({
     return content;
   }
 
-  return <div className="space-y-4 p-6">{content}</div>;
+  return (
+    <div className="overflow-x-auto">
+      <div className="min-w-[600px] space-y-4 p-0 sm:p-6">{content}</div>
+    </div>
+  );
 };
 
 export default AnalyticsCard;

--- a/app/src/scenes/performance/GlobalAnnounce.jsx
+++ b/app/src/scenes/performance/GlobalAnnounce.jsx
@@ -287,13 +287,7 @@ const Evolution = ({ filters }) => {
         <p className="text-text-mention text-base">Trafic reçu grâce à vos partenaires diffuseurs</p>
       </div>
       <div className="border-grey-border overflow-x-auto border p-4">
-        <Tabs
-          tabs={tabs}
-          ariaLabel="Trafic reçu grâce à vos partenaires diffuseurs"
-          panelId="announce-evolution-panel"
-          className="mb-8 flex flex-wrap items-center gap-8 text-sm"
-          variant="underline"
-        />
+        <Tabs tabs={tabs} ariaLabel="Trafic reçu grâce à vos partenaires diffuseurs" panelId="announce-evolution-panel" className="mb-6 gap-8 pb-2 text-sm" variant="underline" />
         <div id="announce-evolution-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
           {loading ? (
             <div className="flex h-[248px] items-center justify-center">
@@ -433,13 +427,7 @@ const Announcers = ({ filters }) => {
         </div>
       ) : (
         <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
-          <Tabs
-            tabs={tabs}
-            ariaLabel="Top partenaires diffuseurs"
-            panelId="announce-traffic-panel"
-            className="mb-8 flex flex-wrap items-center gap-8 text-sm"
-            variant="underline"
-          />
+          <Tabs tabs={tabs} ariaLabel="Top partenaires diffuseurs" panelId="announce-traffic-panel" className="mb-6 gap-8 pb-2 text-sm" variant="underline" />
           <div id="announce-traffic-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
             {!data.length ? (
               <div className="border-grey-border bg-background-grey-hover flex h-[248px] w-full flex-col items-center justify-center border border-dashed">

--- a/app/src/scenes/performance/GlobalAnnounce.jsx
+++ b/app/src/scenes/performance/GlobalAnnounce.jsx
@@ -286,7 +286,7 @@ const Evolution = ({ filters }) => {
         <h2 className="text-3xl font-bold">Evolution</h2>
         <p className="text-text-mention text-base">Trafic reçu grâce à vos partenaires diffuseurs</p>
       </div>
-      <div className="border-grey-border border p-4">
+      <div className="border-grey-border overflow-x-auto border p-4">
         <Tabs
           tabs={tabs}
           ariaLabel="Trafic reçu grâce à vos partenaires diffuseurs"
@@ -294,7 +294,7 @@ const Evolution = ({ filters }) => {
           className="mb-8 flex flex-wrap items-center gap-8 text-sm"
           variant="underline"
         />
-        <div id="announce-evolution-panel" role="tabpanel" aria-labelledby={activeTabId || undefined}>
+        <div id="announce-evolution-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
           {loading ? (
             <div className="flex h-[248px] items-center justify-center">
               <Loader />
@@ -432,7 +432,7 @@ const Announcers = ({ filters }) => {
           <Loader />
         </div>
       ) : (
-        <div className="border-grey-border space-y-4 border p-6">
+        <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
           <Tabs
             tabs={tabs}
             ariaLabel="Top partenaires diffuseurs"
@@ -440,7 +440,7 @@ const Announcers = ({ filters }) => {
             className="mb-8 flex flex-wrap items-center gap-8 text-sm"
             variant="underline"
           />
-          <div id="announce-traffic-panel" role="tabpanel" aria-labelledby={activeTabId || undefined}>
+          <div id="announce-traffic-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
             {!data.length ? (
               <div className="border-grey-border bg-background-grey-hover flex h-[248px] w-full flex-col items-center justify-center border border-dashed">
                 <img src={EmptySVG} alt="" aria-hidden="true" className="h-16 w-16" />

--- a/app/src/scenes/performance/GlobalBroadcast.jsx
+++ b/app/src/scenes/performance/GlobalBroadcast.jsx
@@ -191,7 +191,7 @@ const DistributionMean = ({ filters }) => {
   return (
     <div className="space-y-6">
       <h2 className="text-3xl font-bold">Répartition par moyen de diffusion</h2>
-      <div className="border-grey-border space-y-4 border p-6">
+      <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
         <Tabs
           tabs={tabs}
           ariaLabel="Répartition par moyen de diffusion"
@@ -199,7 +199,7 @@ const DistributionMean = ({ filters }) => {
           className="mb-8 flex flex-wrap items-center gap-8 text-sm"
           variant="underline"
         />
-        <div id="distribution-panel" role="tabpanel" aria-labelledby={activeTabId || undefined}>
+        <div id="distribution-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
           {loading ? (
             <div className="flex h-64 items-center justify-center">
               <Loader />
@@ -411,9 +411,9 @@ const Evolution = ({ filters }) => {
         <h2 className="text-3xl font-bold">Evolution</h2>
         <p className="text-text-mention text-base">Trafic que vous avez généré pour vos partenaires annonceurs</p>
       </div>
-      <div className="border-grey-border border p-4">
+      <div className="border-grey-border overflow-x-auto border p-4">
         <Tabs tabs={tabs} ariaLabel="Evolution" panelId="evolution-panel" className="mb-8 flex flex-wrap items-center gap-8 text-sm" variant="underline" />
-        <div id="evolution-panel" role="tabpanel" aria-labelledby={activeTabId || undefined}>
+        <div id="evolution-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
           {loading ? (
             <div className="flex h-[420px] items-center justify-center">
               <Loader />
@@ -583,8 +583,8 @@ const Announcers = ({ filters }) => {
         </div>
       ) : (
         <>
-          <div className="border-grey-border space-y-4 border p-6">
-            <div className="flex flex-col gap-4">
+          <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
+            <div className="min-w-[600px] flex flex-col gap-4">
               <h3 className="text-2xl font-semibold">Performance des annonceurs</h3>
               <Table
                 caption="Performance des annonceurs"
@@ -615,7 +615,8 @@ const Announcers = ({ filters }) => {
               </Table>
             </div>
           </div>
-          <div className="border-grey-border space-y-4 border p-6">
+          <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
+            <div className="min-w-[600px]">
             <h3 className="text-2xl font-semibold">Répartition des missions par annonceur</h3>
             {!missionData.length ? (
               <div className="border-grey-border bg-background-grey-hover flex h-[248px] w-full flex-col items-center justify-center border border-dashed">
@@ -656,6 +657,7 @@ const Announcers = ({ filters }) => {
                 </div>
               </div>
             )}
+            </div>
           </div>
         </>
       )}

--- a/app/src/scenes/performance/GlobalBroadcast.jsx
+++ b/app/src/scenes/performance/GlobalBroadcast.jsx
@@ -192,13 +192,7 @@ const DistributionMean = ({ filters }) => {
     <div className="space-y-6">
       <h2 className="text-3xl font-bold">Répartition par moyen de diffusion</h2>
       <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
-        <Tabs
-          tabs={tabs}
-          ariaLabel="Répartition par moyen de diffusion"
-          panelId="distribution-panel"
-          className="mb-8 flex flex-wrap items-center gap-8 text-sm"
-          variant="underline"
-        />
+        <Tabs tabs={tabs} ariaLabel="Répartition par moyen de diffusion" panelId="distribution-panel" className="mb-6 gap-8 pb-2 text-sm" variant="underline" />
         <div id="distribution-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
           {loading ? (
             <div className="flex h-64 items-center justify-center">
@@ -412,7 +406,7 @@ const Evolution = ({ filters }) => {
         <p className="text-text-mention text-base">Trafic que vous avez généré pour vos partenaires annonceurs</p>
       </div>
       <div className="border-grey-border overflow-x-auto border p-4">
-        <Tabs tabs={tabs} ariaLabel="Evolution" panelId="evolution-panel" className="mb-8 flex flex-wrap items-center gap-8 text-sm" variant="underline" />
+        <Tabs tabs={tabs} ariaLabel="Evolution" panelId="evolution-panel" className="mb-6 gap-8 pb-2 text-sm" variant="underline" />
         <div id="evolution-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
           {loading ? (
             <div className="flex h-[420px] items-center justify-center">
@@ -584,7 +578,7 @@ const Announcers = ({ filters }) => {
       ) : (
         <>
           <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
-            <div className="min-w-[600px] flex flex-col gap-4">
+            <div className="flex min-w-[600px] flex-col gap-4">
               <h3 className="text-2xl font-semibold">Performance des annonceurs</h3>
               <Table
                 caption="Performance des annonceurs"
@@ -602,9 +596,7 @@ const Announcers = ({ filters }) => {
                   .slice((tableSettings.page - 1) * 5, tableSettings.page * 5)
                   .map((item, i) => (
                     <tr key={i} className={`${i % 2 === 0 ? "bg-table-even" : "bg-table-odd"} table-row`}>
-                      <td className="px-4">
-                        {item.publisherId}
-                      </td>
+                      <td className="px-4">{item.publisherId}</td>
                       <td className="px-4 text-right">{item.printCount.toLocaleString("fr")}</td>
                       <td className="px-4 text-right">{item.clickCount.toLocaleString("fr")}</td>
                       <td className="px-4 text-right">{item.accountCount.toLocaleString("fr")}</td>
@@ -617,46 +609,50 @@ const Announcers = ({ filters }) => {
           </div>
           <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
             <div className="min-w-[600px]">
-            <h3 className="text-2xl font-semibold">Répartition des missions par annonceur</h3>
-            {!missionData.length ? (
-              <div className="border-grey-border bg-background-grey-hover flex h-[248px] w-full flex-col items-center justify-center border border-dashed">
-                <img src={EmptySVG} alt="" aria-hidden="true" className="h-16 w-16" />
-                <p className="text-color-gray-425 text-base">Aucune donnée disponible pour la période</p>
-              </div>
-            ) : (
-              <div className="flex justify-between gap-4">
-                <div className="w-2/3">
-                  <table className="w-full table-auto">
-                    <thead className="text-left">
-                      <tr className="text-text-mention text-xs uppercase">
-                        <th colSpan={3} className="px-4">
-                          Annonceurs
-                        </th>
-                        <th className="px-4 text-right">Nombre de missions</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {missionData.slice(0, 6).map((item, i) => (
-                        <tr key={i}>
-                          <td colSpan={3} className="p-4">
-                            <div className="flex items-center gap-2">
-                              <span className="mr-2 h-4 w-6" style={{ backgroundColor: COLORS[i % COLORS.length] }} />
-                              <div className="flex-1 text-sm font-semibold">{item.key}</div>
-                            </div>
-                          </td>
-                          <td className="px-4 text-right text-sm">{item.doc_count.toLocaleString("fr")}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
+              <h3 className="text-2xl font-semibold">Répartition des missions par annonceur</h3>
+              {!missionData.length ? (
+                <div className="border-grey-border bg-background-grey-hover flex h-[248px] w-full flex-col items-center justify-center border border-dashed">
+                  <img src={EmptySVG} alt="" aria-hidden="true" className="h-16 w-16" />
+                  <p className="text-color-gray-425 text-base">Aucune donnée disponible pour la période</p>
                 </div>
-                <div className="mr-8 ml-24 flex w-1/3 items-center justify-center">
-                  <div className="h-56 w-full">
-                    <Pie data={missionData?.slice(0, 6).map((d, i) => ({ name: d.key, value: d.doc_count, color: COLORS[i % COLORS.length] }))} innerRadius="0%" unit="missions" />
+              ) : (
+                <div className="flex justify-between gap-4">
+                  <div className="w-2/3">
+                    <table className="w-full table-auto">
+                      <thead className="text-left">
+                        <tr className="text-text-mention text-xs uppercase">
+                          <th colSpan={3} className="px-4">
+                            Annonceurs
+                          </th>
+                          <th className="px-4 text-right">Nombre de missions</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {missionData.slice(0, 6).map((item, i) => (
+                          <tr key={i}>
+                            <td colSpan={3} className="p-4">
+                              <div className="flex items-center gap-2">
+                                <span className="mr-2 h-4 w-6" style={{ backgroundColor: COLORS[i % COLORS.length] }} />
+                                <div className="flex-1 text-sm font-semibold">{item.key}</div>
+                              </div>
+                            </td>
+                            <td className="px-4 text-right text-sm">{item.doc_count.toLocaleString("fr")}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                  <div className="mr-8 ml-24 flex w-1/3 items-center justify-center">
+                    <div className="h-56 w-full">
+                      <Pie
+                        data={missionData?.slice(0, 6).map((d, i) => ({ name: d.key, value: d.doc_count, color: COLORS[i % COLORS.length] }))}
+                        innerRadius="0%"
+                        unit="missions"
+                      />
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
             </div>
           </div>
         </>

--- a/app/src/scenes/performance/Mean.jsx
+++ b/app/src/scenes/performance/Mean.jsx
@@ -231,7 +231,7 @@ const Mean = ({ filters, onFiltersChange }) => {
             }[source]
           }
         </h2>
-        <div className="border-grey-border flex flex-col gap-6 border p-6 md:flex-row">
+        <div className="border-grey-border flex flex-col gap-6 overflow-x-auto border p-6 md:flex-row">
           {graphLoading ? (
             <div className="flex w-full justify-center py-10">
               <Loader />
@@ -290,7 +290,7 @@ const Mean = ({ filters, onFiltersChange }) => {
         </div>
       </div>
 
-      <div className="border-grey-border bg-blue-france-975 flex items-center gap-8 border p-8">
+      <div className="border-grey-border bg-blue-france-975 flex flex-col items-center gap-8 overflow-x-auto border p-8 sm:flex-row">
         <div className="relative h-full w-[128px]">
           <img src={JessicaSvg} alt="" aria-hidden="true" className="absolute top-1/2 left-0 h-[72px] w-[72px] -translate-y-1/2 rounded-full" />
           <img src={NassimSvg} alt="" aria-hidden="true" className="absolute top-1/2 right-0 h-[72px] w-[72px] -translate-y-1/2 rounded-full" />
@@ -367,7 +367,8 @@ const SourcePerformance = ({ data, source }) => {
   const paginated = sorted.slice((page - 1) * pageSize, page * pageSize);
 
   return (
-    <div className="border-grey-border space-y-4 border p-6">
+    <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
+      <div className="min-w-[600px]">
       <h3 className="text-2xl font-semibold">Performance par {source === "widget" ? "widget" : "campagne"}</h3>
       <Table
         caption={`Performance par ${source === "widget" ? "widget" : "campagne"}`}
@@ -391,6 +392,7 @@ const SourcePerformance = ({ data, source }) => {
           </tr>
         ))}
       </Table>
+      </div>
     </div>
   );
 };

--- a/app/src/scenes/public-stats/components/Distribution.jsx
+++ b/app/src/scenes/public-stats/components/Distribution.jsx
@@ -46,18 +46,18 @@ const Distribution = ({ filters, onFiltersChange }) => {
   );
 
   return (
-    <div className="border-grey-border mx-auto my-14 w-4/5 max-w-[1200px] flex-1 border bg-white p-12">
-      <div className="flex justify-between">
-        <div className="">
+    <div className="border-grey-border mx-auto my-14 w-full max-w-[1200px] flex-1 border bg-white p-4 px-4 sm:w-4/5 sm:p-12">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
           <h3 className="text-3xl font-bold">Répartition des missions</h3>
         </div>
 
-        <div className="flex">
-          <div className="ml-4 flex items-center gap-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
             <label htmlFor="year" className="sr-only">
               Année
             </label>
-            <select id="year" className="input w-48" value={filters.year} onChange={(e) => onFiltersChange({ ...filters, year: parseInt(e.target.value, 10) })}>
+            <select id="year" className="input w-full sm:w-48" value={filters.year} onChange={(e) => onFiltersChange({ ...filters, year: parseInt(e.target.value, 10) })}>
               <option value={2020}>2020</option>
               <option value={2021}>2021</option>
               <option value={2022}>2022</option>
@@ -69,7 +69,7 @@ const Distribution = ({ filters, onFiltersChange }) => {
             <label htmlFor="department" className="sr-only">
               Département
             </label>
-            <select id="department" className="input w-48" value={departmentCode} onChange={(e) => onFiltersChange({ ...filters, department: e.target.value })}>
+            <select id="department" className="input w-full sm:w-48" value={departmentCode} onChange={(e) => onFiltersChange({ ...filters, department: e.target.value })}>
               <option value="">Départements</option>
               {Object.entries(DEPARTMENT_NAMES)
                 .sort((a, b) => a[0].localeCompare(b[0], "fr", { numeric: true }))

--- a/app/src/scenes/public-stats/components/SomeNumbers.jsx
+++ b/app/src/scenes/public-stats/components/SomeNumbers.jsx
@@ -103,18 +103,18 @@ const SomeNumbers = ({ filters, onFiltersChange }) => {
   }, [analyticsProvider, metabaseVariables, filters]);
 
   return (
-    <div className="border-grey-border mx-auto my-14 w-4/5 max-w-[1200px] flex-1 border bg-white p-12">
-      <div className="flex justify-between">
-        <div className="">
+    <div className="border-grey-border mx-auto my-14 w-full max-w-[1200px] flex-1 border bg-white p-4 px-4 sm:w-4/5 sm:p-12">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
           <h3 className="text-3xl font-bold">En quelques chiffres</h3>
         </div>
 
-        <div className="flex">
-          <div className="ml-4 flex items-center gap-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
             <label htmlFor="year" className="sr-only">
               Année
             </label>
-            <select id="year" className="input w-48" value={filters.year} onChange={(e) => onFiltersChange({ ...filters, year: parseInt(e.target.value, 10) })}>
+            <select id="year" className="input w-full sm:w-48" value={filters.year} onChange={(e) => onFiltersChange({ ...filters, year: parseInt(e.target.value, 10) })}>
               <option value={2020}>2020</option>
               <option value={2021}>2021</option>
               <option value={2022}>2022</option>
@@ -126,7 +126,7 @@ const SomeNumbers = ({ filters, onFiltersChange }) => {
             <label htmlFor="department" className="sr-only">
               Département
             </label>
-            <select id="department" className="input w-48" value={filters.department} onChange={(e) => onFiltersChange({ ...filters, department: e.target.value })}>
+            <select id="department" className="input w-full sm:w-48" value={filters.department} onChange={(e) => onFiltersChange({ ...filters, department: e.target.value })}>
               <option value="">Départements</option>
               {Object.entries(DEPARTMENT_NAMES)
                 .sort((a, b) => a[0].localeCompare(b[0], "fr", { numeric: true }))
@@ -139,7 +139,7 @@ const SomeNumbers = ({ filters, onFiltersChange }) => {
             <label htmlFor="mission-type" className="sr-only">
               Type de mission
             </label>
-            <select id="mission-type" className="input w-48" value={filters.type} onChange={(e) => onFiltersChange({ ...filters, type: e.target.value })}>
+            <select id="mission-type" className="input w-full sm:w-48" value={filters.type} onChange={(e) => onFiltersChange({ ...filters, type: e.target.value })}>
               <option value="">Type de mission</option>
               <option value="benevolat">Bénévolat</option>
               <option value="volontariat">Volontariat</option>

--- a/app/src/scenes/public-stats/index.jsx
+++ b/app/src/scenes/public-stats/index.jsx
@@ -35,18 +35,18 @@ const PublicStats = () => {
   return (
     <div className="flex w-full flex-col bg-white">
       <title>API Engagement - Statistiques</title>
-      <div className="mx-auto my-14 w-4/5 max-w-[1200px] flex-1">
-        <div className="flex justify-between">
+      <div className="mx-auto my-14 w-full max-w-[1200px] flex-1 px-4 sm:w-4/5 sm:px-0">
+        <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
             <h1 className="mb-2 text-4xl font-bold">Statistiques de l'API Engagement</h1>
             <p className="text-text-mention text-lg font-medium">L'API Engagement facilite la diffusion des missions de bénévolat et de volontariat partout en France.</p>
           </div>
 
-          <img className="h-18 w-18" src={APILogo} alt="" aria-hidden="true" />
+          <img className="h-18 w-18 shrink-0" src={APILogo} alt="" aria-hidden="true" />
         </div>
       </div>
       <div className="bg-global-background">
-        <div className="mx-auto my-14 w-4/5 max-w-[1200px] flex-1">
+        <div className="mx-auto my-14 w-full max-w-[1200px] flex-1 px-4 sm:w-4/5 sm:px-0">
           <div className="flex">
             <img className="h-18 w-18" src={dataViz} alt="" aria-hidden="true" />
             <div className="ml-5 flex flex-col">
@@ -58,9 +58,9 @@ const PublicStats = () => {
             </div>
           </div>
         </div>
-        <div className="border-grey-border mx-auto my-14 w-4/5 max-w-[1200px] border bg-white p-12">
+        <div className="border-grey-border mx-auto my-14 w-full max-w-[1200px] border bg-white p-4 px-4 sm:w-4/5 sm:p-12">
           <h3 className="text-3xl font-bold">En quelques mots</h3>
-          <div className="flex-start flex gap-6">
+          <div className="flex-start flex flex-col gap-6 sm:flex-row">
             <div className="text-text-mention mt-8 flex-1 text-lg leading-loose">
               <strong className="text-black">
                 L'API Engagement est un service public numérique qui permet aux plateformes d'engagement associatives, publiques et privées de mettre en commun leurs missions.

--- a/app/src/scenes/publisher/Create.jsx
+++ b/app/src/scenes/publisher/Create.jsx
@@ -64,13 +64,13 @@ const Create = () => {
         Retour
       </Link>
       <h1 className="text-4xl font-bold">Nouveau compte partenaire</h1>
-      <div className="space-y-12 bg-white p-12 shadow-lg">
+      <div className="space-y-12 bg-white p-4 shadow-lg sm:p-12">
         <Informations values={values} onChange={setValues} />
         <div className="h-px w-full bg-gray-900" />
         <div className="space-y-6">
           <h2 className="text-3xl font-bold">Paramètres</h2>
           {errors.settings && <p className="text-error">{errors.settings}</p>}
-          <div className="flex items-start gap-6">
+          <div className="flex flex-col gap-6 sm:flex-row sm:items-start">
             <div className="flex-1">
               <AnnonceurCreation values={values} onChange={setValues} errors={errors} setErrors={setErrors} />
             </div>

--- a/app/src/scenes/publisher/Edit.jsx
+++ b/app/src/scenes/publisher/Edit.jsx
@@ -171,20 +171,20 @@ const Edit = () => {
         <RiArrowLeftLine aria-hidden="true" />
         Retour
       </Link>
-      <div className="flex items-center">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
         <label
           htmlFor="logo"
-          className="flex h-24 w-32 cursor-pointer flex-col items-center justify-center bg-white p-2 shadow-lg transition-all duration-500 hover:bg-gray-900/10"
+          className="flex h-24 w-32 shrink-0 cursor-pointer flex-col items-center justify-center bg-white p-2 shadow-lg transition-all duration-500 hover:bg-gray-900/10"
         >
           <img src={`${[publisher.logo]}?${Date.now()}`} className="object-scale-down" alt="" aria-hidden="true" />
         </label>
         <input id="logo" accept=".gif,.jpg,.jpeg,.png" type="file" hidden onChange={handleFileChange} />
 
-        <div className="ml-8 pt-2">
+        <div className="pt-2 sm:ml-8">
           <h1 className="text-4xl font-bold">Compte partenaire de {values.name}</h1>
         </div>
       </div>
-      <div className="flex flex-col gap-12 bg-white p-12 shadow-lg">
+      <div className="flex flex-col gap-12 bg-white p-4 shadow-lg sm:p-12">
         <Informations values={values} onChange={setValues} />
         <div className="h-px w-full bg-gray-900" />
         <div className="flex w-full flex-col gap-6">
@@ -200,7 +200,7 @@ const Edit = () => {
         <div className="h-px w-full bg-gray-900" />
         <Members values={values} onChange={setValues} />
 
-        <div className="flex items-center justify-end gap-2">
+        <div className="flex flex-wrap items-center justify-end gap-2">
           <button className="red-btn flex items-center" onClick={handleDelete}>
             <TrashSvg className="mr-2" aria-hidden="true" />
             <span>Supprimer</span>

--- a/app/src/scenes/publisher/components/Administration.jsx
+++ b/app/src/scenes/publisher/components/Administration.jsx
@@ -1,7 +1,6 @@
-import { useEffect, useState } from "react";
-import Toggle from "@/components/Toggle";
 import api from "@/services/api";
 import { captureError } from "@/services/error";
+import { useEffect, useState } from "react";
 
 const Administration = ({ values, onChange }) => {
   const [excludedOrganizations, setExcludedOrganizations] = useState([]);
@@ -22,7 +21,7 @@ const Administration = ({ values, onChange }) => {
 
   return (
     <div className="flex items-center gap-6">
-      <div className="flex flex-1 items-center gap-4">
+      {/* <div className="flex flex-1 items-center gap-4">
         <label className="w-1/2 text-base" htmlFor="automated-report">
           Rapport automatisé
         </label>
@@ -34,11 +33,11 @@ const Administration = ({ values, onChange }) => {
           />
           {values.sendReport ? <p className="text-blue-france absolute top-8 right-0 text-base">Oui</p> : <p className="absolute top-8 right-0 text-base text-gray-700">Non</p>}
         </div>
-      </div>
+      </div> */}
       <div className="flex-1 space-y-4">
         <div className="flex flex-col gap-2">
           <label className="text-base" htmlFor="excludedOrganizations">
-            Organisations exclues de la diffusion par JeVeuxAider.gouv.fr
+            Organisations <strong>exclues</strong> de la diffusion par JeVeuxAider.gouv.fr
           </label>
 
           <div className="flex flex-wrap items-center gap-2">

--- a/app/src/scenes/publisher/components/Annonceur.jsx
+++ b/app/src/scenes/publisher/components/Annonceur.jsx
@@ -32,7 +32,7 @@ const Annonceur = ({ values, onChange, errors, setErrors }) => {
   }, [values.id]);
 
   return (
-    <div className="border-grey-border flex flex-1 flex-col gap-6 border p-6">
+    <div className="border-grey-border flex flex-1 flex-col gap-6 overflow-x-auto border p-4 sm:p-6">
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-bold">Annonceur</h3>
         <Toggle

--- a/app/src/scenes/settings/Flux.jsx
+++ b/app/src/scenes/settings/Flux.jsx
@@ -76,23 +76,23 @@ const Flux = () => {
   };
 
   return (
-    <div className="space-y-12 p-12">
+    <div className="space-y-12 p-4 sm:p-12">
       <title>API Engagement - Flux de missions - Paramètres</title>
-      <div className="border-grey-border space-y-8 border p-8">
+      <div className="border-grey-border space-y-8 border p-4 sm:p-8">
         <h2 className="text-3xl font-bold">Configurer votre flux de missions</h2>
 
-        <div className="flex items-center justify-between gap-6">
-          <label className="w-[35%] flex-none font-semibold">Lien du fichier XML à synchroniser</label>
-          <div className="flex flex-1 gap-2">
-            <input className="input border-blue-france-925 bg-blue-france-975 w-full border read-only:opacity-80" value={publisher.feed} readOnly />
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+          <label className="font-semibold sm:w-[35%] sm:flex-none">Lien du fichier XML à synchroniser</label>
+          <div className="flex min-w-0 flex-1 gap-2">
+            <input className="input border-blue-france-925 bg-blue-france-975 min-w-0 flex-1 border read-only:opacity-80" value={publisher.feed} readOnly />
             {user.role === "admin" && <ModifyModal />}
           </div>
         </div>
 
         <div className="h-px w-full bg-gray-900" />
 
-        <div className="flex items-center justify-between gap-6">
-          <label className="w-[35%] font-semibold">Dernière synchronisation</label>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+          <label className="font-semibold sm:w-[35%]">Dernière synchronisation</label>
           <div className="flex flex-1 gap-2">
             {imports.length > 0 && lastSync < new Date(Date.now() - 24 * 60 * 60 * 1000) ? (
               <div className="items-center">
@@ -110,7 +110,7 @@ const Flux = () => {
         </div>
       </div>
 
-      <div className="border-grey-border space-y-6 border p-6">
+      <div className="border-grey-border space-y-6 overflow-x-auto border p-4 sm:p-6">
         <h2 className="text-3xl font-bold">Historique des synchronisations</h2>
 
         <Table

--- a/app/src/scenes/settings/RealTime.jsx
+++ b/app/src/scenes/settings/RealTime.jsx
@@ -111,7 +111,7 @@ const RealTime = () => {
   }, [flux, publisher, setSearchParams, type, sourceId, sourceType]);
 
   return (
-    <div className="space-y-12 p-12">
+    <div className="space-y-12 p-4 sm:p-12">
       <title>API Engagement - Événements en temps réel - Paramètres</title>
       <div className="border-grey-border space-y-8 border p-8">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">

--- a/app/src/scenes/settings/TrackingAnnounce.jsx
+++ b/app/src/scenes/settings/TrackingAnnounce.jsx
@@ -24,9 +24,9 @@ const TrackingAnnounce = () => {
   };
 
   return (
-    <div className="space-y-12 p-12">
+    <div className="space-y-12 p-4 sm:p-12">
       <title>API Engagement - Tracking des événements - Paramètres</title>
-      <div className="border-grey-border space-y-8 border p-8">
+      <div className="border-grey-border space-y-8 border p-4 sm:p-8">
         <h2 className="text-2xl font-bold">Tracking des événements</h2>
 
         <div className="space-y-4 border-b border-b-gray-900 pb-6">
@@ -36,11 +36,11 @@ const TrackingAnnounce = () => {
               Lorsque vous enregistrez une candidature, effectuez cette commande chez vous nous permet de compter cette candidature.
             </p>
           </div>
-          <div className="flex items-center gap-2">
-            <div className="border-blue-france-925 bg-blue-france-975 min-w-0 flex-1 overflow-x-auto rounded-none border px-4 py-2 text-sm">
+          <div className="space-y-2">
+            <div className="border-blue-france-925 bg-blue-france-975 overflow-x-auto rounded-none border px-4 py-2 text-sm">
               <code className="whitespace-nowrap">window.apieng && window.apieng("trackApplication", <span className="text-warning">clientId</span>)</code>
             </div>
-            <button className="secondary-btn shrink-0" onClick={() => handleCopyCommand(`window.apieng && window.apieng("trackApplication", "clientId")`)}>
+            <button className="secondary-btn" onClick={() => handleCopyCommand(`window.apieng && window.apieng("trackApplication", "clientId")`)}>
               Copier
             </button>
           </div>
@@ -53,11 +53,11 @@ const TrackingAnnounce = () => {
                 Lorsque vous enregistrez une création de compte, effectuez cette commande chez vous nous permet de compter cette création de compte.
               </p>
             </div>
-            <div className="flex items-center gap-2">
-              <div className="border-blue-france-925 bg-blue-france-975 min-w-0 flex-1 overflow-x-auto rounded-none border px-4 py-2 text-sm">
+            <div className="space-y-2">
+              <div className="border-blue-france-925 bg-blue-france-975 overflow-x-auto rounded-none border px-4 py-2 text-sm">
                 <code className="whitespace-nowrap">window.apieng && window.apieng("trackAccount", <span className="text-warning">clientId</span>)</code>
               </div>
-              <button className="secondary-btn shrink-0" onClick={() => handleCopyCommand(`window.apieng && window.apieng("trackAccount", "clientId")`)}>
+              <button className="secondary-btn" onClick={() => handleCopyCommand(`window.apieng && window.apieng("trackAccount", "clientId")`)}>
                 Copier
               </button>
             </div>
@@ -73,12 +73,12 @@ const TrackingAnnounce = () => {
         </div>
 
         <div className="space-y-4">
-          <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
             <div>
               <h3 className="text-base font-semibold">Script à integrer sur votre site</h3>
               <p className="text-text-mention text-xs">{`Afin d'assurer le suivi des candidatures générées via l'API Engagement, ajoutez le script ci-dessous dans le <head></head> de votre page sur laquelle un bénévole candidate à une offre`}</p>
             </div>
-            <button className="secondary-btn shrink-0" onClick={handleCopyScript}>
+            <button className="secondary-btn" onClick={handleCopyScript}>
               Copier
             </button>
           </div>

--- a/app/src/scenes/settings/TrackingBroadcast.jsx
+++ b/app/src/scenes/settings/TrackingBroadcast.jsx
@@ -18,7 +18,7 @@ const TrackingBroadcast = () => {
   };
 
   return (
-    <div className="space-y-4 bg-white p-12 shadow-lg">
+    <div className="space-y-12 p-4 sm:p-12">
       <div className="space-y-2">
         <h2 className="text-3xl font-bold">Script à intégrer sur votre site</h2>
         <p className="text-text-mention text-sm">

--- a/app/src/scenes/user/Create.jsx
+++ b/app/src/scenes/user/Create.jsx
@@ -85,7 +85,7 @@ const Create = () => {
         <title>API Engagement - Nouvel utilisateur</title>
         <h1 className="text-4xl font-bold">Nouvel utilisateur</h1>
       </div>
-      <form onSubmit={handleSubmit} className="flex flex-col gap-6 bg-white p-16 shadow-lg">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-6 bg-white p-4 shadow-lg sm:p-16">
         <h2 className="text-3xl font-bold">Les informations</h2>
 
         <div className="grid grid-cols-1 gap-x-10 gap-y-5 lg:grid-cols-2">
@@ -118,7 +118,7 @@ const Create = () => {
 
           <input
             id="publishers"
-            className="input mb-4 w-64 flex-1 bg-gray-950 px-3 py-2 text-sm"
+            className="input mb-4 w-full bg-gray-950 px-3 py-2 text-sm sm:w-64"
             placeholder="Rechercher"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -178,7 +178,7 @@ const Create = () => {
           </Table>
         </div>
 
-        <div className="flex justify-end gap-4">
+        <div className="flex flex-wrap justify-end gap-4">
           <Link to="/admin-account" className="tertiary-btn">
             Retour
           </Link>

--- a/app/src/scenes/user/Edit.jsx
+++ b/app/src/scenes/user/Edit.jsx
@@ -135,8 +135,8 @@ const Edit = () => {
         <title>{`API Engagement - Compte utilisateur - ${user.firstname}`}</title>
         <h1 className="text-4xl font-bold">Compte utilisateur de {user.firstname}</h1>
       </div>
-      <form className="flex flex-col gap-6 bg-white p-16 shadow-lg" onSubmit={handleSubmit}>
-        <div className="flex justify-between">
+      <form className="flex flex-col gap-6 bg-white p-4 shadow-lg sm:p-16" onSubmit={handleSubmit}>
+        <div className="flex flex-wrap items-center justify-between gap-4">
           <h2 className="text-3xl font-bold">Les informations</h2>
           <button type="button" className="text-error flex cursor-pointer items-center text-sm" onClick={handleDelete}>
             <TiDeleteOutline className="mr-2" aria-hidden="true" />
@@ -174,7 +174,7 @@ const Edit = () => {
 
           <input
             id="publishers"
-            className="input mb-4 w-64 flex-1 bg-gray-950 px-3 py-2 text-sm"
+            className="input mb-4 w-full bg-gray-950 px-3 py-2 text-sm sm:w-64"
             placeholder="Rechercher"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -222,7 +222,7 @@ const Edit = () => {
           </Table>
         </div>
 
-        <div className="flex justify-end gap-4">
+        <div className="flex flex-wrap justify-end gap-4">
           <Link to="/admin-account" className="tertiary-btn">
             Retour
           </Link>

--- a/app/src/scenes/warnings/index.jsx
+++ b/app/src/scenes/warnings/index.jsx
@@ -111,8 +111,8 @@ const List = () => {
       <div className="mb-10 flex flex-col gap-8">
         <h1 className="text-3xl font-bold">État du service</h1>
 
-        <div className="flex items-center gap-8 bg-white p-6 shadow-sm">
-          <img className="h-18 w-18" src={APILogo} alt="" aria-hidden="true" />
+        <div className="flex flex-col gap-4 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:gap-8 sm:p-6">
+          <img className="h-18 w-18 shrink-0" src={APILogo} alt="" aria-hidden="true" />
           <div>
             {!state.up ? (
               <p className="text-xl">
@@ -133,7 +133,7 @@ const List = () => {
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-6 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-4 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:gap-6 sm:p-6">
           {currentWarnings.length > 1 ? (
             <>
               <div className="flex items-center justify-center">
@@ -164,9 +164,9 @@ const List = () => {
       </div>
 
       <div className="mb-4 flex flex-col">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-4">
           <h2 className="text-2xl font-bold">Alertes en cours</h2>
-          <a href="mailto:apiengagement@beta.gouv.fr" className="text-blue-france border-grey-border flex items-center border py-2 pr-3 pl-4 text-sm">
+          <a href="mailto:apiengagement@beta.gouv.fr" className="text-blue-france border-grey-border flex shrink-0 items-center border py-2 pr-3 pl-4 text-sm">
             Contacter le support
             <RiMessage2Line className="ml-2" aria-hidden="true" />
           </a>
@@ -181,7 +181,7 @@ const List = () => {
               {currentWarningsByDays[d].map((w, i) => {
                 const label = WARNINGS[w.type] || WARNINGS.OTHER_WARNING;
                 return (
-                  <Link to={LINKS[w.type]} className="flex items-end gap-8 bg-white p-6 shadow-sm" key={i} id={slugify(`${w.type}-${w.publisherName}`)}>
+                  <Link to={LINKS[w.type]} className="flex flex-col gap-4 bg-white p-4 shadow-sm sm:flex-row sm:items-end sm:gap-8 sm:p-6" key={i} id={slugify(`${w.type}-${w.publisherName}`)}>
                     <div className="flex items-center justify-center gap-8">
                       <div className="flex items-center justify-center">{label.emoji}</div>
                       <div className="flex flex-1 flex-col justify-between">
@@ -208,7 +208,7 @@ const List = () => {
       </div>
       <div className="space-y-6">
         <h2 className="text-2xl font-bold">Historiques des alertes passées</h2>
-        <div className="flex w-1/2 items-center justify-start gap-4">
+        <div className="flex w-full flex-col gap-4 sm:w-1/2 sm:flex-row sm:flex-wrap sm:items-center">
           <Select
             options={Object.entries(WARNINGS).map(([k, v]) => ({ value: k, label: v.name }))}
             value={archivedFilters.type}
@@ -244,7 +244,7 @@ const List = () => {
                 {archivedWarningsByDays[d].map((w, i) => {
                   const label = WARNINGS[w.type] || WARNINGS.OTHER_WARNING;
                   return (
-                    <div className="flex items-center gap-8 bg-white p-6 shadow-sm" key={i} id={slugify(`${w.type}-${w.publisherName}`)}>
+                    <div className="flex flex-col gap-4 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:gap-8 sm:p-6" key={i} id={slugify(`${w.type}-${w.publisherName}`)}>
                       <div className="flex items-center justify-center">{label.emoji}</div>
                       <div className="flex flex-1 flex-col justify-between">
                         <div className="mb-3">

--- a/app/src/scenes/widget/Edit.jsx
+++ b/app/src/scenes/widget/Edit.jsx
@@ -132,7 +132,7 @@ const Edit = () => {
         </Link>
       </div>
 
-      <div className="flex items-center justify-between align-baseline">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-4xl font-bold">Modifier un widget</h1>
           <span className="text-text-mention">Créé le {new Date(widget.createdAt).toLocaleDateString("fr")}</span>
@@ -202,7 +202,7 @@ const Frame = ({ widget }) => {
   };
 
   return (
-    <div className="space-y-10 bg-white p-16 shadow-lg">
+    <div className="space-y-10 bg-white p-4 shadow-lg sm:p-16">
       <div className="flex flex-col gap-2">
         <h2 className="text-2xl font-bold">Aperçu du widget</h2>
         <span>Enregistrez le widget pour mettre à jour l'aperçu</span>
@@ -249,11 +249,11 @@ const Code = ({ widget }) => {
   };
 
   return (
-    <div className="space-y-12 bg-white p-12 shadow-lg">
+    <div className="space-y-12 bg-white p-4 shadow-lg sm:p-12">
       <h2 className="text-2xl font-bold">Code à intégrer</h2>
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <p>Vous n’avez plus qu’à intégrer ce code pour afficher le widget sur votre site</p>
-        <button className="secondary-btn flex items-center" onClick={handleCopy}>
+        <button className="secondary-btn flex shrink-0 items-center" onClick={handleCopy}>
           <RiCodeSSlashFill className="mr-2" aria-hidden="true" />
           Copier le code
         </button>
@@ -276,9 +276,9 @@ const StickyBar = ({ onEdit, visible, widget, handleActivate, canSubmit }) => {
   }
 
   return (
-    <div className="fixed top-0 left-0 z-50 w-full items-center bg-white py-4 shadow-lg">
-      <div className="m-auto flex w-[90%] items-center justify-between">
-        <p className="text-2xl font-bold" aria-hidden="true">Modifier un widget</p>
+    <div className="fixed top-0 left-0 z-50 w-full items-center bg-white px-4 py-4 shadow-lg">
+      <div className="m-auto flex w-full items-center justify-between sm:w-[90%]">
+        <p className="hidden text-2xl font-bold sm:block" aria-hidden="true">Modifier un widget</p>
         <div className="flex items-center gap-6">
           <div className="flex flex-col items-end">
             <Toggle aria-label={widget.active ? "Désactiver le widget" : "Activer le widget"} value={widget.active} onChange={(value) => handleActivate(value)} />

--- a/app/src/scenes/widget/components/QueryBuilder.jsx
+++ b/app/src/scenes/widget/components/QueryBuilder.jsx
@@ -37,9 +37,9 @@ const QueryBuilder = ({ values, onChange }) => {
   };
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col overflow-x-auto">
       {values.rules.map((r, i) => (
-        <div key={i} className="my-3 flex w-full items-center gap-4">
+        <div key={i} className="my-3 flex min-w-[600px] items-center gap-4">
           <Rule index={i} fields={FIELDS} rule={r} onChange={(r) => handleRuleChange(r, i)} filters={values.publishers.map((p) => `publishers[]=${p}`).join("&")} />
           <button
             type="button"

--- a/app/src/scenes/widget/components/Settings.jsx
+++ b/app/src/scenes/widget/components/Settings.jsx
@@ -89,11 +89,11 @@ const Settings = ({ widget, values, onChange, loading }) => {
   }, [loading, values.publishers, values.location, values.distance, values.jvaModeration, values.rules]);
 
   return (
-    <div className="space-y-12 bg-white p-12 shadow-lg">
+    <div className="space-y-12 bg-white p-4 shadow-lg sm:p-12">
       <div className="space-y-10">
         <h2 className="text-2xl font-bold">Informations générales</h2>
 
-        <div className="grid grid-cols-2 gap-10">
+        <div className="grid grid-cols-1 gap-10 sm:grid-cols-2">
           <div className="flex flex-col gap-4">
             <label className="text-base" htmlFor="name">
               Nom du widget<span className="text-error ml-1">*</span>
@@ -115,7 +115,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
       <div className="space-y-10">
         <h2 className="text-2xl font-bold">Missions à diffuser</h2>
 
-        <div className="grid grid-cols-2 gap-10">
+        <div className="grid grid-cols-1 gap-10 sm:grid-cols-2">
           <div className="flex flex-col gap-1">
             <label className="text-base">
               Type de mission<span className="text-error ml-1">*</span>
@@ -205,7 +205,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
           {publishers.length === 0 ? (
             <p className="text-text-mention text-sm">Aucun partenaire disponible</p>
           ) : (
-            <div className={`grid grid-cols-3 gap-x-6 gap-y-3 ${values.type === "volontariat" ? "text-gray-625" : ""}`}>
+            <div className={`grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2 lg:grid-cols-3 ${values.type === "volontariat" ? "text-gray-625" : ""}`}>
               {publishers
                 .filter((item) => (values.type === "benevolat" ? item.key !== SC_ID : item.key === SC_ID))
                 .sort((a, b) => b.doc_count - a.doc_count)
@@ -275,7 +275,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
           )}
 
           {values.publishers.includes(JVA_ID) && (
-            <div className="flex w-[50%] items-center justify-between pt-6">
+            <div className="flex w-full flex-col gap-4 pt-6 sm:w-[50%] sm:flex-row sm:items-center sm:justify-between">
               <div> Afficher uniquement les missions modérées par JeVeuxAider.gouv.fr</div>
               <div className="flex items-center gap-4">
                 <Toggle
@@ -307,7 +307,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
       <div className="space-y-10">
         <h2 className="text-2xl font-bold">Personnalisation</h2>
 
-        <div className="grid grid-cols-2 gap-10">
+        <div className="grid grid-cols-1 gap-10 sm:grid-cols-2">
           <div className="flex flex-col gap-4">
             <label className="text-base" htmlFor="style">
               Mode d'affichage<span className="text-error ml-1">*</span>


### PR DESCRIPTION
## Description

Adaptation du responsive design de l'ensemble des pages de l'application pour conformité RGAA critère 10.11 (viewport 320x256px).

**Changements** :
- Adaptation des paddings (`p-12` → `p-4 sm:p-12`) sur toutes les pages
- Grilles responsives (`grid-cols-2/3/4` → `grid-cols-1 sm:grid-cols-2 lg:grid-cols-4`)
- Filtres et formulaires empilés verticalement sur mobile
- Tables scrollables horizontalement avec `overflow-x-auto` et `min-w-[600px]`
- Menu hamburger pour la navigation mobile
- DateRangePicker : boutons de période en colonne, calendrier plein écran avec 1 mois sur mobile
- Tabs scrollables horizontalement avec `whitespace-nowrap`
- Dropdowns contraints à la largeur du viewport (`w-[calc(100vw-2rem)] sm:w-64`)
- Footer et Header adaptés aux petits écrans
- Masquage des éléments décoratifs sur mobile (image auth, logo JVA)
- Modales en plein écran sur mobile

**Pages concernées** : toutes les pages de l'application (performance, broadcast, settings, my-missions, admin-account, admin-mission, admin-organization, admin-stats, admin-warning, admin-report, widget, campaign, publisher, user, account, auth, CGU, public-stats, mission, warnings)

## Liens utiles

- 📝 Ticket Notion : [lien](https://www.notion.so/jeveuxaider/Tableau-de-bord-007-Du-contenu-dispara-t-lorsque-la-feuille-a-une-hauteur-de-256px-et-une-largeur--23172a322d50805ea810cbf9a345553d?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Méthode de test** : Activer la vue adaptative dans l'inspecteur de code et choisir 256px en hauteur et 320px en largeur.

**Points d'attention** :
- 57 fichiers modifiés, vérifier visuellement les pages principales
- Le menu hamburger apparaît sous le breakpoint `lg` (1024px)
- Les fichiers `Broacaster.jsx` et `Announcer.jsx` dans admin-stats ont été renommés en `Diffuseur.jsx` et `Annonceur.jsx` (changement fait par l'utilisateur)