### PR TITLE
fix(jobs): missing trigger receive credentials

### DIFF
--- a/terraform/queues.tf
+++ b/terraform/queues.tf
@@ -27,6 +27,18 @@ resource "scaleway_mnq_sqs_credentials" "async_task_publisher" {
   }
 }
 
+resource "scaleway_mnq_sqs_credentials" "async_task_trigger" {
+  count      = var.enable_async_tasks ? 1 : 0
+  project_id = scaleway_mnq_sqs.main[0].project_id
+  name       = "${var.workspace}-async-task-trigger"
+
+  permissions {
+    can_manage  = false
+    can_receive = true
+    can_publish = false
+  }
+}
+
 locals {
   async_task_queues = {
     mission_enrichment = {


### PR DESCRIPTION
## Description

Il manque au niveau du trigger du container les accès avec la permission `can_receive` pour recevoir des messages venant d'une queue `SQS`

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire