### PR TITLE
feat(app): display mission scoring and admin enrichment

### DIFF
--- a/api/src/controllers/mission.ts
+++ b/api/src/controllers/mission.ts
@@ -4,9 +4,11 @@ import zod from "zod";
 
 import { PUBLISHER_IDS } from "@/config";
 import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
-import { missionService } from "@/services/mission";
-import type { UserRequest } from "@/types/passport";
 import { ipRateLimiter } from "@/middlewares/rate-limit";
+import { missionService } from "@/services/mission";
+import { missionEnrichmentService } from "@/services/mission-enrichment";
+import { missionScoringService } from "@/services/mission-scoring";
+import type { UserRequest } from "@/types/passport";
 import { applyWidgetRules, getDistanceKm } from "@/utils";
 
 const router = Router();
@@ -159,7 +161,7 @@ router.post("/search", passport.authenticate("user", { session: false }), async 
         return data;
       }
 
-      const processingStatuses = await missionService.findMissionAdminProcessingStatuses(data.map((mission) => mission.id));
+      const processingStatuses = await missionEnrichmentService.findAdminProcessingStatuses(data.map((mission) => mission.id));
       return data.map((mission) => ({
         ...mission,
         adminEnrichmentScoringStatus: processingStatuses.get(mission.id) ?? "not_enriched",
@@ -236,7 +238,7 @@ router.get("/:id", passport.authenticate("user", { session: false }), async (req
     }
 
     if (req.user.role === "admin") {
-      const adminData = await missionService.findMissionAdminData(params.data.id);
+      const adminData = await missionEnrichmentService.findAdminData(params.data.id);
       return res.status(200).send({ ok: true, data: { ...data, ...adminData } });
     }
 
@@ -263,7 +265,7 @@ router.post("/:id/enrichment", passport.authenticate("admin", { session: false }
       return res.status(404).send({ ok: false, code: NOT_FOUND });
     }
 
-    await missionService.enqueueMissionEnrichment(params.data.id, { force: true });
+    await missionEnrichmentService.enqueue(params.data.id, { force: true });
     return res.status(200).send({ ok: true });
   } catch (error: any) {
     next(error);
@@ -287,7 +289,7 @@ router.post("/:id/scoring", passport.authenticate("admin", { session: false }), 
       return res.status(404).send({ ok: false, code: NOT_FOUND });
     }
 
-    await missionService.enqueueMissionScoring(params.data.id, { force: true });
+    await missionScoringService.enqueue(params.data.id, { force: true });
     return res.status(200).send({ ok: true });
   } catch (error: any) {
     next(error);

--- a/api/src/controllers/mission.ts
+++ b/api/src/controllers/mission.ts
@@ -35,6 +35,7 @@ const searchSchema = zod.object({
   location: zod.string().optional(),
   distance: zod.string().optional(),
   type: zod.array(zod.string()).optional(),
+  enrichmentScoringStatus: zod.enum(["processed", "enriched_not_scored", "not_enriched", "unprocessed"]).optional(),
   rules: zod
     .array(
       zod.object({
@@ -98,6 +99,10 @@ const findFilters = (user: UserRequest["user"], body: zod.infer<typeof searchSch
     type: body.type,
   };
 
+  if (user.role === "admin" && body.enrichmentScoringStatus) {
+    filters.enrichmentScoringStatus = body.enrichmentScoringStatus;
+  }
+
   if (body.status) {
     filters.statusCode = Array.isArray(body.status) ? (body.status[0] as any) : (body.status as any);
   }
@@ -149,13 +154,26 @@ router.post("/search", passport.authenticate("user", { session: false }), async 
       filters.directFilters = applyWidgetRules(body.data.rules);
     }
 
+    const withAdminProcessingFlags = async (data: Awaited<ReturnType<typeof missionService.findMissions>>["data"]) => {
+      if (req.user.role !== "admin") {
+        return data;
+      }
+
+      const processingStatuses = await missionService.findMissionAdminProcessingStatuses(data.map((mission) => mission.id));
+      return data.map((mission) => ({
+        ...mission,
+        adminEnrichmentScoringStatus: processingStatuses.get(mission.id) ?? "not_enriched",
+        adminHasEnrichmentAndScoring: processingStatuses.get(mission.id) === "processed",
+      }));
+    };
+
     if (body.data.aggs) {
       const { data, total, aggs } = await missionService.findMissionsWithAggregations(filters);
-      return res.status(200).send({ ok: true, data, total, aggs });
-    } else {
-      const { data, total } = await missionService.findMissions(filters);
-      return res.status(200).send({ ok: true, data, total });
+      return res.status(200).send({ ok: true, data: await withAdminProcessingFlags(data), total, aggs });
     }
+
+    const { data, total } = await missionService.findMissions(filters);
+    return res.status(200).send({ ok: true, data: await withAdminProcessingFlags(data), total });
   } catch (error) {
     next(error);
   }
@@ -217,7 +235,60 @@ router.get("/:id", passport.authenticate("user", { session: false }), async (req
       return res.status(404).send({ ok: false, code: NOT_FOUND });
     }
 
+    if (req.user.role === "admin") {
+      const adminData = await missionService.findMissionAdminData(params.data.id);
+      return res.status(200).send({ ok: true, data: { ...data, ...adminData } });
+    }
+
     return res.status(200).send({ ok: true, data });
+  } catch (error: any) {
+    next(error);
+  }
+});
+
+router.post("/:id/enrichment", passport.authenticate("admin", { session: false }), async (req: UserRequest, res: Response, next: NextFunction) => {
+  try {
+    const params = zod
+      .object({
+        id: zod.string(),
+      })
+      .safeParse(req.params);
+
+    if (!params.success) {
+      return res.status(400).send({ ok: false, code: INVALID_PARAMS, message: params.error });
+    }
+
+    const mission = await missionService.findOneMission(params.data.id);
+    if (!mission) {
+      return res.status(404).send({ ok: false, code: NOT_FOUND });
+    }
+
+    await missionService.enqueueMissionEnrichment(params.data.id, { force: true });
+    return res.status(200).send({ ok: true });
+  } catch (error: any) {
+    next(error);
+  }
+});
+
+router.post("/:id/scoring", passport.authenticate("admin", { session: false }), async (req: UserRequest, res: Response, next: NextFunction) => {
+  try {
+    const params = zod
+      .object({
+        id: zod.string(),
+      })
+      .safeParse(req.params);
+
+    if (!params.success) {
+      return res.status(400).send({ ok: false, code: INVALID_PARAMS, message: params.error });
+    }
+
+    const mission = await missionService.findOneMission(params.data.id);
+    if (!mission) {
+      return res.status(404).send({ ok: false, code: NOT_FOUND });
+    }
+
+    await missionService.enqueueMissionScoring(params.data.id, { force: true });
+    return res.status(200).send({ ok: true });
   } catch (error: any) {
     next(error);
   }

--- a/api/src/services/mission-enrichment/index.ts
+++ b/api/src/services/mission-enrichment/index.ts
@@ -1,10 +1,12 @@
 import { Prisma } from "@/db/core";
+import { prisma } from "@/db/postgres";
 import { ENRICHABLE_TAXONOMIES, TAXONOMY } from "@engagement/taxonomy";
 import { generateObject } from "ai";
 
 import { missionRepository } from "@/repositories/mission";
 import { missionEnrichmentRepository } from "@/repositories/mission-enrichment";
 import { asyncTaskBus } from "@/services/async-task";
+import type { MissionRecord, MissionSearchFilters } from "@/types/mission";
 import { CONFIDENCE_THRESHOLD, CURRENT_PROMPT_VERSION, LLM_MAX_RETRIES, LLM_NO_OBJECT_MAX_RETRIES } from "./config";
 import { validateEnrichmentClassifications, type ClassificationInput, type TaxonomyLookup } from "./parser";
 import { buildMissionBlock, buildTaxonomyBlock, PROMPT_REGISTRY } from "./prompts";
@@ -13,6 +15,52 @@ import type { MissionForPrompt, TaxonomyForPrompt } from "./prompts/types";
 const LOG_PREFIX = "[mission-enrichment]";
 
 type TaxonomyWithValues = { key: string; type: string; label: string; values: Array<{ key: string; label: string }> };
+type TaxonomyDefinition = {
+  label: string;
+  values: Record<string, { label: string }>;
+};
+
+const taxonomyByKey = TAXONOMY as Record<string, TaxonomyDefinition>;
+
+const buildAdminTaxonomyValue = (value: { taxonomyKey: string | null; valueKey: string | null }) => {
+  const taxonomy = value.taxonomyKey ? taxonomyByKey[value.taxonomyKey] : undefined;
+  const taxonomyValue = value.valueKey ? taxonomy?.values[value.valueKey] : undefined;
+
+  return {
+    taxonomyKey: value.taxonomyKey,
+    taxonomyLabel: taxonomy?.label ?? value.taxonomyKey,
+    valueKey: value.valueKey,
+    valueLabel: taxonomyValue?.label ?? value.valueKey,
+  };
+};
+
+const extractEnrichmentReason = (evidence: Prisma.JsonValue | null): string | null => {
+  if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) {
+    return null;
+  }
+
+  const reasoning = (evidence as { reasoning?: unknown }).reasoning;
+  return typeof reasoning === "string" && reasoning.trim() ? reasoning : null;
+};
+
+export const buildMissionEnrichmentScoringWhere = (status: NonNullable<MissionSearchFilters["enrichmentScoringStatus"]>): Prisma.MissionWhereInput => {
+  const completedEnrichmentWhere: Prisma.MissionEnrichmentListRelationFilter = { some: { status: "completed" } };
+  const completedScoringWhere: Prisma.MissionScoringListRelationFilter = { some: { missionEnrichment: { status: "completed" } } };
+
+  if (status === "processed") {
+    return { missionScorings: completedScoringWhere };
+  }
+  if (status === "enriched_not_scored") {
+    return {
+      enrichments: completedEnrichmentWhere,
+      missionScorings: { none: completedScoringWhere.some },
+    };
+  }
+  if (status === "not_enriched") {
+    return { enrichments: { none: completedEnrichmentWhere.some } };
+  }
+  return { missionScorings: { none: completedScoringWhere.some } };
+};
 
 const buildTaxonomyLookup = (taxonomies: TaxonomyWithValues[]): TaxonomyLookup => {
   const lookup: TaxonomyLookup = new Map();
@@ -103,6 +151,115 @@ const getTaxonomies = (): TaxonomyWithValues[] =>
   }));
 
 export const missionEnrichmentService = {
+  async enqueue(missionId: string, options: { force?: boolean } = {}): Promise<void> {
+    await asyncTaskBus.publish({ type: "mission.enrichment", payload: { missionId, ...(options.force !== undefined ? { force: options.force } : {}) } });
+  },
+
+  async findAdminData(missionId: string): Promise<Pick<MissionRecord, "adminEnrichment" | "adminScoring">> {
+    const enrichment = await prisma.missionEnrichment.findFirst({
+      where: { missionId, status: "completed" },
+      orderBy: { createdAt: "desc" },
+      include: {
+        values: {
+          orderBy: [{ taxonomyKey: "asc" }, { valueKey: "asc" }],
+        },
+      },
+    });
+
+    if (!enrichment) {
+      return { adminEnrichment: null, adminScoring: null };
+    }
+
+    const scoring = await prisma.missionScoring.findUnique({
+      where: {
+        missionId_missionEnrichmentId: {
+          missionId,
+          missionEnrichmentId: enrichment.id,
+        },
+      },
+      include: {
+        missionScoringValues: {
+          orderBy: [{ taxonomyKey: "asc" }, { valueKey: "asc" }],
+        },
+      },
+    });
+
+    return {
+      adminEnrichment: {
+        id: enrichment.id,
+        promptVersion: enrichment.promptVersion,
+        status: enrichment.status,
+        inputTokens: enrichment.inputTokens,
+        outputTokens: enrichment.outputTokens,
+        totalTokens: enrichment.totalTokens,
+        completedAt: enrichment.completedAt,
+        createdAt: enrichment.createdAt,
+        updatedAt: enrichment.updatedAt,
+        values: enrichment.values.map((value) => ({
+          id: value.id,
+          ...buildAdminTaxonomyValue(value),
+          confidence: value.confidence,
+          reason: extractEnrichmentReason(value.evidence),
+        })),
+      },
+      adminScoring: scoring
+        ? {
+            id: scoring.id,
+            missionEnrichmentId: scoring.missionEnrichmentId,
+            createdAt: scoring.createdAt,
+            updatedAt: scoring.updatedAt,
+            values: scoring.missionScoringValues.map((value) => ({
+              id: value.id,
+              ...buildAdminTaxonomyValue(value),
+              score: value.score,
+              createdAt: value.createdAt,
+              updatedAt: value.updatedAt,
+            })),
+          }
+        : null,
+    };
+  },
+
+  async findAdminProcessingStatuses(missionIds: string[]): Promise<Map<string, NonNullable<MissionRecord["adminEnrichmentScoringStatus"]>>> {
+    if (!missionIds.length) {
+      return new Map();
+    }
+
+    const [enrichments, scorings] = await Promise.all([
+      prisma.missionEnrichment.findMany({
+        where: {
+          missionId: { in: missionIds },
+          status: "completed",
+        },
+        select: { missionId: true },
+        distinct: ["missionId"],
+      }),
+      prisma.missionScoring.findMany({
+        where: {
+          missionId: { in: missionIds },
+          missionEnrichment: { status: "completed" },
+        },
+        select: { missionId: true },
+        distinct: ["missionId"],
+      }),
+    ]);
+
+    const enrichedMissionIds = new Set(enrichments.map((row) => row.missionId));
+    const scoredMissionIds = new Set(scorings.map((row) => row.missionId));
+
+    return new Map(
+      missionIds.map((missionId) => {
+        if (scoredMissionIds.has(missionId)) {
+          return [missionId, "processed"];
+        }
+        if (enrichedMissionIds.has(missionId)) {
+          return [missionId, "enriched_not_scored"];
+        }
+        return [missionId, "not_enriched"];
+      })
+    );
+  },
+
   async enrich(missionId: string, options: { force?: boolean } = {}) {
     // 1. Load mission (needed before idempotence check for updatedAt comparison)
     const mission = await missionRepository.findUnique({
@@ -196,7 +353,9 @@ export const missionEnrichmentService = {
         }
       }
 
-      if (!llmResult) {throw new Error(`${LOG_PREFIX} ${missionId}: no LLM result after retries`);}
+      if (!llmResult) {
+        throw new Error(`${LOG_PREFIX} ${missionId}: no LLM result after retries`);
+      }
 
       const { inputTokens, outputTokens, totalTokens } = llmResult.usage;
       console.log(`${LOG_PREFIX} ${missionId}: LLM response received — tokens: ${inputTokens} in / ${outputTokens} out / ${totalTokens} total`);

--- a/api/src/services/mission-scoring/index.ts
+++ b/api/src/services/mission-scoring/index.ts
@@ -1,5 +1,6 @@
 import { missionEnrichmentRepository } from "@/repositories/mission-enrichment";
 import { missionScoringRepository } from "@/repositories/mission-scoring";
+import { asyncTaskBus } from "@/services/async-task";
 import { computeMissionScoringValues } from "@/services/mission-scoring/calculator";
 import { missionScoringEnrichmentInclude, toScoringInputValues } from "@/services/mission-scoring/data";
 import { PUBLISHER_SCORING_RULES } from "@/services/mission-scoring/publisher-rules";
@@ -18,6 +19,10 @@ const parsePublisherRuleKey = (key: string): { taxonomyKey: string; valueKey: st
 };
 
 export const missionScoringService = {
+  async enqueue(missionId: string, options: { force?: boolean } = {}): Promise<void> {
+    await asyncTaskBus.publish({ type: "mission.scoring", payload: { missionId, ...(options.force !== undefined ? { force: options.force } : {}) } });
+  },
+
   async score(params: { missionId: string; missionEnrichmentId?: string; force?: boolean }) {
     const enrichment = await missionEnrichmentRepository.findFirst({
       where: {

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -4,7 +4,7 @@ import { Mission, Prisma } from "@/db/core";
 import { prisma } from "@/db/postgres";
 import { missionRepository } from "@/repositories/mission";
 import { activityService } from "@/services/activity";
-import { asyncTaskBus } from "@/services/async-task";
+import { buildMissionEnrichmentScoringWhere, missionEnrichmentService } from "@/services/mission-enrichment";
 import type {
   MissionCreateInput,
   MissionFacets,
@@ -19,7 +19,6 @@ import { PublisherOrganizationWithRelations } from "@/types/publisher-organizati
 import { calculateBoundingBox } from "@/utils";
 import { buildJobBoardMap, computeAddressHash, deriveMissionLocation, normalizeMissionAddresses } from "@/utils/mission";
 import { normalizeOptionalString, normalizeStringList } from "@/utils/normalize";
-import { TAXONOMY } from "@engagement/taxonomy";
 import { publisherService } from "./publisher";
 import publisherOrganizationService from "./publisher-organization";
 
@@ -57,34 +56,6 @@ type MissionWithRelations = Mission & {
     updatedAt: Date | null;
     missionAddressId: string | null;
   }>;
-};
-
-type TaxonomyDefinition = {
-  label: string;
-  values: Record<string, { label: string }>;
-};
-
-const taxonomyByKey = TAXONOMY as Record<string, TaxonomyDefinition>;
-
-const buildAdminTaxonomyValue = (value: { taxonomyKey: string | null; valueKey: string | null }) => {
-  const taxonomy = value.taxonomyKey ? taxonomyByKey[value.taxonomyKey] : undefined;
-  const taxonomyValue = value.valueKey ? taxonomy?.values[value.valueKey] : undefined;
-
-  return {
-    taxonomyKey: value.taxonomyKey,
-    taxonomyLabel: taxonomy?.label ?? value.taxonomyKey,
-    valueKey: value.valueKey,
-    valueLabel: taxonomyValue?.label ?? value.valueKey,
-  };
-};
-
-const extractEnrichmentReason = (evidence: Prisma.JsonValue | null): string | null => {
-  if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) {
-    return null;
-  }
-
-  const reasoning = (evidence as { reasoning?: unknown }).reasoning;
-  return typeof reasoning === "string" && reasoning.trim() ? reasoning : null;
 };
 
 const resolveDomainId = async (domainName: string): Promise<string> => {
@@ -386,19 +357,7 @@ export const buildWhere = (filters: MissionSearchFilters): Prisma.MissionWhereIn
   }
 
   if (filters.enrichmentScoringStatus) {
-    const completedEnrichmentWhere: Prisma.MissionEnrichmentListRelationFilter = { some: { status: "completed" } };
-    const completedScoringWhere: Prisma.MissionScoringListRelationFilter = { some: { missionEnrichment: { status: "completed" } } };
-
-    if (filters.enrichmentScoringStatus === "processed") {
-      where.missionScorings = completedScoringWhere;
-    } else if (filters.enrichmentScoringStatus === "enriched_not_scored") {
-      where.enrichments = completedEnrichmentWhere;
-      where.missionScorings = { none: completedScoringWhere.some };
-    } else if (filters.enrichmentScoringStatus === "not_enriched") {
-      where.enrichments = { none: completedEnrichmentWhere.some };
-    } else {
-      where.missionScorings = { none: completedScoringWhere.some };
-    }
+    Object.assign(where, buildMissionEnrichmentScoringWhere(filters.enrichmentScoringStatus));
   }
 
   if (filters.keywords) {
@@ -610,15 +569,7 @@ const baseInclude: MissionInclude = {
 
 export const missionService = {
   async enqueueMissionProcessing(missionId: string): Promise<void> {
-    await this.enqueueMissionEnrichment(missionId);
-  },
-
-  async enqueueMissionEnrichment(missionId: string, options: { force?: boolean } = {}): Promise<void> {
-    await asyncTaskBus.publish({ type: "mission.enrichment", payload: { missionId, ...(options.force !== undefined ? { force: options.force } : {}) } });
-  },
-
-  async enqueueMissionScoring(missionId: string, options: { force?: boolean } = {}): Promise<void> {
-    await asyncTaskBus.publish({ type: "mission.scoring", payload: { missionId, ...(options.force !== undefined ? { force: options.force } : {}) } });
+    await missionEnrichmentService.enqueue(missionId);
   },
 
   async findMissionsByIds(ids: string[]): Promise<MissionRecord[]> {
@@ -642,128 +593,6 @@ export const missionService = {
       include: baseInclude,
     });
     return mission ? toMissionRecord(mission as MissionWithRelations, moderatedBy) : null;
-  },
-
-  async findMissionAdminData(missionId: string): Promise<Pick<MissionRecord, "adminEnrichment" | "adminScoring">> {
-    const enrichment = await prisma.missionEnrichment.findFirst({
-      where: { missionId, status: "completed" },
-      orderBy: { createdAt: "desc" },
-      include: {
-        values: {
-          orderBy: [{ taxonomyKey: "asc" }, { valueKey: "asc" }],
-        },
-      },
-    });
-
-    if (!enrichment) {
-      return { adminEnrichment: null, adminScoring: null };
-    }
-
-    const scoring = await prisma.missionScoring.findUnique({
-      where: {
-        missionId_missionEnrichmentId: {
-          missionId,
-          missionEnrichmentId: enrichment.id,
-        },
-      },
-      include: {
-        missionScoringValues: {
-          orderBy: [{ taxonomyKey: "asc" }, { valueKey: "asc" }],
-        },
-      },
-    });
-
-    return {
-      adminEnrichment: {
-        id: enrichment.id,
-        promptVersion: enrichment.promptVersion,
-        status: enrichment.status,
-        inputTokens: enrichment.inputTokens,
-        outputTokens: enrichment.outputTokens,
-        totalTokens: enrichment.totalTokens,
-        completedAt: enrichment.completedAt,
-        createdAt: enrichment.createdAt,
-        updatedAt: enrichment.updatedAt,
-        values: enrichment.values.map((value) => ({
-          id: value.id,
-          ...buildAdminTaxonomyValue(value),
-          confidence: value.confidence,
-          reason: extractEnrichmentReason(value.evidence),
-        })),
-      },
-      adminScoring: scoring
-        ? {
-            id: scoring.id,
-            missionEnrichmentId: scoring.missionEnrichmentId,
-            createdAt: scoring.createdAt,
-            updatedAt: scoring.updatedAt,
-            values: scoring.missionScoringValues.map((value) => ({
-              id: value.id,
-              ...buildAdminTaxonomyValue(value),
-              score: value.score,
-              createdAt: value.createdAt,
-              updatedAt: value.updatedAt,
-            })),
-          }
-        : null,
-    };
-  },
-
-  async findMissionAdminProcessingStatuses(missionIds: string[]): Promise<Map<string, NonNullable<MissionRecord["adminEnrichmentScoringStatus"]>>> {
-    if (!missionIds.length) {
-      return new Map();
-    }
-
-    const [enrichments, scorings] = await Promise.all([
-      prisma.missionEnrichment.findMany({
-        where: {
-          missionId: { in: missionIds },
-          status: "completed",
-        },
-        select: { missionId: true },
-        distinct: ["missionId"],
-      }),
-      prisma.missionScoring.findMany({
-        where: {
-          missionId: { in: missionIds },
-          missionEnrichment: { status: "completed" },
-        },
-        select: { missionId: true },
-        distinct: ["missionId"],
-      }),
-    ]);
-
-    const enrichedMissionIds = new Set(enrichments.map((row) => row.missionId));
-    const scoredMissionIds = new Set(scorings.map((row) => row.missionId));
-
-    return new Map(
-      missionIds.map((missionId) => {
-        if (scoredMissionIds.has(missionId)) {
-          return [missionId, "processed"];
-        }
-        if (enrichedMissionIds.has(missionId)) {
-          return [missionId, "enriched_not_scored"];
-        }
-        return [missionId, "not_enriched"];
-      }),
-    );
-  },
-
-  async findMissionIdsWithCompletedEnrichmentAndScoring(missionIds: string[]): Promise<Set<string>> {
-    if (!missionIds.length) {
-      return new Set();
-    }
-
-    const rows = await prisma.missionScoring.findMany({
-      where: {
-        missionId: { in: missionIds },
-        missionEnrichment: { status: "completed" },
-      },
-      select: { missionId: true },
-      distinct: ["missionId"],
-    });
-
-    return new Set(rows.map((row) => row.missionId));
   },
 
   async findOneMissionBy(where: Prisma.MissionWhereInput, moderatedBy: string | null = null): Promise<MissionRecord | null> {

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -19,6 +19,7 @@ import { PublisherOrganizationWithRelations } from "@/types/publisher-organizati
 import { calculateBoundingBox } from "@/utils";
 import { buildJobBoardMap, computeAddressHash, deriveMissionLocation, normalizeMissionAddresses } from "@/utils/mission";
 import { normalizeOptionalString, normalizeStringList } from "@/utils/normalize";
+import { TAXONOMY } from "@engagement/taxonomy";
 import { publisherService } from "./publisher";
 import publisherOrganizationService from "./publisher-organization";
 
@@ -56,6 +57,34 @@ type MissionWithRelations = Mission & {
     updatedAt: Date | null;
     missionAddressId: string | null;
   }>;
+};
+
+type TaxonomyDefinition = {
+  label: string;
+  values: Record<string, { label: string }>;
+};
+
+const taxonomyByKey = TAXONOMY as Record<string, TaxonomyDefinition>;
+
+const buildAdminTaxonomyValue = (value: { taxonomyKey: string | null; valueKey: string | null }) => {
+  const taxonomy = value.taxonomyKey ? taxonomyByKey[value.taxonomyKey] : undefined;
+  const taxonomyValue = value.valueKey ? taxonomy?.values[value.valueKey] : undefined;
+
+  return {
+    taxonomyKey: value.taxonomyKey,
+    taxonomyLabel: taxonomy?.label ?? value.taxonomyKey,
+    valueKey: value.valueKey,
+    valueLabel: taxonomyValue?.label ?? value.valueKey,
+  };
+};
+
+const extractEnrichmentReason = (evidence: Prisma.JsonValue | null): string | null => {
+  if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) {
+    return null;
+  }
+
+  const reasoning = (evidence as { reasoning?: unknown }).reasoning;
+  return typeof reasoning === "string" && reasoning.trim() ? reasoning : null;
 };
 
 const resolveDomainId = async (domainName: string): Promise<string> => {
@@ -356,6 +385,22 @@ export const buildWhere = (filters: MissionSearchFilters): Prisma.MissionWhereIn
     where.moderationStatuses = { some: moderationWhere };
   }
 
+  if (filters.enrichmentScoringStatus) {
+    const completedEnrichmentWhere: Prisma.MissionEnrichmentListRelationFilter = { some: { status: "completed" } };
+    const completedScoringWhere: Prisma.MissionScoringListRelationFilter = { some: { missionEnrichment: { status: "completed" } } };
+
+    if (filters.enrichmentScoringStatus === "processed") {
+      where.missionScorings = completedScoringWhere;
+    } else if (filters.enrichmentScoringStatus === "enriched_not_scored") {
+      where.enrichments = completedEnrichmentWhere;
+      where.missionScorings = { none: completedScoringWhere.some };
+    } else if (filters.enrichmentScoringStatus === "not_enriched") {
+      where.enrichments = { none: completedEnrichmentWhere.some };
+    } else {
+      where.missionScorings = { none: completedScoringWhere.some };
+    }
+  }
+
   if (filters.keywords) {
     const keywords = filters.keywords;
     const existingAnd = Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : [];
@@ -565,7 +610,15 @@ const baseInclude: MissionInclude = {
 
 export const missionService = {
   async enqueueMissionProcessing(missionId: string): Promise<void> {
-    await asyncTaskBus.publish({ type: "mission.enrichment", payload: { missionId } });
+    await this.enqueueMissionEnrichment(missionId);
+  },
+
+  async enqueueMissionEnrichment(missionId: string, options: { force?: boolean } = {}): Promise<void> {
+    await asyncTaskBus.publish({ type: "mission.enrichment", payload: { missionId, ...(options.force !== undefined ? { force: options.force } : {}) } });
+  },
+
+  async enqueueMissionScoring(missionId: string, options: { force?: boolean } = {}): Promise<void> {
+    await asyncTaskBus.publish({ type: "mission.scoring", payload: { missionId, ...(options.force !== undefined ? { force: options.force } : {}) } });
   },
 
   async findMissionsByIds(ids: string[]): Promise<MissionRecord[]> {
@@ -589,6 +642,128 @@ export const missionService = {
       include: baseInclude,
     });
     return mission ? toMissionRecord(mission as MissionWithRelations, moderatedBy) : null;
+  },
+
+  async findMissionAdminData(missionId: string): Promise<Pick<MissionRecord, "adminEnrichment" | "adminScoring">> {
+    const enrichment = await prisma.missionEnrichment.findFirst({
+      where: { missionId, status: "completed" },
+      orderBy: { createdAt: "desc" },
+      include: {
+        values: {
+          orderBy: [{ taxonomyKey: "asc" }, { valueKey: "asc" }],
+        },
+      },
+    });
+
+    if (!enrichment) {
+      return { adminEnrichment: null, adminScoring: null };
+    }
+
+    const scoring = await prisma.missionScoring.findUnique({
+      where: {
+        missionId_missionEnrichmentId: {
+          missionId,
+          missionEnrichmentId: enrichment.id,
+        },
+      },
+      include: {
+        missionScoringValues: {
+          orderBy: [{ taxonomyKey: "asc" }, { valueKey: "asc" }],
+        },
+      },
+    });
+
+    return {
+      adminEnrichment: {
+        id: enrichment.id,
+        promptVersion: enrichment.promptVersion,
+        status: enrichment.status,
+        inputTokens: enrichment.inputTokens,
+        outputTokens: enrichment.outputTokens,
+        totalTokens: enrichment.totalTokens,
+        completedAt: enrichment.completedAt,
+        createdAt: enrichment.createdAt,
+        updatedAt: enrichment.updatedAt,
+        values: enrichment.values.map((value) => ({
+          id: value.id,
+          ...buildAdminTaxonomyValue(value),
+          confidence: value.confidence,
+          reason: extractEnrichmentReason(value.evidence),
+        })),
+      },
+      adminScoring: scoring
+        ? {
+            id: scoring.id,
+            missionEnrichmentId: scoring.missionEnrichmentId,
+            createdAt: scoring.createdAt,
+            updatedAt: scoring.updatedAt,
+            values: scoring.missionScoringValues.map((value) => ({
+              id: value.id,
+              ...buildAdminTaxonomyValue(value),
+              score: value.score,
+              createdAt: value.createdAt,
+              updatedAt: value.updatedAt,
+            })),
+          }
+        : null,
+    };
+  },
+
+  async findMissionAdminProcessingStatuses(missionIds: string[]): Promise<Map<string, NonNullable<MissionRecord["adminEnrichmentScoringStatus"]>>> {
+    if (!missionIds.length) {
+      return new Map();
+    }
+
+    const [enrichments, scorings] = await Promise.all([
+      prisma.missionEnrichment.findMany({
+        where: {
+          missionId: { in: missionIds },
+          status: "completed",
+        },
+        select: { missionId: true },
+        distinct: ["missionId"],
+      }),
+      prisma.missionScoring.findMany({
+        where: {
+          missionId: { in: missionIds },
+          missionEnrichment: { status: "completed" },
+        },
+        select: { missionId: true },
+        distinct: ["missionId"],
+      }),
+    ]);
+
+    const enrichedMissionIds = new Set(enrichments.map((row) => row.missionId));
+    const scoredMissionIds = new Set(scorings.map((row) => row.missionId));
+
+    return new Map(
+      missionIds.map((missionId) => {
+        if (scoredMissionIds.has(missionId)) {
+          return [missionId, "processed"];
+        }
+        if (enrichedMissionIds.has(missionId)) {
+          return [missionId, "enriched_not_scored"];
+        }
+        return [missionId, "not_enriched"];
+      }),
+    );
+  },
+
+  async findMissionIdsWithCompletedEnrichmentAndScoring(missionIds: string[]): Promise<Set<string>> {
+    if (!missionIds.length) {
+      return new Set();
+    }
+
+    const rows = await prisma.missionScoring.findMany({
+      where: {
+        missionId: { in: missionIds },
+        missionEnrichment: { status: "completed" },
+      },
+      select: { missionId: true },
+      distinct: ["missionId"],
+    });
+
+    return new Set(rows.map((row) => row.missionId));
   },
 
   async findOneMissionBy(where: Prisma.MissionWhereInput, moderatedBy: string | null = null): Promise<MissionRecord | null> {

--- a/api/src/types/mission.ts
+++ b/api/src/types/mission.ts
@@ -27,6 +27,50 @@ export type MissionAddress = {
   geolocStatus?: string | null;
 };
 
+export type MissionAdminEnrichmentValue = {
+  id: string;
+  taxonomyKey: string | null;
+  taxonomyLabel: string | null;
+  valueKey: string | null;
+  valueLabel: string | null;
+  confidence: number;
+  reason: string | null;
+};
+
+export type MissionAdminEnrichment = {
+  id: string;
+  promptVersion: string;
+  status: string;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  totalTokens: number | null;
+  completedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  values: MissionAdminEnrichmentValue[];
+};
+
+export type MissionAdminScoringValue = {
+  id: string;
+  taxonomyKey: string | null;
+  taxonomyLabel: string | null;
+  valueKey: string | null;
+  valueLabel: string | null;
+  score: number;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type MissionAdminScoring = {
+  id: string;
+  missionEnrichmentId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  values: MissionAdminScoringValue[];
+};
+
+export type MissionAdminEnrichmentScoringStatus = "processed" | "enriched_not_scored" | "not_enriched";
+
 export type MissionFacets = {
   domain: { key: string; count: number }[];
   activity: { key: string; count: number }[];
@@ -134,6 +178,10 @@ export type MissionRecord = {
     Record<JobBoardId, { status: string | null; syncStatus: MissionJobBoardSyncStatus | null; comment: string | null; url: string | null; updatedAt: Date | null }>
   >;
   lastExportedToPgAt: Date | null;
+  adminEnrichment?: MissionAdminEnrichment | null;
+  adminScoring?: MissionAdminScoring | null;
+  adminHasEnrichmentAndScoring?: boolean;
+  adminEnrichmentScoringStatus?: MissionAdminEnrichmentScoringStatus;
   distanceKm?: number;
   createdAt: Date;
   updatedAt: Date;
@@ -183,6 +231,7 @@ export type MissionSearchFilters = {
   limit: number;
   skip: number;
   directFilters?: Prisma.MissionWhereInput;
+  enrichmentScoringStatus?: MissionAdminEnrichmentScoringStatus | "unprocessed";
 };
 
 export type MissionCreateInput = Partial<Omit<MissionRecord, "_id" | "publisherName" | "publisherLogo" | "publisherUrl" | "statusCode">> & {

--- a/app/src/components/Tabs.jsx
+++ b/app/src/components/Tabs.jsx
@@ -104,7 +104,7 @@ const Tabs = ({ tabs, ariaLabel, panelId, className = "", variant = "primary", t
   };
 
   return (
-    <div role="tablist" aria-label={ariaLabel} className={`flex flex-nowrap overflow-x-auto ${className}`}>
+    <div role="tablist" aria-label={ariaLabel} className={`flex flex-nowrap overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${className}`}>
       {tabs.map((tab, index) => (
         <Tab
           key={tab.key}

--- a/app/src/scenes/admin-mission/index.jsx
+++ b/app/src/scenes/admin-mission/index.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { RiCheckboxCircleFill, RiFileDownloadLine, RiInformationLine } from "react-icons/ri";
+import { RiCheckboxCircleFill, RiErrorWarningFill, RiFileDownloadLine, RiInformationLine } from "react-icons/ri";
 import { Link, useSearchParams } from "react-router-dom";
 
 import ErrorIconSvg from "@/assets/svg/error-icon.svg?react";
@@ -21,8 +21,27 @@ const TABLE_HEADER = [
   { title: "Places disponibles", key: "places" },
   { title: "Ville", key: "city.keyword", width: "20%" },
   { title: "Créée le", key: "createdAt" },
+  { title: "Traitement", position: "center" },
   { title: "Statut", key: "statusCode.keyword" },
 ];
+
+const TREATMENT_STATUS_CONFIG = {
+  processed: {
+    Icon: RiCheckboxCircleFill,
+    className: "text-success",
+    label: "Mission enrichie et scorée",
+  },
+  enriched_not_scored: {
+    Icon: RiErrorWarningFill,
+    className: "text-warning",
+    label: "Mission enrichie, scoring manquant",
+  },
+  not_enriched: {
+    Icon: RiErrorWarningFill,
+    className: "text-warning",
+    label: "Mission non enrichie, scoring manquant",
+  },
+};
 
 const AdminMission = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -37,6 +56,7 @@ const AdminMission = () => {
     department: searchParams.get("department") || null,
     city: searchParams.get("city") || null,
     organization: searchParams.get("organization") || null,
+    enrichmentScoringStatus: searchParams.get("enrichmentScoringStatus") || null,
     search: searchParams.get("search") || "",
   });
   const [options, setOptions] = useState({
@@ -191,6 +211,16 @@ const AdminMission = () => {
             onChange={(e) => setFilters({ ...filters, organization: e.value })}
             placeholder="Organisation"
           />
+          <Select
+            options={[
+              { value: "processed", label: "Enrichies + scorées" },
+              { value: "enriched_not_scored", label: "Enrichies non scorées" },
+              { value: "not_enriched", label: "Non enrichies" },
+            ]}
+            value={filters.enrichmentScoringStatus}
+            onChange={(e) => setFilters({ ...filters, enrichmentScoringStatus: e.value })}
+            placeholder="Traitement"
+          />
         </div>
       </div>
 
@@ -237,6 +267,22 @@ const AdminMission = () => {
               <td className="px-4">{item.places}</td>
               <td className="px-4">{item.city}</td>
               <td className="px-4">{new Date(item.createdAt).toLocaleDateString("fr")}</td>
+              <td className="px-4 text-center">
+                {(() => {
+                  const treatmentStatus = TREATMENT_STATUS_CONFIG[item.adminEnrichmentScoringStatus] ?? TREATMENT_STATUS_CONFIG.not_enriched;
+                  const TreatmentIcon = treatmentStatus.Icon;
+                  return (
+                    <Tooltip
+                      ariaLabel={treatmentStatus.label}
+                      triggerClassName={`${treatmentStatus.className} inline-flex justify-center`}
+                      tooltipClassName="border-grey-border border bg-white p-4 text-sm shadow-lg"
+                      content={treatmentStatus.label}
+                    >
+                      <TreatmentIcon role="img" aria-label={treatmentStatus.label} className={`${treatmentStatus.className} text-2xl`} />
+                    </Tooltip>
+                  );
+                })()}
+              </td>
               <td className="px-6">
                 <div className="flex items-center gap-1">
                   {item.statusCode === "ACCEPTED" ? (

--- a/app/src/scenes/mission/View.jsx
+++ b/app/src/scenes/mission/View.jsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from "react";
 import { HiCheckCircle, HiClock, HiLocationMarker, HiXCircle } from "react-icons/hi";
-import { RiCursorFill } from "react-icons/ri";
+import { RiCursorFill, RiInformationLine } from "react-icons/ri";
 import { useParams } from "react-router-dom";
 
+import Tabs from "@/components/Tabs";
 import Tooltip from "@/components/Tooltip";
 import api from "@/services/api";
 import { captureError } from "@/services/error";
+import useStore from "@/services/store";
+import { toast } from "@/services/toast";
 
 const ADDRESSES_PREVIEW_COUNT = 5;
 
@@ -20,6 +23,37 @@ const GEOLOC_STATUS_CONFIG = {
 
 const DEFAULT_GEOLOC_CONFIG = { Icon: HiClock, className: "text-orange-500", label: "Statut inconnu" };
 
+const formatDateTime = (date) => (date ? new Date(date).toLocaleString("fr").replace(" ", " à ") : "N/A");
+
+const formatScore = (value) => (typeof value === "number" ? value.toLocaleString("fr", { maximumFractionDigits: 2 }) : "N/A");
+
+const formatConfidence = (value) =>
+  typeof value === "number" ? `${(value * 100).toLocaleString("fr", { maximumFractionDigits: 0 })} %` : "N/A";
+
+const AdminDataTable = ({ caption, emptyMessage, headers, rows, renderRow }) => {
+  if (!rows?.length) {
+    return <p className="text-text-mention text-sm">{emptyMessage}</p>;
+  }
+
+  return (
+    <div className="border-grey-border overflow-x-auto border">
+      <table className="w-full min-w-[720px] text-left text-sm">
+        <caption className="sr-only">{caption}</caption>
+        <thead className="bg-gray-950 text-xs font-semibold uppercase">
+          <tr>
+            {headers.map((header) => (
+              <th key={header} scope="col" className="px-4 py-3">
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{rows.map(renderRow)}</tbody>
+      </table>
+    </div>
+  );
+};
+
 const AddressStatus = ({ geolocStatus }) => {
   const config = GEOLOC_STATUS_CONFIG[geolocStatus] ?? DEFAULT_GEOLOC_CONFIG;
   return (
@@ -31,8 +65,10 @@ const AddressStatus = ({ geolocStatus }) => {
 
 const View = () => {
   const { id } = useParams();
+  const { user } = useStore();
   const [mission, setMission] = useState(null);
-  const [showRaw, setShowRaw] = useState(false);
+  const [activeTechnicalTab, setActiveTechnicalTab] = useState("enrichment");
+  const [triggeringTask, setTriggeringTask] = useState(null);
   const [showAllAddresses, setShowAllAddresses] = useState(false);
 
   useEffect(() => {
@@ -55,12 +91,45 @@ const View = () => {
     return mission.applicationUrl;
   };
 
+  const handleTriggerTask = async (task) => {
+    setTriggeringTask(task);
+    try {
+      const res = await api.post(`/mission/${id}/${task}`, {});
+      if (!res.ok) {
+        throw res;
+      }
+      toast.success(task === "enrichment" ? "Enrichissement relancé. Rafraîchissez dans quelques secondes." : "Scoring relancé. Rafraîchissez dans quelques secondes.");
+    } catch (error) {
+      captureError(error, { message: task === "enrichment" ? "Erreur lors de la relance de l'enrichissement" : "Erreur lors de la relance du scoring", extra: { id, task } });
+    }
+    setTriggeringTask(null);
+  };
+
   if (!mission) return <p className="p-3">Chargement...</p>;
 
   const addresses = mission.addresses ?? [];
   const isMultiAddress = addresses.length > 1;
   const visibleAddresses = showAllAddresses ? addresses : addresses.slice(0, ADDRESSES_PREVIEW_COUNT);
   const hiddenCount = addresses.length - ADDRESSES_PREVIEW_COUNT;
+  const isAdmin = user?.role === "admin";
+  const rawMission = Object.fromEntries(Object.entries(mission).filter(([key]) => !["adminEnrichment", "adminScoring"].includes(key)));
+  const selectedTechnicalTabKey = isAdmin ? activeTechnicalTab : "raw";
+  const technicalTabs = [
+    ...(isAdmin
+      ? [
+          { key: "enrichment", label: "🧠 Enrichissement" },
+          { key: "scoring", label: "🎯 Scoring" },
+        ]
+      : []),
+    { key: "raw", label: "🧾 Données brutes" },
+  ].map((tab) => ({
+    ...tab,
+    id: `mission-technical-tab-${tab.key}`,
+    isActive: selectedTechnicalTabKey === tab.key,
+    onSelect: () => setActiveTechnicalTab(tab.key),
+  }));
+  const activeTechnicalTabConfig = technicalTabs.find((tab) => tab.isActive) ?? technicalTabs[0];
+  const technicalTabKey = activeTechnicalTabConfig?.key ?? "raw";
 
   return (
     <div className="space-y-12">
@@ -116,16 +185,16 @@ const View = () => {
           </a>
         </div>
 
-        <div className="border-grey-border flex flex-col gap-4 border p-4 sm:flex-row sm:p-6">
-          <div className="flex-1">
+        <div className="border-grey-border grid grid-cols-1 gap-4 border p-4 lg:grid-cols-[minmax(0,2fr)_1px_minmax(280px,1fr)] lg:p-6">
+          <div className="min-w-0">
             <p className="text-xl font-semibold">Presentation de la mission</p>
             <div
               className="mt-2 max-h-96 overflow-y-scroll text-xs leading-relaxed"
               dangerouslySetInnerHTML={{ __html: `<p>${mission.description.replace(/\n/g, "</p><p>")}</p>` }}
             />
           </div>
-          <div className="hidden w-px bg-gray-900 sm:block" />
-          <div className="border-t border-gray-900 pt-4 sm:border-t-0 sm:pt-0">
+          <div className="hidden w-px bg-gray-900 lg:block" />
+          <div className="min-w-0 border-t border-gray-900 pt-4 lg:border-t-0 lg:pt-0">
             <div className="mb-4 space-y-2">
               <p className="text-xl font-semibold">Domaine de la mission</p>
               <span className="inline-block rounded-full bg-gray-950 px-3 py-2">{mission.domain}</span>
@@ -134,7 +203,7 @@ const View = () => {
               <p className="text-text-mention text-xs font-semibold uppercase">Activités</p>
               <div className="flex flex-wrap gap-2">
                 {(mission.activities || []).map((activity, index) => (
-                  <span key={index} className="rounded bg-purple-300 px-3 py-1 text-xs font-semibold text-purple-950 uppercase">
+                  <span key={index} className="max-w-full rounded bg-purple-300 px-3 py-1 text-xs font-semibold break-words text-purple-950 uppercase">
                     {activity}
                   </span>
                 ))}
@@ -144,7 +213,7 @@ const View = () => {
               <p className="text-text-mention text-xs font-semibold uppercase">Compétences</p>
               <div className="flex flex-wrap gap-2">
                 {(mission.softSkills || []).map((skill, index) => (
-                  <span key={index} className="bg-yellow-tournesol-950 text-yellow-tournesol-200 rounded px-3 py-1 text-xs font-semibold uppercase">
+                  <span key={index} className="bg-yellow-tournesol-950 text-yellow-tournesol-200 max-w-full rounded px-3 py-1 text-xs font-semibold break-words uppercase">
                     {skill}
                   </span>
                 ))}
@@ -177,16 +246,120 @@ const View = () => {
         </div>
 
         <div className="mt-6">
-          <button className="tertiary-btn" onClick={() => setShowRaw(!showRaw)}>
-            Données brutes
-          </button>
-        </div>
+          <h3 className="mb-4 text-2xl font-bold">Données techniques</h3>
+          <Tabs
+            tabs={technicalTabs}
+            ariaLabel="Données techniques de la mission"
+            panelId="mission-technical-panel"
+            className="flex items-center gap-4 pl-4 font-semibold text-black"
+            variant="primary"
+            tabClassName="cursor-pointer"
+          />
 
-        {showRaw && (
-          <div className="border-grey-border mt-6 overflow-scroll border p-6 text-xs">
-            <pre>{JSON.stringify(mission, null, 2)}</pre>
-          </div>
-        )}
+          <section id="mission-technical-panel" role="tabpanel" aria-labelledby={activeTechnicalTabConfig?.id} className="border-grey-border space-y-4 border p-6">
+            {isAdmin && technicalTabKey === "enrichment" && (
+              <>
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div>
+                    <h4 className="text-xl font-semibold">Données d&apos;enrichissement</h4>
+                    {mission.adminEnrichment ? (
+                      <p className="text-text-mention mt-1 text-sm">
+                        Version {mission.adminEnrichment.promptVersion} · Statut {mission.adminEnrichment.status} · Complété le{" "}
+                        {formatDateTime(mission.adminEnrichment.completedAt)}
+                      </p>
+                    ) : (
+                      <p className="text-text-mention mt-1 text-sm">Aucun enrichissement complété.</p>
+                    )}
+                  </div>
+                  <button className="secondary-btn shrink-0" type="button" disabled={triggeringTask !== null} onClick={() => handleTriggerTask("enrichment")}>
+                    🧠 Relancer l&apos;enrichment
+                  </button>
+                </div>
+                {mission.adminEnrichment && (
+                  <AdminDataTable
+                    caption="Valeurs d'enrichissement"
+                    emptyMessage="Aucune valeur d'enrichissement."
+                    headers={["Taxonomie", "Valeur", "Confiance"]}
+                    rows={mission.adminEnrichment.values}
+                    renderRow={(value) => (
+                      <tr key={value.id} className="border-grey-border border-t">
+                        <td className="px-4 py-3">
+                          <p className="font-medium">{value.taxonomyLabel}</p>
+                          <p className="text-text-mention text-xs">{value.taxonomyKey}</p>
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-1.5">
+                            <p>{value.valueLabel}</p>
+                            {value.reason && (
+                              <Tooltip
+                                ariaLabel="Voir la raison de classification"
+                                triggerClassName="text-text-mention inline-flex"
+                                tooltipClassName="border-grey-border z-50 max-w-sm border bg-white p-4 text-sm shadow-lg"
+                                content={value.reason}
+                              >
+                                <RiInformationLine className="text-lg" aria-hidden="true" />
+                              </Tooltip>
+                            )}
+                          </div>
+                          <p className="text-text-mention text-xs">{value.valueKey}</p>
+                        </td>
+                        <td className="px-4 py-3">{formatConfidence(value.confidence)}</td>
+                      </tr>
+                    )}
+                  />
+                )}
+              </>
+            )}
+
+            {isAdmin && technicalTabKey === "scoring" && (
+              <>
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div>
+                    <h4 className="text-xl font-semibold">Données de scoring</h4>
+                    {mission.adminScoring ? (
+                      <p className="text-text-mention mt-1 text-sm">
+                        Créé le {formatDateTime(mission.adminScoring.createdAt)} · Mis à jour le {formatDateTime(mission.adminScoring.updatedAt)}
+                      </p>
+                    ) : (
+                      <p className="text-text-mention mt-1 text-sm">Aucun scoring associé au dernier enrichissement complété.</p>
+                    )}
+                  </div>
+                  <button className="secondary-btn shrink-0" type="button" disabled={triggeringTask !== null} onClick={() => handleTriggerTask("scoring")}>
+                    🎯 Relancer le scoring
+                  </button>
+                </div>
+                {mission.adminScoring && (
+                  <AdminDataTable
+                    caption="Valeurs de scoring"
+                    emptyMessage="Aucune valeur de scoring."
+                    headers={["Taxonomie", "Valeur", "Score", "Mis à jour le"]}
+                    rows={mission.adminScoring.values}
+                    renderRow={(value) => (
+                      <tr key={value.id} className="border-grey-border border-t">
+                        <td className="px-4 py-3">
+                          <p className="font-medium">{value.taxonomyLabel}</p>
+                          <p className="text-text-mention text-xs">{value.taxonomyKey}</p>
+                        </td>
+                        <td className="px-4 py-3">
+                          <p>{value.valueLabel}</p>
+                          <p className="text-text-mention text-xs">{value.valueKey}</p>
+                        </td>
+                        <td className="px-4 py-3">{formatScore(value.score)}</td>
+                        <td className="px-4 py-3">{formatDateTime(value.updatedAt)}</td>
+                      </tr>
+                    )}
+                  />
+                )}
+              </>
+            )}
+
+            {technicalTabKey === "raw" && (
+              <div className="overflow-scroll text-xs">
+                <pre>{JSON.stringify(rawMission, null, 2)}</pre>
+              </div>
+            )}
+          </section>
+        </div>
       </div>
     </div>
   );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       - /workspace/app/node_modules
     ports:
       - "3000:3000"
+    command: ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
 
   widget:
     build:

--- a/widget/next.config.js
+++ b/widget/next.config.js
@@ -1,4 +1,3 @@
-const path = require("path");
 const { withSentryConfig } = require("@sentry/nextjs");
 const { withPlausibleProxy } = require("next-plausible");
 
@@ -16,7 +15,7 @@ const nextConfig = {
     ],
   },
   turbopack: {
-    root: path.resolve(__dirname, ".."),
+    root: __dirname,
   },
 };
 

--- a/widget/next.config.js
+++ b/widget/next.config.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const { withSentryConfig } = require("@sentry/nextjs");
 const { withPlausibleProxy } = require("next-plausible");
 
@@ -15,7 +16,7 @@ const nextConfig = {
     ],
   },
   turbopack: {
-    root: __dirname,
+    root: path.resolve(__dirname, ".."),
   },
 };
 


### PR DESCRIPTION
## Description

Cette Pull Request ajoute l'affichage admin des données d'enrichissement et de scoring sur la page de détail d'une mission.

Côté API, `GET /mission/:id` expose désormais, uniquement pour les admins, le dernier enrichissement `completed` et le scoring associé. Les données sont mappées dans un format lisible avec labels de taxonomie, valeurs, confiance, scores et dates utiles, sans exposer les réponses brutes LLM ni les preuves JSON complètes.

Côté back-office, la section `Données techniques` devient une section à onglets avec :
- les données d'enrichissement, incluant la reason en tooltip sur la valeur ;
- les données de scoring ;
- les données brutes, sans les nouveaux champs admin.

La liste admin des missions affiche aussi un indicateur de traitement et un filtre dédié pour distinguer les missions enrichies + scorées, enrichies non scorées et non enrichies. Les admins peuvent également relancer manuellement l'enrichissement ou le scoring depuis les sections dédiées ; les endpoints publient un message sur le bus pour traitement asynchrone.

<img width="1190" height="1194" alt="image" src="https://github.com/user-attachments/assets/4bd7d3ee-e70b-418a-a578-b27197dc1d18" />

## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Visualisation-des-donn-es-enrichies-de-mission-33d72a322d50804cb642f2733e69a147?source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Vérification API : `npx tsc -p tsconfig.build.json --noEmit --ignoreDeprecations 5.0` OK.
- Pas de test ajouté dans le scope de cette PR pour ces endpoints admin peu critiques.
- Pas de migration de données nécessaire.
- La PR contient aussi deux ajustements locaux connexes : commande `app` dans `docker-compose.yml` pour exposer le serveur Vite, et correction du `turbopack.root` côté widget.