### PR TITLE
fix(api): improve gate matching engine

### DIFF
--- a/api/scripts/explain-matching-result.ts
+++ b/api/scripts/explain-matching-result.ts
@@ -16,7 +16,7 @@ import { getTaxonomyList } from "@engagement/taxonomy";
 
 import { prisma } from "@/db/postgres";
 import { matchingEngineService } from "@/services/matching-engine";
-import { CURRENT_MATCHING_ENGINE_VERSION } from "@/services/matching-engine/config";
+import { CURRENT_MATCHING_ENGINE_VERSION, MATCHING_ENGINE_TAXONOMIES } from "@/services/matching-engine/config";
 import type { MatchMissionItem, MatchingEngineTaxonomy, MatchingEngineVersion, MissionMatchingResultItem } from "@/services/matching-engine/types";
 
 const args = process.argv.slice(2);
@@ -26,6 +26,7 @@ const versionArgIndex = args.indexOf("--version");
 
 const limit = limitArgIndex !== -1 ? parseInt(args[limitArgIndex + 1], 10) : 5;
 const version = (versionArgIndex !== -1 ? args[versionArgIndex + 1] : CURRENT_MATCHING_ENGINE_VERSION) as MatchingEngineVersion;
+const matchingEngineTaxonomySet = new Set<string>(MATCHING_ENGINE_TAXONOMIES);
 
 type StoredMissionMatchingResultItem = MissionMatchingResultItem;
 
@@ -38,7 +39,7 @@ type OverlapSignal = {
 };
 
 type UserTaxonomySummary = {
-  taxonomyKey: string;
+  taxonomyKey: MatchingEngineTaxonomy;
   taxonomyLabel: string;
   values: string[];
 };
@@ -59,6 +60,9 @@ type TaxonomyLabelLookup = {
 };
 
 const buildScoringValueKey = (taxonomyKey: string, valueKey: string): string => `${taxonomyKey}.${valueKey}`;
+
+const isMatchingEngineTaxonomy = (taxonomyKey: string | null): taxonomyKey is MatchingEngineTaxonomy =>
+  typeof taxonomyKey === "string" && matchingEngineTaxonomySet.has(taxonomyKey);
 
 const parseStoredResults = (value: unknown): StoredMissionMatchingResultItem[] => {
   if (!Array.isArray(value)) {
@@ -113,7 +117,7 @@ const buildUserTaxonomySummary = (params: { values: ScoringValueWithKeys[]; look
   const byTaxonomy = new Map<string, UserTaxonomySummary>();
 
   for (const value of params.values) {
-    if (!value.taxonomyKey || !value.valueKey) {
+    if (!isMatchingEngineTaxonomy(value.taxonomyKey) || !value.valueKey) {
       continue;
     }
 
@@ -208,12 +212,14 @@ const run = async () => {
 
   const userValuesByTaxonomyValueKey = new Map(
     userScoringValues
-      .filter((value): value is ScoringValueWithKeys & { taxonomyKey: string; valueKey: string } => value.taxonomyKey !== null && value.valueKey !== null)
+      .filter(
+        (value): value is ScoringValueWithKeys & { taxonomyKey: MatchingEngineTaxonomy; valueKey: string } => isMatchingEngineTaxonomy(value.taxonomyKey) && value.valueKey !== null
+      )
       .map((value) => [
         buildScoringValueKey(value.taxonomyKey, value.valueKey),
         {
           score: value.score,
-          taxonomyKey: value.taxonomyKey as MatchingEngineTaxonomy,
+          taxonomyKey: value.taxonomyKey,
           taxonomyLabel: getTaxonomyLabel(taxonomyLabels, value.taxonomyKey),
           valueLabel: getValueLabel(taxonomyLabels, value.taxonomyKey, value.valueKey),
         },
@@ -233,7 +239,7 @@ const run = async () => {
 
       return {
         ...item,
-        title: missionScoring.mission.title,
+        title: missionScoring.mission?.title ?? `Mission introuvable ${item.missionId}`,
         taxonomyScores: storedResult?.taxonomyScores ?? item.taxonomyScores,
       };
     })
@@ -266,10 +272,10 @@ const run = async () => {
       continue;
     }
 
-    const overlapsByTaxonomy = new Map<MatchingEngineTaxonomy, OverlapSignal[]>();
+    const overlapsByTaxonomy = new Map<string, OverlapSignal[]>();
 
     for (const missionValue of missionScoring.missionScoringValues) {
-      if (!missionValue.taxonomyKey || !missionValue.valueKey) {
+      if (!isMatchingEngineTaxonomy(missionValue.taxonomyKey) || !missionValue.valueKey) {
         continue;
       }
 
@@ -278,7 +284,7 @@ const run = async () => {
         continue;
       }
 
-      const taxonomyKey = missionValue.taxonomyKey as MatchingEngineTaxonomy;
+      const taxonomyKey = missionValue.taxonomyKey;
       const overlap: OverlapSignal = {
         taxonomyKey,
         taxonomyLabel: getTaxonomyLabel(taxonomyLabels, missionValue.taxonomyKey),
@@ -299,7 +305,7 @@ const run = async () => {
     );
 
     const taxonomyEntries = Object.entries(rankedItem.taxonomyScores)
-      .filter((entry): entry is [MatchingEngineTaxonomy, number] => typeof entry[1] === "number")
+      .filter((entry): entry is [MatchingEngineTaxonomy, number] => isMatchingEngineTaxonomy(entry[0]) && typeof entry[1] === "number")
       .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0], "fr"));
 
     if (taxonomyEntries.length === 0) {

--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -19,6 +19,22 @@ const missionMatchingResultRepositoryMock = missionMatchingResultRepository as u
   createForUserScoringVersion: ReturnType<typeof vi.fn>;
 };
 
+const getSqlText = (query: unknown): string => {
+  if (typeof query === "object" && query !== null && "sql" in query && typeof query.sql === "string") {
+    return query.sql;
+  }
+
+  if (typeof query === "object" && query !== null && "text" in query && typeof query.text === "string") {
+    return query.text;
+  }
+
+  if (typeof query === "object" && query !== null && "strings" in query && Array.isArray(query.strings)) {
+    return query.strings.join("");
+  }
+
+  return String(query);
+};
+
 describe("matchingEngineService", () => {
   beforeEach(() => {
     prismaMock.$queryRaw.mockReset();
@@ -203,7 +219,11 @@ describe("matchingEngineService", () => {
         userScoringId: "user-scoring-gate-filtered",
       });
 
+      const rankingSql = getSqlText(prismaMock.$queryRaw.mock.calls[1][0]);
       expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(3);
+      expect(rankingSql).toContain("user_gate_values");
+      expect(rankingSql).toContain("matched_gate_taxonomies");
+      expect(rankingSql).not.toContain('AND usv."taxonomy_key" NOT IN');
       expect(result.items).toEqual([
         {
           missionId: "mission-eligible",
@@ -281,6 +301,7 @@ describe("matchingEngineService", () => {
           closestAddress: null,
           taxonomyScores: {
             domaine: 0.7,
+            tranche_age: 1,
           },
         },
       ]);

--- a/api/src/services/matching-engine/config.ts
+++ b/api/src/services/matching-engine/config.ts
@@ -1,7 +1,7 @@
-import { ENRICHABLE_TAXONOMIES } from "@engagement/taxonomy";
+import { ENRICHABLE_TAXONOMIES, GATE_TAXONOMIES } from "@engagement/taxonomy";
 import type { MatchingEngineTaxonomyWeights, MatchingEngineVersion, MatchingEngineVersionConfig } from "./types";
 
-export const MATCHING_ENGINE_TAXONOMIES = ENRICHABLE_TAXONOMIES as readonly (keyof MatchingEngineTaxonomyWeights)[];
+export const MATCHING_ENGINE_TAXONOMIES = [...ENRICHABLE_TAXONOMIES, ...GATE_TAXONOMIES] as readonly (keyof MatchingEngineTaxonomyWeights)[];
 
 export const MATCHING_ENGINE_TOP_RESULTS_LIMIT = 20;
 
@@ -17,6 +17,7 @@ export const MATCHING_ENGINE_VERSIONS = {
       region_internationale: 1,
       engagement_intent: 1,
       formation_onisep: 1,
+      tranche_age: 1,
     } satisfies MatchingEngineTaxonomyWeights,
   },
 } as const satisfies Record<MatchingEngineVersion, MatchingEngineVersionConfig>;

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -96,7 +96,6 @@ const buildRanking = (params: {
       usv."score"::double precision AS "user_score"
     FROM "user_scoring_value" usv
     WHERE usv."user_scoring_id" = ${params.userScoringId}
-      AND usv."taxonomy_key" NOT IN (${buildGateTaxonomiesSql()})
   ),
   user_taxonomy_totals AS (
     SELECT
@@ -444,7 +443,6 @@ const buildTaxonomyScoresSql = (params: { userScoringId: string; missionScoringI
       usv."score"::double precision AS "user_score"
     FROM "user_scoring_value" usv
     WHERE usv."user_scoring_id" = ${params.userScoringId}
-      AND usv."taxonomy_key" NOT IN (${buildGateTaxonomiesSql()})
   ),
   user_taxonomy_totals AS (
     SELECT

--- a/api/src/services/matching-engine/types.ts
+++ b/api/src/services/matching-engine/types.ts
@@ -1,6 +1,6 @@
-import type { EnrichableTaxonomyKey } from "@engagement/taxonomy";
+import type { EnrichableTaxonomyKey, GateTaxonomyKey } from "@engagement/taxonomy";
 
-export type MatchingEngineTaxonomy = EnrichableTaxonomyKey;
+export type MatchingEngineTaxonomy = EnrichableTaxonomyKey | GateTaxonomyKey;
 
 export type MatchingEngineTaxonomyWeights = Record<MatchingEngineTaxonomy, number>;
 


### PR DESCRIPTION
## Description

Les taxonomies de type `gate` étaient bien utilisées comme filtre éliminatoire dans le matching engine, mais elles étaient exclues du calcul de score et des détails `taxonomyScores`.

Conséquence : une mission compatible sur une gate comme `tranche_age.moins_26_ans` pouvait ne pas ressortir si elle n’avait pas d’autre match taxonomique ou géographique suffisant.

### Changements

- Intègre les taxonomies `gate` dans les taxonomies scorées du matching engine.
- Ajoute `tranche_age` aux poids de matching avec un poids `1`.
- Conserve la logique éliminatoire des gates quand elles ne matchent pas.
- Fait remonter les gates matchées dans `taxonomyScores`, comme les autres taxonomies.


## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
