### PR TITLE
refactor(api): rework missions with publisher_organization exclusion

### DIFF
--- a/api/prisma/migrations/20260427124521_add_mission_publisher_organization_index/migration.sql
+++ b/api/prisma/migrations/20260427124521_add_mission_publisher_organization_index/migration.sql
@@ -1,0 +1,8 @@
+-- CreateIndex
+CREATE INDEX CONCURRENTLY mission_publisher_id_start_at_status_code_deleted_at_publisher_organization_id_idx
+ON "public"."mission" ("publisher_id", "start_at" DESC)
+WHERE
+  "status_code" = 'ACCEPTED'::"public"."MissionStatusCode"
+  AND "deleted_at" IS NULL
+  AND "publisher_organization_id" IS NOT NULL;
+

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -255,10 +255,16 @@ export const buildWhere = (filters: MissionSearchFilters): Prisma.MissionWhereIn
     where.publisherOrganizationId = { in: filters.organizationIds };
   }
   if (filters.excludePublisherOrganizationIds?.length) {
-    if (where.publisherOrganization) {
-      where.publisherOrganization["id"] = { notIn: filters.excludePublisherOrganizationIds };
+    const excludedIds = new Set(filters.excludePublisherOrganizationIds);
+    if (filters.organizationIds?.length) {
+      where.publisherOrganizationId = {
+        in: filters.organizationIds.filter((id) => !excludedIds.has(id)),
+      };
     } else {
-      where.publisherOrganization = { id: { notIn: filters.excludePublisherOrganizationIds } };
+      where.publisherOrganizationId = {
+        not: null,
+        notIn: filters.excludePublisherOrganizationIds,
+      };
     }
   }
 


### PR DESCRIPTION
## Description

L’endpoint `GET /v0/mission` générait une requête PostgreSQL coûteuse lors des appels avec exclusions d’organisations.

Le filtre d’exclusion était appliqué via la relation Prisma `publisherOrganization.id`, ce qui produisait une jointure SQL vers `publisher_organization`, alors que l’identifiant est déjà disponible sur la table `mission` via `publisher_organization_id`.

### Changement
- Remplacement du filtre relationnel :

  `publisherOrganization.id NOT IN (...)`

  par un filtre direct sur la colonne :

  `mission.publisher_organization_id NOT IN (...)`

- Conservation de la sémantique existante :
  - exclusion des organisations configurées pour le diffuseur ;
  - exclusion des missions sans `publisher_organization_id` dans ce cas ;
  - intersection correcte si un filtre explicite `organizationIds` est aussi fourni.

- Ajout d’un index partiel concurrent sur les missions publiables, filtrées par annonceur et triées par date de début, pour améliorer le parcours de `/v0/mission`.

## Impact attendu

- Suppression de la jointure inutile vers `publisher_organization` pour ce cas.
- Réduction du volume de lignes lues/filtrées par PostgreSQL.
- Meilleure exploitation du `ORDER BY start_at DESC LIMIT 25` sur les listings publics de missions.


## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
