### PR TITLE
feat(api): fake mission enrichment data script

### DIFF
--- a/api/scripts/seed-fake-mission-enrichment.ts
+++ b/api/scripts/seed-fake-mission-enrichment.ts
@@ -2,13 +2,15 @@
  * Génère de faux enrichissements de mission pour tester le scoring à volume.
  *
  * Exécution :
- *   npx ts-node scripts/seed-fake-mission-enrichment.ts [--reset] [--limit N] [--publisher-id X] [--dry-run]
+ *   npx ts-node scripts/seed-fake-mission-enrichment.ts [--reset] [--limit N] [--publisher-id X] [--prompt-version V] [--dry-run]
  *
  * Options :
- *   --reset         Supprime tous les enrichissements fake (_fake: true) et quitte
- *   --limit N       Traite au max N missions (défaut : illimité)
- *   --publisher-id  Filtre par publisher
- *   --dry-run       Log sans écrire en base
+ *   --reset              Supprime tous les enrichissements fake (_fake: true) toutes versions confondues,
+ *                        ou uniquement la version spécifiée via --prompt-version
+ *   --limit N            Traite au max N missions (défaut : illimité)
+ *   --publisher-id X     Filtre par publisher
+ *   --prompt-version V   Version du prompt à utiliser pour le seed/reset (défaut : CURRENT_PROMPT_VERSION)
+ *   --dry-run            Log sans écrire en base
  */
 
 import dotenv from "dotenv";
@@ -26,6 +28,9 @@ const limitArg = args.indexOf("--limit");
 const limit = limitArg !== -1 ? parseInt(args[limitArg + 1], 10) : undefined;
 const publisherIdArg = args.indexOf("--publisher-id");
 const publisherId = publisherIdArg !== -1 ? args[publisherIdArg + 1] : undefined;
+const promptVersionArg = args.indexOf("--prompt-version");
+// For seed: always use a specific version (default: current). For reset: undefined = all versions.
+const promptVersion = promptVersionArg !== -1 ? args[promptVersionArg + 1] : undefined;
 
 const BATCH_SIZE = 500;
 
@@ -80,26 +85,21 @@ function generateValues(taxonomies: TaxonomyWithValues[]): { taxonomyValueId: st
 // ── Reset ─────────────────────────────────────────────────────────────────────
 
 async function reset() {
-  console.log("[seed-fake-mission-enrichment] Suppression des enrichissements fake...");
+  const versionLabel = promptVersion ?? "toutes versions";
+  console.log(`[seed-fake-mission-enrichment] Suppression des enrichissements fake (${versionLabel})...`);
+
+  const where = {
+    ...(promptVersion ? { promptVersion } : {}),
+    rawResponse: { path: ["_fake"], equals: true },
+  };
 
   if (isDryRun) {
-    const count = await prisma.missionEnrichment.count({
-      where: {
-        promptVersion: CURRENT_PROMPT_VERSION,
-        rawResponse: { path: ["_fake"], equals: true },
-      },
-    });
+    const count = await prisma.missionEnrichment.count({ where });
     console.log(`[seed-fake-mission-enrichment] [dry-run] ${count} enrichissements à supprimer`);
     return;
   }
 
-  const { count } = await prisma.missionEnrichment.deleteMany({
-    where: {
-      promptVersion: CURRENT_PROMPT_VERSION,
-      rawResponse: { path: ["_fake"], equals: true },
-    },
-  });
-
+  const { count } = await prisma.missionEnrichment.deleteMany({ where });
   console.log(`[seed-fake-mission-enrichment] ${count} enrichissements supprimés (cascade sur values + scorings)`);
 }
 
@@ -116,15 +116,16 @@ async function seed() {
     process.exit(1);
   }
 
-  console.log(`[seed-fake-mission-enrichment] ${taxonomies.length} taxonomies chargées`);
+  const seedVersion = promptVersion ?? CURRENT_PROMPT_VERSION;
+  console.log(`[seed-fake-mission-enrichment] ${taxonomies.length} taxonomies chargées (version: ${seedVersion})`);
 
-  // Query missions without a completed enrichment
+  // Query missions without a completed enrichment for the target version
   const missions = await prisma.mission.findMany({
     where: {
       ...(publisherId ? { publisherId } : {}),
       deletedAt: null,
       enrichments: {
-        none: { promptVersion: CURRENT_PROMPT_VERSION, status: "completed" },
+        none: { promptVersion: seedVersion, status: "completed" },
       },
     },
     select: { id: true },
@@ -162,7 +163,7 @@ async function seed() {
           const enrichment = await prisma.missionEnrichment.create({
             data: {
               missionId: mission.id,
-              promptVersion: CURRENT_PROMPT_VERSION,
+              promptVersion: seedVersion,
               status: "completed",
               rawResponse,
               inputTokens: 0,
@@ -204,7 +205,7 @@ async function seed() {
 const run = async () => {
   await prisma.$connect();
   console.log("[seed-fake-mission-enrichment] Connecté à PostgreSQL");
-  console.log(`[seed-fake-mission-enrichment] Options — reset: ${isReset}, limit: ${limit ?? "all"}, publisher: ${publisherId ?? "all"}, dry-run: ${isDryRun}`);
+  console.log(`[seed-fake-mission-enrichment] Options — reset: ${isReset}, limit: ${limit ?? "all"}, publisher: ${publisherId ?? "all"}, prompt-version: ${promptVersion ?? `${CURRENT_PROMPT_VERSION} (défaut)`}, dry-run: ${isDryRun}`);
 
   if (isReset) {
     await reset();

--- a/api/scripts/seed-fake-mission-enrichment.ts
+++ b/api/scripts/seed-fake-mission-enrichment.ts
@@ -160,31 +160,33 @@ async function seed() {
             })),
           };
 
-          const enrichment = await prisma.missionEnrichment.create({
-            data: {
-              missionId: mission.id,
-              promptVersion: seedVersion,
-              status: "completed",
-              rawResponse,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-              completedAt: new Date(),
-            },
-            select: { id: true },
-          });
-
-          if (values.length > 0) {
-            await prisma.missionEnrichmentValue.createMany({
-              data: values.map((v) => ({
-                enrichmentId: enrichment.id,
-                taxonomyValueId: v.taxonomyValueId,
-                confidence: v.confidence,
-                evidence: { extract: "Extrait synthétique", reasoning: "Données générées pour tests de scoring" },
-              })),
-              skipDuplicates: true,
+          await prisma.$transaction(async (tx) => {
+            const enrichment = await tx.missionEnrichment.create({
+              data: {
+                missionId: mission.id,
+                promptVersion: seedVersion,
+                status: "completed",
+                rawResponse,
+                inputTokens: 0,
+                outputTokens: 0,
+                totalTokens: 0,
+                completedAt: new Date(),
+              },
+              select: { id: true },
             });
-          }
+
+            if (values.length > 0) {
+              await tx.missionEnrichmentValue.createMany({
+                data: values.map((v) => ({
+                  enrichmentId: enrichment.id,
+                  taxonomyValueId: v.taxonomyValueId,
+                  confidence: v.confidence,
+                  evidence: { extract: "Extrait synthétique", reasoning: "Données générées pour tests de scoring" },
+                })),
+                skipDuplicates: true,
+              });
+            }
+          });
 
           created++;
         } catch (err) {
@@ -205,7 +207,8 @@ async function seed() {
 const run = async () => {
   await prisma.$connect();
   console.log("[seed-fake-mission-enrichment] Connecté à PostgreSQL");
-  console.log(`[seed-fake-mission-enrichment] Options — reset: ${isReset}, limit: ${limit ?? "all"}, publisher: ${publisherId ?? "all"}, prompt-version: ${promptVersion ?? `${CURRENT_PROMPT_VERSION} (défaut)`}, dry-run: ${isDryRun}`);
+  const versionDisplay = promptVersion ?? (isReset ? "toutes versions" : `${CURRENT_PROMPT_VERSION} (défaut)`);
+  console.log(`[seed-fake-mission-enrichment] Options — reset: ${isReset}, limit: ${limit ?? "all"}, publisher: ${publisherId ?? "all"}, prompt-version: ${versionDisplay}, dry-run: ${isDryRun}`);
 
   if (isReset) {
     await reset();

--- a/api/scripts/seed-fake-mission-enrichment.ts
+++ b/api/scripts/seed-fake-mission-enrichment.ts
@@ -1,0 +1,221 @@
+/**
+ * Génère de faux enrichissements de mission pour tester le scoring à volume.
+ *
+ * Exécution :
+ *   npx ts-node scripts/seed-fake-mission-enrichment.ts [--reset] [--limit N] [--publisher-id X] [--dry-run]
+ *
+ * Options :
+ *   --reset         Supprime tous les enrichissements fake (_fake: true) et quitte
+ *   --limit N       Traite au max N missions (défaut : illimité)
+ *   --publisher-id  Filtre par publisher
+ *   --dry-run       Log sans écrire en base
+ */
+
+import dotenv from "dotenv";
+dotenv.config();
+
+import { prisma } from "@/db/postgres";
+import { CURRENT_PROMPT_VERSION } from "@/services/mission-enrichment/config";
+
+// ── CLI args ──────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const isReset = args.includes("--reset");
+const isDryRun = args.includes("--dry-run");
+const limitArg = args.indexOf("--limit");
+const limit = limitArg !== -1 ? parseInt(args[limitArg + 1], 10) : undefined;
+const publisherIdArg = args.indexOf("--publisher-id");
+const publisherId = publisherIdArg !== -1 ? args[publisherIdArg + 1] : undefined;
+
+const BATCH_SIZE = 500;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function pickRandom<T>(arr: T[], n: number): T[] {
+  const shuffled = [...arr].sort(() => Math.random() - 0.5);
+  return shuffled.slice(0, n);
+}
+
+function randomConfidence(): number {
+  return parseFloat((Math.random() * 0.58 + 0.40).toFixed(4));
+}
+
+type TaxonomyWithValues = {
+  id: string;
+  key: string;
+  type: string;
+  values: { id: string; key: string }[];
+};
+
+function generateValues(taxonomies: TaxonomyWithValues[]): { taxonomyValueId: string; confidence: number }[] {
+  const result: { taxonomyValueId: string; confidence: number }[] = [];
+
+  for (const taxonomy of taxonomies) {
+    const activeValues = taxonomy.values;
+    if (activeValues.length === 0) continue;
+
+    if (taxonomy.type === "categorical") {
+      if (Math.random() < 0.80) {
+        const picked = pickRandom(activeValues, 1)[0];
+        result.push({ taxonomyValueId: picked.id, confidence: randomConfidence() });
+      }
+    } else if (taxonomy.type === "gate") {
+      if (Math.random() < 0.30) {
+        const picked = pickRandom(activeValues, 1)[0];
+        result.push({ taxonomyValueId: picked.id, confidence: randomConfidence() });
+      }
+    } else {
+      // multi_value / ordered
+      const count = Math.floor(Math.random() * 3) + 1;
+      const picked = pickRandom(activeValues, Math.min(count, activeValues.length));
+      for (const v of picked) {
+        result.push({ taxonomyValueId: v.id, confidence: randomConfidence() });
+      }
+    }
+  }
+
+  return result;
+}
+
+// ── Reset ─────────────────────────────────────────────────────────────────────
+
+async function reset() {
+  console.log("[seed-fake-mission-enrichment] Suppression des enrichissements fake...");
+
+  if (isDryRun) {
+    const count = await prisma.missionEnrichment.count({
+      where: {
+        promptVersion: CURRENT_PROMPT_VERSION,
+        rawResponse: { path: ["_fake"], equals: true },
+      },
+    });
+    console.log(`[seed-fake-mission-enrichment] [dry-run] ${count} enrichissements à supprimer`);
+    return;
+  }
+
+  const { count } = await prisma.missionEnrichment.deleteMany({
+    where: {
+      promptVersion: CURRENT_PROMPT_VERSION,
+      rawResponse: { path: ["_fake"], equals: true },
+    },
+  });
+
+  console.log(`[seed-fake-mission-enrichment] ${count} enrichissements supprimés (cascade sur values + scorings)`);
+}
+
+// ── Seed ──────────────────────────────────────────────────────────────────────
+
+async function seed() {
+  // Load all active taxonomy values
+  const taxonomies = await prisma.taxonomy.findMany({
+    include: { values: { where: { active: true }, select: { id: true, key: true } } },
+  });
+
+  if (taxonomies.length === 0) {
+    console.error("[seed-fake-mission-enrichment] Aucune taxonomie trouvée — lancer seed-taxonomy d'abord");
+    process.exit(1);
+  }
+
+  console.log(`[seed-fake-mission-enrichment] ${taxonomies.length} taxonomies chargées`);
+
+  // Query missions without a completed enrichment
+  const missions = await prisma.mission.findMany({
+    where: {
+      ...(publisherId ? { publisherId } : {}),
+      deletedAt: null,
+      enrichments: {
+        none: { promptVersion: CURRENT_PROMPT_VERSION, status: "completed" },
+      },
+    },
+    select: { id: true },
+    take: limit,
+    orderBy: { updatedAt: "desc" },
+  });
+
+  console.log(`[seed-fake-mission-enrichment] ${missions.length} missions à enrichir`);
+
+  if (isDryRun) {
+    console.log("[seed-fake-mission-enrichment] [dry-run] Aucune écriture effectuée");
+    return;
+  }
+
+  let created = 0;
+  let failed = 0;
+
+  // Process in parallel batches
+  for (let i = 0; i < missions.length; i += BATCH_SIZE) {
+    const batch = missions.slice(i, i + BATCH_SIZE);
+
+    await Promise.all(
+      batch.map(async (mission) => {
+        try {
+          const values = generateValues(taxonomies);
+          const rawResponse = {
+            _fake: true,
+            classifications: values.map((v) => ({
+              taxonomyValueId: v.taxonomyValueId,
+              confidence: v.confidence,
+              evidence: { extract: "Extrait synthétique", reasoning: "Données générées pour tests de scoring" },
+            })),
+          };
+
+          const enrichment = await prisma.missionEnrichment.create({
+            data: {
+              missionId: mission.id,
+              promptVersion: CURRENT_PROMPT_VERSION,
+              status: "completed",
+              rawResponse,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+              completedAt: new Date(),
+            },
+            select: { id: true },
+          });
+
+          if (values.length > 0) {
+            await prisma.missionEnrichmentValue.createMany({
+              data: values.map((v) => ({
+                enrichmentId: enrichment.id,
+                taxonomyValueId: v.taxonomyValueId,
+                confidence: v.confidence,
+                evidence: { extract: "Extrait synthétique", reasoning: "Données générées pour tests de scoring" },
+              })),
+              skipDuplicates: true,
+            });
+          }
+
+          created++;
+        } catch (err) {
+          failed++;
+          console.error(`[seed-fake-mission-enrichment] Erreur sur mission ${mission.id}:`, err);
+        }
+      })
+    );
+
+    console.log(`[seed-fake-mission-enrichment] ${Math.min(i + BATCH_SIZE, missions.length)}/${missions.length} traitées (${created} créées, ${failed} erreurs)`);
+  }
+
+  console.log(`[seed-fake-mission-enrichment] Terminé — ${created} enrichissements créés, ${failed} erreurs`);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+const run = async () => {
+  await prisma.$connect();
+  console.log("[seed-fake-mission-enrichment] Connecté à PostgreSQL");
+  console.log(`[seed-fake-mission-enrichment] Options — reset: ${isReset}, limit: ${limit ?? "all"}, publisher: ${publisherId ?? "all"}, dry-run: ${isDryRun}`);
+
+  if (isReset) {
+    await reset();
+  } else {
+    await seed();
+  }
+
+  await prisma.$disconnect();
+};
+
+run().catch((err) => {
+  console.error("[seed-fake-mission-enrichment] Erreur fatale:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Description

Ajoute un script de génération de faux enrichissements de mission pour tester le scoring à volume sans passer par le LLM.

**Contexte** : le job `update-mission-enrichment` appelle Mistral (coût, latence). Ce script génère des `MissionEnrichment` + `MissionEnrichmentValue` cohérents directement en base, en respectant la même structure que les vrais enrichissements.

**Fonctionnement** :
- Sélectionne les missions sans enrichissement `v1` completed (même filtre que le job réel)
- Charge les taxonomies actives en base pour utiliser les vrais IDs
- Génère des valeurs aléatoires selon le type de taxonomie (`categorical`, `multi_value`, `gate`)
- Écrit en batch de 500 missions en parallèle → génération rapide de milliers d'enregistrements
- Marque les records avec `rawResponse._fake: true` pour les identifier et les supprimer proprement

**Usage** :
```bash
# Générer sur toutes les missions
npx ts-node scripts/seed-fake-mission-enrichment.ts

# Limiter + filtrer par publisher
npx ts-node scripts/seed-fake-mission-enrichment.ts --limit 5000 --publisher-id <id>

# Supprimer tous les enrichissements fake (cascade sur values + scorings)
npx ts-node scripts/seed-fake-mission-enrichment.ts --reset

# Dry run
npx ts-node scripts/seed-fake-mission-enrichment.ts --dry-run
```

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Ce script est uniquement destiné à usage local / staging pour préparer des datasets de test. Il ne doit pas être exécuté en production.

Les enrichissements fake sont identifiables via `rawResponse._fake = true` — le `--reset` supprime uniquement ceux-là, sans toucher aux vrais enrichissements.