### PR TITLE
fix(app): align date range picker layout horizontally

### DIFF
--- a/app/src/components/DateRangePicker.jsx
+++ b/app/src/components/DateRangePicker.jsx
@@ -59,7 +59,7 @@ const DateRangePicker = ({ value, onChange }) => {
   };
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-wrap gap-4 sm:items-center">
       <fieldset className="m-0 border-0 p-0">
         <legend className="sr-only">Période</legend>
         <div className="border-grey-border flex flex-col items-stretch gap-2 rounded-sm border sm:w-fit sm:flex-row sm:items-center sm:gap-x-2" role="radiogroup">


### PR DESCRIPTION
## Description

Corrige l'alignement du composant `DateRangePicker` dont les éléments étaient empilés verticalement au lieu d'être disposés en ligne.

**Changements** :
- Remplacement de `flex flex-col` par `flex flex-wrap sm:items-center` sur le conteneur racine, pour que les boutons de période et les champs de date s'affichent côte à côte (et passent à la ligne si nécessaire).

## Liens utiles

- 📝 Ticket Notion : [lien](https://www.notion.so/jeveuxaider/Probl-me-d-affichage-sur-les-filtres-du-Tableau-de-Bord-34f72a322d5080f1bb1ad6c6a60009de?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- À vérifier visuellement sur les pages utilisant `DateRangePicker` (notamment les filtres analytiques) en desktop et en mobile.