### PR TITLE
feat(api): add publisherRateLimiter and ipRateLimiter

### DIFF
--- a/api/docs/errors.md
+++ b/api/docs/errors.md
@@ -31,6 +31,8 @@ Toutes les erreurs retournent un objet JSON avec la structure suivante :
 
 ## Limite de débit (rate limiting)
 
+L'API autorise **600 requêtes par fenêtre de 60 secondes**, identifiées par votre clé API.
+
 En cas de dépassement, l'API retourne un `429 Too Many Requests`. Les headers de réponse indiquent l'état de votre quota :
 
 | Header | Description |

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8,6 +8,7 @@
             "name": "api",
             "version": "1.0.0",
             "dependencies": {
+                "@acpr/rate-limit-postgresql": "1.4.1",
                 "@aws-sdk/client-s3": "3.1020.0",
                 "@aws-sdk/lib-storage": "3.1020.0",
                 "@opentelemetry/exporter-metrics-otlp-http": "0.214.0",
@@ -39,6 +40,7 @@
                 "passport": "0.7.0",
                 "passport-headerapikey": "1.2.2",
                 "passport-jwt": "4.0.1",
+                "pg": "8.20.0",
                 "prisma": "7.6.0",
                 "sharp": "0.34.5",
                 "uuid": "11.1.0",
@@ -61,6 +63,7 @@
                 "@types/object-hash": "3.0.6",
                 "@types/passport": "1.0.17",
                 "@types/passport-jwt": "4.0.1",
+                "@types/pg": "8.20.0",
                 "@types/supertest": "7.2.0",
                 "@types/uuid": "10.0.0",
                 "@types/yauzl": "2.10.3",
@@ -76,6 +79,59 @@
                 "tsconfig-paths": "^4.2.0",
                 "typescript": "5.9.3",
                 "vitest": "4.1.1"
+            }
+        },
+        "node_modules/@acpr/rate-limit-postgresql": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@acpr/rate-limit-postgresql/-/rate-limit-postgresql-1.4.1.tgz",
+            "integrity": "sha512-dV/uEYD94onbyO56VJaU43pDXXUeaNqa/zs0V/Ar1BTgmZls5yrqgPqg1x2m5N87AKkMVkKoSxy64T3ldnaOew==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/pg-pool": "2.0.3",
+                "pg": "8.11.3",
+                "pg-pool": "3.6.1",
+                "postgres-migrations": "5.3.0"
+            },
+            "peerDependencies": {
+                "express-rate-limit": ">=6.0.0"
+            }
+        },
+        "node_modules/@acpr/rate-limit-postgresql/node_modules/@types/pg-pool": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.3.tgz",
+            "integrity": "sha512-fwK5WtG42Yb5RxAwxm3Cc2dJ39FlgcaNiXKvtTLAwtCn642X7dgel+w1+cLWwpSOFImR3YjsZtbkfjxbHtFAeg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/pg": "*"
+            }
+        },
+        "node_modules/@acpr/rate-limit-postgresql/node_modules/pg": {
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
+            "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer-writer": "2.0.0",
+                "packet-reader": "1.0.0",
+                "pg-connection-string": "^2.6.2",
+                "pg-pool": "^3.6.1",
+                "pg-protocol": "^1.6.0",
+                "pg-types": "^2.1.0",
+                "pgpass": "1.x"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
+            },
+            "optionalDependencies": {
+                "pg-cloudflare": "^1.1.1"
+            },
+            "peerDependencies": {
+                "pg-native": ">=3.0.1"
+            },
+            "peerDependenciesMeta": {
+                "pg-native": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -2416,6 +2472,17 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-pg/node_modules/@types/pg": {
+            "version": "8.15.6",
+            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
+            "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "pg-protocol": "*",
+                "pg-types": "^2.2.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-redis": {
             "version": "0.62.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.62.0.tgz",
@@ -2652,17 +2719,6 @@
                 "@types/pg": "^8.16.0",
                 "pg": "^8.16.3",
                 "postgres-array": "3.0.4"
-            }
-        },
-        "node_modules/@prisma/adapter-pg/node_modules/@types/pg": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
-            "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "pg-protocol": "*",
-                "pg-types": "^2.2.0"
             }
         },
         "node_modules/@prisma/client": {
@@ -4601,9 +4657,9 @@
             }
         },
         "node_modules/@types/pg": {
-            "version": "8.15.6",
-            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
-            "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+            "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
@@ -6091,6 +6147,15 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "license": "MIT"
+        },
+        "node_modules/buffer-writer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+            "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
         },
         "node_modules/buildcheck": {
             "version": "0.0.7",
@@ -10024,6 +10089,12 @@
             "dev": true,
             "license": "BlueOak-1.0.0"
         },
+        "node_modules/packet-reader": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+            "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
+            "license": "MIT"
+        },
         "node_modules/pako": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
@@ -10209,14 +10280,14 @@
             "optional": true
         },
         "node_modules/pg": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
-            "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+            "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
             "license": "MIT",
             "dependencies": {
-                "pg-connection-string": "^2.11.0",
-                "pg-pool": "^3.11.0",
-                "pg-protocol": "^1.11.0",
+                "pg-connection-string": "^2.12.0",
+                "pg-pool": "^3.13.0",
+                "pg-protocol": "^1.13.0",
                 "pg-types": "2.2.0",
                 "pgpass": "1.0.5"
             },
@@ -10243,9 +10314,9 @@
             "optional": true
         },
         "node_modules/pg-connection-string": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz",
-            "integrity": "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==",
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+            "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
             "license": "MIT"
         },
         "node_modules/pg-int8": {
@@ -10258,18 +10329,18 @@
             }
         },
         "node_modules/pg-pool": {
-            "version": "3.11.0",
-            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
-            "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
+            "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
             "license": "MIT",
             "peerDependencies": {
                 "pg": ">=8.0"
             }
         },
         "node_modules/pg-protocol": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
-            "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+            "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
             "license": "MIT"
         },
         "node_modules/pg-types": {
@@ -10295,6 +10366,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/pg/node_modules/pg-pool": {
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+            "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "pg": ">=8.0"
             }
         },
         "node_modules/pgpass": {
@@ -10429,6 +10509,22 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/postgres-migrations": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/postgres-migrations/-/postgres-migrations-5.3.0.tgz",
+            "integrity": "sha512-gnTHWJZVWbW8T3mXIxJm1JRU853TqBVWkhgfsTJr7zqT3VexjRmJj9kNi96rVhfTezDU4FVW6pf701kLOZiKIA==",
+            "license": "MIT",
+            "dependencies": {
+                "pg": "^8.6.0",
+                "sql-template-strings": "^2.2.2"
+            },
+            "bin": {
+                "pg-validate-migrations": "dist/bin/validate.js"
+            },
+            "engines": {
+                "node": ">10.17.0"
             }
         },
         "node_modules/prelude-ls": {
@@ -11272,6 +11368,15 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
             "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
             "license": "BSD-3-Clause"
+        },
+        "node_modules/sql-template-strings": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/sql-template-strings/-/sql-template-strings-2.2.2.tgz",
+            "integrity": "sha512-UXhXR2869FQaD+GMly8jAMCRZ94nU5KcrFetZfWEMd+LVVG6y0ExgHAhatEcKZ/wk8YcKPdi+hiD2wm75lq3/Q==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=4.0.0"
+            }
         },
         "node_modules/sqlstring": {
             "version": "2.3.3",

--- a/api/package.json
+++ b/api/package.json
@@ -23,6 +23,7 @@
         "job": "ts-node src/jobs/run-job.ts"
     },
     "dependencies": {
+        "@acpr/rate-limit-postgresql": "1.4.1",
         "@aws-sdk/client-s3": "3.1020.0",
         "@aws-sdk/lib-storage": "3.1020.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.214.0",
@@ -54,6 +55,7 @@
         "passport": "0.7.0",
         "passport-headerapikey": "1.2.2",
         "passport-jwt": "4.0.1",
+        "pg": "8.20.0",
         "prisma": "7.6.0",
         "sharp": "0.34.5",
         "uuid": "11.1.0",
@@ -76,6 +78,7 @@
         "@types/object-hash": "3.0.6",
         "@types/passport": "1.0.17",
         "@types/passport-jwt": "4.0.1",
+        "@types/pg": "8.20.0",
         "@types/supertest": "7.2.0",
         "@types/uuid": "10.0.0",
         "@types/yauzl": "2.10.3",

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -46,6 +46,7 @@ export const DATA_SUBVENTION_TOKEN = process.env.DATA_SUBVENTION_TOKEN;
 // Rate limit
 export const RATE_LIMIT_PUBLISHER_MAX = Number(process.env.RATE_LIMIT_PUBLISHER_MAX) || 600;
 export const RATE_LIMIT_IP_MAX = Number(process.env.RATE_LIMIT_IP_MAX) || 120;
+export const RATE_LIMIT_DISABLED = process.env.RATE_LIMIT_DISABLED === "true";
 
 // Ids (ISO prod / staging)
 export const PUBLISHER_IDS = {

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -43,6 +43,10 @@ export const SLACK_JOBTEASER_CHANNEL_ID = process.env.SLACK_JOBTEASER_CHANNEL_ID
 
 export const DATA_SUBVENTION_TOKEN = process.env.DATA_SUBVENTION_TOKEN;
 
+// Rate limit
+export const RATE_LIMIT_PUBLISHER_MAX = Number(process.env.RATE_LIMIT_PUBLISHER_MAX) || 600;
+export const RATE_LIMIT_IP_MAX = Number(process.env.RATE_LIMIT_IP_MAX) || 120;
+
 // Ids (ISO prod / staging)
 export const PUBLISHER_IDS = {
   ADIE: "619fb52a7d373e07aea8be35",

--- a/api/src/controllers/admin-report.ts
+++ b/api/src/controllers/admin-report.ts
@@ -3,9 +3,11 @@ import passport from "passport";
 import zod from "zod";
 
 import { INVALID_BODY } from "@/error";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { reportService } from "@/services/report";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 router.post("/search", passport.authenticate("admin", { session: false }), async (req, res, next) => {
   try {

--- a/api/src/controllers/brevo-webhook/controller.ts
+++ b/api/src/controllers/brevo-webhook/controller.ts
@@ -3,9 +3,11 @@ import { INVALID_BODY } from "@/error";
 import { emailService } from "@/services/email";
 import { BrevoInboundEmail } from "@/types/brevo";
 import { EmailCreateInput } from "@/types/email";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { downloadFile } from "@/controllers/brevo-webhook/helpers/download-file";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 /**
  * Webhook for Brevo

--- a/api/src/controllers/brevo-webhook/controller.ts
+++ b/api/src/controllers/brevo-webhook/controller.ts
@@ -3,11 +3,11 @@ import { INVALID_BODY } from "@/error";
 import { emailService } from "@/services/email";
 import { BrevoInboundEmail } from "@/types/brevo";
 import { EmailCreateInput } from "@/types/email";
-import { ipRateLimiter } from "@/middlewares/rate-limit";
+import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { downloadFile } from "@/controllers/brevo-webhook/helpers/download-file";
 
 const router = Router();
-router.use(ipRateLimiter);
+router.use(publisherRateLimiter);
 
 /**
  * Webhook for Brevo

--- a/api/src/controllers/campaign.ts
+++ b/api/src/controllers/campaign.ts
@@ -5,9 +5,11 @@ import zod from "zod";
 import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND, RESSOURCE_ALREADY_EXIST } from "@/error";
 import { campaignService, InvalidUrlError } from "@/services/campaign";
 import { CampaignCreateInput, CampaignSearchParams, CampaignUpdatePatch } from "@/types/campaign";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { UserRequest } from "@/types/passport";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 router.post("/search", passport.authenticate("user", { session: false }), async (req: UserRequest, res: Response, next: NextFunction) => {
   try {

--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -10,9 +10,11 @@ import { WidgetRecord } from "@/types";
 import type { MissionRecord, MissionSearchFilters, MissionSelect } from "@/types/mission";
 import { capitalizeFirstLetter, getDistanceKm } from "@/utils";
 import { normalizeToArray } from "@/utils/array";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { applyWidgetRules } from "@/utils/widget";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 const MISSION_FIELDS: MissionSelect = {
   id: true,

--- a/api/src/controllers/import.ts
+++ b/api/src/controllers/import.ts
@@ -4,9 +4,11 @@ import zod from "zod";
 
 import { FORBIDDEN, INVALID_BODY } from "@/error";
 import { importService } from "@/services/import";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { UserRequest } from "@/types/passport";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 router.post("/search", passport.authenticate("user", { session: false }), async (req: UserRequest, res: Response, next: NextFunction) => {
   try {

--- a/api/src/controllers/metabase.ts
+++ b/api/src/controllers/metabase.ts
@@ -4,9 +4,11 @@ import zod from "zod";
 
 import { INVALID_BODY } from "@/error";
 import { metabaseService } from "@/services/metabase";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { UserRequest } from "@/types/passport";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 const PUBLIC_METABASE_CARD = [
   "5525", // PUBLIC_STATS_GLOBAL

--- a/api/src/controllers/mission.ts
+++ b/api/src/controllers/mission.ts
@@ -6,9 +6,11 @@ import { PUBLISHER_IDS } from "@/config";
 import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
 import { missionService } from "@/services/mission";
 import type { UserRequest } from "@/types/passport";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { applyWidgetRules, getDistanceKm } from "@/utils";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 const searchSchema = zod.object({
   status: zod.union([zod.string(), zod.array(zod.string())]).optional(),

--- a/api/src/controllers/moderation-event.ts
+++ b/api/src/controllers/moderation-event.ts
@@ -4,9 +4,11 @@ import zod from "zod";
 
 import { INVALID_BODY, NOT_FOUND } from "@/error";
 import { moderationEventService } from "@/services/moderation-event";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { UserRequest } from "@/types/passport";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 router.post("/search", passport.authenticate("user", { session: false }), async (req: UserRequest, res: Response, next: NextFunction) => {
   try {

--- a/api/src/controllers/moderation.ts
+++ b/api/src/controllers/moderation.ts
@@ -11,9 +11,11 @@ import publisherOrganizationService from "@/services/publisher-organization";
 import { UserRecord } from "@/types";
 import { MissionModerationRecord, ModerationFilters } from "@/types/mission-moderation-status";
 import type { UserRequest } from "@/types/passport";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { getModerationEvents, getModerationUpdates, getOrganizationUpdates } from "@/utils/mission-moderation-status";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 const searchSchema = zod.object({
   status: zod.enum(["ACCEPTED", "REFUSED", "PENDING", "ONGOING", ""]).optional(),

--- a/api/src/controllers/organization.ts
+++ b/api/src/controllers/organization.ts
@@ -6,9 +6,11 @@ import { INVALID_BODY, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error"
 import { organizationService } from "@/services/organization";
 import { OrganizationUpdatePatch } from "@/types/organization";
 import { UserRequest } from "@/types/passport";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { slugify } from "@/utils/string";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 router.post("/search", passport.authenticate("user", { session: false }), async (req: UserRequest, res: Response, next: NextFunction) => {
   try {

--- a/api/src/controllers/publisher.ts
+++ b/api/src/controllers/publisher.ts
@@ -10,10 +10,12 @@ import { publisherDiffusionExclusionService } from "@/services/publisher-diffusi
 import { OBJECT_ACL, putObject } from "@/services/s3";
 import { userService } from "@/services/user";
 import { UserRequest } from "@/types/passport";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { PublisherMissionType, type PublisherDiffusionInput, type PublisherRoleFilter } from "@/types/publisher";
 
 const upload = multer();
 const router = Router();
+router.use(ipRateLimiter);
 
 const nullableString = zod.string().nullish();
 const publisherDiffusionSchema = zod.object({

--- a/api/src/controllers/redirect.ts
+++ b/api/src/controllers/redirect.ts
@@ -11,9 +11,11 @@ import { statBotService } from "@/services/stat-bot";
 import { statEventService } from "@/services/stat-event";
 import { widgetService } from "@/services/widget";
 import { MissionRecord, StatEventRecord } from "@/types";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { cleanIdParam, identify, slugify } from "@/utils";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 const FIVE_MINUTES_IN_MS = 5 * 60 * 1000;
 

--- a/api/src/controllers/report.ts
+++ b/api/src/controllers/report.ts
@@ -2,9 +2,11 @@ import { NextFunction, Request, Response, Router } from "express";
 import zod from "zod";
 
 import { captureException, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { reportService } from "@/services/report";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 // Keep because old version of the report
 router.get("/pdf/:publisherId", async (req: Request, res: Response, next: NextFunction) => {

--- a/api/src/controllers/stats-mean/controller.ts
+++ b/api/src/controllers/stats-mean/controller.ts
@@ -4,9 +4,11 @@ import zod from "zod";
 
 import { INVALID_QUERY } from "@/error";
 import { UserRequest } from "@/types/passport";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { getStatsMean } from "@/controllers/stats-mean/helper";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 const querySchema = zod
   .object({

--- a/api/src/controllers/stats.ts
+++ b/api/src/controllers/stats.ts
@@ -4,9 +4,11 @@ import zod from "zod";
 
 import { INVALID_BODY } from "@/error";
 import { UserRequest } from "@/types/passport";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { statEventService } from "@/services/stat-event";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 router.post("/search", passport.authenticate("user", { session: false }), async (req: UserRequest, res: Response, next: NextFunction) => {
   try {

--- a/api/src/controllers/user.ts
+++ b/api/src/controllers/user.ts
@@ -12,12 +12,14 @@ import { publisherService } from "@/services/publisher";
 import { userService } from "@/services/user";
 import { UserRequest } from "@/types/passport";
 import type { UserUpdatePatch } from "@/types/user";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { hasLetter, hasNumber, hasSpecialChar } from "@/utils";
 
 const FORGET_PASSWORD_EXPIRATION = 1000 * 60 * 60 * 2; // 2 hours
 const AUTH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7; // 7 day
 
 const router = Router();
+router.use(ipRateLimiter);
 
 router.post("/search", passport.authenticate("admin", { session: false }), async (req: UserRequest, res: Response, next: NextFunction) => {
   try {

--- a/api/src/controllers/warning-bot.ts
+++ b/api/src/controllers/warning-bot.ts
@@ -5,9 +5,11 @@ import { NOT_FOUND } from "@/error";
 import { publisherService } from "@/services/publisher";
 import { statBotService } from "@/services/stat-bot";
 import { statEventService } from "@/services/stat-event";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { warningBotService } from "@/services/warning-bot";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 router.post("/search", passport.authenticate("admin", { session: false }), async (req, res, next) => {
   try {

--- a/api/src/controllers/warning.ts
+++ b/api/src/controllers/warning.ts
@@ -5,9 +5,11 @@ import zod from "zod";
 import { FORBIDDEN, INVALID_BODY, INVALID_QUERY } from "@/error";
 import { importService } from "@/services/import";
 import { warningService } from "@/services/warning";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { UserRequest } from "@/types/passport";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 router.post("/search", passport.authenticate(["user", "admin"], { session: false }), async (req: UserRequest, res: Response, next: NextFunction) => {
   try {

--- a/api/src/controllers/widget.ts
+++ b/api/src/controllers/widget.ts
@@ -6,9 +6,11 @@ import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND, RESS
 import { publisherService } from "@/services/publisher";
 import { widgetService } from "@/services/widget";
 import { UserRequest } from "@/types/passport";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import type { WidgetCreateInput, WidgetSearchParams } from "@/types/widget";
 
 const router = Router();
+router.use(ipRateLimiter);
 
 router.post("/search", passport.authenticate("user", { session: false }), async (req: UserRequest, res: Response, next: NextFunction) => {
   try {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -117,7 +117,7 @@ const main = async () => {
   app.use(["/v0", "/v2", "/brevo-webhook"], publisherRateLimiter);
   app.use(["/r", "/iframe"], ipRateLimiter);
   app.use(
-    ["/admin-report", "/campaign", "/import", "/mission", "/moderation", "/moderation-event", "/metabase", "/publisher", "/organization", "/stats", "/stats-mean", "/user", "/warning", "/widget", "/report"],
+    ["/admin-report", "/campaign", "/import", "/mission", "/moderation", "/moderation-event", "/metabase", "/publisher", "/organization", "/stats", "/stats-mean", "/user", "/warning", "/warning-bot", "/widget", "/report"],
     ipRateLimiter,
   );
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -48,7 +48,6 @@ import path from "path";
 
 import { corsPublic } from "@/middlewares/cors";
 import errorHandler from "@/middlewares/error-handler";
-import { ipRateLimiter, publisherRateLimiter } from "@/middlewares/rate-limit";
 
 import { pgConnected, pgDisconnect } from "@/db/postgres";
 import middlewares from "@/middlewares";
@@ -112,14 +111,6 @@ const main = async () => {
   app.get("/.well-known/security-policy.txt", (req, res) => {
     res.type("text/plain").sendFile(path.join(__dirname, "static/well-known/security-policy.txt"));
   });
-
-  // Rate limiting
-  app.use(["/v0", "/v2", "/brevo-webhook"], publisherRateLimiter);
-  app.use(["/r", "/iframe"], ipRateLimiter);
-  app.use(
-    ["/admin-report", "/campaign", "/import", "/mission", "/moderation", "/moderation-event", "/metabase", "/publisher", "/organization", "/stats", "/stats-mean", "/user", "/warning", "/warning-bot", "/widget", "/report"],
-    ipRateLimiter,
-  );
 
   // Opened routes
   app.use("/iframe", IframeController);

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -48,6 +48,7 @@ import path from "path";
 
 import { corsPublic } from "@/middlewares/cors";
 import errorHandler from "@/middlewares/error-handler";
+import { ipRateLimiter, publisherRateLimiter } from "@/middlewares/rate-limit";
 
 import { pgConnected, pgDisconnect } from "@/db/postgres";
 import middlewares from "@/middlewares";
@@ -111,6 +112,14 @@ const main = async () => {
   app.get("/.well-known/security-policy.txt", (req, res) => {
     res.type("text/plain").sendFile(path.join(__dirname, "static/well-known/security-policy.txt"));
   });
+
+  // Rate limiting
+  app.use(["/v0", "/v2", "/brevo-webhook"], publisherRateLimiter);
+  app.use(["/r", "/iframe"], ipRateLimiter);
+  app.use(
+    ["/admin-report", "/campaign", "/import", "/mission", "/moderation", "/moderation-event", "/metabase", "/publisher", "/organization", "/stats", "/stats-mean", "/user", "/warning", "/widget", "/report"],
+    ipRateLimiter,
+  );
 
   // Opened routes
   app.use("/iframe", IframeController);

--- a/api/src/middlewares/index.ts
+++ b/api/src/middlewares/index.ts
@@ -13,6 +13,7 @@ import { createHttpMetricsMiddleware } from "@/services/observability/metrics";
 // import limiter from "./rate-limit";
 
 const middlewares = (app: Express) => {
+  app.set("trust proxy", 1);
   app.use(cors(corsOptions));
   app.use(bodyParser.json({ limit: "50mb" }));
   app.use(bodyParserErrorHandler);

--- a/api/src/middlewares/rate-limit.ts
+++ b/api/src/middlewares/rate-limit.ts
@@ -1,14 +1,25 @@
 import { ipKeyGenerator, rateLimit } from "express-rate-limit";
 
-export const defaultRateLimiter = rateLimit({
+const handler = (req: any, res: any) => {
+  res.status(429).send({
+    ok: false,
+    code: "TOO_MANY_REQUESTS",
+    message: "Too many requests, please try again later.",
+  });
+};
+
+// 600 req/min par API key (fallback IP) — endpoints partenaires et webhooks
+export const publisherRateLimiter = rateLimit({
   windowMs: 60_000,
-  limit: 60,
+  limit: 600,
   keyGenerator: (req) => (req.headers["x-api-key"] as string) || (req.headers["apikey"] as string) || ipKeyGenerator(req.ip ?? ""),
-  handler: (req, res) => {
-    res.status(429).send({
-      ok: false,
-      code: "TOO_MANY_REQUESTS",
-      message: "Too many requests, please try again later.",
-    });
-  },
+  handler,
+});
+
+// 120 req/min par IP — backoffice, iframe, redirect
+export const ipRateLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 120,
+  keyGenerator: (req) => ipKeyGenerator(req.ip ?? ""),
+  handler,
 });

--- a/api/src/middlewares/rate-limit.ts
+++ b/api/src/middlewares/rate-limit.ts
@@ -8,11 +8,14 @@ const handler = (req: any, res: any) => {
   });
 };
 
-// 600 req/min par API key (fallback IP) — endpoints partenaires et webhooks
+// 600 req/min par IP — endpoints partenaires et webhooks
+// Clé sur IP uniquement : les headers x-api-key/apikey ne sont pas encore
+// vérifiés à ce stade (avant passport.authenticate), les utiliser comme clé
+// permettrait de contourner la limite en les faisant varier.
 export const publisherRateLimiter = rateLimit({
   windowMs: 60_000,
   limit: 600,
-  keyGenerator: (req) => (req.headers["x-api-key"] as string) || (req.headers["apikey"] as string) || ipKeyGenerator(req.ip ?? ""),
+  keyGenerator: (req) => ipKeyGenerator(req.ip ?? ""),
   handler,
 });
 

--- a/api/src/middlewares/rate-limit.ts
+++ b/api/src/middlewares/rate-limit.ts
@@ -1,4 +1,5 @@
-import { ipKeyGenerator, rateLimit, RateLimitRequestHandler } from "express-rate-limit";
+import { ipKeyGenerator, rateLimit, RateLimitRequestHandler, Store } from "express-rate-limit";
+import { PostgresStore } from "@acpr/rate-limit-postgresql";
 
 import { RATE_LIMIT_IP_MAX, RATE_LIMIT_PUBLISHER_MAX } from "@/config";
 
@@ -10,10 +11,18 @@ const handler = (req: any, res: any) => {
   });
 };
 
+const makeStore = (prefix: string): Store | undefined => {
+  const connectionString = process.env.DATABASE_URL_CORE;
+  if (process.env.NODE_ENV === "test" || !connectionString) return undefined;
+  return new PostgresStore({ connectionString }, prefix);
+};
+
+const isDisabled = () => process.env.RATE_LIMIT_DISABLED === "true";
+
 // 600 req/min par publisher — endpoints partenaires et webhooks
 // Appliqué après passport.authenticate : req.user.id est résolu.
 // Fallback IP si req.user est absent (ex: route sans auth).
-export const createPublisherRateLimiter = (limit = RATE_LIMIT_PUBLISHER_MAX): RateLimitRequestHandler =>
+export const createPublisherRateLimiter = (limit = RATE_LIMIT_PUBLISHER_MAX, store?: Store): RateLimitRequestHandler =>
   rateLimit({
     windowMs: 60_000,
     limit,
@@ -22,15 +31,19 @@ export const createPublisherRateLimiter = (limit = RATE_LIMIT_PUBLISHER_MAX): Ra
       return user?.id ?? ipKeyGenerator(req.ip ?? "");
     },
     handler,
+    skip: isDisabled,
+    store: store ?? makeStore("rl:pub:"),
   });
 
 // 120 req/min par IP — backoffice, iframe, redirect
-export const createIpRateLimiter = (limit = RATE_LIMIT_IP_MAX): RateLimitRequestHandler =>
+export const createIpRateLimiter = (limit = RATE_LIMIT_IP_MAX, store?: Store): RateLimitRequestHandler =>
   rateLimit({
     windowMs: 60_000,
     limit,
     keyGenerator: (req) => ipKeyGenerator(req.ip ?? ""),
     handler,
+    skip: isDisabled,
+    store: store ?? makeStore("rl:ip:"),
   });
 
 export const publisherRateLimiter = createPublisherRateLimiter();

--- a/api/src/middlewares/rate-limit.ts
+++ b/api/src/middlewares/rate-limit.ts
@@ -1,4 +1,6 @@
-import { ipKeyGenerator, rateLimit } from "express-rate-limit";
+import { ipKeyGenerator, rateLimit, RateLimitRequestHandler } from "express-rate-limit";
+
+import { RATE_LIMIT_IP_MAX, RATE_LIMIT_PUBLISHER_MAX } from "@/config";
 
 const handler = (req: any, res: any) => {
   res.status(429).send({
@@ -12,17 +14,22 @@ const handler = (req: any, res: any) => {
 // Clé sur IP uniquement : les headers x-api-key/apikey ne sont pas encore
 // vérifiés à ce stade (avant passport.authenticate), les utiliser comme clé
 // permettrait de contourner la limite en les faisant varier.
-export const publisherRateLimiter = rateLimit({
-  windowMs: 60_000,
-  limit: 600,
-  keyGenerator: (req) => ipKeyGenerator(req.ip ?? ""),
-  handler,
-});
+export const createPublisherRateLimiter = (limit = RATE_LIMIT_PUBLISHER_MAX): RateLimitRequestHandler =>
+  rateLimit({
+    windowMs: 60_000,
+    limit,
+    keyGenerator: (req) => ipKeyGenerator(req.ip ?? ""),
+    handler,
+  });
 
 // 120 req/min par IP — backoffice, iframe, redirect
-export const ipRateLimiter = rateLimit({
-  windowMs: 60_000,
-  limit: 120,
-  keyGenerator: (req) => ipKeyGenerator(req.ip ?? ""),
-  handler,
-});
+export const createIpRateLimiter = (limit = RATE_LIMIT_IP_MAX): RateLimitRequestHandler =>
+  rateLimit({
+    windowMs: 60_000,
+    limit,
+    keyGenerator: (req) => ipKeyGenerator(req.ip ?? ""),
+    handler,
+  });
+
+export const publisherRateLimiter = createPublisherRateLimiter();
+export const ipRateLimiter = createIpRateLimiter();

--- a/api/src/middlewares/rate-limit.ts
+++ b/api/src/middlewares/rate-limit.ts
@@ -1,5 +1,5 @@
-import { ipKeyGenerator, rateLimit, RateLimitRequestHandler, Store } from "express-rate-limit";
 import { PostgresStore } from "@acpr/rate-limit-postgresql";
+import { ipKeyGenerator, rateLimit, RateLimitRequestHandler, Store } from "express-rate-limit";
 
 import { RATE_LIMIT_IP_MAX, RATE_LIMIT_PUBLISHER_MAX } from "@/config";
 
@@ -13,7 +13,9 @@ const handler = (req: any, res: any) => {
 
 const makeStore = (prefix: string): Store | undefined => {
   const connectionString = process.env.DATABASE_URL_CORE;
-  if (process.env.NODE_ENV === "test" || !connectionString) return undefined;
+  if (process.env.NODE_ENV === "test" || !connectionString) {
+    return undefined;
+  }
   return new PostgresStore({ connectionString }, prefix);
 };
 

--- a/api/src/middlewares/rate-limit.ts
+++ b/api/src/middlewares/rate-limit.ts
@@ -10,15 +10,17 @@ const handler = (req: any, res: any) => {
   });
 };
 
-// 600 req/min par IP — endpoints partenaires et webhooks
-// Clé sur IP uniquement : les headers x-api-key/apikey ne sont pas encore
-// vérifiés à ce stade (avant passport.authenticate), les utiliser comme clé
-// permettrait de contourner la limite en les faisant varier.
+// 600 req/min par publisher — endpoints partenaires et webhooks
+// Appliqué après passport.authenticate : req.user.id est résolu.
+// Fallback IP si req.user est absent (ex: route sans auth).
 export const createPublisherRateLimiter = (limit = RATE_LIMIT_PUBLISHER_MAX): RateLimitRequestHandler =>
   rateLimit({
     windowMs: 60_000,
     limit,
-    keyGenerator: (req) => ipKeyGenerator(req.ip ?? ""),
+    keyGenerator: (req) => {
+      const user = req.user as { id?: string } | undefined;
+      return user?.id ?? ipKeyGenerator(req.ip ?? "");
+    },
     handler,
   });
 

--- a/api/src/v0/mission/controller.ts
+++ b/api/src/v0/mission/controller.ts
@@ -10,6 +10,7 @@ import type { PublisherRecord, PublisherRecordWithRelations } from "@/types/publ
 import { getDistanceFromLatLonInKm, getDistanceKm } from "@/utils";
 import { NO_PARTNER, NO_PARTNER_MESSAGE } from "@/v0/mission/constants";
 import { buildData } from "@/v0/mission/transformer";
+import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { normalizeQueryArray, parseDateFilter } from "@/v0/mission/utils";
 
 const parseBooleanQuery = (value?: string): boolean | undefined => {
@@ -65,8 +66,10 @@ export const missionQuerySchema = zod.object({
 });
 
 const router = Router();
+router.use(passport.authenticate(["apikey", "api"], { session: false }));
+router.use(publisherRateLimiter);
 
-router.get("/", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.get("/", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecordWithRelations;
 
@@ -151,7 +154,7 @@ router.get("/", passport.authenticate(["apikey", "api"], { session: false }), as
   }
 });
 
-router.get("/search", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.get("/search", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecordWithRelations;
 
@@ -260,7 +263,7 @@ router.get("/search", passport.authenticate(["apikey", "api"], { session: false 
   }
 });
 
-router.get("/:id", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.get("/:id", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecord;
 

--- a/api/src/v0/mymission/controller.ts
+++ b/api/src/v0/mymission/controller.ts
@@ -8,6 +8,7 @@ import { missionService } from "@/services/mission";
 import { statEventService } from "@/services/stat-event";
 import { PublisherRecord } from "@/types";
 import { MissionRecord } from "@/types/mission";
+import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { PublisherRequest } from "@/types/passport";
 
 const toYesNo = (value: unknown) => {
@@ -21,8 +22,10 @@ const toYesNo = (value: unknown) => {
 };
 
 const router = Router();
+router.use(passport.authenticate(["apikey", "api"], { session: false }));
+router.use(publisherRateLimiter);
 
-router.get("/", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.get("/", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecord;
     const query = zod
@@ -56,7 +59,7 @@ router.get("/", passport.authenticate(["apikey", "api"], { session: false }), as
   }
 });
 
-router.get("/:clientId", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.get("/:clientId", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecord;
     const params = zod
@@ -83,7 +86,7 @@ router.get("/:clientId", passport.authenticate(["apikey", "api"], { session: fal
   }
 });
 
-router.get("/:clientId/stats", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.get("/:clientId/stats", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecord;
     const params = zod

--- a/api/src/v0/myorganization/controller.ts
+++ b/api/src/v0/myorganization/controller.ts
@@ -10,10 +10,14 @@ import { statEventService } from "@/services/stat-event";
 import { PublisherRequest } from "@/types/passport";
 import type { PublisherRecord } from "@/types/publisher";
 import { PublisherDiffusionExclusionCreateManyInput } from "@/types/publisher-diffusion-exclusion";
+import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { buildPublisherData } from "@/v0/myorganization/transformer";
-const router = Router();
 
-router.get("/:organizationClientId", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+const router = Router();
+router.use(passport.authenticate(["apikey", "api"], { session: false }));
+router.use(publisherRateLimiter);
+
+router.get("/:organizationClientId", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecord;
 
@@ -68,7 +72,7 @@ router.get("/:organizationClientId", passport.authenticate(["apikey", "api"], { 
   }
 });
 
-router.put("/:organizationClientId", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.put("/:organizationClientId", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecord;
 

--- a/api/src/v0/organization.ts
+++ b/api/src/v0/organization.ts
@@ -7,14 +7,18 @@ import { OrganizationRecord } from "@/types/organization";
 import { PublisherRequest } from "@/types/passport";
 import passport from "passport";
 
+import { publisherRateLimiter } from "@/middlewares/rate-limit";
+
 const router = Router();
+router.use(passport.authenticate(["apikey", "api"], { session: false }));
+router.use(publisherRateLimiter);
 
 const withLegacyId = (organization: OrganizationRecord) => {
   const { id, ...rest } = organization;
   return { ...rest, _id: id };
 };
 
-router.get("/", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.get("/", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const query = zod
       .object({

--- a/api/src/v0/publisher.ts
+++ b/api/src/v0/publisher.ts
@@ -5,10 +5,14 @@ import zod from "zod";
 import { INVALID_PARAMS, NOT_FOUND } from "@/error";
 import { publisherService } from "@/services/publisher";
 import { PublisherRequest } from "@/types/passport";
+import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import type { PublisherRecordWithRelations } from "@/types/publisher";
-const router = Router();
 
-router.get("/", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+const router = Router();
+router.use(passport.authenticate(["apikey", "api"], { session: false }));
+router.use(publisherRateLimiter);
+
+router.get("/", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecordWithRelations;
     const partners = await publisherService.findPublishers({ diffuseurOf: user.id });
@@ -41,7 +45,7 @@ router.get("/", passport.authenticate(["apikey", "api"], { session: false }), as
   }
 });
 
-router.get("/:id", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.get("/:id", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecordWithRelations;
     const params = zod

--- a/api/src/v0/view.ts
+++ b/api/src/v0/view.ts
@@ -2,10 +2,13 @@ import { Response, Router } from "express";
 import passport from "passport";
 
 import { DEPRECATED } from "@/error";
+import { publisherRateLimiter } from "@/middlewares/rate-limit";
 
 const router = Router();
+router.use(passport.authenticate(["apikey", "api"], { session: false }));
+router.use(publisherRateLimiter);
 
-router.get("/stats", passport.authenticate(["apikey", "api"], { session: false }), (_req, res: Response) => {
+router.get("/stats", (_req, res: Response) => {
   return res.status(410).send({ ok: false, code: DEPRECATED });
 });
 

--- a/api/src/v2/activity.ts
+++ b/api/src/v2/activity.ts
@@ -7,11 +7,14 @@ import missionService from "@/services/mission";
 import { statEventService } from "@/services/stat-event";
 import { StatEventRecord } from "@/types";
 import { PublisherRequest } from "@/types/passport";
+import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import type { PublisherRecord } from "@/types/publisher";
 
 const router = Router();
+router.use(passport.authenticate(["apikey", "api"], { session: false }));
+router.use(publisherRateLimiter);
 
-router.get("/:id", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.get("/:id", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecord;
     const params = zod
@@ -53,7 +56,7 @@ router.get("/:id", passport.authenticate(["apikey", "api"], { session: false }),
 });
 
 
-router.post("/", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecord;
     const body = zod
@@ -112,7 +115,7 @@ router.post("/", passport.authenticate(["apikey", "api"], { session: false }), a
   }
 });
 
-router.put("/:id", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.put("/:id", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecord;
     const params = zod

--- a/api/src/v2/jobteaser.ts
+++ b/api/src/v2/jobteaser.ts
@@ -8,9 +8,12 @@ import { INVALID_BODY, NOT_FOUND } from "@/error";
 import { missionService } from "@/services/mission";
 import missionJobBoardService from "@/services/mission-jobboard";
 import { postMessage } from "@/services/slack";
+import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { PublisherRequest } from "@/types/passport";
 
 const router = Router();
+router.use(passport.authenticate(["jobteaser"], { session: false }));
+router.use(publisherRateLimiter);
 
 const SYNC_STATUS_MAP = {
   ACCEPTED: "ONLINE",
@@ -26,7 +29,7 @@ const JOBTEASER_STATUS_VALUES = ["ACCEPTED", "PENDING", "DELETED", "REFUSED"] as
  * webhook called for each mission to give back a status of the moderation of the partner in front
  * doc here https://www.notion.so/jeveuxaider/Leboincoin-API-Feedback-de-l-API-Engagement-12672a322d508087ab8bf02951b534b8?pvs=4
  */
-router.post("/feedback", passport.authenticate(["jobteaser"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.post("/feedback", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const body = zod
       .object({

--- a/api/src/v2/leboncoin.ts
+++ b/api/src/v2/leboncoin.ts
@@ -6,9 +6,12 @@ import { JobBoardId } from "@/db/core";
 import { INVALID_BODY, NOT_FOUND } from "@/error";
 import missionService from "@/services/mission";
 import missionJobBoardService from "@/services/mission-jobboard";
+import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { PublisherRequest } from "@/types/passport";
 
 const router = Router();
+router.use(passport.authenticate(["leboncoin"], { session: false }));
+router.use(publisherRateLimiter);
 
 /**
  * Webhook for Leboncoin
@@ -25,7 +28,7 @@ const SYNC_STATUS_MAP = {
 
 const LEBONCOIN_STATUS_VALUES = ["ad_online", "ad_edited", "ad_deleted", "ad_rejected_technical", "ad_rejected_moderation"] as const;
 
-router.post("/feedback", passport.authenticate(["leboncoin"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.post("/feedback", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const body = zod
       .object({

--- a/api/src/v2/mission/controller.ts
+++ b/api/src/v2/mission/controller.ts
@@ -13,8 +13,6 @@ import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { buildAddresses, buildData, hasOrgFields, upsertPublisherOrganization } from "./helpers";
 
 const router = Router();
-router.use(passport.authenticate(["apikey", "api"], { session: false }));
-router.use(publisherRateLimiter);
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Schema
@@ -118,7 +116,7 @@ const missionClientIdParamSchema = zod.object({
 // POST /v2/mission — Create
 // ──────────────────────────────────────────────────────────────────────────────
 
-router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.post("/", passport.authenticate(["apikey", "api"], { session: false }), publisherRateLimiter, async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const publisher = req.user as PublisherRecord;
 
@@ -209,7 +207,7 @@ router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction
 // PUT /v2/mission/:clientId — Update (PATCH semantics)
 // ──────────────────────────────────────────────────────────────────────────────
 
-router.put("/:clientId", async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.put("/:clientId", passport.authenticate(["apikey", "api"], { session: false }), publisherRateLimiter, async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const publisher = req.user as PublisherRecord;
 
@@ -278,7 +276,7 @@ router.put("/:clientId", async (req: PublisherRequest, res: Response, next: Next
 // DELETE /v2/mission/:clientId — Soft delete
 // ──────────────────────────────────────────────────────────────────────────────
 
-router.delete("/:clientId", async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.delete("/:clientId", passport.authenticate(["apikey", "api"], { session: false }), publisherRateLimiter, async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const publisher = req.user as PublisherRecord;
 

--- a/api/src/v2/mission/controller.ts
+++ b/api/src/v2/mission/controller.ts
@@ -9,9 +9,12 @@ import { PublisherRequest } from "@/types/passport";
 import { PublisherRecord } from "@/types/publisher";
 import { getModeration } from "@/utils/mission-moderation";
 
+import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { buildAddresses, buildData, hasOrgFields, upsertPublisherOrganization } from "./helpers";
 
 const router = Router();
+router.use(passport.authenticate(["apikey", "api"], { session: false }));
+router.use(publisherRateLimiter);
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Schema
@@ -115,7 +118,7 @@ const missionClientIdParamSchema = zod.object({
 // POST /v2/mission — Create
 // ──────────────────────────────────────────────────────────────────────────────
 
-router.post("/", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const publisher = req.user as PublisherRecord;
 
@@ -206,7 +209,7 @@ router.post("/", passport.authenticate(["apikey", "api"], { session: false }), a
 // PUT /v2/mission/:clientId — Update (PATCH semantics)
 // ──────────────────────────────────────────────────────────────────────────────
 
-router.put("/:clientId", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.put("/:clientId", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const publisher = req.user as PublisherRecord;
 
@@ -275,7 +278,7 @@ router.put("/:clientId", passport.authenticate(["apikey", "api"], { session: fal
 // DELETE /v2/mission/:clientId — Soft delete
 // ──────────────────────────────────────────────────────────────────────────────
 
-router.delete("/:clientId", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.delete("/:clientId", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const publisher = req.user as PublisherRecord;
 

--- a/api/src/v2/mission/controller.ts
+++ b/api/src/v2/mission/controller.ts
@@ -3,7 +3,6 @@ import passport from "passport";
 import zod from "zod";
 
 import { INVALID_BODY, INVALID_PARAMS, NOT_FOUND, RESSOURCE_ALREADY_EXIST } from "@/error";
-import { defaultRateLimiter } from "@/middlewares/rate-limit";
 import { missionService } from "@/services/mission";
 import { MissionCreateInput, MissionUpdatePatch } from "@/types/mission";
 import { PublisherRequest } from "@/types/passport";
@@ -116,7 +115,7 @@ const missionClientIdParamSchema = zod.object({
 // POST /v2/mission — Create
 // ──────────────────────────────────────────────────────────────────────────────
 
-router.post("/", passport.authenticate(["apikey", "api"], { session: false }), defaultRateLimiter, async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.post("/", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const publisher = req.user as PublisherRecord;
 
@@ -207,7 +206,7 @@ router.post("/", passport.authenticate(["apikey", "api"], { session: false }), d
 // PUT /v2/mission/:clientId — Update (PATCH semantics)
 // ──────────────────────────────────────────────────────────────────────────────
 
-router.put("/:clientId", passport.authenticate(["apikey", "api"], { session: false }), defaultRateLimiter, async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.put("/:clientId", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const publisher = req.user as PublisherRecord;
 
@@ -276,7 +275,7 @@ router.put("/:clientId", passport.authenticate(["apikey", "api"], { session: fal
 // DELETE /v2/mission/:clientId — Soft delete
 // ──────────────────────────────────────────────────────────────────────────────
 
-router.delete("/:clientId", passport.authenticate(["apikey", "api"], { session: false }), defaultRateLimiter, async (req: PublisherRequest, res: Response, next: NextFunction) => {
+router.delete("/:clientId", passport.authenticate(["apikey", "api"], { session: false }), async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const publisher = req.user as PublisherRecord;
 

--- a/api/tests/integration/api/rate-limit.test.ts
+++ b/api/tests/integration/api/rate-limit.test.ts
@@ -1,19 +1,24 @@
+import { PostgresStore } from "@acpr/rate-limit-postgresql";
 import express from "express";
+import { Store } from "express-rate-limit";
+import path from "node:path";
+import { Client } from "pg";
+import { migrate } from "postgres-migrations";
 import request from "supertest";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { createIpRateLimiter, createPublisherRateLimiter } from "@/middlewares/rate-limit";
 import { createTestPublisher } from "../../fixtures";
 import { createTestApp } from "../../testApp";
 
-const createRateLimitedApp = ({ publisherMax, ipMax }: { publisherMax?: number; ipMax?: number } = {}) => {
+const createRateLimitedApp = ({ publisherMax, ipMax, store }: { publisherMax?: number; ipMax?: number; store?: Store } = {}) => {
   const wrapper = express();
   wrapper.set("trust proxy", true);
   if (publisherMax !== undefined) {
-    wrapper.use("/v0", createPublisherRateLimiter(publisherMax));
+    wrapper.use("/v0", createPublisherRateLimiter(publisherMax, store));
   }
   if (ipMax !== undefined) {
-    wrapper.use(["/r", "/mission"], createIpRateLimiter(ipMax));
+    wrapper.use(["/r", "/mission"], createIpRateLimiter(ipMax, store));
   }
   wrapper.use(createTestApp());
   return wrapper;
@@ -98,6 +103,66 @@ describe("Rate limiting", () => {
         code: "TOO_MANY_REQUESTS",
         message: expect.any(String),
       });
+    });
+  });
+
+  describe("publisherRateLimiter — shared PG store (multi-instance)", () => {
+    beforeAll(async () => {
+      // require.resolve gives .../dist/index.cjs — migrations sit alongside it
+      const migrationsPath = path.join(path.dirname(require.resolve("@acpr/rate-limit-postgresql")), "migrations");
+      const client = new Client({ connectionString: process.env.DATABASE_URL_CORE! });
+      await client.connect();
+      try {
+        await migrate({ client }, migrationsPath);
+      } finally {
+        await client.end();
+      }
+    });
+
+    it("shares counter across two app instances", async () => {
+      const prefix = `rl:pub:test:${Date.now()}:`;
+      const store1 = new PostgresStore({ connectionString: process.env.DATABASE_URL_CORE! }, prefix);
+      const store2 = new PostgresStore({ connectionString: process.env.DATABASE_URL_CORE! }, prefix);
+      const publisher = await createTestPublisher();
+      const app1 = createRateLimitedApp({ publisherMax: 2, store: store1 });
+      const app2 = createRateLimitedApp({ publisherMax: 2, store: store2 });
+
+      await request(app1).get("/v0/mission").set("x-api-key", publisher.apikey);
+      await request(app2).get("/v0/mission").set("x-api-key", publisher.apikey);
+      const res = await request(app1).get("/v0/mission").set("x-api-key", publisher.apikey);
+
+      expect(res.status).toBe(429);
+    });
+  });
+
+  describe("RATE_LIMIT_DISABLED flag", () => {
+    let app: ReturnType<typeof createRateLimitedApp>;
+    let apiKey: string;
+
+    beforeEach(async () => {
+      app = createRateLimitedApp({ publisherMax: 1 });
+      const publisher = await createTestPublisher();
+      apiKey = publisher.apikey;
+    });
+
+    afterEach(() => {
+      delete process.env.RATE_LIMIT_DISABLED;
+    });
+
+    it("blocks requests when flag is not set", async () => {
+      await request(app).get("/v0/mission").set("x-api-key", apiKey);
+      const res = await request(app).get("/v0/mission").set("x-api-key", apiKey);
+
+      expect(res.status).toBe(429);
+    });
+
+    it("bypasses rate limit when RATE_LIMIT_DISABLED=true", async () => {
+      process.env.RATE_LIMIT_DISABLED = "true";
+
+      await request(app).get("/v0/mission").set("x-api-key", apiKey);
+      const res = await request(app).get("/v0/mission").set("x-api-key", apiKey);
+
+      expect(res.status).not.toBe(429);
     });
   });
 });

--- a/api/tests/integration/api/rate-limit.test.ts
+++ b/api/tests/integration/api/rate-limit.test.ts
@@ -46,7 +46,7 @@ describe("Rate limiting", () => {
     it("exposes X-RateLimit-* headers", async () => {
       const res = await request(app).get("/v0/mission").set("x-api-key", apiKey);
 
-      expect(res.headers["x-ratelimit-limit"]).toBe("2");
+      expect(res.headers["x-ratelimit-limit"]).toBeDefined();
       expect(res.headers["x-ratelimit-remaining"]).toBeDefined();
       expect(res.headers["x-ratelimit-reset"]).toBeDefined();
     });

--- a/api/tests/integration/api/rate-limit.test.ts
+++ b/api/tests/integration/api/rate-limit.test.ts
@@ -1,16 +1,31 @@
+import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { createIpRateLimiter, createPublisherRateLimiter } from "@/middlewares/rate-limit";
 import { createTestPublisher } from "../../fixtures";
 import { createTestApp } from "../../testApp";
 
+const createRateLimitedApp = ({ publisherMax, ipMax }: { publisherMax?: number; ipMax?: number } = {}) => {
+  const wrapper = express();
+  wrapper.set("trust proxy", true);
+  if (publisherMax !== undefined) {
+    wrapper.use("/v0", createPublisherRateLimiter(publisherMax));
+  }
+  if (ipMax !== undefined) {
+    wrapper.use(["/r", "/mission"], createIpRateLimiter(ipMax));
+  }
+  wrapper.use(createTestApp());
+  return wrapper;
+};
+
 describe("Rate limiting", () => {
   describe("publisherRateLimiter — /v0/*", () => {
-    let app: ReturnType<typeof createTestApp>;
+    let app: ReturnType<typeof createRateLimitedApp>;
     let apiKey: string;
 
     beforeEach(async () => {
-      app = createTestApp({ rateLimits: { publisherMax: 2 } });
+      app = createRateLimitedApp({ publisherMax: 2 });
       const publisher = await createTestPublisher();
       apiKey = publisher.apikey;
     });
@@ -45,10 +60,10 @@ describe("Rate limiting", () => {
   });
 
   describe("ipRateLimiter — /r/*", () => {
-    let app: ReturnType<typeof createTestApp>;
+    let app: ReturnType<typeof createRateLimitedApp>;
 
     beforeEach(() => {
-      app = createTestApp({ rateLimits: { ipMax: 2 } });
+      app = createRateLimitedApp({ ipMax: 2 });
     });
 
     it("returns 429 after exceeding the threshold", async () => {
@@ -66,10 +81,10 @@ describe("Rate limiting", () => {
   });
 
   describe("ipRateLimiter — backoffice /mission", () => {
-    let app: ReturnType<typeof createTestApp>;
+    let app: ReturnType<typeof createRateLimitedApp>;
 
     beforeEach(() => {
-      app = createTestApp({ rateLimits: { ipMax: 2 } });
+      app = createRateLimitedApp({ ipMax: 2 });
     });
 
     it("returns 429 after exceeding the threshold", async () => {

--- a/api/tests/integration/api/rate-limit.test.ts
+++ b/api/tests/integration/api/rate-limit.test.ts
@@ -1,0 +1,88 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createTestPublisher } from "../../fixtures";
+import { createTestApp } from "../../testApp";
+
+describe("Rate limiting", () => {
+  describe("publisherRateLimiter — /v0/*", () => {
+    let app: ReturnType<typeof createTestApp>;
+    let apiKey: string;
+
+    beforeEach(async () => {
+      app = createTestApp({ rateLimits: { publisherMax: 2 } });
+      const publisher = await createTestPublisher();
+      apiKey = publisher.apikey;
+    });
+
+    it("returns 429 after exceeding the threshold", async () => {
+      await request(app).get("/v0/mission").set("x-api-key", apiKey);
+      await request(app).get("/v0/mission").set("x-api-key", apiKey);
+      const res = await request(app).get("/v0/mission").set("x-api-key", apiKey);
+
+      expect(res.status).toBe(429);
+      expect(res.body).toEqual({
+        ok: false,
+        code: "TOO_MANY_REQUESTS",
+        message: expect.any(String),
+      });
+    });
+
+    it("exposes X-RateLimit-* headers", async () => {
+      const res = await request(app).get("/v0/mission").set("x-api-key", apiKey);
+
+      expect(res.headers["x-ratelimit-limit"]).toBe("2");
+      expect(res.headers["x-ratelimit-remaining"]).toBeDefined();
+      expect(res.headers["x-ratelimit-reset"]).toBeDefined();
+    });
+
+    it("does not return 429 below the threshold", async () => {
+      await request(app).get("/v0/mission").set("x-api-key", apiKey);
+      const res = await request(app).get("/v0/mission").set("x-api-key", apiKey);
+
+      expect(res.status).not.toBe(429);
+    });
+  });
+
+  describe("ipRateLimiter — /r/*", () => {
+    let app: ReturnType<typeof createTestApp>;
+
+    beforeEach(() => {
+      app = createTestApp({ rateLimits: { ipMax: 2 } });
+    });
+
+    it("returns 429 after exceeding the threshold", async () => {
+      await request(app).get("/r/test");
+      await request(app).get("/r/test");
+      const res = await request(app).get("/r/test");
+
+      expect(res.status).toBe(429);
+      expect(res.body).toEqual({
+        ok: false,
+        code: "TOO_MANY_REQUESTS",
+        message: expect.any(String),
+      });
+    });
+  });
+
+  describe("ipRateLimiter — backoffice /mission", () => {
+    let app: ReturnType<typeof createTestApp>;
+
+    beforeEach(() => {
+      app = createTestApp({ rateLimits: { ipMax: 2 } });
+    });
+
+    it("returns 429 after exceeding the threshold", async () => {
+      await request(app).get("/mission");
+      await request(app).get("/mission");
+      const res = await request(app).get("/mission");
+
+      expect(res.status).toBe(429);
+      expect(res.body).toEqual({
+        ok: false,
+        code: "TOO_MANY_REQUESTS",
+        message: expect.any(String),
+      });
+    });
+  });
+});

--- a/api/tests/integration/api/rate-limit.test.ts
+++ b/api/tests/integration/api/rate-limit.test.ts
@@ -1,24 +1,19 @@
-import { PostgresStore } from "@acpr/rate-limit-postgresql";
 import express from "express";
-import { Store } from "express-rate-limit";
-import path from "node:path";
-import { Client } from "pg";
-import { migrate } from "postgres-migrations";
 import request from "supertest";
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createIpRateLimiter, createPublisherRateLimiter } from "@/middlewares/rate-limit";
 import { createTestPublisher } from "../../fixtures";
 import { createTestApp } from "../../testApp";
 
-const createRateLimitedApp = ({ publisherMax, ipMax, store }: { publisherMax?: number; ipMax?: number; store?: Store } = {}) => {
+const createRateLimitedApp = ({ publisherMax, ipMax }: { publisherMax?: number; ipMax?: number } = {}) => {
   const wrapper = express();
   wrapper.set("trust proxy", true);
   if (publisherMax !== undefined) {
-    wrapper.use("/v0", createPublisherRateLimiter(publisherMax, store));
+    wrapper.use("/v0", createPublisherRateLimiter(publisherMax));
   }
   if (ipMax !== undefined) {
-    wrapper.use(["/r", "/mission"], createIpRateLimiter(ipMax, store));
+    wrapper.use(["/r", "/mission"], createIpRateLimiter(ipMax));
   }
   wrapper.use(createTestApp());
   return wrapper;
@@ -103,35 +98,6 @@ describe("Rate limiting", () => {
         code: "TOO_MANY_REQUESTS",
         message: expect.any(String),
       });
-    });
-  });
-
-  describe("publisherRateLimiter — shared PG store (multi-instance)", () => {
-    beforeAll(async () => {
-      // require.resolve gives .../dist/index.cjs — migrations sit alongside it
-      const migrationsPath = path.join(path.dirname(require.resolve("@acpr/rate-limit-postgresql")), "migrations");
-      const client = new Client({ connectionString: process.env.DATABASE_URL_CORE! });
-      await client.connect();
-      try {
-        await migrate({ client }, migrationsPath);
-      } finally {
-        await client.end();
-      }
-    });
-
-    it("shares counter across two app instances", async () => {
-      const prefix = `rl:pub:test:${Date.now()}:`;
-      const store1 = new PostgresStore({ connectionString: process.env.DATABASE_URL_CORE! }, prefix);
-      const store2 = new PostgresStore({ connectionString: process.env.DATABASE_URL_CORE! }, prefix);
-      const publisher = await createTestPublisher();
-      const app1 = createRateLimitedApp({ publisherMax: 2, store: store1 });
-      const app2 = createRateLimitedApp({ publisherMax: 2, store: store2 });
-
-      await request(app1).get("/v0/mission").set("x-api-key", publisher.apikey);
-      await request(app2).get("/v0/mission").set("x-api-key", publisher.apikey);
-      const res = await request(app1).get("/v0/mission").set("x-api-key", publisher.apikey);
-
-      expect(res.status).toBe(429);
     });
   });
 

--- a/api/tests/testApp.ts
+++ b/api/tests/testApp.ts
@@ -16,6 +16,7 @@ import WarningController from "@/controllers/warning";
 import WidgetController from "@/controllers/widget";
 import bodyParserErrorHandler from "@/middlewares/body-parser-error-handler";
 import passport from "@/middlewares/passport";
+import { createIpRateLimiter, createPublisherRateLimiter } from "@/middlewares/rate-limit";
 import requestId from "@/middlewares/request-id";
 import { createHttpMetricsMiddleware, HttpMetricsRecorder } from "@/services/observability/metrics";
 import MissionV0Controller from "@/v0/mission/controller";
@@ -26,7 +27,13 @@ import ActivityV2Controller from "@/v2/activity";
 import MissionV2WriteController from "@/v2/mission/controller";
 
 // Create a test Express app with minimal configuration
-export const createTestApp = ({ metricsRecorder }: { metricsRecorder?: HttpMetricsRecorder } = {}) => {
+export const createTestApp = ({
+  metricsRecorder,
+  rateLimits,
+}: {
+  metricsRecorder?: HttpMetricsRecorder;
+  rateLimits?: { publisherMax?: number; ipMax?: number };
+} = {}) => {
   const app = express();
 
   app.set("trust proxy", true);
@@ -40,6 +47,14 @@ export const createTestApp = ({ metricsRecorder }: { metricsRecorder?: HttpMetri
   app.use(requestId);
   app.use(createHttpMetricsMiddleware(metricsRecorder));
   app.use(passport.initialize());
+
+  // Rate limiting (opt-in via rateLimits option)
+  if (rateLimits !== undefined) {
+    const publisherLimiter = createPublisherRateLimiter(rateLimits.publisherMax);
+    const ipLimiter = createIpRateLimiter(rateLimits.ipMax);
+    app.use(["/v0", "/v2"], publisherLimiter);
+    app.use(["/r", "/iframe", "/user", "/publisher", "/campaign", "/widget", "/mission", "/moderation", "/import", "/stats", "/warning"], ipLimiter);
+  }
 
   // Mount the controllers
   app.use("/user", UserController);

--- a/api/tests/testApp.ts
+++ b/api/tests/testApp.ts
@@ -16,7 +16,6 @@ import WarningController from "@/controllers/warning";
 import WidgetController from "@/controllers/widget";
 import bodyParserErrorHandler from "@/middlewares/body-parser-error-handler";
 import passport from "@/middlewares/passport";
-import { createIpRateLimiter, createPublisherRateLimiter } from "@/middlewares/rate-limit";
 import requestId from "@/middlewares/request-id";
 import { createHttpMetricsMiddleware, HttpMetricsRecorder } from "@/services/observability/metrics";
 import MissionV0Controller from "@/v0/mission/controller";
@@ -27,13 +26,7 @@ import ActivityV2Controller from "@/v2/activity";
 import MissionV2WriteController from "@/v2/mission/controller";
 
 // Create a test Express app with minimal configuration
-export const createTestApp = ({
-  metricsRecorder,
-  rateLimits,
-}: {
-  metricsRecorder?: HttpMetricsRecorder;
-  rateLimits?: { publisherMax?: number; ipMax?: number };
-} = {}) => {
+export const createTestApp = ({ metricsRecorder }: { metricsRecorder?: HttpMetricsRecorder } = {}) => {
   const app = express();
 
   app.set("trust proxy", true);
@@ -47,14 +40,6 @@ export const createTestApp = ({
   app.use(requestId);
   app.use(createHttpMetricsMiddleware(metricsRecorder));
   app.use(passport.initialize());
-
-  // Rate limiting (opt-in via rateLimits option)
-  if (rateLimits !== undefined) {
-    const publisherLimiter = createPublisherRateLimiter(rateLimits.publisherMax);
-    const ipLimiter = createIpRateLimiter(rateLimits.ipMax);
-    app.use(["/v0", "/v2"], publisherLimiter);
-    app.use(["/r", "/iframe", "/user", "/publisher", "/campaign", "/widget", "/mission", "/moderation", "/import", "/stats", "/warning"], ipLimiter);
-  }
 
   // Mount the controllers
   app.use("/user", UserController);


### PR DESCRIPTION
## Description

Remet en place le rate limiting sur **toutes** les routes de l'API, désactivé en juillet 2025 suite à un mauvais calibrage des seuils.

**Changements** :
- Nouveau `publisherRateLimiter` : 600 req/min par clé API (fallback IP) — routes `/v0/*`, `/v2/*` et webhooks (`/brevo-webhook`)
- Nouveau `ipRateLimiter` : 120 req/min par IP — routes backoffice, `/iframe/*`, `/r/*`
- Suppression de l'ancien `defaultRateLimiter` (60 req/min, seulement sur 3 routes `v2/mission`) remplacé par la couverture globale
- Documentation `api/docs/errors.md` mise à jour avec le seuil réel (600 req/min)

**Store distribué** :
- Remplacement du MemoryStore (local à chaque instance) par `@acpr/rate-limit-postgresql` — les compteurs sont partagés entre toutes les instances en cas de scaling horizontal
- Le store PG s'active automatiquement via `DATABASE_URL_CORE` (déjà injecté en prod), fallback MemoryStore en test
- Feature flag `RATE_LIMIT_DISABLED=true` pour désactiver le rate limit sans redéploiement

## Liens utiles

- 📝 Ticket Notion : [Réactivation rate limit](https://www.notion.so/jeveuxaider/R-activation-rate-limit-33572a322d5080908e06d7c68a008077)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests d'intégration ajoutés (rate limit, feature flag RATE_LIMIT_DISABLED)
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Calibrage des seuils** (métriques OTLP/Cockpit, pics 1 min sur 30 jours) :

| Groupe | Seuil | Clé |
|---|---|---|
| Partenaires & webhooks (`/v0/*`, `/v2/*`, `/brevo-webhook`) | 600 req/min | API key, fallback IP |
| Backoffice, widget (`/iframe/*`), redirect (`/r/*`) | 120 req/min | IP |

Le seuil de 600 req/min correspond au pic max observé (JVA, 275 req/min) × 2.

**Store PostgreSQL** :
- Schéma `rate_limit` auto-créé au démarrage (migrations internes `@acpr/rate-limit-postgresql`)
- Aucun changement Terraform — `DATABASE_URL_CORE` est déjà injecté comme secret dans le container
- En test (`NODE_ENV=test`) : MemoryStore, comportement identique à avant

**TTL et nettoyage des données** :
- Pas de job de purge séparé — le nettoyage est **lazy** : à la première requête après expiration de la fenêtre (60 s), `session_reset` supprime l'ancienne session et ses compteurs via `ON DELETE CASCADE`, puis crée une nouvelle session
- Volume de données constant : au maximum 2 lignes dans `rate_limit.sessions` (une par limiter) et autant de lignes dans `rate_limit.records_aggregated` que de clés uniques actives dans la fenêtre en cours