### PR TITLE
refactor(api): implemente gate exclusion logic in matching_engine

### DIFF
--- a/api/src/services/__tests__/matching-engine.test.ts
+++ b/api/src/services/__tests__/matching-engine.test.ts
@@ -136,5 +136,107 @@ describe("matchingEngineService", () => {
       expect(result.items).toEqual([]);
       expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(2);
     });
+
+    it("returns only missions that remain after gate exclusion", async () => {
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            id: "user-scoring-gate-filtered",
+            expires_at: null,
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            mission_id: "mission-eligible",
+            mission_scoring_id: "mission-scoring-eligible",
+            total_score: 0.8,
+            taxonomy_score: 0.8,
+            geo_score: null,
+            distance_km: null,
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            mission_scoring_id: "mission-scoring-eligible",
+            dimension_key: "domaine",
+            dimension_score: 0.8,
+          },
+        ]);
+
+      const result = await matchingEngineService.rankMissionsByUserScoring({
+        userScoringId: "user-scoring-gate-filtered",
+      });
+
+      expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(3);
+      expect(result.items).toEqual([
+        {
+          missionId: "mission-eligible",
+          missionScoringId: "mission-scoring-eligible",
+          totalScore: 0.8,
+          taxonomyScore: 0.8,
+          geoScore: null,
+          distanceKm: null,
+          dimensionScores: {
+            domaine: 0.8,
+          },
+        },
+      ]);
+    });
+
+    it("keeps excluded missions out of the final payload and ignores their dimension rows", async () => {
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            id: "user-scoring-gate-dimensions",
+            expires_at: null,
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            mission_id: "mission-1",
+            mission_scoring_id: "mission-scoring-1",
+            total_score: 0.7,
+            taxonomy_score: 0.7,
+            geo_score: null,
+            distance_km: null,
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            mission_scoring_id: "mission-scoring-1",
+            dimension_key: "domaine",
+            dimension_score: 0.7,
+          },
+          {
+            mission_scoring_id: "mission-scoring-excluded",
+            dimension_key: "domaine",
+            dimension_score: 0.2,
+          },
+          {
+            mission_scoring_id: "mission-scoring-1",
+            dimension_key: "tranche_age",
+            dimension_score: 1,
+          },
+        ]);
+
+      const result = await matchingEngineService.rankMissionsByUserScoring({
+        userScoringId: "user-scoring-gate-dimensions",
+      });
+
+      expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(3);
+      expect(result.items).toEqual([
+        {
+          missionId: "mission-1",
+          missionScoringId: "mission-scoring-1",
+          totalScore: 0.7,
+          taxonomyScore: 0.7,
+          geoScore: null,
+          distanceKm: null,
+          dimensionScores: {
+            domaine: 0.7,
+          },
+        },
+      ]);
+    });
   });
 });

--- a/api/src/services/matching-engine.ts
+++ b/api/src/services/matching-engine.ts
@@ -102,6 +102,7 @@ const buildRanking = (params: {
     JOIN "taxonomy" t
       ON t."id" = tv."taxonomy_id"
     WHERE usv."user_scoring_id" = ${params.userScoringId}
+      AND t."type" <> 'gate'
   ),
   user_dimension_totals AS (
     SELECT
@@ -127,6 +128,65 @@ const buildRanking = (params: {
     WHERE m."deleted_at" IS NULL
       AND m."status_code" = 'ACCEPTED'
   ),
+  user_gate_values AS (
+    SELECT DISTINCT
+      tv."taxonomy_id",
+      usv."taxonomy_value_id"
+    FROM "user_scoring_value" usv
+    JOIN "taxonomy_value" tv
+      ON tv."id" = usv."taxonomy_value_id"
+    JOIN "taxonomy" t
+      ON t."id" = tv."taxonomy_id"
+    WHERE usv."user_scoring_id" = ${params.userScoringId}
+      AND t."type" = 'gate'
+  ),
+  mission_gate_values AS (
+    SELECT DISTINCT
+      ams."mission_scoring_id",
+      ams."mission_id",
+      tv."taxonomy_id",
+      msv."taxonomy_value_id"
+    FROM "mission_scoring_value" msv
+    JOIN "taxonomy_value" tv
+      ON tv."id" = msv."taxonomy_value_id"
+    JOIN "taxonomy" t
+      ON t."id" = tv."taxonomy_id"
+    JOIN active_mission_scorings ams
+      ON ams."mission_scoring_id" = msv."mission_scoring_id"
+    WHERE t."type" = 'gate'
+  ),
+  mission_gate_taxonomies AS (
+    SELECT DISTINCT
+      mgv."mission_scoring_id",
+      mgv."taxonomy_id"
+    FROM mission_gate_values mgv
+  ),
+  matched_gate_taxonomies AS (
+    SELECT DISTINCT
+      mgv."mission_scoring_id",
+      mgv."taxonomy_id"
+    FROM mission_gate_values mgv
+    JOIN user_gate_values ugv
+      ON ugv."taxonomy_id" = mgv."taxonomy_id"
+     AND ugv."taxonomy_value_id" = mgv."taxonomy_value_id"
+  ),
+  eligible_mission_scorings AS (
+    SELECT
+      ams."mission_scoring_id",
+      ams."mission_id"
+    FROM active_mission_scorings ams
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM mission_gate_taxonomies mgt
+      WHERE mgt."mission_scoring_id" = ams."mission_scoring_id"
+        AND NOT EXISTS (
+          SELECT 1
+          FROM matched_gate_taxonomies mgtm
+          WHERE mgtm."mission_scoring_id" = mgt."mission_scoring_id"
+            AND mgtm."taxonomy_id" = mgt."taxonomy_id"
+        )
+    )
+  ),
   matched_values AS (
     SELECT
       msv."mission_scoring_id",
@@ -135,8 +195,8 @@ const buildRanking = (params: {
     FROM user_values uv
     JOIN "mission_scoring_value" msv
       ON msv."taxonomy_value_id" = uv."taxonomy_value_id"
-    JOIN active_mission_scorings ams
-      ON ams."mission_scoring_id" = msv."mission_scoring_id"
+    JOIN eligible_mission_scorings ems
+      ON ems."mission_scoring_id" = msv."mission_scoring_id"
     GROUP BY msv."mission_scoring_id", uv."dimension_key"
   ),
   taxonomy_scores AS (
@@ -150,14 +210,14 @@ const buildRanking = (params: {
   ),
   taxonomy_candidates AS (
     SELECT
-      ams."mission_id",
-      ams."mission_scoring_id"
+      ems."mission_id",
+      ems."mission_scoring_id"
     FROM taxonomy_scores ts
-    JOIN active_mission_scorings ams
-      ON ams."mission_scoring_id" = ts."mission_scoring_id"
+    JOIN eligible_mission_scorings ems
+      ON ems."mission_scoring_id" = ts."mission_scoring_id"
     CROSS JOIN weighted_user_totals ut
     WHERE ut."taxonomy_total" > 0
-    ORDER BY ts."weighted_sum" / ut."taxonomy_total" DESC, ams."mission_id" ASC
+    ORDER BY ts."weighted_sum" / ut."taxonomy_total" DESC, ems."mission_id" ASC
     LIMIT ${params.taxonomyCandidateLimit}
   ),
   user_geo AS (
@@ -192,17 +252,17 @@ const buildRanking = (params: {
   ),
   geo_candidates AS (
     SELECT
-      ams."mission_id",
-      ams."mission_scoring_id"
+      ems."mission_id",
+      ems."mission_scoring_id"
     FROM geo_prefilter_settings gps
     JOIN "mission_address" ma
       ON ma."location_lat" IS NOT NULL
      AND ma."location_lon" IS NOT NULL
      AND ma."location_lat" BETWEEN gps."lat" - gps."lat_delta" AND gps."lat" + gps."lat_delta"
      AND ma."location_lon" BETWEEN gps."lon" - gps."lon_delta" AND gps."lon" + gps."lon_delta"
-    JOIN active_mission_scorings ams
-      ON ams."mission_id" = ma."mission_id"
-    GROUP BY ams."mission_id", ams."mission_scoring_id"
+    JOIN eligible_mission_scorings ems
+      ON ems."mission_id" = ma."mission_id"
+    GROUP BY ems."mission_id", ems."mission_scoring_id"
     ORDER BY
       MIN(
         6371.0 * 2.0 * ASIN(
@@ -213,22 +273,22 @@ const buildRanking = (params: {
           )
         )
       ) ASC,
-      ams."mission_id" ASC
+      ems."mission_id" ASC
     LIMIT ${params.geoCandidateLimit}
   ),
   fallback_geo_candidates AS (
     SELECT
-      ams."mission_id",
-      ams."mission_scoring_id"
+      ems."mission_id",
+      ems."mission_scoring_id"
     FROM user_geo ug
     JOIN "mission_address" ma
       ON ma."location_lat" IS NOT NULL
      AND ma."location_lon" IS NOT NULL
-    JOIN active_mission_scorings ams
-      ON ams."mission_id" = ma."mission_id"
+    JOIN eligible_mission_scorings ems
+      ON ems."mission_id" = ma."mission_id"
     WHERE NOT EXISTS (SELECT 1 FROM taxonomy_candidates)
       AND NOT EXISTS (SELECT 1 FROM geo_candidates)
-    GROUP BY ams."mission_id", ams."mission_scoring_id"
+    GROUP BY ems."mission_id", ems."mission_scoring_id"
     ORDER BY
       MIN(
         6371.0 * 2.0 * ASIN(
@@ -239,18 +299,18 @@ const buildRanking = (params: {
           )
         )
       ) ASC,
-      ams."mission_id" ASC
+      ems."mission_id" ASC
     LIMIT ${params.geoCandidateLimit}
   ),
   fallback_candidates AS (
     SELECT
-      ams."mission_id",
-      ams."mission_scoring_id"
-    FROM active_mission_scorings ams
+      ems."mission_id",
+      ems."mission_scoring_id"
+    FROM eligible_mission_scorings ems
     CROSS JOIN weighted_user_totals ut
     WHERE ut."taxonomy_total" = 0
       AND NOT EXISTS (SELECT 1 FROM user_geo)
-    ORDER BY ams."mission_id" ASC
+    ORDER BY ems."mission_id" ASC
     LIMIT ${params.offset + params.limit}
   ),
   candidate_missions AS (
@@ -355,6 +415,7 @@ const buildDimensionScoresSql = (params: { userScoringId: string; missionScoring
     JOIN "taxonomy" t
       ON t."id" = tv."taxonomy_id"
     WHERE usv."user_scoring_id" = ${params.userScoringId}
+      AND t."type" <> 'gate'
   ),
   user_dimension_totals AS (
     SELECT


### PR DESCRIPTION
## Description

Cette PR ajoute la gestion des taxonomies `gate` dans le `matching-engine` comme filtre dur d’éligibilité.

Le comportement devient le suivant :
- les taxonomies `gate` servent uniquement à exclure les missions non éligibles avant le ranking
- l’éligibilité est calculée avec :
  - un `AND` entre taxonomies `gate`
  - un `OR` entre les valeurs d’une même taxonomie `gate`
  - une mission est exclue si elle porte une taxonomie `gate` absente du `user_scoring`

La requête SQL du `matching-engine` a été mise à jour pour :
- isoler les valeurs `gate` côté mission et côté user
- calculer les `mission_scoring` éligibles
- faire reposer tout le pipeline de sélection de candidats sur ces missions éligibles
- conserver les dimensions non `gate` comme seule base du scoring taxonomique

La couverture unitaire a aussi été renforcée pour vérifier le résultat fonctionnel attendu :
- une mission exclue par les `gate` ne remonte pas dans le résultat
- une mission conservée après filtrage remonte normalement
- des lignes de dimensions liées à une mission exclue ne polluent pas le payload final


## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
