### PR TITLE
fix(api): enrichment failures

### DIFF
--- a/api/src/jobs/update-mission-enrichment/handler.ts
+++ b/api/src/jobs/update-mission-enrichment/handler.ts
@@ -49,7 +49,9 @@ export class UpdateMissionEnrichmentHandler implements BaseHandler<UpdateMission
         } catch (error) {
           failed++;
           console.error(`${LOG_PREFIX} failed to enrich ${mission.id}`, error);
-          captureException(error, { extra: { missionId: mission.id } });
+          if ((error as { name?: string })?.name !== "AI_NoObjectGeneratedError") {
+            captureException(error, { extra: { missionId: mission.id } });
+          }
         }
 
         await sleep(JOB_ENRICH_SLEEP_MS);

--- a/api/src/services/mission-enrichment/config.ts
+++ b/api/src/services/mission-enrichment/config.ts
@@ -1,4 +1,5 @@
 export const CONFIDENCE_THRESHOLD = 0.3;
 export const CURRENT_PROMPT_VERSION = "v2" as const;
 export const LLM_MAX_RETRIES = 5;
+export const LLM_NO_OBJECT_MAX_RETRIES = 3;
 export const JOB_ENRICH_SLEEP_MS = 500;

--- a/api/src/services/mission-enrichment/index.ts
+++ b/api/src/services/mission-enrichment/index.ts
@@ -5,7 +5,7 @@ import { generateObject } from "ai";
 import { missionRepository } from "@/repositories/mission";
 import { missionEnrichmentRepository } from "@/repositories/mission-enrichment";
 import { asyncTaskBus } from "@/services/async-task";
-import { CONFIDENCE_THRESHOLD, CURRENT_PROMPT_VERSION, LLM_MAX_RETRIES } from "./config";
+import { CONFIDENCE_THRESHOLD, CURRENT_PROMPT_VERSION, LLM_MAX_RETRIES, LLM_NO_OBJECT_MAX_RETRIES } from "./config";
 import { validateEnrichmentClassifications, type ClassificationInput, type TaxonomyLookup } from "./parser";
 import { buildMissionBlock, buildTaxonomyBlock, PROMPT_REGISTRY } from "./prompts";
 import type { MissionForPrompt, TaxonomyForPrompt } from "./prompts/types";

--- a/api/src/services/mission-enrichment/index.ts
+++ b/api/src/services/mission-enrichment/index.ts
@@ -174,15 +174,27 @@ export const missionEnrichmentService = {
       const systemPrompt = promptVersion.buildSystemPrompt(buildTaxonomyBlock(toTaxonomyForPrompt(taxonomies)));
       const userMessage = promptVersion.buildUserMessage(buildMissionBlock(toMissionForPrompt(mission)));
 
-      // 7. Call LLM with structured output
-      llmResult = await generateObject({
-        model: promptVersion.MODEL,
-        schema: promptVersion.ENRICHMENT_SCHEMA,
-        system: systemPrompt,
-        prompt: userMessage,
-        maxRetries: LLM_MAX_RETRIES,
-        temperature: promptVersion.TEMPERATURE,
-      });
+      // 7. Call LLM with structured output (retry on AI_NoObjectGeneratedError)
+      for (let attempt = 1; attempt <= LLM_NO_OBJECT_MAX_RETRIES; attempt++) {
+        try {
+          llmResult = await generateObject({
+            model: promptVersion.MODEL,
+            schema: promptVersion.ENRICHMENT_SCHEMA,
+            system: systemPrompt,
+            prompt: userMessage,
+            maxRetries: LLM_MAX_RETRIES,
+            temperature: promptVersion.TEMPERATURE,
+          });
+          break;
+        } catch (error) {
+          const isNoObject = (error as { name?: string })?.name === "AI_NoObjectGeneratedError";
+          if (isNoObject && attempt < LLM_NO_OBJECT_MAX_RETRIES) {
+            console.warn(`${LOG_PREFIX} ${missionId}: AI_NoObjectGeneratedError — retry ${attempt}/${LLM_NO_OBJECT_MAX_RETRIES}`);
+            continue;
+          }
+          throw error;
+        }
+      }
 
       const { inputTokens, outputTokens, totalTokens } = llmResult.usage;
       console.log(`${LOG_PREFIX} ${missionId}: LLM response received — tokens: ${inputTokens} in / ${outputTokens} out / ${totalTokens} total`);

--- a/api/src/services/mission-scoring/index.ts
+++ b/api/src/services/mission-scoring/index.ts
@@ -1,10 +1,10 @@
-import { parseTaxonomyValueKey } from "@engagement/taxonomy";
 import { missionEnrichmentRepository } from "@/repositories/mission-enrichment";
 import { missionScoringRepository } from "@/repositories/mission-scoring";
 import { computeMissionScoringValues } from "@/services/mission-scoring/calculator";
 import { missionScoringEnrichmentInclude, toScoringInputValues } from "@/services/mission-scoring/data";
 import { PUBLISHER_SCORING_RULES } from "@/services/mission-scoring/publisher-rules";
 import type { ComputedMissionScoringValue } from "@/services/mission-scoring/types";
+import { parseTaxonomyValueKey } from "@engagement/taxonomy";
 
 const LOG_PREFIX = "[mission-scoring]";
 
@@ -73,9 +73,7 @@ export const missionScoringService = {
     });
 
     // Merge: start with enrichment values, publisher rules override on same taxonomy key
-    const mergedValuesMap = new Map<string, ComputedMissionScoringValue>(
-      result.values.map((value) => [`${value.taxonomyKey}.${value.valueKey}`, value] as const)
-    );
+    const mergedValuesMap = new Map<string, ComputedMissionScoringValue>(result.values.map((value) => [`${value.taxonomyKey}.${value.valueKey}`, value] as const));
     for (const pv of publisherValues) {
       mergedValuesMap.set(`${pv.taxonomyKey}.${pv.valueKey}`, pv);
     }
@@ -86,16 +84,24 @@ export const missionScoringService = {
       return;
     }
 
-    await missionScoringRepository.replaceForEnrichment({
-      missionId: params.missionId,
-      missionEnrichmentId: enrichmentId,
-      values: allValues.map((value) => ({
-        missionEnrichmentValueId: value.missionEnrichmentValueId,
-        taxonomyKey: value.taxonomyKey,
-        valueKey: value.valueKey,
-        score: value.score,
-      })),
-    });
+    try {
+      await missionScoringRepository.replaceForEnrichment({
+        missionId: params.missionId,
+        missionEnrichmentId: enrichmentId,
+        values: allValues.map((value) => ({
+          missionEnrichmentValueId: value.missionEnrichmentValueId,
+          taxonomyKey: value.taxonomyKey,
+          valueKey: value.valueKey,
+          score: value.score,
+        })),
+      });
+    } catch (error) {
+      if ((error as { code?: string }).code === "P2002") {
+        console.log(`${LOG_PREFIX} skipping mission=${params.missionId} enrichment=${enrichmentId} — lost race to concurrent scorer`);
+        return;
+      }
+      throw error;
+    }
 
     console.log(
       `${LOG_PREFIX} mission=${params.missionId} enrichment=${enrichmentId} completed — ${allValues.length} value(s) persisted (${result.values.length} enrichment + ${publisherValues.length} publisher rules), ${result.ignored.length} ignored`

--- a/api/src/worker/handlers/mission-enrichment.ts
+++ b/api/src/worker/handlers/mission-enrichment.ts
@@ -2,6 +2,14 @@ import { missionEnrichmentService } from "@/services/mission-enrichment";
 
 export const handleMissionEnrichment = async (payload: { missionId: string; force?: boolean }) => {
   console.log(`[mission.enrichment] start missionId=${payload.missionId}`);
-  await missionEnrichmentService.enrich(payload.missionId, { force: payload.force });
+  try {
+    await missionEnrichmentService.enrich(payload.missionId, { force: payload.force });
+  } catch (error) {
+    if ((error as { name?: string })?.name === "AI_NoObjectGeneratedError") {
+      console.warn(`[mission.enrichment] AI_NoObjectGeneratedError missionId=${payload.missionId} — enrichment marked failed, not sent to Sentry`);
+      return;
+    }
+    throw error;
+  }
   console.log(`[mission.enrichment] done missionId=${payload.missionId}`);
 };


### PR DESCRIPTION
## Description

Deux erreurs récurrentes remontaient dans Sentry depuis les jobs/worker d'enrichissement et de scoring des missions.

### 1. `AI_NoObjectGeneratedError` — enrichissement LLM ([Sentry #1973](https://sentry.api-engagement.beta.gouv.fr/organizations/sentry/issues/1973/?referrer=slack&notification_uuid=9cfe5562-18a0-42c9-9cab-b1121200cd07&alert_rule_id=4&alert_type=issue))

Le SDK Vercel AI lève une `AI_NoObjectGeneratedError` quand le LLM répond mais que sa sortie ne respecte pas le schéma Zod attendu. Contrairement aux erreurs réseau, cette erreur n'est **pas** couverte par le `maxRetries` interne de `generateObject()`.

**Fix :**
- Ajout d'une boucle de retry (3 tentatives) autour de `generateObject()` spécifiquement pour ce type d'erreur, dans `missionEnrichmentService.enrich()`.
- Après épuisement des retries, l'enrichissement est bien marqué `failed` en base, mais l'erreur **n'est plus envoyée à Sentry** (ni depuis le worker handler, ni depuis le job batch) — c'est un échec LLM attendu, pas un bug applicatif.

### 2. `PrismaClientKnownRequestError` P2002 — scoring concurrent ([Sentry #1975](https://sentry.api-engagement.beta.gouv.fr/organizations/sentry/issues/1975/?referrer=slack&notification_uuid=81120b49-a0d1-465f-a7a5-181ac676f5fd&alert_rule_id=4&alert_type=issue))

Le job `update-mission-scoring` peut être déclenché en double (relance manuelle, double tick cron). Les deux instances sélectionnent les mêmes enrichissements sans scoring, passent toutes les deux le `findUnique` à null, puis tentent simultanément un INSERT → violation de la contrainte unique `(mission_id, mission_enrichment_id)`.

**Fix :**
- Même pattern que la gestion de race condition dans l'enrichissement : capture du `P2002` autour de `replaceForEnrichment()` dans `missionScoringService.score()`, traité silencieusement comme une victoire de l'instance concurrente.

## Liens utiles

- 🐛 Sentry #1973 — AI_NoObjectGeneratedError : https://sentry.api-engagement.beta.gouv.fr/organizations/sentry/issues/1973/
- 🐛 Sentry #1975 — PrismaClientKnownRequestError P2002 : https://sentry.api-engagement.beta.gouv.fr/organizations/sentry/issues/1975/

## Type de changement

- [x] Correction de bug
- [x] Amélioration de performance

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Les deux fixes sont purement défensifs et idempotents — aucun changement de comportement fonctionnel pour les cas nominaux.