### PR TITLE
fix(api): remove mission FK in stat_events

### DIFF
--- a/api/prisma/migrations/20260402104518_remove_stat_event_legacy_field/migration.sql
+++ b/api/prisma/migrations/20260402104518_remove_stat_event_legacy_field/migration.sql
@@ -34,6 +34,3 @@ DROP COLUMN "mission_organization_id",
 DROP COLUMN "mission_organization_name",
 DROP COLUMN "mission_postal_code",
 DROP COLUMN "mission_title";
-
--- AddForeignKey
-ALTER TABLE "stat_event" ADD CONSTRAINT "stat_event_mission_id_fkey" FOREIGN KEY ("mission_id") REFERENCES "mission"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -257,8 +257,7 @@ model StatEvent {
   fromPublisher Publisher @relation("StatEventFromPublisher", fields: [fromPublisherId], references: [id])
   toPublisher   Publisher @relation("StatEventToPublisher", fields: [toPublisherId], references: [id])
 
-  missionId String? @map("mission_id")
-  mission   Mission? @relation("MissionStatEvents", fields: [missionId], references: [id], onDelete: SetNull)
+  missionId         String?  @map("mission_id")
   tag               String?
   tags              String[] @default([])
   exportToAnalytics String?  @map("export_to_analytics")
@@ -597,8 +596,6 @@ model Mission {
   moderationStatuses    MissionModerationStatus[]
   jobBoards             MissionJobBoard[]
   activities            MissionActivity[]
-
-  statEvents            StatEvent[]               @relation("MissionStatEvents")
 
   // TODO: restore relations
   // missionEvents      MissionEvent[]

--- a/api/src/repositories/mission.ts
+++ b/api/src/repositories/mission.ts
@@ -1,6 +1,38 @@
 import { Mission, Prisma } from "@/db/core";
 import { prisma } from "@/db/postgres";
 
+const statEventContextSelect = {
+  id: true,
+  clientId: true,
+  title: true,
+  domain: {
+    select: {
+      name: true,
+    },
+  },
+  publisherOrganization: {
+    select: {
+      id: true,
+      name: true,
+      clientId: true,
+    },
+  },
+  addresses: {
+    select: {
+      postalCode: true,
+      departmentName: true,
+    },
+    orderBy: {
+      createdAt: "asc" as const,
+    },
+    take: 1,
+  },
+} satisfies Prisma.MissionSelect;
+
+export type MissionStatEventContext = Prisma.MissionGetPayload<{
+  select: typeof statEventContextSelect;
+}>;
+
 export const missionRepository = {
   async findMany(params: Prisma.MissionFindManyArgs = {}): Promise<Mission[]> {
     return prisma.mission.findMany(params);
@@ -16,6 +48,21 @@ export const missionRepository = {
 
   async findFirst(params: Prisma.MissionFindFirstArgs): Promise<Mission | null> {
     return prisma.mission.findFirst(params);
+  },
+
+  async findStatEventContexts(ids: string[]): Promise<MissionStatEventContext[]> {
+    if (!ids.length) {
+      return [];
+    }
+
+    return prisma.mission.findMany({
+      where: {
+        id: {
+          in: ids,
+        },
+      },
+      select: statEventContextSelect,
+    });
   },
 
   async create(data: Prisma.MissionCreateInput): Promise<Mission> {

--- a/api/src/repositories/stat-event.ts
+++ b/api/src/repositories/stat-event.ts
@@ -8,15 +8,6 @@ const defaultInclude = {
   toPublisher: {
     select: { id: true, name: true },
   },
-  mission: {
-    select: {
-      clientId: true,
-      title: true,
-      domain: { select: { name: true } },
-      publisherOrganization: { select: { id: true, name: true, clientId: true } },
-      addresses: { select: { postalCode: true, departmentName: true }, take: 1, orderBy: { createdAt: "asc" as const } },
-    },
-  },
 } satisfies Prisma.StatEventInclude;
 
 export const statEventRepository = {

--- a/api/src/services/stat-event.ts
+++ b/api/src/services/stat-event.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@/db/core";
 
+import { MissionStatEventContext, missionRepository } from "@/repositories/mission";
 import { statEventRepository } from "@/repositories/stat-event";
 import { publisherService } from "@/services/publisher";
 import {
@@ -25,19 +26,10 @@ import {
 
 const DEFAULT_TYPES: StatEventType[] = ["click", "print", "apply", "account"];
 
-type PrismaStatEventWithRelations = Prisma.StatEventGetPayload<{
+type PrismaStatEventWithPublishers = Prisma.StatEventGetPayload<{
   include: {
     fromPublisher: { select: { id: true; name: true } };
     toPublisher: { select: { id: true; name: true } };
-    mission: {
-      select: {
-        clientId: true;
-        title: true;
-        domain: { select: { name: true } };
-        publisherOrganization: { select: { id: true; name: true; clientId: true } };
-        addresses: { select: { postalCode: true; departmentName: true } };
-      };
-    };
   };
 }>;
 
@@ -74,8 +66,16 @@ function toPrisma(data: Partial<StatEventRecord>, options: { includeDefaults?: b
   return mapped;
 }
 
-function toStatEventRecord(row: PrismaStatEventWithRelations): StatEventRecord {
-  const { fromPublisher, toPublisher, mission, id, ...rest } = row;
+const getMissionIds = (rows: Array<{ missionId: string | null }>): string[] =>
+  Array.from(new Set(rows.map((row) => row.missionId).filter((missionId): missionId is string => typeof missionId === "string" && missionId.trim().length > 0)));
+
+async function buildMissionContextMap(rows: Array<{ missionId: string | null }>): Promise<Map<string, MissionStatEventContext>> {
+  const missions = await missionRepository.findStatEventContexts(getMissionIds(rows));
+  return new Map(missions.map((mission) => [mission.id, mission]));
+}
+
+function toStatEventRecord(row: PrismaStatEventWithPublishers, mission?: MissionStatEventContext): StatEventRecord {
+  const { fromPublisher, toPublisher, id, ...rest } = row;
   const primaryAddress = mission?.addresses?.[0];
 
   return {
@@ -94,6 +94,29 @@ function toStatEventRecord(row: PrismaStatEventWithRelations): StatEventRecord {
   } as StatEventRecord;
 }
 
+async function toStatEventRecordOrNull(row: PrismaStatEventWithPublishers | null): Promise<StatEventRecord | null> {
+  if (!row) {
+    return null;
+  }
+
+  const missionContextMap = await buildMissionContextMap([row]);
+  const mission = row.missionId ? missionContextMap.get(row.missionId) : undefined;
+  return toStatEventRecord(row, mission);
+}
+
+async function toStatEventRecords(rows: PrismaStatEventWithPublishers[]): Promise<StatEventRecord[]> {
+  if (!rows.length) {
+    return [];
+  }
+
+  const missionContextMap = await buildMissionContextMap(rows);
+
+  return rows.map((row) => {
+    const mission = row.missionId ? missionContextMap.get(row.missionId) : undefined;
+    return toStatEventRecord(row, mission);
+  });
+}
+
 async function createStatEvent(event: StatEventRecord): Promise<string> {
   const result = await statEventRepository.create({ data: toPrisma(event) });
   return result.id;
@@ -105,13 +128,13 @@ async function updateStatEvent(id: string, patch: Partial<StatEventRecord>) {
 }
 
 async function findOneStatEventById(id: string): Promise<StatEventRecord | null> {
-  const result = (await statEventRepository.findUnique({ where: { id } })) as PrismaStatEventWithRelations | null;
-  return result ? toStatEventRecord(result) : null;
+  const result = (await statEventRepository.findUnique({ where: { id } })) as PrismaStatEventWithPublishers | null;
+  return toStatEventRecordOrNull(result);
 }
 
 async function findOneStatEventByLegacyId(esId: string): Promise<StatEventRecord | null> {
-  const result = (await statEventRepository.findUnique({ where: { esId } })) as PrismaStatEventWithRelations | null;
-  return result ? toStatEventRecord(result) : null;
+  const result = (await statEventRepository.findUnique({ where: { esId } })) as PrismaStatEventWithPublishers | null;
+  return toStatEventRecordOrNull(result);
 }
 
 async function countStatEvents() {
@@ -122,8 +145,8 @@ async function findOneStatEventByMissionId(missionId: string): Promise<StatEvent
   const result = (await statEventRepository.findFirst({
     where: { missionId },
     orderBy: { createdAt: "desc" },
-  })) as PrismaStatEventWithRelations | null;
-  return result ? toStatEventRecord(result) : null;
+  })) as PrismaStatEventWithPublishers | null;
+  return toStatEventRecordOrNull(result);
 }
 
 async function countStatEventsByTypeSince({ publisherId, from, types }: CountByTypeParams) {
@@ -220,8 +243,8 @@ async function findOneStatEventByClientEventId({ clientEventId, toPublisherId, t
 
   const result = (await statEventRepository.findFirst({
     where,
-  })) as PrismaStatEventWithRelations | null;
-  return result ? toStatEventRecord(result) : null;
+  })) as PrismaStatEventWithPublishers | null;
+  return toStatEventRecordOrNull(result);
 }
 
 async function findStatEventByIdOrClientEventId({
@@ -305,9 +328,9 @@ async function findStatEvents({ fromPublisherId, toPublisherId, type, sourceId, 
     orderBy: { createdAt: "desc" },
     skip,
     take: size,
-  })) as PrismaStatEventWithRelations[];
+  })) as PrismaStatEventWithPublishers[];
 
-  return rows.map(toStatEventRecord);
+  return toStatEventRecords(rows);
 }
 
 async function findStatEventWarningBotCandidatesSince({ from, minClicks }: FindWarningBotCandidatesParams): Promise<WarningBotCandidate[]> {
@@ -584,7 +607,7 @@ async function scrollStatEvents({ type, batchSize = 5000, cursor = null, filters
       where: whereForRows,
       orderBy: [{ createdAt: "asc" }, { id: "asc" }],
       take: batchSize,
-    }) as Promise<PrismaStatEventWithRelations[]>,
+    }) as Promise<PrismaStatEventWithPublishers[]>,
     cursor ? Promise.resolve(0) : statEventRepository.count({ where: whereForCount }),
   ]);
 
@@ -597,7 +620,7 @@ async function scrollStatEvents({ type, batchSize = 5000, cursor = null, filters
         });
 
   return {
-    events: rows.map(toStatEventRecord),
+    events: await toStatEventRecords(rows),
     cursor: nextCursor,
     total: cursor ? 0 : total,
   };


### PR DESCRIPTION
## Description

Nous avons dans nos bases de production et staging des `stat_event` avec des `mission_id` qui n'existent plus dans la table `mission`. 

Nous ne pouvons donc pas ajouter pour le moment de FK entre ces 2 tables. Après analyse on trouve encore des `mission_id` qui n'existent pas après le 04/04/2026 donc c'est un problème récurrent et récent. 

En attendant de statuer le problème et de trouver une solution nous ne pouvons pas ajouter cette FK.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

