### PR TITLE
refactor(api): improve enrichment prompt with structured output

### DIFF
--- a/api/scripts/mission-enrichment/export-dataset.ts
+++ b/api/scripts/mission-enrichment/export-dataset.ts
@@ -3,7 +3,7 @@ dotenv.config();
 
 import { prisma } from "@/db/postgres";
 import { CURRENT_PROMPT_VERSION } from "@/services/mission-enrichment/config";
-import { parseEnrichmentResponse, type TaxonomyLookup } from "@/services/mission-enrichment/parser";
+import { validateEnrichmentClassifications, type TaxonomyLookup } from "@/services/mission-enrichment/parser";
 import fs from "fs";
 import path from "path";
 
@@ -206,8 +206,11 @@ async function main() {
     // Skipped classifications from rawResponse
     if (enrichment.rawResponse) {
       try {
-        const { skipped } = parseEnrichmentResponse(
-          typeof enrichment.rawResponse === "string" ? enrichment.rawResponse : JSON.stringify(enrichment.rawResponse),
+        const raw = typeof enrichment.rawResponse === "string" ? enrichment.rawResponse : JSON.stringify(enrichment.rawResponse);
+        const parsed = JSON.parse(raw) as { classifications?: unknown[] };
+        const classifications = Array.isArray(parsed.classifications) ? parsed.classifications : [];
+        const { skipped } = validateEnrichmentClassifications(
+          classifications as Parameters<typeof validateEnrichmentClassifications>[0],
           taxonomyLookup,
           0 // threshold = 0 to recover all items (already filtered in valid)
         );

--- a/api/src/services/mission-enrichment/__tests__/parser.test.ts
+++ b/api/src/services/mission-enrichment/__tests__/parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseEnrichmentResponse, type TaxonomyLookup } from "@/services/mission-enrichment/parser";
+import { validateEnrichmentClassifications, type TaxonomyLookup } from "@/services/mission-enrichment/parser";
 
 const buildLookup = (): TaxonomyLookup => {
   const lookup: TaxonomyLookup = new Map();
@@ -25,10 +25,9 @@ const validClassification = {
   evidence: { extract: "soins infirmiers", reasoning: "mission de santé" },
 };
 
-describe("parseEnrichmentResponse", () => {
-  it("parses valid JSON response", () => {
-    const raw = JSON.stringify({ classifications: [validClassification] });
-    const { valid, skipped } = parseEnrichmentResponse(raw, buildLookup(), 0.3);
+describe("validateEnrichmentClassifications", () => {
+  it("validates and resolves taxonomy value ID", () => {
+    const { valid, skipped } = validateEnrichmentClassifications([validClassification], buildLookup(), 0.3);
 
     expect(valid).toHaveLength(1);
     expect(valid[0].taxonomyValueId).toBe("tv-sante");
@@ -36,26 +35,12 @@ describe("parseEnrichmentResponse", () => {
     expect(skipped).toHaveLength(0);
   });
 
-  it("handles JSON wrapped in markdown code fences", () => {
-    const raw = "```json\n" + JSON.stringify({ classifications: [validClassification] }) + "\n```";
-    const { valid } = parseEnrichmentResponse(raw, buildLookup(), 0.3);
-
-    expect(valid).toHaveLength(1);
-    expect(valid[0].value_key).toBe("sante_soins");
-  });
-
-  it("handles code fences without json tag", () => {
-    const raw = "```\n" + JSON.stringify({ classifications: [validClassification] }) + "\n```";
-    const { valid } = parseEnrichmentResponse(raw, buildLookup(), 0.3);
-
-    expect(valid).toHaveLength(1);
-  });
-
   it("skips unknown dimension keys", () => {
-    const raw = JSON.stringify({
-      classifications: [{ ...validClassification, dimension_key: "unknown_dim" }],
-    });
-    const { valid, skipped } = parseEnrichmentResponse(raw, buildLookup(), 0.3);
+    const { valid, skipped } = validateEnrichmentClassifications(
+      [{ ...validClassification, dimension_key: "unknown_dim" }],
+      buildLookup(),
+      0.3
+    );
 
     expect(valid).toHaveLength(0);
     expect(skipped).toHaveLength(1);
@@ -63,10 +48,11 @@ describe("parseEnrichmentResponse", () => {
   });
 
   it("skips unknown value keys", () => {
-    const raw = JSON.stringify({
-      classifications: [{ ...validClassification, value_key: "unknown_val" }],
-    });
-    const { valid, skipped } = parseEnrichmentResponse(raw, buildLookup(), 0.3);
+    const { valid, skipped } = validateEnrichmentClassifications(
+      [{ ...validClassification, value_key: "unknown_val" }],
+      buildLookup(),
+      0.3
+    );
 
     expect(valid).toHaveLength(0);
     expect(skipped).toHaveLength(1);
@@ -74,10 +60,11 @@ describe("parseEnrichmentResponse", () => {
   });
 
   it("skips classifications below confidence threshold", () => {
-    const raw = JSON.stringify({
-      classifications: [{ ...validClassification, confidence: 0.2 }],
-    });
-    const { valid, skipped } = parseEnrichmentResponse(raw, buildLookup(), 0.3);
+    const { valid, skipped } = validateEnrichmentClassifications(
+      [{ ...validClassification, confidence: 0.2 }],
+      buildLookup(),
+      0.3
+    );
 
     expect(valid).toHaveLength(0);
     expect(skipped).toHaveLength(1);
@@ -85,19 +72,21 @@ describe("parseEnrichmentResponse", () => {
   });
 
   it("keeps classifications at exactly the threshold", () => {
-    const raw = JSON.stringify({
-      classifications: [{ ...validClassification, confidence: 0.3 }],
-    });
-    const { valid } = parseEnrichmentResponse(raw, buildLookup(), 0.3);
+    const { valid } = validateEnrichmentClassifications(
+      [{ ...validClassification, confidence: 0.3 }],
+      buildLookup(),
+      0.3
+    );
 
     expect(valid).toHaveLength(1);
   });
 
   it("handles multiple classifications across dimensions", () => {
-    const raw = JSON.stringify({
-      classifications: [validClassification, { ...validClassification, dimension_key: "type_mission", value_key: "ponctuelle", confidence: 0.8 }],
-    });
-    const { valid } = parseEnrichmentResponse(raw, buildLookup(), 0.3);
+    const { valid } = validateEnrichmentClassifications(
+      [validClassification, { ...validClassification, dimension_key: "type_mission", value_key: "ponctuelle", confidence: 0.8 }],
+      buildLookup(),
+      0.3
+    );
 
     expect(valid).toHaveLength(2);
     expect(valid[0].taxonomyValueId).toBe("tv-sante");
@@ -105,41 +94,59 @@ describe("parseEnrichmentResponse", () => {
   });
 
   it("handles empty classifications array", () => {
-    const raw = JSON.stringify({ classifications: [] });
-    const { valid, skipped } = parseEnrichmentResponse(raw, buildLookup(), 0.3);
+    const { valid, skipped } = validateEnrichmentClassifications([], buildLookup(), 0.3);
 
     expect(valid).toHaveLength(0);
     expect(skipped).toHaveLength(0);
   });
 
-  it("throws on invalid JSON", () => {
-    expect(() => parseEnrichmentResponse("not json", buildLookup(), 0.3)).toThrow();
-  });
-
-  it("throws on missing classifications key", () => {
-    const raw = JSON.stringify({ results: [] });
-    expect(() => parseEnrichmentResponse(raw, buildLookup(), 0.3)).toThrow();
-  });
-
-  it("throws on invalid classification structure", () => {
-    const raw = JSON.stringify({
-      classifications: [{ dimension_key: "domaine" }],
-    });
-    expect(() => parseEnrichmentResponse(raw, buildLookup(), 0.3)).toThrow();
-  });
-
   it("separates valid and skipped correctly in mixed response", () => {
-    const raw = JSON.stringify({
-      classifications: [
+    const { valid, skipped } = validateEnrichmentClassifications(
+      [
         validClassification,
         { ...validClassification, dimension_key: "unknown" },
         { ...validClassification, confidence: 0.1 },
         { ...validClassification, dimension_key: "domaine", value_key: "social_solidarite", confidence: 0.5 },
       ],
-    });
-    const { valid, skipped } = parseEnrichmentResponse(raw, buildLookup(), 0.3);
+      buildLookup(),
+      0.3
+    );
 
     expect(valid).toHaveLength(2);
     expect(skipped).toHaveLength(2);
+  });
+
+  it("deduplicates same dimension+value, keeps highest confidence", () => {
+    const { valid } = validateEnrichmentClassifications(
+      [
+        { ...validClassification, confidence: 0.7 },
+        { ...validClassification, confidence: 0.9 },
+      ],
+      buildLookup(),
+      0.3
+    );
+
+    expect(valid).toHaveLength(1);
+    expect(valid[0].confidence).toBe(0.9);
+  });
+
+  it("enforces categorical constraint: keeps only highest confidence value", () => {
+    const lookup: TaxonomyLookup = new Map([
+      ["type_mission", { type: "categorical", values: new Map([["ponctuelle", "tv-p"], ["reguliere", "tv-r"]]) }],
+    ]);
+
+    const { valid, skipped } = validateEnrichmentClassifications(
+      [
+        { ...validClassification, dimension_key: "type_mission", value_key: "ponctuelle", confidence: 0.6 },
+        { ...validClassification, dimension_key: "type_mission", value_key: "reguliere", confidence: 0.9 },
+      ],
+      lookup,
+      0.3
+    );
+
+    expect(valid).toHaveLength(1);
+    expect(valid[0].value_key).toBe("reguliere");
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].reason).toContain("categorical_superseded");
   });
 });

--- a/api/src/services/mission-enrichment/__tests__/parser.test.ts
+++ b/api/src/services/mission-enrichment/__tests__/parser.test.ts
@@ -130,6 +130,32 @@ describe("validateEnrichmentClassifications", () => {
     expect(valid[0].confidence).toBe(0.9);
   });
 
+  it("fuzzy matches reordered value_key tokens", () => {
+    // "soins_sante" vs "sante_soins" → Jaccard = 1.0
+    const { valid, skipped } = validateEnrichmentClassifications(
+      [{ ...validClassification, value_key: "soins_sante" }],
+      buildLookup(),
+      0.3
+    );
+
+    expect(valid).toHaveLength(1);
+    expect(valid[0].value_key).toBe("sante_soins");
+    expect(valid[0].taxonomyValueId).toBe("tv-sante");
+    expect(skipped).toHaveLength(0);
+  });
+
+  it("skips value_key with insufficient fuzzy similarity", () => {
+    // "culture_arts" has no tokens in common with "sante_soins" or "social_solidarite"
+    const { valid, skipped } = validateEnrichmentClassifications(
+      [{ ...validClassification, value_key: "culture_arts" }],
+      buildLookup(),
+      0.3
+    );
+
+    expect(valid).toHaveLength(0);
+    expect(skipped[0].reason).toContain("unknown_value");
+  });
+
   it("enforces categorical constraint: keeps only highest confidence value", () => {
     const lookup: TaxonomyLookup = new Map([
       ["type_mission", { type: "categorical", values: new Map([["ponctuelle", "tv-p"], ["reguliere", "tv-r"]]) }],

--- a/api/src/services/mission-enrichment/index.ts
+++ b/api/src/services/mission-enrichment/index.ts
@@ -1,6 +1,5 @@
 import { Prisma } from "@/db/core";
 import { generateObject } from "ai";
-import { z } from "zod";
 
 import { missionRepository } from "@/repositories/mission";
 import { missionEnrichmentRepository } from "@/repositories/mission-enrichment";
@@ -28,20 +27,6 @@ const buildTaxonomyLookup = (taxonomies: DimensionWithValues[]): TaxonomyLookup 
   }
   return lookup;
 };
-
-// Static schema — validates structure only.
-// value_key and dimension_key correctness is handled by fuzzy matching + taxonomy lookup
-// in validateEnrichmentClassifications, which skips or corrects invalid values gracefully.
-const ENRICHMENT_SCHEMA = z.object({
-  classifications: z.array(
-    z.object({
-      dimension_key: z.string(),
-      value_key: z.string(),
-      confidence: z.number().min(0).max(1),
-      evidence: z.object({ extract: z.string(), reasoning: z.string() }),
-    })
-  ),
-});
 
 const missionInclude = {
   domain: { select: { name: true } },
@@ -176,7 +161,7 @@ export const missionEnrichmentService = {
       // 7. Call LLM with structured output
       llmResult = await generateObject({
         model: promptVersion.MODEL,
-        schema: ENRICHMENT_SCHEMA,
+        schema: promptVersion.ENRICHMENT_SCHEMA,
         system: systemPrompt,
         prompt: userMessage,
         maxRetries: LLM_MAX_RETRIES,

--- a/api/src/services/mission-enrichment/index.ts
+++ b/api/src/services/mission-enrichment/index.ts
@@ -12,7 +12,7 @@ import type { MissionForPrompt, TaxonomyForPrompt } from "./prompts/types";
 
 const LOG_PREFIX = "[mission-enrichment]";
 
-type DimensionWithValues = { key: string; type: string; values: Array<{ key: string; id: string; active: boolean }> };
+type DimensionWithValues = { key: string; type: string; label: string; values: Array<{ key: string; id: string; label: string; active: boolean }> };
 
 const buildTaxonomyLookup = (taxonomies: DimensionWithValues[]): TaxonomyLookup => {
   const lookup: TaxonomyLookup = new Map();
@@ -29,24 +29,23 @@ const buildTaxonomyLookup = (taxonomies: DimensionWithValues[]): TaxonomyLookup 
   return lookup;
 };
 
-const buildEnrichmentSchema = (dimensions: DimensionWithValues[]) => {
-  const dimensionKeys = dimensions.map((d) => d.key) as [string, ...string[]];
-  const valueKeys = dimensions.flatMap((d) => d.values.filter((v) => v.active).map((v) => v.key)) as [string, ...string[]];
-
-  return z.object({
-    classifications: z.array(
-      z.object({
-        dimension_key: z.enum(dimensionKeys),
-        value_key: z.enum(valueKeys),
-        confidence: z.number().min(0).max(1),
-        evidence: z.object({
-          extract: z.string(),
-          reasoning: z.string(),
-        }),
-      })
-    ),
-  });
-};
+// Static schema — validates structure only.
+// value_key and dimension_key correctness is handled by fuzzy matching + taxonomy lookup
+// in validateEnrichmentClassifications, which skips or corrects invalid values gracefully.
+// evidence accepts string | object — Mistral occasionally flattens the nested object.
+const ENRICHMENT_SCHEMA = z.object({
+  classifications: z.array(
+    z.object({
+      dimension_key: z.string(),
+      value_key: z.string(),
+      confidence: z.number().min(0).max(1),
+      evidence: z.union([
+        z.object({ extract: z.string(), reasoning: z.string() }),
+        z.string(),
+      ]),
+    })
+  ),
+});
 
 const missionInclude = {
   domain: { select: { name: true } },
@@ -173,16 +172,15 @@ export const missionEnrichmentService = {
         data: { status: "processing" },
       });
 
-      // 6. Build prompts + schema
+      // 6. Build prompts
       const promptVersion = PROMPT_REGISTRY[CURRENT_PROMPT_VERSION];
       const systemPrompt = promptVersion.buildSystemPrompt(buildTaxonomyBlock(toTaxonomyForPrompt(dimensions)));
       const userMessage = promptVersion.buildUserMessage(buildMissionBlock(toMissionForPrompt(mission)));
-      const schema = buildEnrichmentSchema(dimensions);
 
       // 7. Call LLM with structured output
       llmResult = await generateObject({
         model: promptVersion.MODEL,
-        schema,
+        schema: ENRICHMENT_SCHEMA,
         system: systemPrompt,
         prompt: userMessage,
         maxRetries: LLM_MAX_RETRIES,
@@ -191,9 +189,14 @@ export const missionEnrichmentService = {
       const { inputTokens, outputTokens, totalTokens } = llmResult.usage;
       console.log(`${LOG_PREFIX} ${missionId}: LLM response received — tokens: ${inputTokens} in / ${outputTokens} out / ${totalTokens} total`);
 
-      // 8. Validate classifications against taxonomy rules
+      // 8. Normalize + validate classifications against taxonomy rules
+      // evidence may be a flat string when Mistral ignores the nested object schema
+      const classifications = llmResult.object.classifications.map((c) => ({
+        ...c,
+        evidence: typeof c.evidence === "string" ? { extract: c.evidence, reasoning: "" } : c.evidence,
+      }));
       const { valid, skipped } = validateEnrichmentClassifications(
-        llmResult.object.classifications,
+        classifications,
         buildTaxonomyLookup(dimensions),
         CONFIDENCE_THRESHOLD
       );

--- a/api/src/services/mission-enrichment/index.ts
+++ b/api/src/services/mission-enrichment/index.ts
@@ -32,17 +32,13 @@ const buildTaxonomyLookup = (taxonomies: DimensionWithValues[]): TaxonomyLookup 
 // Static schema — validates structure only.
 // value_key and dimension_key correctness is handled by fuzzy matching + taxonomy lookup
 // in validateEnrichmentClassifications, which skips or corrects invalid values gracefully.
-// evidence accepts string | object — Mistral occasionally flattens the nested object.
 const ENRICHMENT_SCHEMA = z.object({
   classifications: z.array(
     z.object({
       dimension_key: z.string(),
       value_key: z.string(),
       confidence: z.number().min(0).max(1),
-      evidence: z.union([
-        z.object({ extract: z.string(), reasoning: z.string() }),
-        z.string(),
-      ]),
+      evidence: z.object({ extract: z.string(), reasoning: z.string() }),
     })
   ),
 });
@@ -190,13 +186,8 @@ export const missionEnrichmentService = {
       console.log(`${LOG_PREFIX} ${missionId}: LLM response received — tokens: ${inputTokens} in / ${outputTokens} out / ${totalTokens} total`);
 
       // 8. Normalize + validate classifications against taxonomy rules
-      // evidence may be a flat string when Mistral ignores the nested object schema
-      const classifications = llmResult.object.classifications.map((c) => ({
-        ...c,
-        evidence: typeof c.evidence === "string" ? { extract: c.evidence, reasoning: "" } : c.evidence,
-      }));
       const { valid, skipped } = validateEnrichmentClassifications(
-        classifications,
+        llmResult.object.classifications,
         buildTaxonomyLookup(dimensions),
         CONFIDENCE_THRESHOLD
       );

--- a/api/src/services/mission-enrichment/index.ts
+++ b/api/src/services/mission-enrichment/index.ts
@@ -1,17 +1,20 @@
 import { Prisma } from "@/db/core";
-import { generateText } from "ai";
+import { generateObject } from "ai";
+import { z } from "zod";
 
 import { missionRepository } from "@/repositories/mission";
 import { missionEnrichmentRepository } from "@/repositories/mission-enrichment";
 import { taxonomyRepository } from "@/repositories/taxonomy";
 import { CONFIDENCE_THRESHOLD, CURRENT_PROMPT_VERSION, LLM_MAX_RETRIES } from "./config";
-import { parseEnrichmentResponse, type TaxonomyLookup } from "./parser";
+import { validateEnrichmentClassifications, type TaxonomyLookup } from "./parser";
 import { buildMissionBlock, buildTaxonomyBlock, PROMPT_REGISTRY } from "./prompts";
 import type { MissionForPrompt, TaxonomyForPrompt } from "./prompts/types";
 
 const LOG_PREFIX = "[mission-enrichment]";
 
-const buildTaxonomyLookup = (taxonomies: Array<{ key: string; type: string; values: Array<{ key: string; id: string; active: boolean }> }>): TaxonomyLookup => {
+type DimensionWithValues = { key: string; type: string; values: Array<{ key: string; id: string; active: boolean }> };
+
+const buildTaxonomyLookup = (taxonomies: DimensionWithValues[]): TaxonomyLookup => {
   const lookup: TaxonomyLookup = new Map();
   for (const taxonomy of taxonomies) {
     const values = new Map<string, string>();
@@ -24,6 +27,25 @@ const buildTaxonomyLookup = (taxonomies: Array<{ key: string; type: string; valu
     lookup.set(taxonomy.key, { type: taxonomy.type, values });
   }
   return lookup;
+};
+
+const buildEnrichmentSchema = (dimensions: DimensionWithValues[]) => {
+  const dimensionKeys = dimensions.map((d) => d.key) as [string, ...string[]];
+  const valueKeys = dimensions.flatMap((d) => d.values.filter((v) => v.active).map((v) => v.key)) as [string, ...string[]];
+
+  return z.object({
+    classifications: z.array(
+      z.object({
+        dimension_key: z.enum(dimensionKeys),
+        value_key: z.enum(valueKeys),
+        confidence: z.number().min(0).max(1),
+        evidence: z.object({
+          extract: z.string(),
+          reasoning: z.string(),
+        }),
+      })
+    ),
+  });
 };
 
 const missionInclude = {
@@ -142,7 +164,7 @@ export const missionEnrichmentService = {
     }
 
     // Declared outside try/catch so the catch block can persist them on failure
-    let llmResult: Awaited<ReturnType<typeof generateText>> | undefined;
+    let llmResult: Awaited<ReturnType<typeof generateObject>> | undefined;
 
     try {
       // 5. Mark as processing
@@ -151,14 +173,16 @@ export const missionEnrichmentService = {
         data: { status: "processing" },
       });
 
-      // 6. Build prompts
+      // 6. Build prompts + schema
       const promptVersion = PROMPT_REGISTRY[CURRENT_PROMPT_VERSION];
       const systemPrompt = promptVersion.buildSystemPrompt(buildTaxonomyBlock(toTaxonomyForPrompt(dimensions)));
       const userMessage = promptVersion.buildUserMessage(buildMissionBlock(toMissionForPrompt(mission)));
+      const schema = buildEnrichmentSchema(dimensions);
 
-      // 7. Call LLM
-      llmResult = await generateText({
+      // 7. Call LLM with structured output
+      llmResult = await generateObject({
         model: promptVersion.MODEL,
+        schema,
         system: systemPrompt,
         prompt: userMessage,
         maxRetries: LLM_MAX_RETRIES,
@@ -167,15 +191,12 @@ export const missionEnrichmentService = {
       const { inputTokens, outputTokens, totalTokens } = llmResult.usage;
       console.log(`${LOG_PREFIX} ${missionId}: LLM response received — tokens: ${inputTokens} in / ${outputTokens} out / ${totalTokens} total`);
 
-      // 8. Parse + validate response
-      let valid: ReturnType<typeof parseEnrichmentResponse>["valid"];
-      let skipped: ReturnType<typeof parseEnrichmentResponse>["skipped"];
-      try {
-        ({ valid, skipped } = parseEnrichmentResponse(llmResult.text, buildTaxonomyLookup(dimensions), CONFIDENCE_THRESHOLD));
-      } catch (parseError) {
-        console.error(`${LOG_PREFIX} ${missionId}: failed to parse LLM response\n${llmResult.text}`);
-        throw parseError;
-      }
+      // 8. Validate classifications against taxonomy rules
+      const { valid, skipped } = validateEnrichmentClassifications(
+        llmResult.object.classifications,
+        buildTaxonomyLookup(dimensions),
+        CONFIDENCE_THRESHOLD
+      );
 
       if (skipped.length > 0) {
         console.warn(
@@ -187,7 +208,7 @@ export const missionEnrichmentService = {
       // 9. Persist values + mark completed (atomic)
       await missionEnrichmentRepository.completeWithValues(
         enrichment.id,
-        llmResult.text,
+        JSON.stringify(llmResult.object),
         { inputTokens, outputTokens, totalTokens },
         valid.map((v) => ({
           taxonomyValueId: v.taxonomyValueId,
@@ -204,7 +225,7 @@ export const missionEnrichmentService = {
           data: {
             status: "failed",
             ...(llmResult && {
-              rawResponse: llmResult.text,
+              rawResponse: JSON.stringify(llmResult.object),
               inputTokens: llmResult.usage.inputTokens,
               outputTokens: llmResult.usage.outputTokens,
               totalTokens: llmResult.usage.totalTokens,

--- a/api/src/services/mission-enrichment/index.ts
+++ b/api/src/services/mission-enrichment/index.ts
@@ -213,16 +213,22 @@ export const missionEnrichmentService = {
 
       console.log(`${LOG_PREFIX} ${missionId}: enrichment completed — ${valid.length} values persisted`);
     } catch (error) {
+      // NoObjectGeneratedError (schema validation failure) exposes the raw LLM text and usage
+      // directly on the error — llmResult may never have been assigned in this case.
+      const errPayload = error as { text?: string; usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number } };
+      const rawResponse = llmResult ? JSON.stringify(llmResult.object) : (errPayload.text ?? null);
+      const usage = llmResult?.usage ?? errPayload.usage;
+
       await missionEnrichmentRepository
         .update({
           where: { id: enrichment.id },
           data: {
             status: "failed",
-            ...(llmResult && {
-              rawResponse: JSON.stringify(llmResult.object),
-              inputTokens: llmResult.usage.inputTokens,
-              outputTokens: llmResult.usage.outputTokens,
-              totalTokens: llmResult.usage.totalTokens,
+            ...(rawResponse !== null && { rawResponse }),
+            ...(usage && {
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+              totalTokens: usage.totalTokens,
             }),
           },
         })

--- a/api/src/services/mission-enrichment/parser.ts
+++ b/api/src/services/mission-enrichment/parser.ts
@@ -1,16 +1,9 @@
-import { z } from "zod";
-
-const classificationItemSchema = z.object({
-  dimension_key: z.string(),
-  value_key: z.string(),
-  confidence: z.number().min(0).max(1),
-  evidence: z.object({
-    extract: z.string(),
-    reasoning: z.string(),
-  }),
-});
-
-export type ClassificationInput = z.infer<typeof classificationItemSchema>;
+export type ClassificationInput = {
+  dimension_key: string;
+  value_key: string;
+  confidence: number;
+  evidence: { extract: string; reasoning: string };
+};
 
 export type ParsedClassification = ClassificationInput & {
   taxonomyValueId: string;
@@ -24,6 +17,39 @@ type TaxonomyMeta = { type: string; values: Map<string, string> };
 
 // taxonomyKey -> { type, values: valueKey -> taxonomyValueId }
 export type TaxonomyLookup = Map<string, TaxonomyMeta>;
+
+const FUZZY_MATCH_THRESHOLD = 0.6;
+
+/**
+ * Jaccard similarity on underscore-split tokens.
+ * "sante_social_aide_personne" vs "social_sante_aide_personne" → 1.0
+ * "gestion_commerce_finance" vs "commerce_gestion_finance" → 1.0
+ */
+const jaccardSimilarity = (a: string, b: string): number => {
+  const setA = new Set(a.split("_"));
+  const setB = new Set(b.split("_"));
+  const intersection = new Set([...setA].filter((t) => setB.has(t)));
+  const union = new Set([...setA, ...setB]);
+  return intersection.size / union.size;
+};
+
+/**
+ * Find the closest value_key in the taxonomy for a given dimension.
+ * Returns the best match if similarity >= FUZZY_MATCH_THRESHOLD, null otherwise.
+ */
+const fuzzyMatchValueKey = (
+  candidate: string,
+  validKeys: Iterable<string>
+): { key: string; score: number } | null => {
+  let best: { key: string; score: number } | null = null;
+  for (const key of validKeys) {
+    const score = jaccardSimilarity(candidate, key);
+    if (score >= FUZZY_MATCH_THRESHOLD && (!best || score > best.score)) {
+      best = { key, score };
+    }
+  }
+  return best;
+};
 
 export const validateEnrichmentClassifications = (
   classifications: ClassificationInput[],
@@ -40,42 +66,52 @@ export const validateEnrichmentClassifications = (
       continue;
     }
 
-    const taxonomyValueId = taxonomy.values.get(item.value_key);
+    let resolvedKey = item.value_key;
+    let taxonomyValueId = taxonomy.values.get(resolvedKey);
+
     if (!taxonomyValueId) {
-      skipped.push({ ...item, reason: `unknown_value: ${item.dimension_key}.${item.value_key}` });
-      continue;
+      const match = fuzzyMatchValueKey(item.value_key, taxonomy.values.keys());
+      if (match) {
+        resolvedKey = match.key;
+        taxonomyValueId = taxonomy.values.get(resolvedKey)!;
+      } else {
+        skipped.push({ ...item, reason: `unknown_value: ${item.dimension_key}.${item.value_key}` });
+        continue;
+      }
     }
 
-    if (item.confidence < confidenceThreshold) {
-      skipped.push({ ...item, reason: `below_threshold: ${item.confidence} < ${confidenceThreshold}` });
+    const normalizedItem = { ...item, value_key: resolvedKey };
+
+    if (normalizedItem.confidence < confidenceThreshold) {
+      skipped.push({ ...normalizedItem, reason: `below_threshold: ${normalizedItem.confidence} < ${confidenceThreshold}` });
       continue;
     }
 
     // Deduplicate same taxonomy.value_key — keep highest confidence
-    const dedupeKey = `${item.dimension_key}.${item.value_key}`;
+    const dedupeKey = `${normalizedItem.dimension_key}.${normalizedItem.value_key}`;
     const existingIndex = valid.findIndex((v) => `${v.dimension_key}.${v.value_key}` === dedupeKey);
     if (existingIndex !== -1) {
-      if (item.confidence > valid[existingIndex].confidence) {
-        valid[existingIndex] = { ...item, taxonomyValueId };
+      if (normalizedItem.confidence > valid[existingIndex].confidence) {
+        valid[existingIndex] = { ...normalizedItem, taxonomyValueId };
       }
       continue;
     }
 
     // For categorical taxonomies, only keep the single highest-confidence value
     if (taxonomy.type === "categorical") {
-      const existingCategorical = valid.findIndex((v) => v.dimension_key === item.dimension_key);
+      const existingCategorical = valid.findIndex((v) => v.dimension_key === normalizedItem.dimension_key);
       if (existingCategorical !== -1) {
-        if (item.confidence > valid[existingCategorical].confidence) {
-          skipped.push({ ...valid[existingCategorical], reason: `categorical_superseded: lower confidence than ${item.value_key}` });
-          valid[existingCategorical] = { ...item, taxonomyValueId };
+        if (normalizedItem.confidence > valid[existingCategorical].confidence) {
+          skipped.push({ ...valid[existingCategorical], reason: `categorical_superseded: lower confidence than ${normalizedItem.value_key}` });
+          valid[existingCategorical] = { ...normalizedItem, taxonomyValueId };
         } else {
-          skipped.push({ ...item, reason: `categorical_duplicate: ${item.dimension_key} already has a higher confidence value` });
+          skipped.push({ ...normalizedItem, reason: `categorical_duplicate: ${normalizedItem.dimension_key} already has a higher confidence value` });
         }
         continue;
       }
     }
 
-    valid.push({ ...item, taxonomyValueId });
+    valid.push({ ...normalizedItem, taxonomyValueId });
   }
 
   return { valid, skipped };

--- a/api/src/services/mission-enrichment/parser.ts
+++ b/api/src/services/mission-enrichment/parser.ts
@@ -1,3 +1,5 @@
+import { fuzzyMatchKey } from "@/utils/string";
+
 export type ClassificationInput = {
   dimension_key: string;
   value_key: string;
@@ -20,37 +22,6 @@ export type TaxonomyLookup = Map<string, TaxonomyMeta>;
 
 const FUZZY_MATCH_THRESHOLD = 0.6;
 
-/**
- * Jaccard similarity on underscore-split tokens.
- * "sante_social_aide_personne" vs "social_sante_aide_personne" → 1.0
- * "gestion_commerce_finance" vs "commerce_gestion_finance" → 1.0
- */
-const jaccardSimilarity = (a: string, b: string): number => {
-  const setA = new Set(a.split("_"));
-  const setB = new Set(b.split("_"));
-  const intersection = new Set([...setA].filter((t) => setB.has(t)));
-  const union = new Set([...setA, ...setB]);
-  return intersection.size / union.size;
-};
-
-/**
- * Find the closest value_key in the taxonomy for a given dimension.
- * Returns the best match if similarity >= FUZZY_MATCH_THRESHOLD, null otherwise.
- */
-const fuzzyMatchValueKey = (
-  candidate: string,
-  validKeys: Iterable<string>
-): { key: string; score: number } | null => {
-  let best: { key: string; score: number } | null = null;
-  for (const key of validKeys) {
-    const score = jaccardSimilarity(candidate, key);
-    if (score >= FUZZY_MATCH_THRESHOLD && (!best || score > best.score)) {
-      best = { key, score };
-    }
-  }
-  return best;
-};
-
 export const validateEnrichmentClassifications = (
   classifications: ClassificationInput[],
   taxonomyLookup: TaxonomyLookup,
@@ -70,7 +41,7 @@ export const validateEnrichmentClassifications = (
     let taxonomyValueId = taxonomy.values.get(resolvedKey);
 
     if (!taxonomyValueId) {
-      const match = fuzzyMatchValueKey(item.value_key, taxonomy.values.keys());
+      const match = fuzzyMatchKey(item.value_key, taxonomy.values.keys(), FUZZY_MATCH_THRESHOLD);
       if (match) {
         resolvedKey = match.key;
         taxonomyValueId = taxonomy.values.get(resolvedKey)!;

--- a/api/src/services/mission-enrichment/parser.ts
+++ b/api/src/services/mission-enrichment/parser.ts
@@ -1,4 +1,3 @@
-import { jsonrepair } from "jsonrepair";
 import { z } from "zod";
 
 const classificationItemSchema = z.object({
@@ -11,15 +10,13 @@ const classificationItemSchema = z.object({
   }),
 });
 
-const classificationResponseSchema = z.object({
-  classifications: z.array(classificationItemSchema),
-});
+export type ClassificationInput = z.infer<typeof classificationItemSchema>;
 
-export type ParsedClassification = z.infer<typeof classificationItemSchema> & {
+export type ParsedClassification = ClassificationInput & {
   taxonomyValueId: string;
 };
 
-export type SkippedClassification = z.infer<typeof classificationItemSchema> & {
+export type SkippedClassification = ClassificationInput & {
   reason: string;
 };
 
@@ -28,36 +25,15 @@ type TaxonomyMeta = { type: string; values: Map<string, string> };
 // taxonomyKey -> { type, values: valueKey -> taxonomyValueId }
 export type TaxonomyLookup = Map<string, TaxonomyMeta>;
 
-const extractJson = (raw: string): string => {
-  const fenceMatch = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
-  if (fenceMatch) {
-    return fenceMatch[1].trim();
-  }
-  return raw.trim();
-};
-
-const parseJson = (jsonStr: string): unknown => {
-  try {
-    return JSON.parse(jsonStr);
-  } catch {
-    // Fallback: jsonrepair handles trailing commas, multi-value strings,
-    // and other structural deviations that LLMs occasionally produce
-    return JSON.parse(jsonrepair(jsonStr));
-  }
-};
-
-export const parseEnrichmentResponse = (
-  rawText: string,
+export const validateEnrichmentClassifications = (
+  classifications: ClassificationInput[],
   taxonomyLookup: TaxonomyLookup,
   confidenceThreshold: number
 ): { valid: ParsedClassification[]; skipped: SkippedClassification[] } => {
-  const jsonStr = extractJson(rawText);
-  const parsed = classificationResponseSchema.parse(parseJson(jsonStr));
-
   const valid: ParsedClassification[] = [];
   const skipped: SkippedClassification[] = [];
 
-  for (const item of parsed.classifications) {
+  for (const item of classifications) {
     const taxonomy = taxonomyLookup.get(item.dimension_key);
     if (!taxonomy) {
       skipped.push({ ...item, reason: `unknown_dimension: ${item.dimension_key}` });

--- a/api/src/services/mission-enrichment/prompts/index.ts
+++ b/api/src/services/mission-enrichment/prompts/index.ts
@@ -1,4 +1,5 @@
 import type { LanguageModel } from "ai";
+import type { ZodTypeAny } from "zod";
 
 import * as v1 from "./v1";
 
@@ -8,6 +9,7 @@ export type { MissionForPrompt, TaxonomyForPrompt } from "./types";
 export type PromptEntry = {
   VERSION: string;
   MODEL: LanguageModel;
+  ENRICHMENT_SCHEMA: ZodTypeAny;
   buildSystemPrompt: (taxonomyBlock: string) => string;
   buildUserMessage: (missionBlock: string) => string;
 };

--- a/api/src/services/mission-enrichment/prompts/v1.ts
+++ b/api/src/services/mission-enrichment/prompts/v1.ts
@@ -25,7 +25,8 @@ Ta tâche est d'analyser une mission et de la classifier selon un référentiel 
    - \`region_internationale\` : uniquement si la mission se déroule explicitement à l'étranger.
 
 5. Pour l'evidence, fournis :
-   - \`extract\` : un extrait textuel LITTÉRAL tiré du texte de la mission (titre, description, tâches…)
+   - \`extract\` : un extrait textuel LITTÉRAL tiré du texte de la mission (titre, description, tâches…).
+     IMPORTANT : \`extract\` doit être une SEULE chaîne de caractères. Si tu veux citer plusieurs passages, concatène-les avec \` / \` comme séparateur.
    - \`reasoning\` : une phrase courte expliquant pourquoi cet extrait justifie la classification
 
 ## Taxonomie active
@@ -33,25 +34,6 @@ Ta tâche est d'analyser une mission et de la classifier selon un référentiel 
 --- DÉBUT TAXONOMIE ---
 ${taxonomyBlock}
 --- FIN TAXONOMIE ---
-
-## Format de sortie
-
-Réponds UNIQUEMENT avec un objet JSON valide, sans texte avant ni après.
-Structure attendue :
-
-{
-  "classifications": [
-    {
-      "dimension_key": "<dimension_key>",
-      "value_key": "<value_key>",
-      "confidence": <0.0 à 1.0>,
-      "evidence": {
-        "extract": "<extrait littéral du texte de la mission>",
-        "reasoning": "<explication courte>"
-      }
-    }
-  ]
-}
 
 Si aucune valeur n'est applicable pour une dimension, ne l'inclus pas dans le tableau.`;
 

--- a/api/src/services/mission-enrichment/prompts/v1.ts
+++ b/api/src/services/mission-enrichment/prompts/v1.ts
@@ -1,7 +1,18 @@
 import { mistral } from "@ai-sdk/mistral";
+import { z } from "zod";
 
 export const VERSION = "v1";
 export const MODEL = mistral("mistral-small-2603", { temperature: 0 });
+export const ENRICHMENT_SCHEMA = z.object({
+  classifications: z.array(
+    z.object({
+      dimension_key: z.string(),
+      value_key: z.string(),
+      confidence: z.number().min(0).max(1),
+      evidence: z.object({ extract: z.string(), reasoning: z.string() }),
+    })
+  ),
+});
 
 export const buildSystemPrompt = (taxonomyBlock: string): string => `\
 Tu es un classificateur de missions d'engagement bénévole et civique.

--- a/api/src/services/mission-enrichment/prompts/v1.ts
+++ b/api/src/services/mission-enrichment/prompts/v1.ts
@@ -24,10 +24,19 @@ Ta tâche est d'analyser une mission et de la classifier selon un référentiel 
      à la gendarmerie ou à la police. Ne l'utilise pas pour du bénévolat associatif classique.
    - \`region_internationale\` : uniquement si la mission se déroule explicitement à l'étranger.
 
-5. Pour l'evidence, fournis :
+5. Pour l'evidence, fournis un OBJET avec exactement deux champs — jamais une chaîne simple :
    - \`extract\` : un extrait textuel LITTÉRAL tiré du texte de la mission (titre, description, tâches…).
-     IMPORTANT : \`extract\` doit être une SEULE chaîne de caractères. Si tu veux citer plusieurs passages, concatène-les avec \` / \` comme séparateur.
+     Si tu veux citer plusieurs passages, concatène-les avec \` / \` comme séparateur.
    - \`reasoning\` : une phrase courte expliquant pourquoi cet extrait justifie la classification
+
+   Exemple correct :
+   \`\`\`
+   "evidence": { "extract": "...", "reasoning": "..." }
+   \`\`\`
+   Exemple INCORRECT (ne jamais faire) :
+   \`\`\`
+   "evidence": "...", "reasoning": "..."
+   \`\`\`
 
 ## Taxonomie active
 

--- a/api/src/services/mission-enrichment/prompts/v1.ts
+++ b/api/src/services/mission-enrichment/prompts/v1.ts
@@ -1,7 +1,7 @@
 import { mistral } from "@ai-sdk/mistral";
 
 export const VERSION = "v1";
-export const MODEL = mistral("mistral-small-2603");
+export const MODEL = mistral("mistral-small-2603", { temperature: 0 });
 
 export const buildSystemPrompt = (taxonomyBlock: string): string => `\
 Tu es un classificateur de missions d'engagement bénévole et civique.
@@ -43,6 +43,140 @@ Ta tâche est d'analyser une mission et de la classifier selon un référentiel 
 --- DÉBUT TAXONOMIE ---
 ${taxonomyBlock}
 --- FIN TAXONOMIE ---
+
+## Exemples
+
+### Exemple 1
+
+**Mission :** Bénévole visiteur en EHPAD — Rendre visite chaque semaine à des personnes âgées isolées, animer des ateliers de lecture et de jeux de société, accompagner les résidents lors de sorties. Mission régulière, 2h par semaine.
+
+**Résultat attendu :**
+\`\`\`json
+{
+  "classifications": [
+    {
+      "dimension_key": "domaine",
+      "value_key": "social_solidarite",
+      "confidence": 0.97,
+      "evidence": {
+        "extract": "Rendre visite chaque semaine à des personnes âgées isolées",
+        "reasoning": "La mission cible la lutte contre l'isolement des personnes âgées, domaine social et solidarité."
+      }
+    },
+    {
+      "dimension_key": "engagement_intent",
+      "value_key": "aide_directe",
+      "confidence": 0.95,
+      "evidence": {
+        "extract": "Rendre visite chaque semaine à des personnes âgées isolées / accompagner les résidents lors de sorties",
+        "reasoning": "Contact direct et régulier avec les bénéficiaires."
+      }
+    },
+    {
+      "dimension_key": "engagement_intent",
+      "value_key": "animation",
+      "confidence": 0.9,
+      "evidence": {
+        "extract": "animer des ateliers de lecture et de jeux de société",
+        "reasoning": "La mission inclut explicitement l'animation d'ateliers collectifs."
+      }
+    },
+    {
+      "dimension_key": "competence_rome",
+      "value_key": "management_social_soin",
+      "confidence": 0.9,
+      "evidence": {
+        "extract": "Rendre visite chaque semaine à des personnes âgées isolées / accompagner les résidents",
+        "reasoning": "Accompagnement humain et soutien aux personnes vulnérables."
+      }
+    },
+    {
+      "dimension_key": "secteur_activite",
+      "value_key": "sante_social_aide_personne",
+      "confidence": 0.95,
+      "evidence": {
+        "extract": "Rendre visite chaque semaine à des personnes âgées isolées",
+        "reasoning": "Mission dans le secteur de l'aide à la personne en EHPAD."
+      }
+    },
+    {
+      "dimension_key": "type_mission",
+      "value_key": "reguliere",
+      "confidence": 0.99,
+      "evidence": {
+        "extract": "Mission régulière, 2h par semaine",
+        "reasoning": "Fréquence hebdomadaire explicite."
+      }
+    }
+  ]
+}
+\`\`\`
+
+### Exemple 2
+
+**Mission :** Développeur bénévole — Contribuer au développement d'une application mobile pour une association caritative. Mission ponctuelle sur un weekend (hackathon), en équipe de 5 développeurs.
+
+**Résultat attendu :**
+\`\`\`json
+{
+  "classifications": [
+    {
+      "dimension_key": "domaine",
+      "value_key": "gestion_projet",
+      "confidence": 0.85,
+      "evidence": {
+        "extract": "Contribuer au développement d'une application mobile / en équipe de 5 développeurs",
+        "reasoning": "Mission de développement logiciel avec travail en équipe structuré."
+      }
+    },
+    {
+      "dimension_key": "competence_rome",
+      "value_key": "communication_creation_numerique",
+      "confidence": 0.97,
+      "evidence": {
+        "extract": "développement d'une application mobile",
+        "reasoning": "Compétence numérique et création digitale au cœur de la mission."
+      }
+    },
+    {
+      "dimension_key": "competence_rome",
+      "value_key": "cooperation_organisation_soft_skills",
+      "confidence": 0.8,
+      "evidence": {
+        "extract": "en équipe de 5 développeurs",
+        "reasoning": "Travail collaboratif en équipe."
+      }
+    },
+    {
+      "dimension_key": "engagement_intent",
+      "value_key": "support_organisation",
+      "confidence": 0.9,
+      "evidence": {
+        "extract": "Contribuer au développement d'une application mobile pour une association caritative",
+        "reasoning": "Apport de compétences techniques au service de l'organisation."
+      }
+    },
+    {
+      "dimension_key": "secteur_activite",
+      "value_key": "numerique_communication",
+      "confidence": 0.95,
+      "evidence": {
+        "extract": "développement d'une application mobile",
+        "reasoning": "Mission dans le secteur numérique."
+      }
+    },
+    {
+      "dimension_key": "type_mission",
+      "value_key": "ponctuelle",
+      "confidence": 0.99,
+      "evidence": {
+        "extract": "Mission ponctuelle sur un weekend (hackathon)",
+        "reasoning": "Mission explicitement ponctuelle."
+      }
+    }
+  ]
+}
+\`\`\`
 
 Si aucune valeur n'est applicable pour une dimension, ne l'inclus pas dans le tableau.`;
 

--- a/api/src/utils/__tests__/string.test.ts
+++ b/api/src/utils/__tests__/string.test.ts
@@ -170,6 +170,19 @@ describe("String Utils", () => {
       const result = fuzzyMatchKey("formation_education_animation", keys, 0.6);
       expect(result?.key).toBe("education_formation_animation");
     });
+
+    it("breaks ties by lexical order (lowest key wins)", () => {
+      // "alpha_beta" and "beta_alpha" both score 1.0 against "alpha_beta" — "alpha_beta" < "beta_alpha"
+      const tiedKeys = ["beta_alpha", "alpha_beta"];
+      const result = fuzzyMatchKey("alpha_beta", tiedKeys, 0.6);
+      expect(result?.key).toBe("alpha_beta");
+    });
+
+    it("tie-break is stable regardless of iteration order", () => {
+      const tiedKeys1 = ["beta_alpha", "alpha_beta"];
+      const tiedKeys2 = ["alpha_beta", "beta_alpha"];
+      expect(fuzzyMatchKey("alpha_beta", tiedKeys1, 0.6)?.key).toBe(fuzzyMatchKey("alpha_beta", tiedKeys2, 0.6)?.key);
+    });
   });
 
   describe("hasLetter", () => {

--- a/api/src/utils/__tests__/string.test.ts
+++ b/api/src/utils/__tests__/string.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { capitalizeFirstLetter, hasLetter, hasNumber, hasSpecialChar, slugify } from "@/utils/string";
+import { capitalizeFirstLetter, fuzzyMatchKey, hasLetter, hasNumber, hasSpecialChar, jaccardSimilarity, slugify } from "@/utils/string";
 
 describe("String Utils", () => {
   describe("slugify", () => {
@@ -100,6 +100,75 @@ describe("String Utils", () => {
 
     it("should return false for an empty string", () => {
       expect(hasNumber("")).toBe(false);
+    });
+  });
+
+  describe("jaccardSimilarity", () => {
+    it("returns 1.0 for identical keys", () => {
+      expect(jaccardSimilarity("sante_social", "sante_social")).toBe(1);
+    });
+
+    it("returns 1.0 for reordered tokens", () => {
+      expect(jaccardSimilarity("sante_social", "social_sante")).toBe(1);
+    });
+
+    it("returns 1.0 despite case differences", () => {
+      expect(jaccardSimilarity("Production_construction", "production_construction")).toBe(1);
+    });
+
+    it("returns 1.0 despite diacritic differences", () => {
+      expect(jaccardSimilarity("qualite_logistique", "qualité_logistique")).toBe(1);
+    });
+
+    it("returns 1.0 for reordered tokens with mixed case and diacritics", () => {
+      // Simulates: LLM outputs normalized form, taxonomy has legacy casing
+      expect(jaccardSimilarity("production_construction_qualite_logistique", "Production_construction_qualité_logistique")).toBe(1);
+    });
+
+    it("returns 0 for fully disjoint tokens", () => {
+      expect(jaccardSimilarity("sante_social", "culture_arts")).toBe(0);
+    });
+
+    it("returns partial score for overlapping tokens", () => {
+      // intersection: {sante}, union: {sante, social, soin} → 1/3
+      expect(jaccardSimilarity("sante_social", "sante_soin")).toBeCloseTo(1 / 3);
+    });
+  });
+
+  describe("fuzzyMatchKey", () => {
+    const keys = ["sante_social_aide_personne", "education_formation_animation", "culture_creation_medias"];
+
+    it("returns exact match at score 1.0", () => {
+      const result = fuzzyMatchKey("sante_social_aide_personne", keys, 0.6);
+      expect(result).toEqual({ key: "sante_social_aide_personne", score: 1 });
+    });
+
+    it("matches reordered tokens", () => {
+      const result = fuzzyMatchKey("social_sante_aide_personne", keys, 0.6);
+      expect(result?.key).toBe("sante_social_aide_personne");
+      expect(result?.score).toBe(1);
+    });
+
+    it("matches despite diacritics and casing", () => {
+      const keysWithAccent = ["Production_construction_qualité_logistique"];
+      const result = fuzzyMatchKey("production_construction_qualite_logistique", keysWithAccent, 0.6);
+      expect(result?.key).toBe("Production_construction_qualité_logistique");
+      expect(result?.score).toBe(1);
+    });
+
+    it("returns null when best score is below threshold", () => {
+      const result = fuzzyMatchKey("numerique_communication", keys, 0.6);
+      expect(result).toBeNull();
+    });
+
+    it("returns null for empty candidates list", () => {
+      const result = fuzzyMatchKey("sante_social", [], 0.6);
+      expect(result).toBeNull();
+    });
+
+    it("returns the best match among multiple candidates", () => {
+      const result = fuzzyMatchKey("formation_education_animation", keys, 0.6);
+      expect(result?.key).toBe("education_formation_animation");
     });
   });
 

--- a/api/src/utils/string.ts
+++ b/api/src/utils/string.ts
@@ -91,12 +91,24 @@ export const cleanIdParam = (param: string): string => {
 export const isBlank = (value?: string | null) => value === null || value === undefined || value === "";
 
 /**
+ * Normalize a string for fuzzy comparison: lowercase + remove diacritics.
+ * "Qualité" → "qualite", "SANTE" → "sante"
+ */
+const normalizeToken = (s: string): string =>
+  s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Mn}/gu, "");
+
+/**
  * Jaccard similarity between two underscore-separated token strings.
- * Order-insensitive: "sante_social" and "social_sante" → 1.0
+ * Order-insensitive and case/diacritic-insensitive:
+ * "sante_social" and "social_sante" → 1.0
+ * "Qualité_logistique" and "qualite_logistique" → 1.0
  */
 export const jaccardSimilarity = (a: string, b: string): number => {
-  const setA = new Set(a.split("_"));
-  const setB = new Set(b.split("_"));
+  const setA = new Set(a.split("_").map(normalizeToken));
+  const setB = new Set(b.split("_").map(normalizeToken));
   const intersection = new Set([...setA].filter((t) => setB.has(t)));
   const union = new Set([...setA, ...setB]);
   return intersection.size / union.size;

--- a/api/src/utils/string.ts
+++ b/api/src/utils/string.ts
@@ -127,7 +127,7 @@ export const fuzzyMatchKey = (
   let best: { key: string; score: number } | null = null;
   for (const key of validKeys) {
     const score = jaccardSimilarity(candidate, key);
-    if (score >= threshold && (!best || score > best.score)) {
+    if (score >= threshold && (!best || score > best.score || (score === best.score && key < best.key))) {
       best = { key, score };
     }
   }

--- a/api/src/utils/string.ts
+++ b/api/src/utils/string.ts
@@ -89,3 +89,35 @@ export const cleanIdParam = (param: string): string => {
 };
 
 export const isBlank = (value?: string | null) => value === null || value === undefined || value === "";
+
+/**
+ * Jaccard similarity between two underscore-separated token strings.
+ * Order-insensitive: "sante_social" and "social_sante" → 1.0
+ */
+export const jaccardSimilarity = (a: string, b: string): number => {
+  const setA = new Set(a.split("_"));
+  const setB = new Set(b.split("_"));
+  const intersection = new Set([...setA].filter((t) => setB.has(t)));
+  const union = new Set([...setA, ...setB]);
+  return intersection.size / union.size;
+};
+
+/**
+ * Find the closest match for a candidate string among a set of valid keys,
+ * using Jaccard similarity on underscore-split tokens.
+ * Returns the best match if its score >= threshold, null otherwise.
+ */
+export const fuzzyMatchKey = (
+  candidate: string,
+  validKeys: Iterable<string>,
+  threshold: number
+): { key: string; score: number } | null => {
+  let best: { key: string; score: number } | null = null;
+  for (const key of validKeys) {
+    const score = jaccardSimilarity(candidate, key);
+    if (score >= threshold && (!best || score > best.score)) {
+      best = { key, score };
+    }
+  }
+  return best;
+};


### PR DESCRIPTION
## Description

Refactoring du service d'enrichissement de missions pour améliorer la robustesse du parsing LLM.

**Problèmes observés :**
- Erreurs sporadiques `JSONRepairError: Colon expected` — le LLM produisait plusieurs chaînes séparées par des virgules dans le champ `extract`
- Clés `value_key` hallucinées hors référentiel (ex. `gestion_commerce_finance` au lieu de `commerce_gestion_finance`)
- Clé `production_construction_qualité_logistique` avec majuscule et accent non normalisés

**Solutions apportées :**

- **Structured output** : `generateText` → `generateObject` avec schéma Zod statique. Garantit JSON valide, structure `evidence` correcte et `confidence` typée — sans dépendre d'un schéma dynamique à partir des taxonomies.

- **Fuzzy matching** : quand une `value_key` est inconnue, on cherche la clé la plus proche par similarité Jaccard sur les tokens `_` (seuil 0.6). `social_sante_aide_personne` → `sante_social_aide_personne` est récupéré au lieu d'être silencieusement écarté. L'helper `fuzzyMatchKey` est rangé dans `utils/string.ts`.

- **Few-shot examples** : deux exemples complets (mission → classifications JSON) ajoutés dans le system prompt. Améliore la cohérence structurelle sur Mistral small qui répond bien à l'imitation.

- **`temperature: 0`** : élimine la variabilité non déterministe des réponses.

- **Prompt** : ajout d'une contrainte explicite sur `evidence` (objet imbriqué, pas une string) avec exemple d'erreur à éviter.

- **Simplification parser** : suppression de `jsonrepair`, `extractJson`, `parseJson`, et du schéma Zod de parsing. `parseEnrichmentResponse` → `validateEnrichmentClassifications` prend directement un tableau d'objets.

## Type de changement

- [x] Correction de bug
- [x] Amélioration de performance
- [x] Refactoring

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Le seed taxonomy (`seed-taxonomy.ts`) a été modifié sur la branche de base pour normaliser la clé `production_construction_qualité_logistique` → `production_construction_qualite_logistique`. Ce changement nécessite de relancer le script de seed en prod.