### PR TITLE
refactor(api): delete rate limit shared store

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8,7 +8,6 @@
             "name": "api",
             "version": "1.0.0",
             "dependencies": {
-                "@acpr/rate-limit-postgresql": "1.4.1",
                 "@aws-sdk/client-s3": "3.1020.0",
                 "@aws-sdk/lib-storage": "3.1020.0",
                 "@opentelemetry/exporter-metrics-otlp-http": "0.214.0",
@@ -79,59 +78,6 @@
                 "tsconfig-paths": "^4.2.0",
                 "typescript": "5.9.3",
                 "vitest": "4.1.1"
-            }
-        },
-        "node_modules/@acpr/rate-limit-postgresql": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@acpr/rate-limit-postgresql/-/rate-limit-postgresql-1.4.1.tgz",
-            "integrity": "sha512-dV/uEYD94onbyO56VJaU43pDXXUeaNqa/zs0V/Ar1BTgmZls5yrqgPqg1x2m5N87AKkMVkKoSxy64T3ldnaOew==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/pg-pool": "2.0.3",
-                "pg": "8.11.3",
-                "pg-pool": "3.6.1",
-                "postgres-migrations": "5.3.0"
-            },
-            "peerDependencies": {
-                "express-rate-limit": ">=6.0.0"
-            }
-        },
-        "node_modules/@acpr/rate-limit-postgresql/node_modules/@types/pg-pool": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.3.tgz",
-            "integrity": "sha512-fwK5WtG42Yb5RxAwxm3Cc2dJ39FlgcaNiXKvtTLAwtCn642X7dgel+w1+cLWwpSOFImR3YjsZtbkfjxbHtFAeg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/pg": "*"
-            }
-        },
-        "node_modules/@acpr/rate-limit-postgresql/node_modules/pg": {
-            "version": "8.11.3",
-            "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
-            "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
-            "license": "MIT",
-            "dependencies": {
-                "buffer-writer": "2.0.0",
-                "packet-reader": "1.0.0",
-                "pg-connection-string": "^2.6.2",
-                "pg-pool": "^3.6.1",
-                "pg-protocol": "^1.6.0",
-                "pg-types": "^2.1.0",
-                "pgpass": "1.x"
-            },
-            "engines": {
-                "node": ">= 8.0.0"
-            },
-            "optionalDependencies": {
-                "pg-cloudflare": "^1.1.1"
-            },
-            "peerDependencies": {
-                "pg-native": ">=3.0.1"
-            },
-            "peerDependenciesMeta": {
-                "pg-native": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -6148,15 +6094,6 @@
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "license": "MIT"
         },
-        "node_modules/buffer-writer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
-            "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/buildcheck": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
@@ -10089,12 +10026,6 @@
             "dev": true,
             "license": "BlueOak-1.0.0"
         },
-        "node_modules/packet-reader": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
-            "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
-            "license": "MIT"
-        },
         "node_modules/pako": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
@@ -10328,15 +10259,6 @@
                 "node": ">=4.0.0"
             }
         },
-        "node_modules/pg-pool": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
-            "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
-            "license": "MIT",
-            "peerDependencies": {
-                "pg": ">=8.0"
-            }
-        },
         "node_modules/pg-protocol": {
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
@@ -10509,22 +10431,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/postgres-migrations": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/postgres-migrations/-/postgres-migrations-5.3.0.tgz",
-            "integrity": "sha512-gnTHWJZVWbW8T3mXIxJm1JRU853TqBVWkhgfsTJr7zqT3VexjRmJj9kNi96rVhfTezDU4FVW6pf701kLOZiKIA==",
-            "license": "MIT",
-            "dependencies": {
-                "pg": "^8.6.0",
-                "sql-template-strings": "^2.2.2"
-            },
-            "bin": {
-                "pg-validate-migrations": "dist/bin/validate.js"
-            },
-            "engines": {
-                "node": ">10.17.0"
             }
         },
         "node_modules/prelude-ls": {
@@ -11368,15 +11274,6 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
             "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
             "license": "BSD-3-Clause"
-        },
-        "node_modules/sql-template-strings": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/sql-template-strings/-/sql-template-strings-2.2.2.tgz",
-            "integrity": "sha512-UXhXR2869FQaD+GMly8jAMCRZ94nU5KcrFetZfWEMd+LVVG6y0ExgHAhatEcKZ/wk8YcKPdi+hiD2wm75lq3/Q==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=4.0.0"
-            }
         },
         "node_modules/sqlstring": {
             "version": "2.3.3",

--- a/api/package.json
+++ b/api/package.json
@@ -23,7 +23,7 @@
         "job": "ts-node src/jobs/run-job.ts"
     },
     "dependencies": {
-"@aws-sdk/client-s3": "3.1020.0",
+        "@aws-sdk/client-s3": "3.1020.0",
         "@aws-sdk/lib-storage": "3.1020.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.214.0",
         "@opentelemetry/resources": "2.6.1",

--- a/api/package.json
+++ b/api/package.json
@@ -23,8 +23,7 @@
         "job": "ts-node src/jobs/run-job.ts"
     },
     "dependencies": {
-        "@acpr/rate-limit-postgresql": "1.4.1",
-        "@aws-sdk/client-s3": "3.1020.0",
+"@aws-sdk/client-s3": "3.1020.0",
         "@aws-sdk/lib-storage": "3.1020.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.214.0",
         "@opentelemetry/resources": "2.6.1",

--- a/api/src/middlewares/rate-limit.ts
+++ b/api/src/middlewares/rate-limit.ts
@@ -1,5 +1,4 @@
-import { PostgresStore } from "@acpr/rate-limit-postgresql";
-import { ipKeyGenerator, rateLimit, RateLimitRequestHandler, Store } from "express-rate-limit";
+import { ipKeyGenerator, rateLimit, RateLimitRequestHandler } from "express-rate-limit";
 
 import { RATE_LIMIT_IP_MAX, RATE_LIMIT_PUBLISHER_MAX } from "@/config";
 
@@ -11,20 +10,12 @@ const handler = (req: any, res: any) => {
   });
 };
 
-const makeStore = (prefix: string): Store | undefined => {
-  const connectionString = process.env.DATABASE_URL_CORE;
-  if (process.env.NODE_ENV === "test" || !connectionString) {
-    return undefined;
-  }
-  return new PostgresStore({ connectionString }, prefix);
-};
-
 const isDisabled = () => process.env.RATE_LIMIT_DISABLED === "true";
 
 // 600 req/min par publisher — endpoints partenaires et webhooks
 // Appliqué après passport.authenticate : req.user.id est résolu.
 // Fallback IP si req.user est absent (ex: route sans auth).
-export const createPublisherRateLimiter = (limit = RATE_LIMIT_PUBLISHER_MAX, store?: Store): RateLimitRequestHandler =>
+export const createPublisherRateLimiter = (limit = RATE_LIMIT_PUBLISHER_MAX): RateLimitRequestHandler =>
   rateLimit({
     windowMs: 60_000,
     limit,
@@ -34,18 +25,16 @@ export const createPublisherRateLimiter = (limit = RATE_LIMIT_PUBLISHER_MAX, sto
     },
     handler,
     skip: isDisabled,
-    store: store ?? makeStore("rl:pub:"),
   });
 
 // 120 req/min par IP — backoffice, iframe, redirect
-export const createIpRateLimiter = (limit = RATE_LIMIT_IP_MAX, store?: Store): RateLimitRequestHandler =>
+export const createIpRateLimiter = (limit = RATE_LIMIT_IP_MAX): RateLimitRequestHandler =>
   rateLimit({
     windowMs: 60_000,
     limit,
     keyGenerator: (req) => ipKeyGenerator(req.ip ?? ""),
     handler,
     skip: isDisabled,
-    store: store ?? makeStore("rl:ip:"),
   });
 
 export const publisherRateLimiter = createPublisherRateLimiter();


### PR DESCRIPTION
## Description

Supprime le store PostgreSQL partagé utilisé par le rate limiter (`@acpr/rate-limit-postgresql`).

Le rate limiter effectuait un aller-retour en base de données à chaque requête pour lire/écrire les compteurs, ce qui dégradait les performances. En passant au store in-memory natif d'`express-rate-limit`, les compteurs sont gérés localement par instance — sans surcoût réseau.

**Changements :**
- Suppression de la dépendance `@acpr/rate-limit-postgresql`
- Suppression de `makeStore` et du paramètre `store` optionnel sur les deux factories (`createPublisherRateLimiter`, `createIpRateLimiter`)
- Le comportement en test était déjà in-memory (`makeStore` retournait `undefined` si `NODE_ENV=test`) — aucun changement sur les tests

## Liens utiles

_Aucun ticket associé._

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [x] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Point d'attention :** avec le store in-memory, les compteurs de rate limit ne sont plus partagés entre les instances de l'API. En pratique, cela augmente légèrement les seuils effectifs (chaque instance a son propre compteur), ce qui reste acceptable compte tenu des limites configurées (600 req/min publisher, 120 req/min IP). La limitation est documentée dans le [PAS](https://www.notion.so/jeveuxaider/API-Engagement-PAS-Plan-Assurance-S-curit-34172a322d5080faac70f4425c7aa098).