### PR TITLE
feat(analytics): plateforme Engagement pipeline

### DIFF
--- a/analytics/db/migrations/20260505074828_add_plateforme_engagement_schema.sql.sql
+++ b/analytics/db/migrations/20260505074828_add_plateforme_engagement_schema.sql.sql
@@ -1,0 +1,79 @@
+-- migrate:up
+CREATE TABLE IF NOT EXISTS "analytics_raw"."user_scoring" (
+  "id" TEXT PRIMARY KEY,
+  "distinct_id" TEXT,
+  "mission_alert_enabled" BOOLEAN NOT NULL DEFAULT false,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expires_at" TIMESTAMP(3),
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "analytics_raw"."user_scoring_value" (
+  "id" TEXT PRIMARY KEY,
+  "user_scoring_id" TEXT NOT NULL,
+  "taxonomy_key" TEXT,
+  "value_key" TEXT,
+  "score" DOUBLE PRECISION NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "analytics_raw"."matching_engine_result" (
+  "id" TEXT PRIMARY KEY,
+  "user_scoring_id" TEXT NOT NULL,
+  "matching_engine_version" TEXT NOT NULL,
+  "results" JSONB NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "analytics_raw"."mission_enrichment" (
+  "id" TEXT PRIMARY KEY,
+  "mission_id" TEXT NOT NULL,
+  "status" TEXT NOT NULL,
+  "prompt_version" TEXT NOT NULL,
+  "input_tokens" INTEGER,
+  "output_tokens" INTEGER,
+  "total_tokens" INTEGER,
+  "completed_at" TIMESTAMP(3),
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "analytics_raw"."mission_enrichment_value" (
+  "id" TEXT PRIMARY KEY,
+  "enrichment_id" TEXT NOT NULL,
+  "taxonomy_key" TEXT,
+  "value_key" TEXT,
+  "confidence" DOUBLE PRECISION NOT NULL,
+  "evidence" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "analytics_raw"."mission_scoring" (
+  "id" TEXT PRIMARY KEY,
+  "mission_id" TEXT NOT NULL,
+  "mission_enrichment_id" TEXT NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS "analytics_raw"."mission_scoring_value" (
+  "id" TEXT PRIMARY KEY,
+  "mission_scoring_id" TEXT NOT NULL,
+  "mission_enrichment_value_id" TEXT,
+  "taxonomy_key" TEXT,
+  "value_key" TEXT,
+  "score" DOUBLE PRECISION NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- migrate:down
+DROP TABLE IF EXISTS "analytics_raw"."mission_scoring_value";
+DROP TABLE IF EXISTS "analytics_raw"."mission_scoring";
+DROP TABLE IF EXISTS "analytics_raw"."mission_enrichment_value";
+DROP TABLE IF EXISTS "analytics_raw"."mission_enrichment";
+DROP TABLE IF EXISTS "analytics_raw"."matching_engine_result";
+DROP TABLE IF EXISTS "analytics_raw"."user_scoring_value";
+DROP TABLE IF EXISTS "analytics_raw"."user_scoring";

--- a/analytics/dbt/analytics/models/marts/mission/__models.yml
+++ b/analytics/dbt/analytics/models/marts/mission/__models.yml
@@ -537,6 +537,188 @@ models:
         description: Date de dernière mise à jour (curseur incrémental).
         tests:
           - not_null
+  - name: matching_engine_result
+    description: >
+      Vue d'exposition des résultats persistés du moteur de matching, dérivée de `stg_matching_engine_result`. Chaque
+      ligne conserve le résultat JSON calculé pour un scoring utilisateur et une version donnée de l'algorithme.
+    columns:
+      - name: id
+        description: Identifiant unique du résultat de matching.
+        tests:
+          - not_null
+          - unique
+      - name: user_scoring_id
+        description: Identifiant du scoring utilisateur utilisé comme entrée du matching.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('user_scoring')
+                field: id
+      - name: matching_engine_version
+        description: Version du moteur de matching ayant produit le résultat.
+        tests:
+          - not_null
+      - name: results
+        description: Résultats détaillés du matching au format JSON.
+        tests:
+          - not_null
+      - name: created_at
+        description: Timestamp de création du résultat.
+        tests:
+          - not_null
+  - name: mission_enrichment
+    description: >
+      Vue d'exposition des enrichissements de mission, dérivée de `stg_mission_enrichment`. Chaque ligne représente une
+      tentative d'enrichissement pour une mission et une version de prompt.
+    columns:
+      - name: id
+        description: Identifiant unique de l'enrichissement.
+        tests:
+          - not_null
+          - unique
+      - name: mission_id
+        description: Identifiant de la mission enrichie.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('mission')
+                field: id
+      - name: status
+        description: Statut de l'enrichissement (`pending`, `processing`, `completed`, `failed`).
+        tests:
+          - not_null
+      - name: prompt_version
+        description: Version du prompt utilisée pour produire l'enrichissement.
+        tests:
+          - not_null
+      - name: input_tokens
+        description: Nombre de tokens d'entrée consommés, si disponible.
+      - name: output_tokens
+        description: Nombre de tokens de sortie produits, si disponible.
+      - name: total_tokens
+        description: Nombre total de tokens consommés, si disponible.
+      - name: completed_at
+        description: Timestamp de fin de traitement lorsque l'enrichissement est terminé.
+      - name: created_at
+        description: Timestamp de création de l'enrichissement.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Timestamp de dernière mise à jour de l'enrichissement.
+        tests:
+          - not_null
+  - name: mission_enrichment_value
+    description: >
+      Vue d'exposition des valeurs extraites lors de l'enrichissement des missions, dérivée de
+      `stg_mission_enrichment_value`.
+    columns:
+      - name: id
+        description: Identifiant unique de la valeur d'enrichissement.
+        tests:
+          - not_null
+          - unique
+      - name: enrichment_id
+        description: Identifiant de l'enrichissement parent.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('mission_enrichment')
+                field: id
+      - name: taxonomy_key
+        description: Clé de la taxonomie détectée.
+      - name: value_key
+        description: Clé de la valeur de taxonomie détectée.
+      - name: confidence
+        description: Score de confiance associé à la valeur détectée.
+        tests:
+          - not_null
+      - name: evidence
+        description: Éléments de preuve ou justification de l'enrichissement au format JSON.
+      - name: created_at
+        description: Timestamp de création de la valeur d'enrichissement.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Timestamp de dernière mise à jour de la valeur d'enrichissement.
+        tests:
+          - not_null
+  - name: mission_scoring
+    description: >
+      Vue d'exposition des scorings de mission, dérivée de `stg_mission_scoring`. Chaque ligne relie une mission à
+      l'enrichissement utilisé pour calculer ses valeurs de scoring.
+    columns:
+      - name: id
+        description: Identifiant unique du scoring de mission.
+        tests:
+          - not_null
+          - unique
+      - name: mission_id
+        description: Identifiant de la mission scorée.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('mission')
+                field: id
+      - name: mission_enrichment_id
+        description: Identifiant de l'enrichissement utilisé comme base du scoring.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('mission_enrichment')
+                field: id
+      - name: created_at
+        description: Timestamp de création du scoring de mission.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Timestamp de dernière mise à jour du scoring de mission.
+        tests:
+          - not_null
+  - name: mission_scoring_value
+    description: >
+      Vue d'exposition des valeurs de scoring des missions par taxonomie, dérivée de `stg_mission_scoring_value`.
+    columns:
+      - name: id
+        description: Identifiant unique de la valeur de scoring mission.
+        tests:
+          - not_null
+          - unique
+      - name: mission_scoring_id
+        description: Identifiant du scoring de mission parent.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('mission_scoring')
+                field: id
+      - name: mission_enrichment_value_id
+        description: Identifiant de la valeur d'enrichissement ayant servi au scoring, si applicable.
+        tests:
+          - relationships:
+              arguments:
+                to: ref('mission_enrichment_value')
+                field: id
+      - name: taxonomy_key
+        description: Clé de la taxonomie scorée.
+      - name: value_key
+        description: Clé de la valeur de taxonomie scorée.
+      - name: score
+        description: Score de mission calculé pour cette valeur de taxonomie.
+        tests:
+          - not_null
+      - name: created_at
+        description: Timestamp de création de la valeur de scoring.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Timestamp de dernière mise à jour de la valeur de scoring.
+        tests:
+          - not_null
   - name: mission_moderation_status
     description: >
       Mart des statuts de modération par mission. Le modèle expose l'historique

--- a/analytics/dbt/analytics/models/marts/mission/matching_engine_result.sql
+++ b/analytics/dbt/analytics/models/marts/mission/matching_engine_result.sql
@@ -1,0 +1,9 @@
+{{ config(materialized = 'view') }}
+
+select
+  id,
+  user_scoring_id,
+  matching_engine_version,
+  results,
+  created_at
+from {{ ref('stg_matching_engine_result') }}

--- a/analytics/dbt/analytics/models/marts/mission/mission_enrichment.sql
+++ b/analytics/dbt/analytics/models/marts/mission/mission_enrichment.sql
@@ -1,0 +1,14 @@
+{{ config(materialized = 'view') }}
+
+select
+  id,
+  mission_id,
+  status,
+  prompt_version,
+  input_tokens,
+  output_tokens,
+  total_tokens,
+  completed_at,
+  created_at,
+  updated_at
+from {{ ref('stg_mission_enrichment') }}

--- a/analytics/dbt/analytics/models/marts/mission/mission_enrichment_value.sql
+++ b/analytics/dbt/analytics/models/marts/mission/mission_enrichment_value.sql
@@ -1,0 +1,12 @@
+{{ config(materialized = 'view') }}
+
+select
+  id,
+  enrichment_id,
+  taxonomy_key,
+  value_key,
+  confidence,
+  evidence,
+  created_at,
+  updated_at
+from {{ ref('stg_mission_enrichment_value') }}

--- a/analytics/dbt/analytics/models/marts/mission/mission_scoring.sql
+++ b/analytics/dbt/analytics/models/marts/mission/mission_scoring.sql
@@ -1,0 +1,9 @@
+{{ config(materialized = 'view') }}
+
+select
+  id,
+  mission_id,
+  mission_enrichment_id,
+  created_at,
+  updated_at
+from {{ ref('stg_mission_scoring') }}

--- a/analytics/dbt/analytics/models/marts/mission/mission_scoring_value.sql
+++ b/analytics/dbt/analytics/models/marts/mission/mission_scoring_value.sql
@@ -1,0 +1,12 @@
+{{ config(materialized = 'view') }}
+
+select
+  id,
+  mission_scoring_id,
+  mission_enrichment_value_id,
+  taxonomy_key,
+  value_key,
+  score,
+  created_at,
+  updated_at
+from {{ ref('stg_mission_scoring_value') }}

--- a/analytics/dbt/analytics/models/marts/user/__models.yml
+++ b/analytics/dbt/analytics/models/marts/user/__models.yml
@@ -78,3 +78,62 @@ models:
         description: Timestamp de la connexion rapportée par l'application.
         tests:
           - not_null
+  - name: user_scoring
+    description: >
+      Vue d'exposition des scorings utilisateur, dérivée de `stg_user_scoring`. Chaque ligne représente une demande de
+      scoring utilisateur avec son état d'alerte mission et ses dates de validité.
+    columns:
+      - name: id
+        description: Identifiant unique du scoring utilisateur.
+        tests:
+          - not_null
+          - unique
+      - name: distinct_id
+        description: Identifiant anonyme ou technique permettant de rattacher plusieurs interactions utilisateur.
+      - name: mission_alert_enabled
+        description: Indique si l'utilisateur a activé l'alerte mission associée à ce scoring.
+        tests:
+          - not_null
+      - name: created_at
+        description: Timestamp de création du scoring utilisateur.
+        tests:
+          - not_null
+      - name: expires_at
+        description: Timestamp d'expiration du scoring, si une limite de validité est définie.
+      - name: updated_at
+        description: Timestamp de dernière mise à jour du scoring utilisateur.
+        tests:
+          - not_null
+  - name: user_scoring_value
+    description: >
+      Vue d'exposition des scores utilisateur par valeur de taxonomie, dérivée de `stg_user_scoring_value`.
+    columns:
+      - name: id
+        description: Identifiant unique de la valeur de scoring utilisateur.
+        tests:
+          - not_null
+          - unique
+      - name: user_scoring_id
+        description: Identifiant du scoring utilisateur parent.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('user_scoring')
+                field: id
+      - name: taxonomy_key
+        description: Clé de la taxonomie utilisée pour qualifier le scoring.
+      - name: value_key
+        description: Clé de la valeur de taxonomie scorée.
+      - name: score
+        description: Score utilisateur calculé pour cette valeur de taxonomie.
+        tests:
+          - not_null
+      - name: created_at
+        description: Timestamp de création de la valeur de scoring.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Timestamp de dernière mise à jour de la valeur de scoring.
+        tests:
+          - not_null

--- a/analytics/dbt/analytics/models/marts/user/user_scoring.sql
+++ b/analytics/dbt/analytics/models/marts/user/user_scoring.sql
@@ -1,0 +1,10 @@
+{{ config(materialized = 'view') }}
+
+select
+  id,
+  distinct_id,
+  mission_alert_enabled,
+  created_at,
+  expires_at,
+  updated_at
+from {{ ref('stg_user_scoring') }}

--- a/analytics/dbt/analytics/models/marts/user/user_scoring_value.sql
+++ b/analytics/dbt/analytics/models/marts/user/user_scoring_value.sql
@@ -1,0 +1,11 @@
+{{ config(materialized = 'view') }}
+
+select
+  id,
+  user_scoring_id,
+  taxonomy_key,
+  value_key,
+  score,
+  created_at,
+  updated_at
+from {{ ref('stg_user_scoring_value') }}

--- a/analytics/dbt/analytics/models/raw.yml
+++ b/analytics/dbt/analytics/models/raw.yml
@@ -698,3 +698,136 @@ sources:
             description: Timestamp de création du rattachement.
           - name: updated_at
             description: Timestamp de dernière mise à jour (curseur d'export).
+      - name: user_scoring
+        description: >-
+          Profils de scoring utilisateur synchronisés depuis la base opérationnelle. Chaque ligne représente une
+          demande de scoring, éventuellement rattachée à un identifiant anonyme et à une alerte mission.
+        columns:
+          - name: id
+            description: Identifiant unique du scoring utilisateur.
+          - name: distinct_id
+            description: Identifiant anonyme ou technique permettant de rattacher plusieurs interactions utilisateur.
+          - name: mission_alert_enabled
+            description: Indique si l'utilisateur a activé l'alerte mission associée à ce scoring.
+          - name: created_at
+            description: Timestamp de création du scoring.
+          - name: expires_at
+            description: Timestamp d'expiration du scoring, si défini.
+          - name: updated_at
+            description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
+      - name: user_scoring_value
+        description: >-
+          Scores utilisateur calculés par valeur de taxonomie. Chaque ligne rattache un scoring utilisateur à un couple
+          `taxonomy_key` / `value_key` et expose le score associé.
+        columns:
+          - name: id
+            description: Identifiant unique de la valeur de scoring utilisateur.
+          - name: user_scoring_id
+            description: Identifiant du scoring utilisateur parent.
+          - name: taxonomy_key
+            description: Clé de la taxonomie scorée.
+          - name: value_key
+            description: Clé de la valeur de taxonomie scorée.
+          - name: score
+            description: Score utilisateur calculé.
+          - name: created_at
+            description: Timestamp de création de la valeur de scoring.
+          - name: updated_at
+            description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
+      - name: matching_engine_result
+        description: >-
+          Résultats persistés du moteur de matching, exportés depuis la table opérationnelle `mission_matching_result`.
+          Chaque ligne conserve le résultat JSON produit pour un scoring utilisateur et une version de l'algorithme.
+        columns:
+          - name: id
+            description: Identifiant unique du résultat de matching.
+          - name: user_scoring_id
+            description: Identifiant du scoring utilisateur utilisé comme entrée.
+          - name: matching_engine_version
+            description: Version du moteur de matching ayant produit le résultat.
+          - name: results
+            description: Résultats détaillés au format JSON.
+          - name: created_at
+            description: Timestamp de création du résultat.
+      - name: mission_enrichment
+        description: >-
+          Enrichissements de mission synchronisés depuis la base opérationnelle. Chaque ligne trace une tentative
+          d'enrichissement pour une mission et une version de prompt, avec statut et métriques de tokens.
+        columns:
+          - name: id
+            description: Identifiant unique de l'enrichissement.
+          - name: mission_id
+            description: Identifiant de la mission enrichie.
+          - name: status
+            description: Statut de l'enrichissement (`pending`, `processing`, `completed`, `failed`).
+          - name: prompt_version
+            description: Version du prompt utilisée.
+          - name: input_tokens
+            description: Nombre de tokens d'entrée consommés, si disponible.
+          - name: output_tokens
+            description: Nombre de tokens de sortie produits, si disponible.
+          - name: total_tokens
+            description: Nombre total de tokens consommés, si disponible.
+          - name: completed_at
+            description: Timestamp de fin de traitement lorsque l'enrichissement est terminé.
+          - name: created_at
+            description: Timestamp de création de l'enrichissement.
+          - name: updated_at
+            description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
+      - name: mission_enrichment_value
+        description: >-
+          Valeurs de taxonomie extraites lors de l'enrichissement des missions, avec score de confiance et éléments de
+          preuve éventuels.
+        columns:
+          - name: id
+            description: Identifiant unique de la valeur d'enrichissement.
+          - name: enrichment_id
+            description: Identifiant de l'enrichissement parent.
+          - name: taxonomy_key
+            description: Clé de la taxonomie détectée.
+          - name: value_key
+            description: Clé de la valeur de taxonomie détectée.
+          - name: confidence
+            description: Score de confiance de la valeur détectée.
+          - name: evidence
+            description: Éléments de preuve ou justification au format JSON.
+          - name: created_at
+            description: Timestamp de création de la valeur d'enrichissement.
+          - name: updated_at
+            description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
+      - name: mission_scoring
+        description: >-
+          Scorings de mission dérivés des enrichissements. Chaque ligne relie une mission à l'enrichissement utilisé
+          pour produire ses valeurs de scoring.
+        columns:
+          - name: id
+            description: Identifiant unique du scoring de mission.
+          - name: mission_id
+            description: Identifiant de la mission scorée.
+          - name: mission_enrichment_id
+            description: Identifiant de l'enrichissement utilisé comme base du scoring.
+          - name: created_at
+            description: Timestamp de création du scoring.
+          - name: updated_at
+            description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
+      - name: mission_scoring_value
+        description: >-
+          Scores de mission calculés par valeur de taxonomie. Chaque ligne correspond au score d'une mission pour un
+          couple `taxonomy_key` / `value_key`.
+        columns:
+          - name: id
+            description: Identifiant unique de la valeur de scoring mission.
+          - name: mission_scoring_id
+            description: Identifiant du scoring de mission parent.
+          - name: mission_enrichment_value_id
+            description: Identifiant de la valeur d'enrichissement liée, si applicable.
+          - name: taxonomy_key
+            description: Clé de la taxonomie scorée.
+          - name: value_key
+            description: Clé de la valeur de taxonomie scorée.
+          - name: score
+            description: Score de mission calculé.
+          - name: created_at
+            description: Timestamp de création de la valeur de scoring.
+          - name: updated_at
+            description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.

--- a/analytics/dbt/analytics/models/staging/mission/__models.yml
+++ b/analytics/dbt/analytics/models/staging/mission/__models.yml
@@ -163,6 +163,185 @@ models:
         description: Timestamp de dernière mise à jour (curseur d'export).
         tests:
           - not_null
+  - name: stg_matching_engine_result
+    description: >
+      Staging des résultats persistés du moteur de matching exportés depuis `analytics_raw.matching_engine_result`.
+      Chaque ligne conserve le résultat JSON calculé pour un scoring utilisateur et une version donnée de l'algorithme
+      de matching.
+    columns:
+      - name: id
+        description: Identifiant unique du résultat de matching.
+        tests:
+          - not_null
+          - unique
+      - name: user_scoring_id
+        description: Identifiant du scoring utilisateur utilisé comme entrée du matching.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_user_scoring')
+                field: id
+      - name: matching_engine_version
+        description: Version du moteur de matching ayant produit le résultat.
+        tests:
+          - not_null
+      - name: results
+        description: Résultats détaillés du matching au format JSON.
+        tests:
+          - not_null
+      - name: created_at
+        description: Timestamp de création du résultat.
+        tests:
+          - not_null
+  - name: stg_mission_enrichment
+    description: >
+      Staging des enrichissements de mission exportés depuis `analytics_raw.mission_enrichment`. Chaque ligne représente
+      une tentative d'enrichissement d'une mission pour une version de prompt, avec son statut, ses métriques de tokens
+      et sa date de complétion.
+    columns:
+      - name: id
+        description: Identifiant unique de l'enrichissement.
+        tests:
+          - not_null
+          - unique
+      - name: mission_id
+        description: Identifiant de la mission enrichie.
+        tests:
+          - not_null
+      - name: status
+        description: Statut de l'enrichissement (`pending`, `processing`, `completed`, `failed`).
+        tests:
+          - not_null
+      - name: prompt_version
+        description: Version du prompt utilisée pour produire l'enrichissement.
+        tests:
+          - not_null
+      - name: input_tokens
+        description: Nombre de tokens d'entrée consommés, si disponible.
+      - name: output_tokens
+        description: Nombre de tokens de sortie produits, si disponible.
+      - name: total_tokens
+        description: Nombre total de tokens consommés, si disponible.
+      - name: completed_at
+        description: Timestamp de fin de traitement lorsque l'enrichissement est terminé.
+      - name: created_at
+        description: Timestamp de création de l'enrichissement.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
+        tests:
+          - not_null
+  - name: stg_mission_enrichment_value
+    description: >
+      Staging des valeurs extraites lors de l'enrichissement des missions depuis
+      `analytics_raw.mission_enrichment_value`. Chaque ligne décrit une valeur de taxonomie détectée, sa confiance et
+      les éventuels éléments de preuve au format JSON.
+    columns:
+      - name: id
+        description: Identifiant unique de la valeur d'enrichissement.
+        tests:
+          - not_null
+          - unique
+      - name: enrichment_id
+        description: Identifiant de l'enrichissement parent.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_mission_enrichment')
+                field: id
+      - name: taxonomy_key
+        description: Clé de la taxonomie détectée.
+      - name: value_key
+        description: Clé de la valeur de taxonomie détectée.
+      - name: confidence
+        description: Score de confiance associé à la valeur détectée.
+        tests:
+          - not_null
+      - name: evidence
+        description: Éléments de preuve ou justification de l'enrichissement au format JSON.
+      - name: created_at
+        description: Timestamp de création de la valeur d'enrichissement.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
+        tests:
+          - not_null
+  - name: stg_mission_scoring
+    description: >
+      Staging des scorings de mission exportés depuis `analytics_raw.mission_scoring`. Chaque ligne relie une mission à
+      l'enrichissement utilisé pour calculer ses valeurs de scoring.
+    columns:
+      - name: id
+        description: Identifiant unique du scoring de mission.
+        tests:
+          - not_null
+          - unique
+      - name: mission_id
+        description: Identifiant de la mission scorée.
+        tests:
+          - not_null
+      - name: mission_enrichment_id
+        description: Identifiant de l'enrichissement utilisé comme base du scoring.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_mission_enrichment')
+                field: id
+      - name: created_at
+        description: Timestamp de création du scoring de mission.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
+        tests:
+          - not_null
+  - name: stg_mission_scoring_value
+    description: >
+      Staging des valeurs de scoring des missions par taxonomie exportées depuis
+      `analytics_raw.mission_scoring_value`. Chaque ligne correspond au score d'une mission pour un couple
+      `taxonomy_key` / `value_key`, éventuellement relié à une valeur d'enrichissement.
+    columns:
+      - name: id
+        description: Identifiant unique de la valeur de scoring mission.
+        tests:
+          - not_null
+          - unique
+      - name: mission_scoring_id
+        description: Identifiant du scoring de mission parent.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_mission_scoring')
+                field: id
+      - name: mission_enrichment_value_id
+        description: Identifiant de la valeur d'enrichissement ayant servi au scoring, si applicable.
+        tests:
+          - relationships:
+              arguments:
+                to: ref('stg_mission_enrichment_value')
+                field: id
+      - name: taxonomy_key
+        description: Clé de la taxonomie scorée.
+      - name: value_key
+        description: Clé de la valeur de taxonomie scorée.
+      - name: score
+        description: Score de mission calculé pour cette valeur de taxonomie.
+        tests:
+          - not_null
+      - name: created_at
+        description: Timestamp de création de la valeur de scoring.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
+        tests:
+          - not_null
   - name: stg_mission_address
     description: >
       Staging des adresses associées aux missions, exportées depuis `analytics_raw.mission_address`. Le modèle applique

--- a/analytics/dbt/analytics/models/staging/mission/stg_matching_engine_result.sql
+++ b/analytics/dbt/analytics/models/staging/mission/stg_matching_engine_result.sql
@@ -1,0 +1,7 @@
+select
+  id,
+  user_scoring_id,
+  matching_engine_version,
+  results,
+  created_at::timestamp as created_at
+from {{ source('analytics_raw', 'matching_engine_result') }}

--- a/analytics/dbt/analytics/models/staging/mission/stg_mission_enrichment.sql
+++ b/analytics/dbt/analytics/models/staging/mission/stg_mission_enrichment.sql
@@ -1,0 +1,12 @@
+select
+  id,
+  mission_id,
+  status,
+  prompt_version,
+  input_tokens::integer as input_tokens,
+  output_tokens::integer as output_tokens,
+  total_tokens::integer as total_tokens,
+  completed_at::timestamp as completed_at,
+  created_at::timestamp as created_at,
+  updated_at::timestamp as updated_at
+from {{ source('analytics_raw', 'mission_enrichment') }}

--- a/analytics/dbt/analytics/models/staging/mission/stg_mission_enrichment_value.sql
+++ b/analytics/dbt/analytics/models/staging/mission/stg_mission_enrichment_value.sql
@@ -1,0 +1,10 @@
+select
+  id,
+  enrichment_id,
+  taxonomy_key,
+  value_key,
+  confidence::double precision as confidence,
+  evidence,
+  created_at::timestamp as created_at,
+  updated_at::timestamp as updated_at
+from {{ source('analytics_raw', 'mission_enrichment_value') }}

--- a/analytics/dbt/analytics/models/staging/mission/stg_mission_scoring.sql
+++ b/analytics/dbt/analytics/models/staging/mission/stg_mission_scoring.sql
@@ -1,0 +1,7 @@
+select
+  id,
+  mission_id,
+  mission_enrichment_id,
+  created_at::timestamp as created_at,
+  updated_at::timestamp as updated_at
+from {{ source('analytics_raw', 'mission_scoring') }}

--- a/analytics/dbt/analytics/models/staging/mission/stg_mission_scoring_value.sql
+++ b/analytics/dbt/analytics/models/staging/mission/stg_mission_scoring_value.sql
@@ -1,0 +1,10 @@
+select
+  id,
+  mission_scoring_id,
+  mission_enrichment_value_id,
+  taxonomy_key,
+  value_key,
+  score::double precision as score,
+  created_at::timestamp as created_at,
+  updated_at::timestamp as updated_at
+from {{ source('analytics_raw', 'mission_scoring_value') }}

--- a/analytics/dbt/analytics/models/staging/user/__models.yml
+++ b/analytics/dbt/analytics/models/staging/user/__models.yml
@@ -61,3 +61,64 @@ models:
           - not_null
       - name: created_at
         description: Timestamp de création de l'entrée.
+  - name: stg_user_scoring
+    description: >
+      Staging des profils de scoring utilisateur exportés depuis `analytics_raw.user_scoring`. Chaque ligne représente
+      une demande de scoring utilisateur, avec ses dates de création, d'expiration et de dernière mise à jour.
+    columns:
+      - name: id
+        description: Identifiant unique du scoring utilisateur.
+        tests:
+          - not_null
+          - unique
+      - name: distinct_id
+        description: Identifiant anonyme ou technique permettant de rattacher plusieurs interactions utilisateur.
+      - name: mission_alert_enabled
+        description: Indique si l'utilisateur a activé l'alerte mission associée à ce scoring.
+        tests:
+          - not_null
+      - name: created_at
+        description: Timestamp de création du scoring utilisateur.
+        tests:
+          - not_null
+      - name: expires_at
+        description: Timestamp d'expiration du scoring, si une limite de validité est définie.
+      - name: updated_at
+        description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
+        tests:
+          - not_null
+  - name: stg_user_scoring_value
+    description: >
+      Staging des valeurs de scoring utilisateur par taxonomie exportées depuis
+      `analytics_raw.user_scoring_value`. Chaque ligne décrit le score calculé pour un couple `taxonomy_key` /
+      `value_key` rattaché à un scoring utilisateur.
+    columns:
+      - name: id
+        description: Identifiant unique de la valeur de scoring utilisateur.
+        tests:
+          - not_null
+          - unique
+      - name: user_scoring_id
+        description: Identifiant du scoring utilisateur parent.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_user_scoring')
+                field: id
+      - name: taxonomy_key
+        description: Clé de la taxonomie utilisée pour qualifier le scoring.
+      - name: value_key
+        description: Clé de la valeur de taxonomie scorée.
+      - name: score
+        description: Score utilisateur calculé pour cette valeur de taxonomie.
+        tests:
+          - not_null
+      - name: created_at
+        description: Timestamp de création de la valeur de scoring.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
+        tests:
+          - not_null

--- a/analytics/dbt/analytics/models/staging/user/stg_user_scoring.sql
+++ b/analytics/dbt/analytics/models/staging/user/stg_user_scoring.sql
@@ -1,0 +1,8 @@
+select
+  id,
+  distinct_id,
+  mission_alert_enabled::boolean as mission_alert_enabled,
+  created_at::timestamp as created_at,
+  expires_at::timestamp as expires_at,
+  updated_at::timestamp as updated_at
+from {{ source('analytics_raw', 'user_scoring') }}

--- a/analytics/dbt/analytics/models/staging/user/stg_user_scoring_value.sql
+++ b/analytics/dbt/analytics/models/staging/user/stg_user_scoring_value.sql
@@ -1,0 +1,9 @@
+select
+  id,
+  user_scoring_id,
+  taxonomy_key,
+  value_key,
+  score::double precision as score,
+  created_at::timestamp as created_at,
+  updated_at::timestamp as updated_at
+from {{ source('analytics_raw', 'user_scoring_value') }}

--- a/analytics/src/jobs/export-to-analytics-raw/config.ts
+++ b/analytics/src/jobs/export-to-analytics-raw/config.ts
@@ -629,4 +629,116 @@ export const exportDefinitions: ExportDefinition[] = [
       conflictColumns: ["id"],
     },
   },
+  {
+    key: "user_scoring",
+    batchSize: 2000,
+    source: {
+      table: "user_scoring",
+      cursor: {
+        field: "updated_at",
+        idField: "id",
+      },
+      columns: ["id", "distinct_id", "mission_alert_enabled", "created_at", "expires_at", "updated_at"],
+    },
+    destination: {
+      table: "user_scoring",
+      conflictColumns: ["id"],
+    },
+  },
+  {
+    key: "user_scoring_value",
+    batchSize: 2000,
+    source: {
+      table: "user_scoring_value",
+      cursor: {
+        field: "updated_at",
+        idField: "id",
+      },
+      columns: ["id", "user_scoring_id", "taxonomy_key", "value_key", "score", "created_at", "updated_at"],
+    },
+    destination: {
+      table: "user_scoring_value",
+      conflictColumns: ["id"],
+    },
+  },
+  {
+    key: "matching_engine_result",
+    batchSize: 2000,
+    source: {
+      table: "mission_matching_result",
+      cursor: {
+        field: "created_at",
+        idField: "id",
+      },
+      columns: ["id", "user_scoring_id", "matching_engine_version", "results", "created_at"],
+    },
+    destination: {
+      table: "matching_engine_result",
+      conflictColumns: ["id"],
+    },
+  },
+  {
+    key: "mission_scoring",
+    batchSize: 2000,
+    source: {
+      table: "mission_scoring",
+      cursor: {
+        field: "updated_at",
+        idField: "id",
+      },
+      columns: ["id", "mission_id", "mission_enrichment_id", "created_at", "updated_at"],
+    },
+    destination: {
+      table: "mission_scoring",
+      conflictColumns: ["id"],
+    },
+  },
+  {
+    key: "mission_scoring_value",
+    batchSize: 2000,
+    source: {
+      table: "mission_scoring_value",
+      cursor: {
+        field: "updated_at",
+        idField: "id",
+      },
+      columns: ["id", "mission_scoring_id", "mission_enrichment_value_id", "taxonomy_key", "value_key", "score", "created_at", "updated_at"],
+    },
+    destination: {
+      table: "mission_scoring_value",
+      conflictColumns: ["id"],
+    },
+  },
+  {
+    key: "mission_enrichment",
+    batchSize: 2000,
+    source: {
+      table: "mission_enrichment",
+      cursor: {
+        field: "updated_at",
+        idField: "id",
+      },
+      columns: ["id", "mission_id", "status", "prompt_version", "input_tokens", "output_tokens", "total_tokens", "completed_at", "created_at", "updated_at"],
+    },
+    destination: {
+      table: "mission_enrichment",
+      conflictColumns: ["id"],
+    },
+  },
+  {
+    key: "mission_enrichment_value",
+    batchSize: 2000,
+    source: {
+      table: "mission_enrichment_value",
+      cursor: {
+        field: "updated_at",
+        idField: "id",
+      },
+      columns: ["id", "enrichment_id", "taxonomy_key", "value_key", "confidence", "evidence"],
+    },
+    destination: {
+      table: "mission_enrichment_value",
+      conflictColumns: ["id"],
+    },
+  },
 ];

--- a/analytics/src/jobs/export-to-analytics-raw/config.ts
+++ b/analytics/src/jobs/export-to-analytics-raw/config.ts
@@ -672,6 +672,10 @@ export const exportDefinitions: ExportDefinition[] = [
       },
       columns: ["id", "user_scoring_id", "matching_engine_version", "results", "created_at"],
     },
+    transform: (row) => ({
+      ...row,
+      results: row.results === null || row.results === undefined ? null : JSON.stringify(row.results),
+    }),
     destination: {
       table: "matching_engine_result",
       conflictColumns: ["id"],
@@ -734,7 +738,7 @@ export const exportDefinitions: ExportDefinition[] = [
         field: "updated_at",
         idField: "id",
       },
-      columns: ["id", "enrichment_id", "taxonomy_key", "value_key", "confidence", "evidence"],
+      columns: ["id", "enrichment_id", "taxonomy_key", "value_key", "confidence", "evidence", "created_at", "updated_at"],
     },
     destination: {
       table: "mission_enrichment_value",

--- a/api/prisma/migrations/20260508124447_add_mission_enrichment_created_updated/migration.sql
+++ b/api/prisma/migrations/20260508124447_add_mission_enrichment_created_updated/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "mission_enrichment_value"
+ADD COLUMN "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN "updated_at" TIMESTAMP(3);
+
+UPDATE "mission_enrichment_value"
+SET "updated_at" = CURRENT_TIMESTAMP
+WHERE "updated_at" IS NULL;
+
+ALTER TABLE "mission_enrichment_value"
+ALTER COLUMN "updated_at" SET NOT NULL;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1033,6 +1033,8 @@ model MissionEnrichmentValue {
   valueKey        String? @map("value_key")
   confidence      Float
   evidence        Json?
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @updatedAt @map("updated_at")
 
   enrichment           MissionEnrichment     @relation(fields: [enrichmentId], references: [id], onDelete: Cascade)
   taxonomyValue        TaxonomyValue?        @relation(fields: [taxonomyValueId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Description

Cette PR ajoute le pipeline analytics lié au scoring utilisateur, à l’enrichissement de mission, au scoring de mission et aux résultats du moteur de matching.

Elle ajoute notamment :
- les exports `analytics_raw` pour les nouvelles tables métier ;
- les tables raw analytics associées ;
- les sources dbt documentées ;
- les modèles staging dbt ;
- les marts dbt basiques en `view` pour exposer les nouvelles tables ;
- la migration Prisma ajoutant `created_at` / `updated_at` sur `mission_enrichment_value`, avec backfill de `updated_at` pour les lignes existantes.

## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Pipeline-mod-les-de-la-plateforme-de-l-engagement-35072a322d508023b937ead7f61a8d8d?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire
