### PR TITLE
refactor(api): use tsvector for organization search

### DIFF
--- a/api/prisma/migrations/20260421120000_add_organization_search_text_fts_index/migration.sql
+++ b/api/prisma/migrations/20260421120000_add_organization_search_text_fts_index/migration.sql
@@ -1,0 +1,4 @@
+-- CreateIndex
+CREATE INDEX "organization_search_text_fts_idx"
+ON "public"."organization"
+USING GIN (to_tsvector('simple', COALESCE("search_text", '')));

--- a/api/scripts/README.md
+++ b/api/scripts/README.md
@@ -26,7 +26,7 @@ Ce répertoire contient des scripts de maintenance/migration pour l’API. Les s
 - **backfill-organization-search-text.ts**
 
   - Exécution: `npx ts-node scripts/backfill-organization-search-text.ts [--batch <taille>] [--last-id <id>] [--only-null]`
-  - Usage: Calcule `organization.search_text` en minuscules (title + short_title + rna + siret + siren) pour accélérer la recherche.
+  - Usage: Calcule `organization.search_text` en minuscules, sans accents et sans ponctuation (title + short_title + rna + siret + siren) pour accélérer la recherche.
   - Options: `--batch <taille>` (défaut: 500), `--last-id <id>` pour reprendre à un identifiant donné, `--only-null` pour ne traiter que les lignes non encore remplies.
 
 - **mongo-backfill/**

--- a/api/scripts/backfill-organization-search-text.ts
+++ b/api/scripts/backfill-organization-search-text.ts
@@ -1,5 +1,5 @@
 /**
- * Backfill : calcule le champ search_text des organisations.
+ * Backfill : calcule le champ search_text normalisé des organisations.
  *
  * Exécution :
  *   npx ts-node scripts/backfill-organization-search-text.ts [--batch <taille>] [--last-id <id>] [--only-null]
@@ -8,7 +8,7 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-import { prismaCore } from "../src/db/postgres";
+import { prisma } from "../src/db/postgres";
 import { buildOrganizationSearchText } from "../src/utils/organization";
 
 const parseBatchSize = () => {
@@ -35,7 +35,7 @@ const run = async () => {
   const startedAt = new Date();
   console.log(`[OrganizationSearchTextBackfill] Démarré à ${startedAt.toISOString()}. Batch=${BATCH_SIZE}. onlyNull=${onlyNull}.`);
 
-  await prismaCore.$connect();
+  await prisma.$connect();
 
   let total = 0;
   let lastId: string | null = INITIAL_LAST_ID;
@@ -46,7 +46,7 @@ const run = async () => {
       ...(lastId ? { id: { gt: lastId } } : {}),
     };
 
-    const batch = await prismaCore.organization.findMany({
+    const batch = await prisma.organization.findMany({
       where,
       select: { id: true, title: true, shortTitle: true, rna: true, siret: true, siren: true },
       orderBy: { id: "asc" },
@@ -68,9 +68,9 @@ const run = async () => {
       }),
     }));
 
-    await prismaCore.$transaction(
+    await prisma.$transaction(
       updates.map((row) =>
-        prismaCore.organization.update({
+        prisma.organization.update({
           where: { id: row.id },
           data: { searchText: row.searchText },
         })
@@ -87,7 +87,7 @@ const run = async () => {
 };
 
 const shutdown = async (exitCode: number) => {
-  await prismaCore.$disconnect().catch(() => undefined);
+  await prisma.$disconnect().catch(() => undefined);
   process.exit(exitCode);
 };
 

--- a/api/src/repositories/organization.ts
+++ b/api/src/repositories/organization.ts
@@ -43,7 +43,7 @@ export const organizationRepository = {
       conditions.push(Prisma.sql`o."search_text" LIKE ${`%${args.queryText}%`}`);
     }
 
-    const whereClause = conditions.length ? Prisma.sql`WHERE ${Prisma.join(conditions, Prisma.sql` AND `)}` : Prisma.empty;
+    const whereClause = conditions.length ? Prisma.sql`WHERE ${Prisma.join(conditions, " AND ")}` : Prisma.empty;
     const idRows = await prisma.$queryRaw<Array<{ id: string }>>(
       Prisma.sql`
         SELECT o."id"

--- a/api/src/repositories/organization.ts
+++ b/api/src/repositories/organization.ts
@@ -1,9 +1,71 @@
 import { Organization, Prisma } from "@/db/core";
 import { prisma } from "@/db/postgres";
 
+type OrganizationV0SearchArgs = {
+  rna?: string | null;
+  siret?: string | null;
+  queryRna?: string | null;
+  querySiret?: string | null;
+  querySiren?: string | null;
+  queryText?: string | null;
+  queryTs?: string | null;
+  skip: number;
+  take: number;
+};
+
+const organizationTextSearchExpression = Prisma.sql`to_tsvector('simple', COALESCE(o."search_text", ''))`;
+
 export const organizationRepository = {
   async findMany(params: Prisma.OrganizationFindManyArgs = {}): Promise<Organization[]> {
     return prisma.organization.findMany(params);
+  },
+
+  async findManyForV0Search(args: OrganizationV0SearchArgs): Promise<Organization[]> {
+    const conditions: Prisma.Sql[] = [];
+
+    if (args.rna) {
+      conditions.push(Prisma.sql`o."rna" = ${args.rna}`);
+    }
+
+    if (args.siret) {
+      conditions.push(Prisma.sql`(o."siret" = ${args.siret} OR ${args.siret} = ANY(o."sirets"))`);
+    }
+
+    if (args.queryRna) {
+      conditions.push(Prisma.sql`o."rna" = ${args.queryRna}`);
+    } else if (args.querySiret) {
+      conditions.push(Prisma.sql`(o."siret" = ${args.querySiret} OR ${args.querySiret} = ANY(o."sirets"))`);
+    } else if (args.querySiren) {
+      conditions.push(Prisma.sql`o."siren" = ${args.querySiren}`);
+    } else if (args.queryTs) {
+      conditions.push(Prisma.sql`${organizationTextSearchExpression} @@ to_tsquery('simple', ${args.queryTs})`);
+    } else if (args.queryText) {
+      conditions.push(Prisma.sql`o."search_text" LIKE ${`%${args.queryText}%`}`);
+    }
+
+    const whereClause = conditions.length ? Prisma.sql`WHERE ${Prisma.join(conditions, Prisma.sql` AND `)}` : Prisma.empty;
+    const idRows = await prisma.$queryRaw<Array<{ id: string }>>(
+      Prisma.sql`
+        SELECT o."id"
+        FROM "organization" o
+        ${whereClause}
+        ORDER BY o."updated_at" DESC
+        LIMIT ${args.take}
+        OFFSET ${args.skip}
+      `
+    );
+
+    const ids = idRows.map((row) => row.id);
+    if (!ids.length) {
+      return [];
+    }
+
+    const organizations = await prisma.organization.findMany({
+      where: { id: { in: ids } },
+    });
+    const organizationById = new Map(organizations.map((organization) => [organization.id, organization]));
+
+    return ids.map((id) => organizationById.get(id)).filter((organization): organization is Organization => Boolean(organization));
   },
 
   async findFirst(params: Prisma.OrganizationFindFirstArgs): Promise<Organization | null> {

--- a/api/src/services/__tests__/organization.test.ts
+++ b/api/src/services/__tests__/organization.test.ts
@@ -1,10 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { prisma } from "@/db/postgres";
+import { organizationRepository } from "@/repositories/organization";
 import { organizationService } from "@/services/organization";
 
 const organizationCrud = (prisma as any).organization as {
   findUnique: ReturnType<typeof vi.fn>;
+  findMany: ReturnType<typeof vi.fn>;
+  count: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
   upsert: ReturnType<typeof vi.fn>;
 };
@@ -12,8 +15,11 @@ const organizationCrud = (prisma as any).organization as {
 describe("organizationService searchText maintenance", () => {
   beforeEach(() => {
     organizationCrud.findUnique.mockReset();
+    organizationCrud.findMany.mockReset();
+    organizationCrud.count.mockReset();
     organizationCrud.update.mockReset();
     organizationCrud.upsert.mockReset();
+    vi.restoreAllMocks();
   });
 
   it("recomputes searchText on updateOrganization when an identifier changes", async () => {
@@ -61,6 +67,69 @@ describe("organizationService searchText maintenance", () => {
         update: expect.objectContaining({
           searchText: "croix rouge cr w123456789 12345678901234 123456789",
         }),
+      })
+    );
+  });
+
+  it("normalizes accented queries for generic organization search", async () => {
+    organizationCrud.count.mockResolvedValue(0);
+    organizationCrud.findMany.mockResolvedValue([]);
+
+    await organizationService.findOrganizationsByFilters({ query: "Association des étudiants" });
+
+    expect(organizationCrud.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: [
+            {
+              OR: [
+                {
+                  searchText: { contains: "association des etudiants" },
+                },
+              ],
+            },
+          ],
+        },
+      })
+    );
+  });
+
+  it("routes a SIREN query to the exact-match v0 search path", async () => {
+    const spy = vi.spyOn(organizationRepository, "findManyForV0Search").mockResolvedValue([]);
+
+    await organizationService.findOrganizationsForV0({ query: "123456789" });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        querySiren: "123456789",
+        queryTs: null,
+        queryText: null,
+      })
+    );
+  });
+
+  it("routes a long text query to the full-text v0 search path", async () => {
+    const spy = vi.spyOn(organizationRepository, "findManyForV0Search").mockResolvedValue([]);
+
+    await organizationService.findOrganizationsForV0({ query: "Association des étudiants" });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryText: "association des etudiants",
+        queryTs: "association:* & des:* & etudiants:*",
+      })
+    );
+  });
+
+  it("keeps the LIKE fallback for short queries on the v0 search path", async () => {
+    const spy = vi.spyOn(organizationRepository, "findManyForV0Search").mockResolvedValue([]);
+
+    await organizationService.findOrganizationsForV0({ query: "as" });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryText: "as",
+        queryTs: null,
       })
     );
   });

--- a/api/src/services/organization.ts
+++ b/api/src/services/organization.ts
@@ -13,7 +13,7 @@ import {
 } from "@/types/organization";
 import { chunk } from "@/utils/array";
 import { normalizeOptionalString, normalizeSlug, normalizeStringArray } from "@/utils/normalize";
-import { buildOrganizationSearchText, isValidRNA, isValidSiret } from "@/utils/organization";
+import { buildOrganizationPrefixTsQuery, buildOrganizationSearchText, isValidRNA, isValidSiren, isValidSiret, normalizeOrganizationSearchQuery } from "@/utils/organization";
 import { slugify } from "@/utils/string";
 
 const DEFAULT_LIMIT = 25;
@@ -50,8 +50,10 @@ const buildSearchWhere = (params: OrganizationSearchParams): Prisma.Organization
         and.push({ rna: query });
       } else if (isValidSiret(query)) {
         and.push({ OR: [{ siret: query }, { sirets: { has: query } }] });
+      } else if (isValidSiren(query)) {
+        and.push({ siren: query });
       } else {
-        const normalizedQuery = query.toLowerCase();
+        const normalizedQuery = normalizeOrganizationSearchQuery(query) ?? query.toLowerCase();
         const textConditions: Prisma.OrganizationWhereInput[] = [{ searchText: { contains: normalizedQuery } }];
 
         and.push({ OR: textConditions });
@@ -327,6 +329,45 @@ export const organizationService = (() => {
     };
   };
 
+  const findOrganizationsForV0 = async (params: Pick<OrganizationSearchParams, "query" | "rna" | "siret" | "offset" | "limit"> = {}): Promise<OrganizationRecord[]> => {
+    const limit = Math.min(Math.max(params.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+    const offset = Math.max(params.offset ?? 0, 0);
+    const query = params.query?.trim() ?? "";
+    const normalizedRna = normalizeOptionalString(params.rna);
+    const normalizedSiret = normalizeOptionalString(params.siret);
+
+    let queryRna: string | null = null;
+    let querySiret: string | null = null;
+    let querySiren: string | null = null;
+    let queryText: string | null = null;
+    let queryTs: string | null = null;
+
+    if (query) {
+      if (isValidRNA(query)) {
+        queryRna = query;
+      } else if (isValidSiret(query)) {
+        querySiret = query;
+      } else if (isValidSiren(query)) {
+        querySiren = query;
+      } else {
+        queryText = normalizeOrganizationSearchQuery(query) ?? query.toLowerCase();
+        queryTs = buildOrganizationPrefixTsQuery(query);
+      }
+    }
+
+    return organizationRepository.findManyForV0Search({
+      rna: normalizedRna,
+      siret: normalizedSiret,
+      queryRna,
+      querySiret,
+      querySiren,
+      queryText,
+      queryTs,
+      skip: offset,
+      take: limit,
+    });
+  };
+
   const findOneOrganizationById = async (id: string): Promise<OrganizationRecord | null> => {
     if (!id) {
       return null;
@@ -485,6 +526,7 @@ export const organizationService = (() => {
 
   return {
     findOrganizationsByFilters,
+    findOrganizationsForV0,
     findOneOrganizationById,
     findOrganizationsByIds,
     createOrganization,

--- a/api/src/utils/__tests__/organization.test.ts
+++ b/api/src/utils/__tests__/organization.test.ts
@@ -1,4 +1,4 @@
-import { buildOrganizationSearchText, isValidRNA, isValidSiret } from "@/utils/organization";
+import { buildOrganizationPrefixTsQuery, buildOrganizationSearchText, isValidRNA, isValidSiret, normalizeOrganizationSearchQuery, tokenizeOrganizationSearchQuery } from "@/utils/organization";
 import { describe, expect, it } from "vitest";
 
 describe("isValidRNA", () => {
@@ -42,5 +42,35 @@ describe("buildOrganizationSearchText", () => {
     expect(buildOrganizationSearchText({ title: "Croix Rouge", rna: "W123456789", siret: "12345678901234", siren: "123456789" })).toBe(
       "croix rouge w123456789 12345678901234 123456789"
     );
+  });
+
+  it("should remove accents and punctuation from search text", () => {
+    expect(buildOrganizationSearchText({ title: "Association des étudiants !", shortTitle: "A.É." })).toBe("association des etudiants a e");
+  });
+});
+
+describe("normalizeOrganizationSearchQuery", () => {
+  it("should normalize accents, punctuation and spaces", () => {
+    expect(normalizeOrganizationSearchQuery("  Association des étudiants !  ")).toBe("association des etudiants");
+  });
+
+  it("should return null when nothing searchable remains", () => {
+    expect(normalizeOrganizationSearchQuery(" !!! ")).toBeNull();
+  });
+});
+
+describe("tokenizeOrganizationSearchQuery", () => {
+  it("should keep unique tokens with a minimum length", () => {
+    expect(tokenizeOrganizationSearchQuery("Association des étudiants des")).toEqual(["association", "des", "etudiants"]);
+  });
+});
+
+describe("buildOrganizationPrefixTsQuery", () => {
+  it("should build a prefix tsquery from normalized tokens", () => {
+    expect(buildOrganizationPrefixTsQuery("Association des étudiants")).toBe("association:* & des:* & etudiants:*");
+  });
+
+  it("should return null when no token meets the minimum length", () => {
+    expect(buildOrganizationPrefixTsQuery("a l")).toBeNull();
   });
 });

--- a/api/src/utils/organization.ts
+++ b/api/src/utils/organization.ts
@@ -1,8 +1,20 @@
 export const isValidRNA = (rna: string): boolean => Boolean(rna && rna.length === 10 && rna.startsWith("W") && /^[W0-9]+$/.test(rna));
 export const isValidSiret = (siret: string): boolean => Boolean(siret && siret.length === 14 && /^[0-9]+$/.test(siret));
 export const isValidSiren = (siren: string): boolean => Boolean(siren && siren.length === 9 && /^[0-9]+$/.test(siren));
+export const ORGANIZATION_FTS_MIN_TOKEN_LENGTH = 3;
 
 const normalizeString = (value?: unknown | null) => (value?.toString() || "").replace(/[^a-zA-Z0-9]/g, "").toUpperCase();
+const normalizeSearchString = (value?: string | null) => {
+  const normalized = (value ?? "")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return normalized.length ? normalized : null;
+};
 
 export const normalizeRNA = (value?: unknown | null) => {
   const normalized = normalizeString(value);
@@ -27,6 +39,25 @@ export const normalizeName = (value?: unknown | null) => {
   return null;
 };
 
+export const normalizeOrganizationSearchQuery = (value?: string | null) => normalizeSearchString(value);
+export const tokenizeOrganizationSearchQuery = (value?: string | null, minTokenLength = ORGANIZATION_FTS_MIN_TOKEN_LENGTH): string[] => {
+  const normalized = normalizeOrganizationSearchQuery(value);
+  if (!normalized) {
+    return [];
+  }
+
+  return Array.from(new Set(normalized.split(" ").filter((token) => token.length >= minTokenLength)));
+};
+
+export const buildOrganizationPrefixTsQuery = (value?: string | null, minTokenLength = ORGANIZATION_FTS_MIN_TOKEN_LENGTH): string | null => {
+  const tokens = tokenizeOrganizationSearchQuery(value, minTokenLength);
+  if (!tokens.length) {
+    return null;
+  }
+
+  return tokens.map((token) => `${token}:*`).join(" & ");
+};
+
 type OrganizationSearchTextInput = {
   title?: string | null;
   shortTitle?: string | null;
@@ -36,12 +67,11 @@ type OrganizationSearchTextInput = {
 };
 
 export const buildOrganizationSearchText = ({ title, shortTitle, rna, siret, siren }: OrganizationSearchTextInput): string | null => {
-  const parts = [title, shortTitle, rna, siret, siren].map((value) => (typeof value === "string" ? value.trim() : "")).filter((value) => value.length > 0);
+  const parts = [title, shortTitle, rna, siret, siren].map((value) => normalizeSearchString(typeof value === "string" ? value : null)).filter((value): value is string => Boolean(value));
 
   if (!parts.length) {
     return null;
   }
 
-  const combined = parts.join(" ").replace(/\s+/g, " ").trim().toLowerCase();
-  return combined.length ? combined : null;
+  return parts.join(" ");
 };

--- a/api/src/v0/organization.ts
+++ b/api/src/v0/organization.ts
@@ -35,13 +35,12 @@ router.get("/", async (req: PublisherRequest, res: Response, next: NextFunction)
       return res.status(400).send({ ok: false, code: INVALID_QUERY, message: query.error });
     }
 
-    const { results } = await organizationService.findOrganizationsByFilters({
+    const results = await organizationService.findOrganizationsForV0({
       query: query.data.q,
       rna: query.data.rna,
       siret: query.data.siret,
       offset: query.data.skip,
       limit: query.data.limit,
-      includeTotal: "none",
     });
 
     return res.status(200).send({ ok: true, data: results.map(withLegacyId) });


### PR DESCRIPTION
## Description

Cette PR améliore les performances de recherche de `/v0/organization` sans changer le contrat API.

Elle introduit une recherche hybride côté API :
- chemin exact pour `RNA`, `SIRET` et `SIREN`
- recherche full-text pour les requêtes texte multi-mots
- fallback `LIKE` pour les requêtes trop courtes

Elle normalise aussi `organization.search_text` pour rendre la recherche insensible aux accents et à la ponctuation, tout en conservant le tri final par `updated_at DESC`.

En complément, la PR ajoute :
- un index GIN d’expression sur `to_tsvector('simple', coalesce(search_text, ''))`


## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Slow-query-v0-organization-33372a322d5080fca9b0f18118d8ca8d?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [x] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
