### PR TITLE
feat(api): enable service civique missions in grimpio job

### DIFF
--- a/api/src/jobs/grimpio/__tests__/transformers.test.ts
+++ b/api/src/jobs/grimpio/__tests__/transformers.test.ts
@@ -1,4 +1,5 @@
 import { ASC_100_LOGO_URL, JVA_100_LOGO_URL, PUBLISHER_IDS } from "@/config";
+import { ASC_CONTRACT_TYPE, JVA_CONTRACT_TYPE } from "@/jobs/grimpio/config";
 import { missionToGrimpioJob, missionToGrimpioJobASC, missionToGrimpioJobJVA } from "@/jobs/grimpio/transformers";
 import { MissionRecord } from "@/types/mission";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -80,7 +81,7 @@ describe("missionToGrimpioJobJVA", () => {
     const job = missionToGrimpioJobJVA(mission);
 
     expect(job.title).toBe(`Bénévolat - ${mission.title}`);
-    expect(job.contractType).toBe("bénévolat");
+    expect(job.contractType).toBe(JVA_CONTRACT_TYPE);
     expect(job.enterpriseName).toBe(mission.organizationName);
     expect(job.enterpriseIndustry).toBe("Association ONG");
     expect(job.externalId).toBe(mission.clientId);
@@ -147,7 +148,7 @@ describe("missionToGrimpioJobASC", () => {
     const job = missionToGrimpioJobASC(mission);
 
     expect(job.title).toBe(`Service Civique - ${mission.title}`);
-    expect(job.contractType).toBe("service_civique");
+    expect(job.contractType).toBe(ASC_CONTRACT_TYPE);
     expect(job.enterpriseName).toBe(mission.organizationName);
     expect(job.enterpriseIndustry).toBe("Association - ONG");
     expect(job.externalId).toBe(mission.clientId);
@@ -194,7 +195,7 @@ describe("missionToGrimpioJob", () => {
     const job = missionToGrimpioJob(mission);
 
     expect(job.title).toBe(`Bénévolat - ${mission.title}`);
-    expect(job.contractType).toBe("bénévolat");
+    expect(job.contractType).toBe(JVA_CONTRACT_TYPE);
     expect(job.enterpriseIndustry).toBe("Association ONG");
   });
 
@@ -203,7 +204,7 @@ describe("missionToGrimpioJob", () => {
     const job = missionToGrimpioJob(mission);
 
     expect(job.title).toBe(`Service Civique - ${mission.title}`);
-    expect(job.contractType).toBe("service_civique");
+    expect(job.contractType).toBe(ASC_CONTRACT_TYPE);
     expect(job.enterpriseIndustry).toBe("Association - ONG");
   });
 

--- a/api/src/jobs/grimpio/config.ts
+++ b/api/src/jobs/grimpio/config.ts
@@ -36,4 +36,4 @@ export const AUDIENCE_MAPPING: { [key: string]: string } = {
 
 // Contract type mappings
 export const JVA_CONTRACT_TYPE = "bénévolat";
-export const ASC_CONTRACT_TYPE = "service_civique";
+export const ASC_CONTRACT_TYPE = "CIVIC_SERVICE";

--- a/api/src/jobs/grimpio/handler.ts
+++ b/api/src/jobs/grimpio/handler.ts
@@ -62,17 +62,17 @@ export class GrimpioHandler implements BaseHandler<GrimpioJobPayload, GrimpioJob
       result.counter.expired += jvaJobs.expired;
 
       // TODO: Uncomment when Service Civique is available
-      // console.log(`[Grimpio Job] Querying and processing missions of Service Civique`);
-      // const scMissionsCursor = getMissionsCursor({
-      //   publisherIds: [PUBLISHER_IDS.SERVICE_CIVIQUE],
-      // });
+      console.log(`[Grimpio Job] Querying and processing missions of Service Civique`);
+      const scMissionsCursor = getMissionsCursor({
+        publisherIds: [PUBLISHER_IDS.SERVICE_CIVIQUE],
+      });
 
-      // const scJobs = await generateJobs(scMissionsCursor);
-      // console.log(`[Grimpio Job] ${scJobs.processed} Service Civique missions processed, ${scJobs.jobs.length} jobs added to the feed`);
-      // jobs.push(...scJobs.jobs);
-      // result.counter.processed += scJobs.processed;
-      // result.counter.sent += scJobs.jobs.length;
-      // result.counter.expired += scJobs.expired;
+      const scJobs = await generateJobs(scMissionsCursor);
+      console.log(`[Grimpio Job] ${scJobs.processed} Service Civique missions processed, ${scJobs.jobs.length} jobs added to the feed`);
+      jobs.push(...scJobs.jobs);
+      result.counter.processed += scJobs.processed;
+      result.counter.sent += scJobs.jobs.length;
+      result.counter.expired += scJobs.expired;
 
       console.log(`[Grimpio Job] Generating XML for ${jobs.length} jobs`);
       const xml = generateXML(jobs);
@@ -116,6 +116,14 @@ export class GrimpioHandler implements BaseHandler<GrimpioJobPayload, GrimpioJob
       };
     } catch (error) {
       captureException(error);
+      if (error instanceof Error && error.message.includes("Grimpio publisher not found")) {
+        return {
+          success: false,
+          timestamp: new Date(),
+          url: "",
+          counter: { processed: 0, sent: 0, expired: 0 },
+        };
+      }
 
       await importService.createImport({
         name: `GRIMPIO`,


### PR DESCRIPTION
## Description

Active la prise en charge des missions Service Civique dans le job Grimpio (jusqu'ici en attente derrière un TODO) et harmonise la valeur du contract type côté config.

**Changements** :
- `handler.ts` : décommente le bloc qui récupère et traite les missions du publisher Service Civique, et les ajoute au flux Grimpio (en plus des missions JVA déjà gérées).
- `handler.ts` : ajoute un retour propre (success: false, compteurs à 0) lorsqu'on rencontre l'erreur "Grimpio publisher not found" pour éviter d'écrire un échec d'import bruyant.
- `config.ts` : remplace `ASC_CONTRACT_TYPE = "service_civique"` par `"CIVIC_SERVICE"` pour s'aligner sur la valeur attendue par Grimpio.

## Liens utiles

- 📝 Ticket Notion : [lien](https://www.notion.so/jeveuxaider/Diffuser-les-missions-de-Service-Civique-sur-Grimp-io-34c72a322d508017852aeb372ad35377?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- À surveiller au prochain run Grimpio : volume de missions Service Civique injectées et absence de régression sur les missions JVA.
- Vérifier auprès de Grimpio que la valeur `CIVIC_SERVICE` est bien celle attendue côté ATS.