### PR TITLE
feat(api): user scoring distinct_id + mission_alert_enabled

### DIFF
--- a/api/prisma/migrations/20260430074723_add_user_scoring_distinct_id_mission_alert/migration.sql
+++ b/api/prisma/migrations/20260430074723_add_user_scoring_distinct_id_mission_alert/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "user_scoring" ADD COLUMN     "distinct_id" TEXT,
+ADD COLUMN     "mission_alert_enabled" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1039,8 +1039,8 @@ model MissionEnrichmentValue {
   missionScoringValues MissionScoringValue[]
 
   @@unique([enrichmentId, taxonomyValueId], map: "mission_enrichment_value_unique")
-  @@index([taxonomyValueId], map: "mission_enrichment_value_taxonomy_value_id_idx")
   @@unique([enrichmentId, taxonomyKey, valueKey], map: "mission_enrichment_value_taxonomy_value_unique")
+  @@index([taxonomyValueId], map: "mission_enrichment_value_taxonomy_value_id_idx")
   @@index([taxonomyKey, valueKey], map: "mission_enrichment_value_taxonomy_value_idx")
   @@map("mission_enrichment_value")
 }
@@ -1088,10 +1088,12 @@ model MissionScoringValue {
 }
 
 model UserScoring {
-  id        String    @id @default(uuid())
-  createdAt DateTime  @default(now()) @map("created_at")
-  expiresAt DateTime? @map("expires_at")
-  updatedAt DateTime  @updatedAt @map("updated_at")
+  id                  String    @id @default(uuid())
+  distinctId          String?   @map("distinct_id")
+  missionAlertEnabled Boolean   @default(false) @map("mission_alert_enabled")
+  createdAt           DateTime  @default(now()) @map("created_at")
+  expiresAt           DateTime? @map("expires_at")
+  updatedAt           DateTime  @updatedAt @map("updated_at")
 
   values          UserScoringValue[]
   geo             UserScoringGeo?
@@ -1125,7 +1127,7 @@ model UserScoringValue {
   createdAt       DateTime @default(now()) @map("created_at")
   updatedAt       DateTime @updatedAt @map("updated_at")
 
-  userScoring   UserScoring   @relation(fields: [userScoringId], references: [id], onDelete: Cascade)
+  userScoring   UserScoring    @relation(fields: [userScoringId], references: [id], onDelete: Cascade)
   taxonomyValue TaxonomyValue? @relation(fields: [taxonomyValueId], references: [id], onDelete: Restrict)
 
   @@unique([userScoringId, taxonomyValueId], map: "user_scoring_value_user_scoring_taxonomy_value_key")

--- a/api/src/controllers/user-scoring.ts
+++ b/api/src/controllers/user-scoring.ts
@@ -17,6 +17,8 @@ const bodySchema = zod.object({
       radius_km: zod.number().positive().optional(),
     })
     .optional(),
+  distinctId: zod.string().optional(),
+  missionAlertEnabled: zod.boolean().default(false),
 });
 
 router.post("/", async (req, res, next) => {

--- a/api/src/controllers/user-scoring.ts
+++ b/api/src/controllers/user-scoring.ts
@@ -3,13 +3,16 @@ import zod from "zod";
 
 import { isValidTaxonomyValueKey } from "@engagement/taxonomy";
 
-import { INVALID_BODY } from "@/error";
+import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, NOT_FOUND } from "@/error";
 import { userScoringService } from "@/services/user-scoring";
 
 const router = Router();
 
+const answersSchema = zod.array(zod.object({ taxonomy_value_key: zod.string() })).min(1);
+const distinctIdSchema = zod.string().trim().min(1);
+
 const bodySchema = zod.object({
-  answers: zod.array(zod.object({ taxonomy_value_key: zod.string() })).min(1),
+  answers: answersSchema,
   geo: zod
     .object({
       lat: zod.number().min(-90).max(90),
@@ -17,8 +20,22 @@ const bodySchema = zod.object({
       radius_km: zod.number().positive().optional(),
     })
     .optional(),
-  distinctId: zod.string().optional(),
+  distinctId: distinctIdSchema.optional(),
   missionAlertEnabled: zod.boolean().default(false),
+});
+
+const updateBodySchema = zod
+  .object({
+    answers: answersSchema.optional(),
+    distinctId: distinctIdSchema,
+    missionAlertEnabled: zod.boolean().optional(),
+  })
+  .refine((body) => body.answers !== undefined || body.missionAlertEnabled !== undefined, {
+    message: "answers or missionAlertEnabled is required",
+  });
+
+const userScoringParamsSchema = zod.object({
+  userScoringId: zod.string().uuid(),
 });
 
 router.post("/", async (req, res, next) => {
@@ -37,6 +54,44 @@ router.post("/", async (req, res, next) => {
 
     const data = await userScoringService.create({ ...body.data, answers: validAnswers });
     return res.status(201).send({ ok: true, data });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put("/:userScoringId", async (req, res, next) => {
+  try {
+    const params = userScoringParamsSchema.safeParse(req.params);
+    if (!params.success) {
+      return res.status(400).send({ ok: false, code: INVALID_PARAMS, error: params.error });
+    }
+
+    const body = updateBodySchema.safeParse(req.body);
+    if (!body.success) {
+      return res.status(400).send({ ok: false, code: INVALID_BODY, error: body.error });
+    }
+
+    const validAnswers = body.data.answers?.filter((a) => isValidTaxonomyValueKey(a.taxonomy_value_key));
+    if (body.data.answers && validAnswers?.length === 0) {
+      return res.status(400).send({ ok: false, code: INVALID_BODY, message: "No valid taxonomy_value_key provided" });
+    }
+
+    const data = await userScoringService.update({
+      userScoringId: params.data.userScoringId,
+      distinctId: body.data.distinctId,
+      answers: validAnswers,
+      missionAlertEnabled: body.data.missionAlertEnabled,
+    });
+
+    if (data.status === "not_found") {
+      return res.status(404).send({ ok: false, code: NOT_FOUND, message: "User scoring not found" });
+    }
+
+    if (data.status === "forbidden") {
+      return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Invalid distinctId" });
+    }
+
+    return res.status(200).send({ ok: true, data: data.data });
   } catch (error) {
     next(error);
   }

--- a/api/src/repositories/user-scoring.ts
+++ b/api/src/repositories/user-scoring.ts
@@ -1,15 +1,19 @@
-import { prisma } from "@/db/postgres";
 import type { UserScoring } from "@/db/core";
+import { prisma } from "@/db/postgres";
 
 export const userScoringRepository = {
   create(params: {
     expiresAt: Date;
     values: Array<{ taxonomyKey: string; valueKey: string; score?: number }>;
     geo?: { lat: number; lon: number; radiusKm?: number };
+    distinctId?: string;
+    missionAlertEnabled: boolean;
   }): Promise<UserScoring> {
     return prisma.userScoring.create({
       data: {
         expiresAt: params.expiresAt,
+        distinctId: params.distinctId,
+        missionAlertEnabled: params.missionAlertEnabled,
         values: {
           createMany: {
             data: params.values.map((value) => ({

--- a/api/src/repositories/user-scoring.ts
+++ b/api/src/repositories/user-scoring.ts
@@ -2,6 +2,13 @@ import type { UserScoring } from "@/db/core";
 import { prisma } from "@/db/postgres";
 
 export const userScoringRepository = {
+  findById(id: string): Promise<Pick<UserScoring, "id" | "distinctId"> | null> {
+    return prisma.userScoring.findUnique({
+      where: { id },
+      select: { id: true, distinctId: true },
+    });
+  },
+
   create(params: {
     expiresAt: Date;
     values: Array<{ taxonomyKey: string; valueKey: string; score?: number }>;
@@ -35,6 +42,37 @@ export const userScoringRepository = {
             }
           : {}),
       },
+    });
+  },
+
+  update(params: {
+    userScoringId: string;
+    values: Array<{ taxonomyKey: string; valueKey: string; score?: number }>;
+    missionAlertEnabled?: boolean;
+  }): Promise<{ createdCount: number; missionAlertEnabled: boolean }> {
+    return prisma.$transaction(async (tx) => {
+      const createdValues = params.values.length
+        ? await tx.userScoringValue.createMany({
+            data: params.values.map((value) => ({
+              userScoringId: params.userScoringId,
+              taxonomyKey: value.taxonomyKey,
+              valueKey: value.valueKey,
+              score: value.score ?? 1.0,
+            })),
+            skipDuplicates: true,
+          })
+        : { count: 0 };
+
+      const userScoring = await tx.userScoring.update({
+        where: { id: params.userScoringId },
+        data: params.missionAlertEnabled === undefined ? { updatedAt: new Date() } : { missionAlertEnabled: params.missionAlertEnabled },
+        select: { missionAlertEnabled: true },
+      });
+
+      return {
+        createdCount: createdValues.count,
+        missionAlertEnabled: userScoring.missionAlertEnabled,
+      };
     });
   },
 };

--- a/api/src/services/user-scoring/index.ts
+++ b/api/src/services/user-scoring/index.ts
@@ -15,27 +15,36 @@ interface CreateUserScoringInput {
   missionAlertEnabled: boolean;
 }
 
+interface UpdateUserScoringInput {
+  userScoringId: string;
+  distinctId: string;
+  answers?: Array<{ taxonomy_value_key: string }>;
+  missionAlertEnabled?: boolean;
+}
+
+const buildValuesToPersist = (answers: Array<{ taxonomy_value_key: string }>) => {
+  const seen = new Set<string>();
+  const uniqueKeys: string[] = [];
+  for (const answer of answers) {
+    const key = answer.taxonomy_value_key;
+    if (!seen.has(key)) {
+      seen.add(key);
+      uniqueKeys.push(key);
+    }
+  }
+
+  // Caller (controller) is responsible for filtering invalid keys before reaching here.
+  const pairs = uniqueKeys.map((key) => parseTaxonomyValueKey(key)!);
+  return pairs.map(({ taxonomyKey, valueKey }) => ({
+    taxonomyKey,
+    valueKey,
+    score: 1.0,
+  }));
+};
+
 export const userScoringService = {
   async create(input: CreateUserScoringInput) {
-    // Deduplicate (keep first occurrence)
-    const seen = new Set<string>();
-    const uniqueKeys: string[] = [];
-    for (const answer of input.answers) {
-      const key = answer.taxonomy_value_key;
-      if (!seen.has(key)) {
-        seen.add(key);
-        uniqueKeys.push(key);
-      }
-    }
-
-    // Caller (controller) is responsible for filtering invalid keys before reaching here.
-    const pairs = uniqueKeys.map((key) => parseTaxonomyValueKey(key)!);
-    const valuesToPersist = pairs.map(({ taxonomyKey, valueKey }) => ({
-      taxonomyKey,
-      valueKey,
-      score: 1.0,
-    }));
-
+    const valuesToPersist = buildValuesToPersist(input.answers);
     const expiresAt = new Date(Date.now() + USER_SCORING_TTL_DAYS * 24 * 60 * 60 * 1000);
 
     const userScoring = await userScoringRepository.create({
@@ -47,5 +56,32 @@ export const userScoringService = {
     });
 
     return { id: userScoring.id, created_at: userScoring.createdAt };
+  },
+
+  async update(input: UpdateUserScoringInput) {
+    const userScoring = await userScoringRepository.findById(input.userScoringId);
+    if (!userScoring) {
+      return { status: "not_found" as const };
+    }
+
+    if (!userScoring.distinctId || userScoring.distinctId !== input.distinctId) {
+      return { status: "forbidden" as const };
+    }
+
+    const valuesToPersist = input.answers ? buildValuesToPersist(input.answers) : [];
+    const result = await userScoringRepository.update({
+      userScoringId: input.userScoringId,
+      values: valuesToPersist,
+      missionAlertEnabled: input.missionAlertEnabled,
+    });
+
+    return {
+      status: "success" as const,
+      data: {
+        user_scoring_id: input.userScoringId,
+        created_count: result.createdCount,
+        mission_alert_enabled: result.missionAlertEnabled,
+      },
+    };
   },
 };

--- a/api/src/services/user-scoring/index.ts
+++ b/api/src/services/user-scoring/index.ts
@@ -11,6 +11,8 @@ interface CreateUserScoringInput {
     lon: number;
     radius_km?: number;
   };
+  distinctId?: string;
+  missionAlertEnabled: boolean;
 }
 
 export const userScoringService = {
@@ -40,6 +42,8 @@ export const userScoringService = {
       expiresAt,
       values: valuesToPersist,
       geo: input.geo ? { lat: input.geo.lat, lon: input.geo.lon, radiusKm: input.geo.radius_km } : undefined,
+      distinctId: input?.distinctId,
+      missionAlertEnabled: input.missionAlertEnabled,
     });
 
     return { id: userScoring.id, created_at: userScoring.createdAt };

--- a/api/tests/integration/api/user-scoring.test.ts
+++ b/api/tests/integration/api/user-scoring.test.ts
@@ -95,6 +95,24 @@ describe("POST /user-scoring", () => {
     expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual(["domaine.social_solidarite", "type_mission.ponctuelle"]);
   });
 
+  it("should create a user scoring with distinctId and missionAlertEnabled", async () => {
+    const res = await request(app)
+      .post("/user-scoring")
+      .send({
+        answers: [{ taxonomy_value_key: taxonomyValueKey }],
+        distinctId: "distinct-user-1",
+        missionAlertEnabled: true,
+      });
+
+    expect(res.status).toBe(201);
+
+    const userScoring = await prisma.userScoring.findUniqueOrThrow({
+      where: { id: res.body.data.id },
+    });
+    expect(userScoring.distinctId).toBe("distinct-user-1");
+    expect(userScoring.missionAlertEnabled).toBe(true);
+  });
+
   it("should deduplicate answers with repeated taxonomy_value_key", async () => {
     const res = await request(app)
       .post("/user-scoring")
@@ -207,6 +225,206 @@ describe("POST /user-scoring", () => {
         geo: { lat: 48.8566, lon: 999 },
       });
     expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+});
+
+describe("PUT /user-scoring/:userScoringId", () => {
+  const distinctId = "distinct-user-1";
+  let taxonomyValueKey: string;
+  let secondaryTaxonomyValueKey: string;
+
+  beforeEach(async () => {
+    taxonomyValueKey = "domaine.social_solidarite" satisfies TaxonomyValueKey;
+    secondaryTaxonomyValueKey = "type_mission.ponctuelle" satisfies TaxonomyValueKey;
+  });
+
+  const createUserScoring = async (params: { distinctId?: string } = { distinctId }) => {
+    const res = await request(app)
+      .post("/user-scoring")
+      .send({ answers: [{ taxonomy_value_key: taxonomyValueKey }], distinctId: params.distinctId });
+
+    expect(res.status).toBe(201);
+    return res.body.data.id as string;
+  };
+
+  it("should add answers to an existing user scoring", async () => {
+    const userScoringId = await createUserScoring();
+
+    const res = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({ distinctId, answers: [{ taxonomy_value_key: secondaryTaxonomyValueKey }] });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: { user_scoring_id: userScoringId, created_count: 1, mission_alert_enabled: false },
+    });
+
+    const values = await prisma.userScoringValue.findMany({
+      where: { userScoringId },
+      orderBy: [{ taxonomyKey: "asc" }, { valueKey: "asc" }],
+    });
+    expect(values).toHaveLength(2);
+    expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual(["domaine.social_solidarite", "type_mission.ponctuelle"]);
+  });
+
+  it("should update missionAlertEnabled without adding answers", async () => {
+    const userScoringId = await createUserScoring();
+
+    const res = await request(app).put(`/user-scoring/${userScoringId}`).send({ distinctId, missionAlertEnabled: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: { user_scoring_id: userScoringId, created_count: 0, mission_alert_enabled: true },
+    });
+
+    const userScoring = await prisma.userScoring.findUniqueOrThrow({
+      where: { id: userScoringId },
+    });
+    expect(userScoring.missionAlertEnabled).toBe(true);
+
+    const values = await prisma.userScoringValue.findMany({
+      where: { userScoringId },
+    });
+    expect(values).toHaveLength(1);
+  });
+
+  it("should add answers and update missionAlertEnabled in the same request", async () => {
+    const userScoringId = await createUserScoring();
+
+    const res = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({
+        distinctId,
+        missionAlertEnabled: true,
+        answers: [{ taxonomy_value_key: secondaryTaxonomyValueKey }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: { user_scoring_id: userScoringId, created_count: 1, mission_alert_enabled: true },
+    });
+
+    const userScoring = await prisma.userScoring.findUniqueOrThrow({
+      where: { id: userScoringId },
+    });
+    expect(userScoring.missionAlertEnabled).toBe(true);
+
+    const values = await prisma.userScoringValue.findMany({
+      where: { userScoringId },
+    });
+    expect(values).toHaveLength(2);
+  });
+
+  it("should skip duplicate answers when adding answers", async () => {
+    const userScoringId = await createUserScoring();
+
+    const res = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({
+        distinctId,
+        answers: [{ taxonomy_value_key: taxonomyValueKey }, { taxonomy_value_key: secondaryTaxonomyValueKey }, { taxonomy_value_key: secondaryTaxonomyValueKey }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.created_count).toBe(1);
+
+    const values = await prisma.userScoringValue.findMany({
+      where: { userScoringId },
+    });
+    expect(values).toHaveLength(2);
+  });
+
+  it("should silently skip invalid answers when adding answers", async () => {
+    const userScoringId = await createUserScoring();
+
+    const res = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({
+        distinctId,
+        answers: [{ taxonomy_value_key: secondaryTaxonomyValueKey }, { taxonomy_value_key: "domaine.does_not_exist" }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.created_count).toBe(1);
+  });
+
+  it("should return 400 when all added answers are invalid", async () => {
+    const userScoringId = await createUserScoring();
+
+    const res = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({ distinctId, answers: [{ taxonomy_value_key: "domaine.does_not_exist" }] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("should return 400 when no update field is provided", async () => {
+    const userScoringId = await createUserScoring();
+
+    const res = await request(app).put(`/user-scoring/${userScoringId}`).send({ distinctId });
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("should return 400 when distinctId is missing", async () => {
+    const userScoringId = await createUserScoring();
+
+    const res = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({ answers: [{ taxonomy_value_key: secondaryTaxonomyValueKey }] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("should return 403 when distinctId does not match the user scoring", async () => {
+    const userScoringId = await createUserScoring();
+
+    const res = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({ distinctId: "another-distinct-user", answers: [{ taxonomy_value_key: secondaryTaxonomyValueKey }] });
+
+    expect(res.status).toBe(403);
+    expect(res.body.ok).toBe(false);
+
+    const values = await prisma.userScoringValue.findMany({
+      where: { userScoringId },
+    });
+    expect(values).toHaveLength(1);
+  });
+
+  it("should return 403 when user scoring has no distinctId", async () => {
+    const userScoringId = await createUserScoring({ distinctId: undefined });
+
+    const res = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({ distinctId, answers: [{ taxonomy_value_key: secondaryTaxonomyValueKey }] });
+
+    expect(res.status).toBe(403);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("should return 400 when userScoringId is not a uuid", async () => {
+    const res = await request(app)
+      .put("/user-scoring/not-a-uuid")
+      .send({ distinctId, answers: [{ taxonomy_value_key: taxonomyValueKey }] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("should return 404 when user scoring does not exist", async () => {
+    const res = await request(app)
+      .put("/user-scoring/00000000-0000-4000-8000-000000000000")
+      .send({ distinctId, answers: [{ taxonomy_value_key: taxonomyValueKey }] });
+
+    expect(res.status).toBe(404);
     expect(res.body.ok).toBe(false);
   });
 });


### PR DESCRIPTION
## Description

Ajout de deux nouveaux champs sur `user_scoring` :

- `distinct_id` : identifiant permettant de rattacher un scoring à une même personne côté client.
- `mission_alert_enabled` : indique si l’utilisateur souhaite recevoir des alertes de missions similaires.

Ajout également d’un endpoint de mise à jour du `user_scoring` :

`PUT /user-scoring/:userScoringId`

Cet endpoint permet de modifier un `user_scoring` existant en envoyant au moins l’un des deux champs suivants :

- `answers` : ajoute de nouvelles `user_scoring_value`
- `missionAlertEnabled` : met à jour la préférence d’alerte missions

Le `distinctId` est obligatoire sur cet endpoint et doit correspondre au `distinct_id` stocké sur le `user_scoring` ciblé.


## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/M-canique-d-emailing-34c72a322d508054b371c6ad5e425ce4?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

Comportement de `PUT /user-scoring/:userScoringId` :
- `200` si la mise à jour est acceptée
- `400` si le body ne contient ni `answers` ni `missionAlertEnabled`
- `400` si `distinctId` est absent ou vide
- `400` si `userScoringId` n’est pas un UUID valide
- `400` si les `answers` fournies ne contiennent aucune valeur valide
- `403` si le `distinctId` ne correspond pas au `user_scoring`
- `403` si le `user_scoring` existant n’a pas de `distinct_id`
- `404` si le `user_scoring` n’existe pas
