### PR TITLE
feat(api): typesense infrastructure

### DIFF
--- a/terraform/containers.tf
+++ b/terraform/containers.tf
@@ -1,18 +1,19 @@
 resource "scaleway_container" "api" {
-  name            = "${var.workspace}-api"
-  description     = "API ${var.workspace} container"
-  namespace_id    = scaleway_container_namespace.main.id
-  registry_image  = "ghcr.io/${var.github_repository}/api:${var.env}${var.image_tag == "latest" ? "" : "-${var.image_tag}"}"
-  port            = 8080
-  cpu_limit       = var.api_cpu_limit
-  memory_limit    = var.api_memory_limit
-  min_scale       = var.api_min_scale
-  max_scale       = var.api_max_scale
-  timeout         = 60
-  privacy         = "public"
-  protocol        = "http1"
-  http_option     = "redirected" # https only
-  deploy          = true
+  name                = "${var.workspace}-api"
+  description         = "API ${var.workspace} container"
+  namespace_id        = scaleway_container_namespace.main.id
+  registry_image      = "ghcr.io/${var.github_repository}/api:${var.env}${var.image_tag == "latest" ? "" : "-${var.image_tag}"}"
+  port                = 8080
+  cpu_limit           = var.api_cpu_limit
+  memory_limit        = var.api_memory_limit
+  min_scale           = var.api_min_scale
+  max_scale           = var.api_max_scale
+  timeout             = 60
+  privacy             = "public"
+  protocol            = "http1"
+  http_option         = "redirected" # https only
+  deploy              = true
+  private_network_id  = scaleway_vpc_private_network.main.id
 
   health_check {
     http {
@@ -27,19 +28,21 @@ resource "scaleway_container" "api" {
   }
 
   environment_variables = {
-    "ENV"                               = var.env
-    "IMAGE_VERSION"                     = var.image_tag
-    "API_URL"                           = var.api_hostname != "" ? "https://${var.api_hostname}" : ""
-    "APP_URL"                           = var.app_hostname != "" ? "https://${var.app_hostname}" : ""
-    "BENEVOLAT_URL"                     = var.benevolat_hostname != "" ? "https://${var.benevolat_hostname}" : ""
-    "VOLONTARIAT_URL"                   = var.volontariat_hostname != "" ? "https://${var.volontariat_hostname}" : ""
-    "PILOTY_BASE_URL"                   = var.piloty_hostname
-    "BUCKET_NAME"                       = var.bucket_name
-    "SLACK_JOBTEASER_CHANNEL_ID"        = var.slack_jobteaser_channel_id
-    "PRISMA_POOL_SIZE_CORE"             = "20"
-    "PRISMA_POOL_TIMEOUT"               = "20"
-    "PRISMA_CONNECT_TIMEOUT"            = "10"
-    "COCKPIT_METRICS_OTLP_URL"          = var.cockpit_metrics_otlp_url
+    "ENV"                        = var.env
+    "IMAGE_VERSION"              = var.image_tag
+    "API_URL"                    = var.api_hostname != "" ? "https://${var.api_hostname}" : ""
+    "APP_URL"                    = var.app_hostname != "" ? "https://${var.app_hostname}" : ""
+    "BENEVOLAT_URL"              = var.benevolat_hostname != "" ? "https://${var.benevolat_hostname}" : ""
+    "VOLONTARIAT_URL"            = var.volontariat_hostname != "" ? "https://${var.volontariat_hostname}" : ""
+    "PILOTY_BASE_URL"            = var.piloty_hostname
+    "BUCKET_NAME"                = var.bucket_name
+    "SLACK_JOBTEASER_CHANNEL_ID" = var.slack_jobteaser_channel_id
+    "PRISMA_POOL_SIZE_CORE"      = "20"
+    "PRISMA_POOL_TIMEOUT"        = "20"
+    "PRISMA_CONNECT_TIMEOUT"     = "10"
+    "COCKPIT_METRICS_OTLP_URL"   = var.cockpit_metrics_otlp_url
+    "TYPESENSE_HOST"             = var.typesense_load_balancer_private_ip
+    "TYPESENSE_PORT"             = "8108"
 
     # Feature flags ES migration
     "WRITE_STATS_DUAL" = "true"
@@ -64,6 +67,7 @@ resource "scaleway_container" "api" {
     "METABASE_API_KEY"       = lookup(local.secrets, "METABASE_API_KEY", "")
     "METABASE_URL"           = lookup(local.secrets, "METABASE_URL", "")
     "COCKPIT_METRICS_TOKEN"  = lookup(local.secrets, "COCKPIT_METRICS_TOKEN", "")
+    "TYPESENSE_API_KEY"      = lookup(local.secrets, "TYPESENSE_API_KEY", "")
   }
 }
 
@@ -92,14 +96,14 @@ resource "scaleway_container" "api_worker" {
   }
 
   environment_variables = {
-    "ENV"                               = var.env
-    "IMAGE_VERSION"                     = var.image_tag
-    "PORT_WORKER"                       = "8080"
-    "PRISMA_POOL_SIZE_CORE"             = "20"
-    "PRISMA_POOL_TIMEOUT"               = "20"
-    "PRISMA_CONNECT_TIMEOUT"            = "10"
-    "SCW_QUEUE_URL_MISSION_ENRICHMENT"  = module.async_task_queues["mission_enrichment"].url
-    "SCW_QUEUE_URL_MISSION_SCORING"     = module.async_task_queues["mission_scoring"].url
+    "ENV"                              = var.env
+    "IMAGE_VERSION"                    = var.image_tag
+    "PORT_WORKER"                      = "8080"
+    "PRISMA_POOL_SIZE_CORE"            = "20"
+    "PRISMA_POOL_TIMEOUT"              = "20"
+    "PRISMA_CONNECT_TIMEOUT"           = "10"
+    "SCW_QUEUE_URL_MISSION_ENRICHMENT" = module.async_task_queues["mission_enrichment"].url
+    "SCW_QUEUE_URL_MISSION_SCORING"    = module.async_task_queues["mission_scoring"].url
   }
 
   secret_environment_variables = {

--- a/terraform/envs/poc.tfvars
+++ b/terraform/envs/poc.tfvars
@@ -11,6 +11,9 @@ api_memory_limit = 512
 api_min_scale    = 1
 api_max_scale    = 1
 
+private_network_cidr = "10.43.0.0/22"
+
+enable_public_gateway = true
 enable_app            = false
 enable_widget         = false
 enable_async_tasks    = true
@@ -18,3 +21,14 @@ enable_intern_jobs    = false
 enable_analytics_jobs = false
 enable_mission_jobs   = false
 enable_poc_quiz       = true
+enable_typesense      = true
+
+typesense_load_balancer_private_ip = "10.43.2.10"
+typesense_nodes = {
+  node-1 = {
+    zone              = "fr-par-1"
+    private_ip        = "10.43.2.11"
+    instance_type     = "PLAY2-PICO"
+    typesense_version = "30.2"
+  }
+}

--- a/terraform/jobs-analytics.tf
+++ b/terraform/jobs-analytics.tf
@@ -15,13 +15,14 @@ locals {
 }
 
 resource "scaleway_job_definition" "analytics-stat-event" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-stat-event"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-stat-event"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -34,13 +35,14 @@ resource "scaleway_job_definition" "analytics-stat-event" {
 }
 
 resource "scaleway_job_definition" "analytics-moderation-event" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-moderation-event"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-moderation-event"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -53,13 +55,14 @@ resource "scaleway_job_definition" "analytics-moderation-event" {
 }
 
 resource "scaleway_job_definition" "analytics-email" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-email"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-email"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -72,13 +75,14 @@ resource "scaleway_job_definition" "analytics-email" {
 }
 
 resource "scaleway_job_definition" "analytics-mission-event" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-mission-event"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-mission-event"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -91,13 +95,14 @@ resource "scaleway_job_definition" "analytics-mission-event" {
 }
 
 resource "scaleway_job_definition" "analytics-mission-address" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-mission-address"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-mission-address"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -110,13 +115,14 @@ resource "scaleway_job_definition" "analytics-mission-address" {
 }
 
 resource "scaleway_job_definition" "analytics-publisher" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-publisher"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-publisher"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -129,13 +135,14 @@ resource "scaleway_job_definition" "analytics-publisher" {
 }
 
 resource "scaleway_job_definition" "analytics-publisher-organization" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-publisher-organization"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-publisher-organization"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -148,13 +155,14 @@ resource "scaleway_job_definition" "analytics-publisher-organization" {
 }
 
 resource "scaleway_job_definition" "analytics-organization" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-organization"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-organization"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -167,13 +175,14 @@ resource "scaleway_job_definition" "analytics-organization" {
 }
 
 resource "scaleway_job_definition" "analytics-import" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-import"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-import"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -186,13 +195,14 @@ resource "scaleway_job_definition" "analytics-import" {
 }
 
 resource "scaleway_job_definition" "analytics-publisher-diffusion-exclusion" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-publisher-diffusion-exclusion"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-publisher-diffusion-exclusion"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -205,13 +215,14 @@ resource "scaleway_job_definition" "analytics-publisher-diffusion-exclusion" {
 }
 
 resource "scaleway_job_definition" "analytics-user" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-user"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-user"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -224,13 +235,14 @@ resource "scaleway_job_definition" "analytics-user" {
 }
 
 resource "scaleway_job_definition" "analytics-user-publisher" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-user-publisher"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-user-publisher"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -243,13 +255,14 @@ resource "scaleway_job_definition" "analytics-user-publisher" {
 }
 
 resource "scaleway_job_definition" "analytics-login-history" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-login-history"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-login-history"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -262,13 +275,14 @@ resource "scaleway_job_definition" "analytics-login-history" {
 }
 
 resource "scaleway_job_definition" "analytics-campaign" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-campaign"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-campaign"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -281,13 +295,14 @@ resource "scaleway_job_definition" "analytics-campaign" {
 }
 
 resource "scaleway_job_definition" "analytics-campaign-tracker" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-campaign-tracker"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-campaign-tracker"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -300,13 +315,14 @@ resource "scaleway_job_definition" "analytics-campaign-tracker" {
 }
 
 resource "scaleway_job_definition" "analytics-widget" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-widget"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-widget"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -319,13 +335,14 @@ resource "scaleway_job_definition" "analytics-widget" {
 }
 
 resource "scaleway_job_definition" "analytics-widget-publisher" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-widget-publisher"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-widget-publisher"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -338,13 +355,14 @@ resource "scaleway_job_definition" "analytics-widget-publisher" {
 }
 
 resource "scaleway_job_definition" "analytics-widget-rule" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-widget-rule"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-widget-rule"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -357,13 +375,14 @@ resource "scaleway_job_definition" "analytics-widget-rule" {
 }
 
 resource "scaleway_job_definition" "analytics-mission" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-mission"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-mission"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -376,13 +395,14 @@ resource "scaleway_job_definition" "analytics-mission" {
 }
 
 resource "scaleway_job_definition" "analytics-domain" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-domain"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-domain"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -395,13 +415,14 @@ resource "scaleway_job_definition" "analytics-domain" {
 }
 
 resource "scaleway_job_definition" "analytics-activity" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-activity"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-activity"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -414,13 +435,14 @@ resource "scaleway_job_definition" "analytics-activity" {
 }
 
 resource "scaleway_job_definition" "analytics-mission-activity" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-mission-activity"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-mission-activity"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -433,13 +455,14 @@ resource "scaleway_job_definition" "analytics-mission-activity" {
 }
 
 resource "scaleway_job_definition" "analytics-mission-moderation-status" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-mission-moderation-status"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-mission-moderation-status"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -452,13 +475,14 @@ resource "scaleway_job_definition" "analytics-mission-moderation-status" {
 }
 
 resource "scaleway_job_definition" "analytics-mission-jobboard" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-mission-jobboard"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-mission-jobboard"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 3 * * *" # Every day at 3:00 AM
@@ -471,13 +495,14 @@ resource "scaleway_job_definition" "analytics-mission-jobboard" {
 }
 
 resource "scaleway_job_definition" "analytics-dbt-run" {
-  count        = var.enable_analytics_jobs ? 1 : 0
-  name         = "analytics-${var.env}-dbt-run"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_analytics_uri
-  timeout      = "120m"
+  count                  = var.enable_analytics_jobs ? 1 : 0
+  name                   = "analytics-${var.env}-dbt-run"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_analytics_uri
+  timeout                = "120m"
 
   cron {
     schedule = "0 5 * * *" # Every day at 5:00 AM

--- a/terraform/jobs.tf
+++ b/terraform/jobs.tf
@@ -27,9 +27,11 @@ locals {
 #   project_id   = var.project_id
 #   cpu_limit    = 1000
 #   memory_limit = 2048
+#   local_storage_capacity = 1024
 #   image_uri    = local.image_uri
 #   # Max old space workaround: https://stackoverflow.com/questions/48387040/how-do-i-determine-the-correct-max-old-space-size-for-node-js
-#   command      = "node --max-old-space-size=1800 dist/jobs/run-job.js letudiant"
+#   startup_command = ["node"]
+#   args            = ["--max-old-space-size=1800", "dist/jobs/run-job.js", "letudiant"]
 #   timeout      = "45m"
 #
 #   cron {
@@ -42,15 +44,17 @@ locals {
 
 # Job Definition for the 'talent' task
 resource "scaleway_job_definition" "talent" {
-  count        = var.enable_intern_jobs ? 1 : 0
-  name         = "${terraform.workspace}-talent"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_uri
+  count                  = var.enable_intern_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-talent"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
   # Max old space workaround: https://stackoverflow.com/questions/48387040/how-do-i-determine-the-correct-max-old-space-size-for-node-js
-  command = "node --max-old-space-size=1800 dist/jobs/run-job.js talent"
-  timeout = "45m"
+  startup_command = ["node"]
+  args            = ["--max-old-space-size=1800", "dist/jobs/run-job.js", "talent"]
+  timeout         = "45m"
 
   cron {
     schedule = "0 */3 * * *" # Every 3 hours
@@ -62,15 +66,17 @@ resource "scaleway_job_definition" "talent" {
 
 # Job Definition for the 'grimpio' task
 resource "scaleway_job_definition" "grimpio" {
-  count        = var.enable_intern_jobs ? 1 : 0
-  name         = "${terraform.workspace}-grimpio"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_uri
+  count                  = var.enable_intern_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-grimpio"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
   # Max old space workaround: https://stackoverflow.com/questions/48387040/how-do-i-determine-the-correct-max-old-space-size-for-node-js
-  command = "node --max-old-space-size=1800 dist/jobs/run-job.js grimpio"
-  timeout = "45m"
+  startup_command = ["node"]
+  args            = ["--max-old-space-size=1800", "dist/jobs/run-job.js", "grimpio"]
+  timeout         = "45m"
 
   cron {
     schedule = "0 1 * * *" # Every day at 1:00 AM
@@ -82,14 +88,16 @@ resource "scaleway_job_definition" "grimpio" {
 
 # Job Definition for the 'linkedin' task
 resource "scaleway_job_definition" "linkedin" {
-  count        = var.enable_intern_jobs ? 1 : 0
-  name         = "${terraform.workspace}-linkedin"
-  project_id   = var.project_id
-  cpu_limit    = 1500
-  memory_limit = 2048
-  image_uri    = local.image_uri
-  command      = "node --max-old-space-size=1800 dist/jobs/run-job.js linkedin"
-  timeout      = "30m"
+  count                  = var.enable_intern_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-linkedin"
+  project_id             = var.project_id
+  cpu_limit              = 1500
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["--max-old-space-size=1800", "dist/jobs/run-job.js", "linkedin"]
+  timeout                = "30m"
 
   cron {
     schedule = "0 */6 * * *" # Every 6 hours
@@ -101,14 +109,16 @@ resource "scaleway_job_definition" "linkedin" {
 
 # Job Definition for the 'import-organizations' task
 resource "scaleway_job_definition" "import-organizations" {
-  count        = var.enable_intern_jobs ? 1 : 0
-  name         = "${terraform.workspace}-import-organizations"
-  project_id   = var.project_id
-  cpu_limit    = 2000
-  memory_limit = 4096
-  image_uri    = local.image_uri
-  command      = "node --max-old-space-size=1800 dist/jobs/run-job.js import-organizations"
-  timeout      = "45m"
+  count                  = var.enable_intern_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-import-organizations"
+  project_id             = var.project_id
+  cpu_limit              = 2000
+  memory_limit           = 4096
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["--max-old-space-size=1800", "dist/jobs/run-job.js", "import-organizations"]
+  timeout                = "45m"
 
   cron {
     schedule = "0 0 2 * *" # At 00:00 on day-of-month 2
@@ -120,14 +130,16 @@ resource "scaleway_job_definition" "import-organizations" {
 
 # Job Definition for the 'warnings' task
 resource "scaleway_job_definition" "warnings" {
-  count        = var.enable_intern_jobs ? 1 : 0
-  name         = "${terraform.workspace}-warnings"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_uri
-  command      = "node dist/jobs/run-job.js warnings"
-  timeout      = "15m"
+  count                  = var.enable_intern_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-warnings"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["dist/jobs/run-job.js", "warnings"]
+  timeout                = "15m"
 
   cron {
     schedule = "30 */3 * * *" # Every 3 hours at 30 minutes
@@ -139,14 +151,16 @@ resource "scaleway_job_definition" "warnings" {
 
 # Job Definition for the 'linkedin-stats' task
 resource "scaleway_job_definition" "linkedin-stats" {
-  count        = var.enable_intern_jobs ? 1 : 0
-  name         = "${terraform.workspace}-linkedin-stats"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_uri
-  command      = "node dist/jobs/run-job.js linkedin-stats"
-  timeout      = "15m"
+  count                  = var.enable_intern_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-linkedin-stats"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["dist/jobs/run-job.js", "linkedin-stats"]
+  timeout                = "15m"
 
   cron {
     schedule = "0 9 * * 5" # Every friday at 09:00 AM
@@ -158,14 +172,16 @@ resource "scaleway_job_definition" "linkedin-stats" {
 
 # Job Definition for the 'leboncoin' task
 resource "scaleway_job_definition" "leboncoin" {
-  count        = var.enable_intern_jobs ? 1 : 0
-  name         = "${terraform.workspace}-leboncoin"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_uri
-  command      = "node dist/jobs/run-job.js leboncoin"
-  timeout      = "15m"
+  count                  = var.enable_intern_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-leboncoin"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["dist/jobs/run-job.js", "leboncoin"]
+  timeout                = "15m"
 
   cron {
     schedule = "0 10 * * *" # Every day at 10:00 AM
@@ -177,14 +193,16 @@ resource "scaleway_job_definition" "leboncoin" {
 
 # Job Definition for the 'brevo' task
 resource "scaleway_job_definition" "brevo" {
-  count        = var.enable_intern_jobs ? 1 : 0
-  name         = "${terraform.workspace}-brevo"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_uri
-  command      = "node dist/jobs/run-job.js brevo"
-  timeout      = "15m"
+  count                  = var.enable_intern_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-brevo"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["dist/jobs/run-job.js", "brevo"]
+  timeout                = "15m"
 
   cron {
     schedule = "0 1 * * *" # Every day at 1 AM
@@ -196,14 +214,16 @@ resource "scaleway_job_definition" "brevo" {
 
 # Job Definition for the 'moderation' task
 resource "scaleway_job_definition" "moderation" {
-  count        = var.enable_intern_jobs ? 1 : 0
-  name         = "${terraform.workspace}-moderation"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_uri
-  command      = "node dist/jobs/run-job.js moderation"
-  timeout      = "15m"
+  count                  = var.enable_intern_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-moderation"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["dist/jobs/run-job.js", "moderation"]
+  timeout                = "15m"
 
   cron {
     schedule = "55 */3 * * *" # Every 3 hours at 55 minutes (after import-missions)
@@ -215,14 +235,16 @@ resource "scaleway_job_definition" "moderation" {
 
 # Job Definition for the 'enrich-missions-geoloc' task
 resource "scaleway_job_definition" "enrich-missions-geoloc" {
-  count        = var.enable_mission_jobs ? 1 : 0
-  name         = "${terraform.workspace}-enrich-missions-geoloc"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_uri
-  command      = "node dist/jobs/run-job.js enrich-missions-geoloc"
-  timeout      = "30m"
+  count                  = var.enable_mission_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-enrich-missions-geoloc"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["dist/jobs/run-job.js", "enrich-missions-geoloc"]
+  timeout                = "30m"
 
   cron {
     schedule = "30 */2 * * *" # Every 2 hours at 30 minutes (after import-missions)
@@ -234,14 +256,16 @@ resource "scaleway_job_definition" "enrich-missions-geoloc" {
 
 # Job Definition for the 'import-missions' task (all environments)
 resource "scaleway_job_definition" "import-missions" {
-  count        = var.enable_mission_jobs ? 1 : 0
-  name         = "${terraform.workspace}-import-missions"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_uri
-  command      = "node dist/jobs/run-job.js import-missions"
-  timeout      = "60m"
+  count                  = var.enable_mission_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-import-missions"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["dist/jobs/run-job.js", "import-missions"]
+  timeout                = "60m"
 
   cron {
     schedule = "15 */6 * * *" # Every 6 hours at 15 minutes
@@ -253,42 +277,48 @@ resource "scaleway_job_definition" "import-missions" {
 
 # Job Definition for the 'update-mission-enrichment' task (on-demand only, no cron)
 resource "scaleway_job_definition" "update-mission-enrichment" {
-  count        = var.enable_intern_jobs ? 1 : 0
-  name         = "${terraform.workspace}-update-mission-enrichment"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_uri
-  command      = "node dist/jobs/run-job.js update-mission-enrichment"
-  timeout      = "24h"
+  count                  = var.enable_intern_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-update-mission-enrichment"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["dist/jobs/run-job.js", "update-mission-enrichment"]
+  timeout                = "24h"
 
   env = local.all_env_vars
 }
 
 # Job Definition for the 'update-mission-scoring' task (on-demand only, no cron)
 resource "scaleway_job_definition" "update-mission-scoring" {
-  count        = var.enable_intern_jobs ? 1 : 0
-  name         = "${terraform.workspace}-update-mission-scoring"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_uri
-  command      = "node dist/jobs/run-job.js update-mission-scoring"
-  timeout      = "24h"
+  count                  = var.enable_intern_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-update-mission-scoring"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["dist/jobs/run-job.js", "update-mission-scoring"]
+  timeout                = "24h"
 
   env = local.all_env_vars
 }
 
 # Job Definition for the 'verify-publisher-organization' task
 resource "scaleway_job_definition" "verify-publisher-organization" {
-  count        = var.enable_mission_jobs ? 1 : 0
-  name         = "${terraform.workspace}-verify-publisher-organization"
-  project_id   = var.project_id
-  cpu_limit    = 1000
-  memory_limit = 2048
-  image_uri    = local.image_uri
-  command      = "node dist/jobs/run-job.js verify-publisher-organization"
-  timeout      = "60m"
+  count                  = var.enable_mission_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-verify-publisher-organization"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["dist/jobs/run-job.js", "verify-publisher-organization"]
+  timeout                = "60m"
 
   cron {
     schedule = "45 */6 * * *" # Every 6 hours at 45 minutes
@@ -299,14 +329,16 @@ resource "scaleway_job_definition" "verify-publisher-organization" {
 }
 
 resource "scaleway_job_definition" "rdb-backup" {
-  count        = var.enable_rdb_backup_job ? 1 : 0
-  name         = "${terraform.workspace}-rdb-backup"
-  project_id   = var.project_id
-  cpu_limit    = 250
-  memory_limit = 512
-  image_uri    = local.image_uri
-  command      = "node dist/jobs/run-job.js rdb-backup"
-  timeout      = "10m"
+  count                  = var.enable_rdb_backup_job ? 1 : 0
+  name                   = "${terraform.workspace}-rdb-backup"
+  project_id             = var.project_id
+  cpu_limit              = 250
+  memory_limit           = 512
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["dist/jobs/run-job.js", "rdb-backup"]
+  timeout                = "10m"
 
   cron {
     schedule = "0 3 * * *"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     scaleway = {
       source  = "scaleway/scaleway"
-      version = "~> 2.55.0"
+      version = "~> 2.74.0"
     }
   }
   backend "s3" {

--- a/terraform/modules/typesense/main.tf
+++ b/terraform/modules/typesense/main.tf
@@ -1,0 +1,128 @@
+locals {
+  api_port     = 8108
+  peering_port = 8107
+  node_keys    = sort(keys(var.nodes))
+  node_zones   = toset(distinct([for node in var.nodes : node.zone]))
+}
+
+
+resource "scaleway_ipam_ip" "node" {
+  for_each = var.nodes
+
+  address = each.value.private_ip
+  source {
+    private_network_id = var.private_network_id
+  }
+}
+
+resource "scaleway_instance_security_group" "typesense" {
+  for_each = local.node_zones
+
+  name                    = "${var.name_prefix}-${each.key}-sg"
+  project_id              = var.project_id
+  zone                    = each.key
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+  tags                    = ["typesense", var.workspace]
+
+  inbound_rule {
+    action   = "accept"
+    port     = "22"
+    ip_range = var.private_network_cidr
+  }
+
+  inbound_rule {
+    action   = "accept"
+    port     = tostring(local.api_port)
+    ip_range = var.private_network_cidr
+  }
+
+  inbound_rule {
+    action   = "accept"
+    port     = tostring(local.peering_port)
+    ip_range = var.private_network_cidr
+  }
+}
+
+resource "scaleway_instance_server" "node" {
+  for_each = var.nodes
+
+  name              = "${var.name_prefix}-${each.key}"
+  project_id        = var.project_id
+  zone              = each.value.zone
+  type              = each.value.instance_type
+  image             = "ubuntu_resolute"
+  state             = "started"
+  enable_dynamic_ip = false
+  security_group_id = scaleway_instance_security_group.typesense[each.value.zone].id
+  tags              = ["typesense", var.workspace, each.key]
+
+  user_data = {
+    cloud-init = templatefile("${path.module}/templates/cloud-init.yaml.tftpl", {
+      api_port               = local.api_port
+      node_private_ip        = each.value.private_ip
+      peering_port           = local.peering_port
+      typesense_api_key_b64  = base64encode(var.typesense_api_key)
+      typesense_nodes        = join(",", [for key in local.node_keys : "${var.nodes[key].private_ip}:${local.peering_port}:${local.api_port}"])
+      typesense_version      = each.value.typesense_version
+      typesense_docker_image = "typesense/typesense"
+      typesense_container    = "typesense"
+    })
+  }
+}
+
+resource "scaleway_instance_private_nic" "node" {
+  for_each = var.nodes
+
+  server_id          = scaleway_instance_server.node[each.key].id
+  private_network_id = var.private_network_id
+  ipam_ip_ids        = [scaleway_ipam_ip.node[each.key].id]
+  zone               = each.value.zone
+}
+
+resource "scaleway_ipam_ip" "load_balancer" {
+  address = var.load_balancer_private_ip
+
+  source {
+    private_network_id = var.private_network_id
+  }
+}
+
+resource "scaleway_lb" "typesense" {
+  name               = "${var.name_prefix}-lb"
+  description        = "Private Typesense load balancer for ${var.workspace}"
+  project_id         = var.project_id
+  zone               = var.load_balancer_zone
+  type               = var.load_balancer_type
+  assign_flexible_ip = false
+  tags               = ["typesense", var.workspace]
+
+  private_network {
+    private_network_id = var.private_network_id
+    ipam_ids           = [scaleway_ipam_ip.load_balancer.id]
+  }
+}
+
+resource "scaleway_lb_backend" "typesense" {
+  name                     = "${var.name_prefix}-backend"
+  lb_id                    = scaleway_lb.typesense.id
+  forward_protocol         = "tcp"
+  forward_port             = local.api_port
+  forward_port_algorithm   = "roundrobin"
+  proxy_protocol           = "none"
+  server_ips               = [for key in local.node_keys : var.nodes[key].private_ip]
+  health_check_port        = local.api_port
+  health_check_delay       = "10s"
+  health_check_timeout     = "5s"
+  health_check_max_retries = 3
+
+  depends_on = [scaleway_instance_private_nic.node]
+}
+
+resource "scaleway_lb_frontend" "typesense" {
+  name           = "${var.name_prefix}-frontend"
+  lb_id          = scaleway_lb.typesense.id
+  backend_id     = scaleway_lb_backend.typesense.id
+  inbound_port   = local.api_port
+  timeout_client = "30s"
+}

--- a/terraform/modules/typesense/templates/cloud-init.yaml.tftpl
+++ b/terraform/modules/typesense/templates/cloud-init.yaml.tftpl
@@ -1,0 +1,89 @@
+#cloud-config
+package_update: true
+packages:
+  - ca-certificates
+  - curl
+  - docker.io
+
+write_files:
+  - path: /etc/typesense/nodes
+    permissions: "0644"
+    owner: root:root
+    content: |
+      ${typesense_nodes}
+
+  - path: /etc/typesense/typesense.env
+    permissions: "0600"
+    owner: root:root
+    content: |
+      TYPESENSE_API_KEY_B64=${typesense_api_key_b64}
+      TYPESENSE_DOCKER_IMAGE=${typesense_docker_image}
+      TYPESENSE_VERSION=${typesense_version}
+      TYPESENSE_CONTAINER=${typesense_container}
+      TYPESENSE_DATA_DIR=/var/lib/typesense
+      TYPESENSE_SNAPSHOT_PATH=/var/lib/typesense-snapshots
+      TYPESENSE_API_PORT=${api_port}
+      TYPESENSE_PEERING_PORT=${peering_port}
+      TYPESENSE_PEERING_ADDRESS=${node_private_ip}
+
+  - path: /usr/local/bin/run-typesense
+    permissions: "0750"
+    owner: root:root
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      source /etc/typesense/typesense.env
+
+      until ip addr | grep -q "$TYPESENSE_PEERING_ADDRESS"; do
+        echo "Waiting for private IP $TYPESENSE_PEERING_ADDRESS"
+        sleep 5
+      done
+
+      mkdir -p "$TYPESENSE_DATA_DIR" "$TYPESENSE_SNAPSHOT_PATH"
+      chown -R 1000:1000 "$TYPESENSE_DATA_DIR" "$TYPESENSE_SNAPSHOT_PATH"
+
+      TYPESENSE_API_KEY="$(printf '%s' "$TYPESENSE_API_KEY_B64" | base64 -d)"
+      export TYPESENSE_API_KEY
+
+      exec docker run --rm \
+        --name "$TYPESENSE_CONTAINER" \
+        --network host \
+        --volume "$TYPESENSE_DATA_DIR:/data" \
+        --volume "$TYPESENSE_SNAPSHOT_PATH:/snapshots" \
+        --volume /etc/typesense/nodes:/etc/typesense/nodes:ro \
+        "$TYPESENSE_DOCKER_IMAGE:$TYPESENSE_VERSION" \
+        --data-dir /data \
+        --api-key "$TYPESENSE_API_KEY" \
+        --api-address 0.0.0.0 \
+        --api-port "$TYPESENSE_API_PORT" \
+        --peering-address "$TYPESENSE_PEERING_ADDRESS" \
+        --peering-port "$TYPESENSE_PEERING_PORT" \
+        --nodes /etc/typesense/nodes
+
+  - path: /etc/systemd/system/typesense.service
+    permissions: "0644"
+    owner: root:root
+    content: |
+      [Unit]
+      Description=Typesense
+      Requires=docker.service
+      After=docker.service network-online.target
+      Wants=network-online.target
+
+      [Service]
+      Restart=always
+      RestartSec=10
+      EnvironmentFile=/etc/typesense/typesense.env
+      ExecStartPre=-/usr/bin/docker rm -f typesense
+      ExecStartPre=/usr/bin/docker pull ${typesense_docker_image}:${typesense_version}
+      ExecStart=/usr/local/bin/run-typesense
+      ExecStop=/usr/bin/docker stop typesense
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - systemctl enable --now docker
+  - systemctl daemon-reload
+  - systemctl enable --now typesense

--- a/terraform/modules/typesense/variables.tf
+++ b/terraform/modules/typesense/variables.tf
@@ -1,0 +1,79 @@
+variable "project_id" {
+  type        = string
+  description = "Scaleway Project ID."
+}
+
+variable "workspace" {
+  type        = string
+  description = "Deployment workspace name."
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix used for Typesense resources."
+}
+
+variable "region" {
+  type        = string
+  default     = "fr-par"
+  description = "Scaleway region."
+}
+
+variable "nodes" {
+  type = map(object({
+    zone              = string
+    private_ip        = string
+    instance_type     = string
+    typesense_version = string
+  }))
+  description = "Typesense nodes keyed by stable node name, with one private IP per node."
+
+  validation {
+    condition     = length(var.nodes) == 1 || (length(var.nodes) >= 3 && length(var.nodes) % 2 == 1)
+    error_message = "Typesense requires either 1 node or an odd number of at least 3 nodes."
+  }
+}
+
+
+variable "private_network_cidr" {
+  type        = string
+  description = "CIDR block used by the Typesense Private Network."
+}
+
+variable "private_network_id" {
+  type        = string
+  description = "Scaleway Private Network ID used by Typesense nodes."
+}
+
+variable "load_balancer_private_ip" {
+  type        = string
+  description = "Private IP used by the Typesense load balancer."
+
+  validation {
+    condition     = can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}$", var.load_balancer_private_ip))
+    error_message = "load_balancer_private_ip must be an IPv4 address without CIDR suffix, for example 10.43.2.10."
+  }
+}
+
+variable "load_balancer_type" {
+  type        = string
+  default     = "LB-S"
+  description = "Scaleway Load Balancer type used by Typesense."
+}
+
+variable "load_balancer_zone" {
+  type        = string
+  default     = "fr-par-1"
+  description = "Zone used by the Typesense load balancer."
+}
+
+variable "typesense_api_key" {
+  type        = string
+  sensitive   = true
+  description = "Typesense admin API key."
+
+  validation {
+    condition     = length(var.typesense_api_key) > 0
+    error_message = "typesense_api_key must not be empty when the Typesense module is enabled."
+  }
+}

--- a/terraform/modules/typesense/versions.tf
+++ b/terraform/modules/typesense/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+    }
+  }
+}

--- a/terraform/typesense.tf
+++ b/terraform/typesense.tf
@@ -1,0 +1,16 @@
+module "typesense" {
+  count  = var.enable_typesense ? 1 : 0
+  source = "./modules/typesense"
+
+  project_id               = var.project_id
+  workspace                = var.workspace
+  name_prefix              = "${var.workspace}-typesense"
+  region                   = "fr-par"
+  nodes                    = var.typesense_nodes
+  private_network_cidr     = var.private_network_cidr
+  private_network_id       = scaleway_vpc_private_network.main.id
+  load_balancer_private_ip = var.typesense_load_balancer_private_ip
+  load_balancer_type       = var.typesense_load_balancer_type
+  load_balancer_zone       = var.public_gateway_zone
+  typesense_api_key        = lookup(local.secrets, "TYPESENSE_API_KEY", "")
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -168,6 +168,7 @@ variable "enable_mission_jobs" {
   type        = bool
   default     = true
   description = "Enable always-on mission jobs (import-missions, enrich-missions-geoloc, verify-publisher-organization)"
+}
 
 variable "enable_rdb_backup_job" {
   type        = bool
@@ -232,4 +233,70 @@ variable "plateform_min_scale" {
 variable "plateform_max_scale" {
   type    = number
   default = 1
+}
+
+# Network
+
+variable "private_network_cidr" {
+  type        = string
+  description = "CIDR block used by the workspace Private Network."
+}
+
+variable "enable_public_gateway" {
+  type        = bool
+  default     = false
+  description = "Enable a Public Gateway with SSH bastion for this workspace."
+}
+
+variable "public_gateway_zone" {
+  type        = string
+  default     = "fr-par-1"
+  description = "Zone used by the Public Gateway."
+}
+
+variable "public_gateway_type" {
+  type        = string
+  default     = "VPC-GW-S"
+  description = "The type of the Public Gateway"
+}
+
+variable "public_gateway_bastion_port" {
+  type        = number
+  default     = 61000
+  description = "SSH bastion port exposed by the Public Gateway."
+}
+
+# Typesense
+
+variable "enable_typesense" {
+  type        = bool
+  default     = false
+  description = "Enable the self-hosted Typesense HA cluster."
+}
+
+variable "typesense_nodes" {
+  type = map(object({
+    zone              = string
+    private_ip        = string
+    instance_type     = string
+    typesense_version = string
+  }))
+  description = "Typesense nodes keyed by stable node name, with one private IP per node."
+}
+
+variable "typesense_load_balancer_private_ip" {
+  type        = string
+  default     = ""
+  description = "Private IP used by the Typesense load balancer."
+
+  validation {
+    condition     = var.typesense_load_balancer_private_ip == "" || can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}$", var.typesense_load_balancer_private_ip))
+    error_message = "typesense_load_balancer_private_ip must be empty or an IPv4 address without CIDR suffix, for example 10.43.2.10."
+  }
+}
+
+variable "typesense_load_balancer_type" {
+  type        = string
+  default     = "LB-S"
+  description = "Scaleway Load Balancer type used by Typesense."
 }

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,45 @@
+resource "scaleway_vpc" "main" {
+  name = "${var.workspace}-vpc"
+  tags = ["${var.workspace}"]
+}
+
+resource "scaleway_vpc_private_network" "main" {
+  name   = "${var.workspace}-private-network"
+  vpc_id = scaleway_vpc.main.id
+  tags   = ["${var.workspace}"]
+
+  ipv4_subnet {
+    subnet = var.private_network_cidr
+  }
+}
+
+resource "scaleway_vpc_public_gateway_ip" "main" {
+  count      = var.enable_public_gateway ? 1 : 0
+  project_id = var.project_id
+  zone       = var.public_gateway_zone
+  tags       = ["${var.workspace}"]
+}
+
+resource "scaleway_vpc_public_gateway" "main" {
+  count           = var.enable_public_gateway ? 1 : 0
+  name            = "${var.workspace}-gateway"
+  project_id      = var.project_id
+  zone            = var.public_gateway_zone
+  type            = var.public_gateway_type
+  ip_id           = scaleway_vpc_public_gateway_ip.main[0].id
+  bastion_enabled = true
+  bastion_port    = var.public_gateway_bastion_port
+  tags            = ["${var.workspace}"]
+}
+
+resource "scaleway_vpc_gateway_network" "main" {
+  count              = var.enable_public_gateway ? 1 : 0
+  zone               = var.public_gateway_zone
+  gateway_id         = scaleway_vpc_public_gateway.main[0].id
+  private_network_id = scaleway_vpc_private_network.main.id
+  enable_masquerade  = true
+
+  ipam_config {
+    push_default_route = true
+  }
+}


### PR DESCRIPTION
## Description

Ajout d’une première brique d’infrastructure Typesense self-hosted sur Scaleway.

Cette PR introduit :
- un VPC/private network par workspace ;
- un Public Gateway optionnel avec bastion SSH ;
- un module Terraform `typesense` pour provisionner une ou plusieurs instances Typesense privées ;
- un Load Balancer privé Typesense exposé uniquement sur le private network ;
- le raccord des containers API/API worker au private network pour interroger Typesense via le LB.

## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Monter-une-instance-typesense-35072a322d50809fb036c5eb99376a53?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
