### PR TITLE
refactor(plateform): change user-scoring payload

### DIFF
--- a/plateform/app/components/quiz/multi-select-icon.tsx
+++ b/plateform/app/components/quiz/multi-select-icon.tsx
@@ -17,20 +17,17 @@ export default function MultiSelectIcon({ onChange, options, selected, error }: 
     <fieldset className={`fr-fieldset ${error ? "fr-fieldset--error" : ""}`}>
       <div className="fr-fieldset__content grid grid-cols-1 md:grid-cols-2 max-w-4xl! mx-0! gap-x-6 gap-y-4!">
         {options.map((o) => (
-          <div key={o.taxonomyKey} className="fr-fieldset__element mb-0!">
+          <div key={o.value} className="fr-fieldset__element mb-0!">
             <div className="fr-checkbox-group fr-checkbox-rich mt-0! mb-0!">
               <input
-                value={o.taxonomyKey}
+                value={o.value}
                 type="checkbox"
-                id={`multi-select-icon-${o.taxonomyKey}`}
+                id={`multi-select-icon-${o.value}`}
                 name="multi-select-icon"
-                onChange={() => toggle(o.taxonomyKey)}
-                checked={selected.includes(o.taxonomyKey)}
+                onChange={() => toggle(o.value)}
+                checked={selected.includes(o.value)}
               />
-              <label
-                className="fr-label text-base before:size-4! after:absolute after:inset-0 after:right-[-5.5rem] after:content-['']"
-                htmlFor={`multi-select-icon-${o.taxonomyKey}`}
-              >
+              <label className="fr-label text-base before:size-4! after:absolute after:inset-0 after:right-[-5.5rem] after:content-['']" htmlFor={`multi-select-icon-${o.value}`}>
                 {o.label}
                 {o.sublabel && <span className="fr-hint-text">{o.sublabel}</span>}
               </label>

--- a/plateform/app/components/quiz/single-select-icon.tsx
+++ b/plateform/app/components/quiz/single-select-icon.tsx
@@ -13,17 +13,17 @@ export default function SingleSelectIcon({ onChange, options, selected, error, l
     <fieldset className={`fr-fieldset ${error ? "fr-fieldset--error" : ""}`} aria-labelledby={`single-select-icon-messages ${labelId}`}>
       <div className="fr-fieldset__content grid grid-cols-1 md:grid-cols-2 max-w-4xl! mx-0! gap-x-6 gap-y-4!">
         {options.map((o) => (
-          <div key={o.taxonomyKey} className="fr-fieldset__element mb-0!">
+          <div key={o.value} className="fr-fieldset__element mb-0!">
             <div className="fr-radio-group fr-radio-rich mb-0!">
               <input
-                value={o.taxonomyKey}
+                value={o.value}
                 type="radio"
-                id={`single-select-icon-${o.taxonomyKey}`}
+                id={`single-select-icon-${o.value}`}
                 name="single-select-icon"
-                onChange={() => onChange(o.taxonomyKey)}
-                checked={selected === o.taxonomyKey}
+                onChange={() => onChange(o.value)}
+                checked={selected === o.value}
               />
-              <label className="fr-label text-base" htmlFor={`single-select-icon-${o.taxonomyKey}`}>
+              <label className="fr-label text-base" htmlFor={`single-select-icon-${o.value}`}>
                 {o.label}
                 {o.sublabel && <span className="fr-hint-text">{o.sublabel}</span>}
               </label>

--- a/plateform/app/components/quiz/single-select.tsx
+++ b/plateform/app/components/quiz/single-select.tsx
@@ -1,7 +1,7 @@
 import type { StepOption } from "~/types/quiz";
 
 type Props = {
-  onChange: (taxonomyKey: string) => void;
+  onChange: (value: string) => void;
   options: StepOption[];
   selected?: string;
   error?: string;
@@ -16,19 +16,19 @@ export default function SingleSelect({ onChange, options, selected, error, label
         {options.map((o) => (
           <div className="fr-fieldset__element">
             <div
-              key={o.taxonomyKey}
+              key={o.value}
               className={`fr-radio-group flex items-center bg-white border px-4 h-12 w-full max-w-80! ${error ? "border-border-plain-error" : "border-border-default-grey"}`}
             >
               <input
                 className="ml-1"
                 type="radio"
-                id={`single-select-${o.taxonomyKey}`}
+                id={`single-select-${o.value}`}
                 name="single-select"
-                value={o.taxonomyKey}
-                onChange={() => onChange(o.taxonomyKey)}
-                checked={selected === o.taxonomyKey}
+                value={o.value}
+                onChange={() => onChange(o.value)}
+                checked={selected === o.value}
               />
-              <label className="fr-label" htmlFor={`single-select-${o.taxonomyKey}`}>
+              <label className="fr-label" htmlFor={`single-select-${o.value}`}>
                 {o.label}
               </label>
             </div>

--- a/plateform/app/config/quiz-flow.ts
+++ b/plateform/app/config/quiz-flow.ts
@@ -4,6 +4,7 @@ import { and, not, numericRange, or, screenAnswer, type Condition } from "~/util
 // À étendre au fil des PR (autres precision_*, etc.).
 export type StepId =
   | "age"
+  | "tranche_age"
   | "handicap"
   | "statut"
   | "localisation"

--- a/plateform/app/config/quiz-flow.ts
+++ b/plateform/app/config/quiz-flow.ts
@@ -48,65 +48,53 @@ export const QUIZ_FLOW: StepDef[] = [
   {
     id: "precision_thematique",
     route: "/quiz/precision-thematique",
-    condition: or(screenAnswer("motivation", "motivation.me_sentir_utile"), screenAnswer("motivation", "motivation.reprendre_confiance")),
+    condition: or(screenAnswer("motivation", "me_sentir_utile"), screenAnswer("motivation", "reprendre_confiance")),
   },
   // → booster_parcoursup (lyceen) : 2 sous-steps avant le step domaine commun.
   {
     id: "precision_parcoursup_formation",
     route: "/quiz/precision-parcoursup-formation",
-    condition: screenAnswer("motivation", "motivation.booster_parcoursup"),
+    condition: screenAnswer("motivation", "booster_parcoursup"),
   },
   {
     id: "precision_parcoursup_formation_nom",
     route: "/quiz/precision-parcoursup-formation-nom",
-    condition: and(screenAnswer("motivation", "motivation.booster_parcoursup"), screenAnswer("precision_parcoursup_formation", "parcoursup_formation.oui")),
+    condition: and(screenAnswer("motivation", "booster_parcoursup"), screenAnswer("precision_parcoursup_formation", "oui")),
   },
   // → step `domaine` partagé : decouvrir_domaine, booster_parcoursup, ne_sais_pas. Titre adapté au contexte dans le step.
   {
     id: "precision_domaine",
     route: "/quiz/precision-domaine",
-    condition: or(
-      screenAnswer("motivation", "motivation.decouvrir_domaine"),
-      screenAnswer("motivation", "motivation.booster_parcoursup"),
-      screenAnswer("motivation", "motivation.ne_sais_pas"),
-    ),
+    condition: or(screenAnswer("motivation", "decouvrir_domaine"), screenAnswer("motivation", "booster_parcoursup"), screenAnswer("motivation", "ne_sais_pas")),
   },
   // → step `formation_onisep` partagé : tester_orientation, experience_terrain, preparer_reconversion.
   {
     id: "precision_formation_onisep",
     route: "/quiz/precision-formation-onisep",
-    condition: or(
-      screenAnswer("motivation", "motivation.tester_orientation"),
-      screenAnswer("motivation", "motivation.experience_terrain"),
-      screenAnswer("motivation", "motivation.preparer_reconversion"),
-    ),
+    condition: or(screenAnswer("motivation", "tester_orientation"), screenAnswer("motivation", "experience_terrain"), screenAnswer("motivation", "preparer_reconversion")),
   },
   // → step `competence_rome` partagé : booster_cv, enrichir_cv, competences_interet_general.
   {
     id: "precision_competences",
     route: "/quiz/precision-competences",
-    condition: or(
-      screenAnswer("motivation", "motivation.booster_cv"),
-      screenAnswer("motivation", "motivation.enrichir_cv"),
-      screenAnswer("motivation", "motivation.competences_interet_general"),
-    ),
+    condition: or(screenAnswer("motivation", "booster_cv"), screenAnswer("motivation", "enrichir_cv"), screenAnswer("motivation", "competences_interet_general")),
   },
   // → reprendre_activite (demandeur d'emploi) : mapping référentiel ROME (secteurs d'activité).
   {
     id: "precision_reprendre_activite",
     route: "/quiz/precision-reprendre-activite",
-    condition: screenAnswer("motivation", "motivation.reprendre_activite"),
+    condition: screenAnswer("motivation", "reprendre_activite"),
   },
   // → servir_le_pays (toutes branches applicables).
   {
     id: "precision_servir_pays",
     route: "/quiz/precision-servir-pays",
-    condition: screenAnswer("motivation", "motivation.servir_le_pays"),
+    condition: screenAnswer("motivation", "servir_le_pays"),
   },
   // → partir_etranger (étudiant + actif), masqué si `type_mission = ponctuelle` (règle produit).
   {
     id: "precision_international",
     route: "/quiz/precision-international",
-    condition: and(screenAnswer("motivation", "motivation.partir_etranger"), not(screenAnswer("duree", "type_mission.ponctuelle"))),
+    condition: and(screenAnswer("motivation", "partir_etranger"), not(screenAnswer("duree", "ponctuelle"))),
   },
 ];

--- a/plateform/app/config/quiz-options.ts
+++ b/plateform/app/config/quiz-options.ts
@@ -9,7 +9,7 @@ export const OPTIONS = Object.fromEntries(
   getTaxonomyList().flatMap((taxonomy) =>
     taxonomy.values.map((value) => {
       const key = `${taxonomy.key}.${value.key}` as TaxonomyValueKey;
-      return [key, { label: value.label, sublabel: value.sublabel, icon: value.icon, taxonomyKey: key }];
+      return [key, { label: value.label, sublabel: value.sublabel, icon: value.icon, taxonomy: taxonomy.key, value: value.key }];
     }),
   ),
 ) as Record<TaxonomyValueKey, StepOption>;

--- a/plateform/app/routes/quiz/_layout.tsx
+++ b/plateform/app/routes/quiz/_layout.tsx
@@ -111,7 +111,7 @@ export default function QuizLayout() {
   const recapItems = (["statut", "duree", "motivation"] as const).flatMap((stepId) => {
     const answer = answers[stepId];
     if (!answer || answer.type !== "options") return [];
-    return answer.option_ids.map((id) => OPTIONS[id as TaxonomyValueKey]?.label).filter(Boolean) as string[];
+    return answer.option_ids.map((id) => OPTIONS[`${answer.taxonomy}.${id}` as TaxonomyValueKey]?.label).filter(Boolean) as string[];
   });
 
   const goBack = () => {

--- a/plateform/app/routes/quiz/_layout.tsx
+++ b/plateform/app/routes/quiz/_layout.tsx
@@ -58,10 +58,9 @@ export default function QuizLayout() {
 
   const saveCurrentScoring = async (): Promise<boolean> => {
     const freshAnswers = useQuizStore.getState().answers;
-    const freshGeo = useQuizStore.getState().geo;
     const freshUserScoringId = useQuizStore.getState().userScoringId;
     const freshDistinctId = useQuizStore.getState().distinctId;
-    const payload = buildPayload(freshAnswers, freshGeo);
+    const payload = buildPayload(freshAnswers);
 
     if (payload.answers.length === 0) {
       return true;

--- a/plateform/app/routes/quiz/age.tsx
+++ b/plateform/app/routes/quiz/age.tsx
@@ -27,6 +27,8 @@ export default function AgeStep() {
     e.preventDefault();
     if (!valid) return;
     setAnswer(STEP_ID, { type: "numeric", value: numeric });
+    const existingHandicap = answers["handicap"]?.type === "options" ? answers["handicap"].option_ids[0] === "handicap.oui" : false;
+    setAnswer("tranche_age", { type: "age_params", age: numeric, handicap: existingHandicap });
     goNext();
   };
 

--- a/plateform/app/routes/quiz/age.tsx
+++ b/plateform/app/routes/quiz/age.tsx
@@ -28,7 +28,7 @@ export default function AgeStep() {
     if (!valid) return;
     setAnswer(STEP_ID, { type: "numeric", value: numeric });
     const existingHandicap = answers["handicap"]?.type === "options" ? answers["handicap"].option_ids[0] === "handicap.oui" : false;
-    setAnswer("tranche_age", { type: "age_params", age: numeric, handicap: existingHandicap });
+    setAnswer("tranche_age", { type: "params", taxonomy: "tranche_age", params: { age: numeric, handicap: existingHandicap } });
     goNext();
   };
 

--- a/plateform/app/routes/quiz/age.tsx
+++ b/plateform/app/routes/quiz/age.tsx
@@ -27,7 +27,7 @@ export default function AgeStep() {
     e.preventDefault();
     if (!valid) return;
     setAnswer(STEP_ID, { type: "numeric", value: numeric });
-    const existingHandicap = answers["handicap"]?.type === "options" ? answers["handicap"].option_ids[0] === "handicap.oui" : false;
+    const existingHandicap = answers["handicap"]?.type === "options" ? answers["handicap"].option_ids[0] === "oui" : false;
     setAnswer("tranche_age", { type: "params", taxonomy: "tranche_age", params: { age: numeric, handicap: existingHandicap } });
     goNext();
   };

--- a/plateform/app/routes/quiz/duree.tsx
+++ b/plateform/app/routes/quiz/duree.tsx
@@ -32,7 +32,7 @@ export default function DureeStep() {
 
   const handleSelect = (value: string[]) => {
     setError(undefined);
-    setAnswer(STEP_ID, { type: "options", option_ids: value });
+    setAnswer(STEP_ID, { type: "options", taxonomy: "type_mission", option_ids: value });
   };
 
   const handleNext = () => {

--- a/plateform/app/routes/quiz/handicap.tsx
+++ b/plateform/app/routes/quiz/handicap.tsx
@@ -19,10 +19,10 @@ export default function HandicapStep() {
 
   const handleSelect = (value: string) => {
     setError(undefined);
-    setAnswer(STEP_ID, { type: "options", option_ids: [value] });
+    setAnswer(STEP_ID, { type: "options", taxonomy: "handicap", option_ids: [value] });
     const existing = answers["tranche_age"];
     if (existing?.type === "params") {
-      setAnswer("tranche_age", { ...existing, params: { ...existing.params, handicap: value === "handicap.oui" } });
+      setAnswer("tranche_age", { ...existing, params: { ...existing.params, handicap: value === "oui" } });
     }
   };
 

--- a/plateform/app/routes/quiz/handicap.tsx
+++ b/plateform/app/routes/quiz/handicap.tsx
@@ -21,8 +21,8 @@ export default function HandicapStep() {
     setError(undefined);
     setAnswer(STEP_ID, { type: "options", option_ids: [value] });
     const existing = answers["tranche_age"];
-    if (existing?.type === "age_params") {
-      setAnswer("tranche_age", { ...existing, handicap: value === "handicap.oui" });
+    if (existing?.type === "params") {
+      setAnswer("tranche_age", { ...existing, params: { ...existing.params, handicap: value === "handicap.oui" } });
     }
   };
 

--- a/plateform/app/routes/quiz/handicap.tsx
+++ b/plateform/app/routes/quiz/handicap.tsx
@@ -20,6 +20,10 @@ export default function HandicapStep() {
   const handleSelect = (value: string) => {
     setError(undefined);
     setAnswer(STEP_ID, { type: "options", option_ids: [value] });
+    const existing = answers["tranche_age"];
+    if (existing?.type === "age_params") {
+      setAnswer("tranche_age", { ...existing, handicap: value === "handicap.oui" });
+    }
   };
 
   const handleNext = () => {

--- a/plateform/app/routes/quiz/localisation.tsx
+++ b/plateform/app/routes/quiz/localisation.tsx
@@ -10,7 +10,7 @@ import Photo1 from "~/assets/images/humanitaire-02.jpeg";
 import NextButton from "~/components/quiz/next-button";
 import { QUIZ_TRANSITION_MS } from "~/services/config";
 
-type Suggestion = { label: string; lat: number; lon: number };
+type Suggestion = { label: string; lat: number; lon: number; country_code?: string };
 
 type AddressFeature = {
   properties: { name: string; postcode: string; id: string };
@@ -22,11 +22,11 @@ export default function LocalisationStep() {
   const { goNext, transitioning, setTransitioning } = useOutletContext<QuizOutletContext>();
 
   const locAnswer = answers["localisation"];
-  const savedLocation = locAnswer?.type === "params" ? (locAnswer.params as { lat: number; lon: number; label: string }) : null;
+  const savedLocation = locAnswer?.type === "params" ? (locAnswer.params as { lat: number; lon: number; country_code?: string }) : null;
 
-  const [value, setValue] = useState(savedLocation?.label ?? "");
+  const [value, setValue] = useState("");
   const [options, setOptions] = useState<Suggestion[]>([]);
-  const [selected, setSelected] = useState<Suggestion | null>(savedLocation);
+  const [selected, setSelected] = useState<Suggestion | null>(savedLocation ? { label: "", ...savedLocation } : null);
   const [showOptions, setShowOptions] = useState(false);
   const [locating, setLocating] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -58,6 +58,7 @@ export default function LocalisationStep() {
             label: `${f.properties.name} (${f.properties.postcode})`,
             lat: f.geometry.coordinates[1],
             lon: f.geometry.coordinates[0],
+            country_code: "fr",
           })),
         );
         setShowOptions(true);
@@ -85,7 +86,12 @@ export default function LocalisationStep() {
         const data: { features?: AddressFeature[] } = await feature.json();
 
         if (!data.features) return;
-        const here: Suggestion = { label: data.features[0].properties.name, lat: data.features[0].geometry.coordinates[1], lon: data.features[0].geometry.coordinates[0] };
+        const here: Suggestion = {
+          label: data.features[0].properties.name,
+          lat: data.features[0].geometry.coordinates[1],
+          lon: data.features[0].geometry.coordinates[0],
+          country_code: "fr",
+        };
         setSelected(here);
         setShowOptions(false);
         setValue(here.label);
@@ -98,7 +104,11 @@ export default function LocalisationStep() {
   const handleSubmit = (e: SubmitEvent) => {
     e.preventDefault();
     if (!selected) return;
-    setAnswer("localisation", { type: "params", taxonomy: "location", params: { lat: selected.lat, lon: selected.lon, label: selected.label } });
+    setAnswer("localisation", {
+      type: "params",
+      taxonomy: "location",
+      params: { lat: selected.lat, lon: selected.lon, ...(selected.country_code ? { country_code: selected.country_code } : {}) },
+    });
     setValue(selected.label);
     setTransitioning(true);
   };

--- a/plateform/app/routes/quiz/localisation.tsx
+++ b/plateform/app/routes/quiz/localisation.tsx
@@ -18,25 +18,20 @@ type AddressFeature = {
 };
 
 export default function LocalisationStep() {
-  const geo = useQuizStore((s) => s.geo);
-  const setGeo = useQuizStore((s) => s.setGeo);
+  const { answers, setAnswer } = useQuizStore();
   const { goNext, transitioning, setTransitioning } = useOutletContext<QuizOutletContext>();
 
-  const [value, setValue] = useState("");
+  const locAnswer = answers["localisation"];
+  const savedLocation = locAnswer?.type === "params" ? (locAnswer.params as { lat: number; lon: number; label: string }) : null;
+
+  const [value, setValue] = useState(savedLocation?.label ?? "");
   const [options, setOptions] = useState<Suggestion[]>([]);
-  const [selected, setSelected] = useState<Suggestion | null>(null);
+  const [selected, setSelected] = useState<Suggestion | null>(savedLocation);
   const [showOptions, setShowOptions] = useState(false);
   const [locating, setLocating] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (geo) {
-      setSelected({ label: geo.label, lat: geo.lat, lon: geo.lon });
-      setValue(geo.label || "");
-      setShowOptions(false);
-      return;
-    }
-
     const handleClickOutside = (event: MouseEvent) => {
       if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
         setShowOptions(false);
@@ -103,7 +98,7 @@ export default function LocalisationStep() {
   const handleSubmit = (e: SubmitEvent) => {
     e.preventDefault();
     if (!selected) return;
-    setGeo(selected);
+    setAnswer("localisation", { type: "params", taxonomy: "location", params: { lat: selected.lat, lon: selected.lon, label: selected.label } });
     setValue(selected.label);
     setTransitioning(true);
   };

--- a/plateform/app/routes/quiz/motivation.tsx
+++ b/plateform/app/routes/quiz/motivation.tsx
@@ -15,11 +15,11 @@ import { QUIZ_TRANSITION_MS } from "~/services/config";
 
 const STEP_ID = "motivation";
 
-const lyceen = screenAnswer("statut", "statut.lyceen");
-const etudiant = screenAnswer("statut", "statut.etudiant");
-const demandeurEmploi = screenAnswer("statut", "statut.demandeur_emploi");
-const actif = screenAnswer("statut", "statut.actif");
-const retraite = screenAnswer("statut", "statut.retraite");
+const lyceen = screenAnswer("statut", "lyceen");
+const etudiant = screenAnswer("statut", "etudiant");
+const demandeurEmploi = screenAnswer("statut", "demandeur_emploi");
+const actif = screenAnswer("statut", "actif");
+const retraite = screenAnswer("statut", "retraite");
 
 const STEP_OPTIONS: StepOption[] = [
   OPTIONS["motivation.me_sentir_utile"],
@@ -52,7 +52,7 @@ export default function MotivationStep() {
 
   const handleChange = (value: string) => {
     setError(undefined);
-    setAnswer(STEP_ID, { type: "options", option_ids: [value] });
+    setAnswer(STEP_ID, { type: "options", taxonomy: "motivation", option_ids: [value] });
   };
 
   const handleNext = () => {

--- a/plateform/app/routes/quiz/precision-competences.tsx
+++ b/plateform/app/routes/quiz/precision-competences.tsx
@@ -23,8 +23,8 @@ const STEP_OPTIONS = [
 ];
 
 const TITLE_BY_MOTIVATION: Record<string, string> = {
-  "motivation.competences_interet_general": "Quel est ton domaine de compétences ?",
-  "motivation.booster_cv": "Dans quel domaine souhaites-tu booster tes compétences",
+  "competences_interet_general": "Quel est ton domaine de compétences ?",
+  "booster_cv": "Dans quel domaine souhaites-tu booster tes compétences",
 };
 
 const DEFAULT_TITLE = "Quel type de compétences t'attire le plus ?";
@@ -40,7 +40,7 @@ export default function PrecisionCompetencesStep() {
 
   const handleSelect = (value: string[]) => {
     setError(undefined);
-    setAnswer(STEP_ID, { type: "options", option_ids: value });
+    setAnswer(STEP_ID, { type: "options", taxonomy: "competence_rome", option_ids: value });
   };
 
   const handleNext = () => {

--- a/plateform/app/routes/quiz/precision-domaine.tsx
+++ b/plateform/app/routes/quiz/precision-domaine.tsx
@@ -24,8 +24,8 @@ const STEP_OPTIONS = [
   OPTIONS["domaine.je_ne_sais_pas"],
 ];
 const TITLE_BY_MOTIVATION: Record<string, string> = {
-  "motivation.ne_sais_pas": "Est-ce qu'un domaine te plaît plus qu'un autre ?",
-  "motivation.decouvrir_domaine": "Quel domaine t'attirerait le plus ?",
+  "ne_sais_pas": "Est-ce qu'un domaine te plaît plus qu'un autre ?",
+  "decouvrir_domaine": "Quel domaine t'attirerait le plus ?",
 };
 
 const DEFAULT_TITLE = "Dans quel domaine aimerais-tu avoir une expérience ?";
@@ -41,7 +41,7 @@ export default function PrecisionDomaineStep() {
 
   const handleSelect = (value: string[]) => {
     setError(undefined);
-    setAnswer(STEP_ID, { type: "options", option_ids: value });
+    setAnswer(STEP_ID, { type: "options", taxonomy: "domaine", option_ids: value });
   };
 
   const handleNext = () => {

--- a/plateform/app/routes/quiz/precision-formation-onisep.tsx
+++ b/plateform/app/routes/quiz/precision-formation-onisep.tsx
@@ -24,8 +24,8 @@ const STEP_OPTIONS = [
 ];
 
 const TITLE_BY_MOTIVATION: Record<string, string> = {
-  "motivation.experience_terrain": "Dans quel domaine réalises-tu tes études ?",
-  "motivation.preparer_reconversion": "Dans quel domaine souhaites-tu préparer ta reconversion ?",
+  "experience_terrain": "Dans quel domaine réalises-tu tes études ?",
+  "preparer_reconversion": "Dans quel domaine souhaites-tu préparer ta reconversion ?",
 };
 
 const DEFAULT_TITLE = "Vers quoi veux-tu t'orienter ?";
@@ -41,7 +41,7 @@ export default function PrecisionFormationOnisepStep() {
 
   const handleSelect = (value: string[]) => {
     setError(undefined);
-    setAnswer(STEP_ID, { type: "options", option_ids: value });
+    setAnswer(STEP_ID, { type: "options", taxonomy: "formation_onisep", option_ids: value });
   };
 
   const handleNext = () => {

--- a/plateform/app/routes/quiz/precision-international.tsx
+++ b/plateform/app/routes/quiz/precision-international.tsx
@@ -25,7 +25,7 @@ export default function PrecisionInternationalStep() {
 
   const handleSelect = (value: string[]) => {
     setError(undefined);
-    setAnswer(STEP_ID, { type: "options", option_ids: value });
+    setAnswer(STEP_ID, { type: "options", taxonomy: "region_internationale", option_ids: value });
   };
   const selected = answers[STEP_ID]?.type === "options" ? answers[STEP_ID].option_ids : [];
 

--- a/plateform/app/routes/quiz/precision-parcoursup-formation.tsx
+++ b/plateform/app/routes/quiz/precision-parcoursup-formation.tsx
@@ -19,7 +19,7 @@ export default function PrecisionParcoursupFormationStep() {
 
   const handleSelect = (value: string) => {
     setError(undefined);
-    setAnswer(STEP_ID, { type: "options", option_ids: [value] });
+    setAnswer(STEP_ID, { type: "options", taxonomy: "parcoursup_formation", option_ids: [value] });
   };
 
   const handleNext = () => {

--- a/plateform/app/routes/quiz/precision-reprendre-activite.tsx
+++ b/plateform/app/routes/quiz/precision-reprendre-activite.tsx
@@ -29,7 +29,7 @@ export default function PrecisionReprendreActiviteStep() {
 
   const handleSelect = (value: string[]) => {
     setError(undefined);
-    setAnswer(STEP_ID, { type: "options", option_ids: value });
+    setAnswer(STEP_ID, { type: "options", taxonomy: "secteur_activite", option_ids: value });
   };
   const selected = answers[STEP_ID]?.type === "options" ? answers[STEP_ID].option_ids : [];
 

--- a/plateform/app/routes/quiz/precision-servir-pays.tsx
+++ b/plateform/app/routes/quiz/precision-servir-pays.tsx
@@ -27,7 +27,7 @@ export default function PrecisionServirPaysStep() {
 
   const handleSelect = (value: string[]) => {
     setError(undefined);
-    setAnswer(STEP_ID, { type: "options", option_ids: value });
+    setAnswer(STEP_ID, { type: "options", taxonomy: "servir_pays", option_ids: value });
   };
   const selected = answers[STEP_ID]?.type === "options" ? answers[STEP_ID].option_ids : [];
 

--- a/plateform/app/routes/quiz/precision-thematique.tsx
+++ b/plateform/app/routes/quiz/precision-thematique.tsx
@@ -28,7 +28,7 @@ export default function PrecisionThematiqueStep() {
 
   const handleSelect = (value: string[]) => {
     setError(undefined);
-    setAnswer(STEP_ID, { type: "options", option_ids: value });
+    setAnswer(STEP_ID, { type: "options", taxonomy: "engagement_intent", option_ids: value });
   };
   const selected = answers[STEP_ID]?.type === "options" ? answers[STEP_ID].option_ids : [];
 

--- a/plateform/app/routes/quiz/statut.tsx
+++ b/plateform/app/routes/quiz/statut.tsx
@@ -34,7 +34,7 @@ export default function StatutStep() {
 
   const handleSelect = (value: string) => {
     setError(undefined);
-    setAnswer(STEP_ID, { type: "options", option_ids: [value] });
+    setAnswer(STEP_ID, { type: "options", taxonomy: "statut", option_ids: [value] });
   };
 
   const handleNext = () => {

--- a/plateform/app/routes/results.tsx
+++ b/plateform/app/routes/results.tsx
@@ -24,19 +24,25 @@ export default function ResultsPage() {
   const userValues = useMemo<MatchingDebugUserValue[]>(
     () =>
       Object.values(answers).flatMap((answer) => {
-        if (answer?.type !== "options") {
-          return [];
-        }
-
-        return answer.option_ids.map((optionId) => {
-          const [taxonomyKey, taxonomyValueKey] = optionId.split(".", 2);
-          return {
-            taxonomyKey: taxonomyKey ?? "unknown",
-            taxonomyValueKey: taxonomyValueKey ?? optionId,
-            taxonomyValueLabel: OPTIONS[optionId as keyof typeof OPTIONS]?.label ?? optionId,
+        if (answer?.type === "options") {
+          return answer.option_ids.map((optionId) => ({
+            taxonomyKey: answer.taxonomy,
+            taxonomyValueKey: optionId,
+            taxonomyValueLabel: OPTIONS[`${answer.taxonomy}.${optionId}` as keyof typeof OPTIONS]?.label ?? optionId,
             userScore: 1,
-          };
-        });
+          }));
+        }
+        if (answer?.type === "params") {
+          return [
+            {
+              taxonomyKey: answer.taxonomy,
+              taxonomyValueKey: JSON.stringify(answer.params),
+              taxonomyValueLabel: JSON.stringify(answer.params),
+              userScore: 1,
+            },
+          ];
+        }
+        return [];
       }),
     [answers],
   );

--- a/plateform/app/services/user-scoring.ts
+++ b/plateform/app/services/user-scoring.ts
@@ -1,6 +1,6 @@
 import api from "~/services/api";
 
-type ApiAnswer = { taxonomy: string; value: string } | { taxonomy: string; params: object };
+type ApiAnswer = { taxonomy: string; value: string } | { taxonomy: string; params: Record<string, unknown> };
 
 type UserScoringPayload = {
   answers: ApiAnswer[];

--- a/plateform/app/services/user-scoring.ts
+++ b/plateform/app/services/user-scoring.ts
@@ -1,8 +1,9 @@
 import api from "~/services/api";
 
+type ApiAnswer = { taxonomy: string; value: string } | { taxonomy: string; params: object };
+
 type UserScoringPayload = {
-  answers: Array<{ taxonomy_value_key: string }>;
-  geo?: { lat: number; lon: number };
+  answers: ApiAnswer[];
 };
 
 type UserScoringCreateResponse = {

--- a/plateform/app/stores/quiz.ts
+++ b/plateform/app/stores/quiz.ts
@@ -30,6 +30,6 @@ export const useQuizStore = create<QuizStore>()(
       // reset efface les réponses et le scoring mais conserve distinctId.
       reset: () => set({ answers: {}, geo: undefined, userScoringId: undefined }),
     }),
-    { name: "quiz-answers", version: 3 },
+    { name: "quiz-answers", version: 4 },
   ),
 );

--- a/plateform/app/stores/quiz.ts
+++ b/plateform/app/stores/quiz.ts
@@ -5,11 +5,9 @@ import type { QuizAnswers, ScreenAnswer } from "~/types/quiz";
 
 interface QuizStore {
   answers: QuizAnswers;
-  geo?: { lat: number; lon: number; label: string };
   userScoringId?: string;
   distinctId: string;
   setAnswer: (stepId: StepId, answer: ScreenAnswer) => void;
-  setGeo: (geo: { lat: number; lon: number; label: string }) => void;
   setUserScoringId: (id: string) => void;
   reset: () => void;
 }
@@ -20,16 +18,14 @@ export const useQuizStore = create<QuizStore>()(
   persist(
     (set) => ({
       answers: {},
-      geo: undefined,
       userScoringId: undefined,
       // Généré une fois et conservé entre sessions pour authentifier les PUT.
       distinctId: crypto.randomUUID(),
       setAnswer: (stepId, answer) => set((s) => ({ answers: { ...s.answers, [stepId]: answer } })),
-      setGeo: (geo) => set({ geo }),
       setUserScoringId: (id) => set({ userScoringId: id }),
       // reset efface les réponses et le scoring mais conserve distinctId.
-      reset: () => set({ answers: {}, geo: undefined, userScoringId: undefined }),
+      reset: () => set({ answers: {}, userScoringId: undefined }),
     }),
-    { name: "quiz-answers", version: 4 },
+    { name: "quiz-answers", version: 5 },
   ),
 );

--- a/plateform/app/types/quiz.ts
+++ b/plateform/app/types/quiz.ts
@@ -6,7 +6,7 @@ import type { Condition } from "~/utils/conditions";
 // - numeric  : valeur brute (ex: age), utilisée uniquement dans les conditions
 // - location : coordonnées géographiques (LocalisationStep)
 export type ScreenAnswer =
-  | { type: "options"; option_ids: string[] }
+  | { type: "options"; taxonomy: string; option_ids: string[] }
   | { type: "numeric"; value: number }
   | { type: "params"; taxonomy: string; params: Record<string, unknown> }
   | { type: "text"; value: string };
@@ -14,14 +14,13 @@ export type ScreenAnswer =
 export type QuizAnswers = Partial<Record<StepId, ScreenAnswer>>;
 
 // Option d'un step de type select (single ou multi).
-// `taxonomyKey` est l'identifiant canonique (namespace.key) utilisé à la fois
-// comme clé React, valeur stockée dans `option_ids`, et payload /user-scoring.
 // Le catalogue des options vit dans `~/config/quiz-options`.
 export interface StepOption {
   label: string;
   sublabel?: string;
   icon?: string;
-  taxonomyKey: string;
+  taxonomy: string;
+  value: string;
   hiddenIf?: Condition;
 }
 

--- a/plateform/app/types/quiz.ts
+++ b/plateform/app/types/quiz.ts
@@ -8,8 +8,7 @@ import type { Condition } from "~/utils/conditions";
 export type ScreenAnswer =
   | { type: "options"; option_ids: string[] }
   | { type: "numeric"; value: number }
-  | { type: "age_params"; age: number; handicap: boolean }
-  | { type: "location"; lat: number; lon: number }
+  | { type: "params"; taxonomy: string; params: Record<string, unknown> }
   | { type: "text"; value: string };
 
 export type QuizAnswers = Partial<Record<StepId, ScreenAnswer>>;

--- a/plateform/app/types/quiz.ts
+++ b/plateform/app/types/quiz.ts
@@ -8,6 +8,7 @@ import type { Condition } from "~/utils/conditions";
 export type ScreenAnswer =
   | { type: "options"; option_ids: string[] }
   | { type: "numeric"; value: number }
+  | { type: "age_params"; age: number; handicap: boolean }
   | { type: "location"; lat: number; lon: number }
   | { type: "text"; value: string };
 

--- a/plateform/app/utils/quiz.ts
+++ b/plateform/app/utils/quiz.ts
@@ -15,16 +15,10 @@ export function refreshSteps(
   return { next, prev, current, steps: freshSteps };
 }
 
-// Construit le payload /user-scoring à partir des réponses stockées.
-// - "params"  → { taxonomy, params } (taxonomy inscrite par le step lui-même)
-// - "options" → une entrée { taxonomy, value } par option_id (taxonomy inscrite par le step)
-// - autres    → non envoyés (numeric = conditions UI, text = champs libres non scorés)
-// "handicap" est exclu : sa sémantique est capturée dans answers["tranche_age"].params.handicap.
 export const buildPayload = (answers: QuizAnswers) => {
   const apiAnswers: Array<{ taxonomy: string; value: string } | { taxonomy: string; params: Record<string, unknown> }> = [];
 
-  for (const [stepId, answer] of Object.entries(answers)) {
-    if (stepId === "handicap") continue;
+  for (const [, answer] of Object.entries(answers)) {
     if (answer?.type === "params") {
       apiAnswers.push({ taxonomy: answer.taxonomy, params: answer.params });
     } else if (answer?.type === "options") {

--- a/plateform/app/utils/quiz.ts
+++ b/plateform/app/utils/quiz.ts
@@ -16,11 +16,10 @@ export function refreshSteps(
 }
 
 // Construit le payload /user-scoring à partir des réponses stockées.
-// Règles de sérialisation par type :
-//   - "params"  → { taxonomy, params } (chaque step inscrit sa propre taxonomy)
-//   - "options" → une entrée { taxonomy, value } par option_id (split sur le premier ".")
-//   - autres    → non envoyés (numeric = conditions UI, text = champs libres non scorés)
-// "handicap" est exclu : sa sémantique est déjà capturée dans answers["tranche_age"].params.handicap.
+// - "params"  → { taxonomy, params } (taxonomy inscrite par le step lui-même)
+// - "options" → une entrée { taxonomy, value } par option_id (taxonomy inscrite par le step)
+// - autres    → non envoyés (numeric = conditions UI, text = champs libres non scorés)
+// "handicap" est exclu : sa sémantique est capturée dans answers["tranche_age"].params.handicap.
 export const buildPayload = (answers: QuizAnswers) => {
   const apiAnswers: Array<{ taxonomy: string; value: string } | { taxonomy: string; params: Record<string, unknown> }> = [];
 
@@ -29,9 +28,8 @@ export const buildPayload = (answers: QuizAnswers) => {
     if (answer?.type === "params") {
       apiAnswers.push({ taxonomy: answer.taxonomy, params: answer.params });
     } else if (answer?.type === "options") {
-      for (const optionId of answer.option_ids) {
-        const dot = optionId.indexOf(".");
-        apiAnswers.push({ taxonomy: optionId.slice(0, dot), value: optionId.slice(dot + 1) });
+      for (const value of answer.option_ids) {
+        apiAnswers.push({ taxonomy: answer.taxonomy, value });
       }
     }
   }

--- a/plateform/app/utils/quiz.ts
+++ b/plateform/app/utils/quiz.ts
@@ -16,13 +16,27 @@ export function refreshSteps(
 }
 
 // Construit le payload /user-scoring à partir des réponses stockées.
-// Les `option_ids` sont déjà des taxonomy keys (format `namespace.key`) depuis la migration
-// vers le catalogue `config/quiz-options` — pas de lookup intermédiaire nécessaire.
-// On projette explicitement { lat, lon } pour ne pas envoyer label (champ UI uniquement).
-export const buildPayload = (answers: QuizAnswers, geo: { lat: number; lon: number; label?: string } | undefined) => {
-  const taxonomyKeys = Object.values(answers).flatMap((a) => (a?.type === "options" ? a.option_ids : []));
-  return {
-    answers: taxonomyKeys.map((key) => ({ taxonomy_value_key: key })),
-    geo: geo ? { lat: geo.lat, lon: geo.lon } : undefined,
-  };
+// Format de sortie : { taxonomy, value } pour les options, { taxonomy, params } pour les entrées paramétrées.
+export const buildPayload = (answers: QuizAnswers, geo: { lat: number; lon: number; label: string } | undefined) => {
+  const apiAnswers: Array<{ taxonomy: string; value: string } | { taxonomy: string; params: object }> = [];
+
+  for (const [stepId, answer] of Object.entries(answers)) {
+    if (stepId === "age" || stepId === "handicap") continue;
+    if (answer?.type === "age_params") {
+      apiAnswers.push({ taxonomy: "tranche_age", params: { age: answer.age, handicap: answer.handicap } });
+    } else if (answer?.type === "options") {
+      for (const optionId of answer.option_ids) {
+        const dotIndex = optionId.indexOf(".");
+        const taxonomy = optionId.slice(0, dotIndex);
+        const value = optionId.slice(dotIndex + 1);
+        apiAnswers.push({ taxonomy, value });
+      }
+    }
+  }
+
+  if (geo) {
+    apiAnswers.push({ taxonomy: "location", params: { lat: geo.lat, lon: geo.lon, label: geo.label } });
+  }
+
+  return { answers: apiAnswers };
 };

--- a/plateform/app/utils/quiz.ts
+++ b/plateform/app/utils/quiz.ts
@@ -16,26 +16,24 @@ export function refreshSteps(
 }
 
 // Construit le payload /user-scoring à partir des réponses stockées.
-// Format de sortie : { taxonomy, value } pour les options, { taxonomy, params } pour les entrées paramétrées.
-export const buildPayload = (answers: QuizAnswers, geo: { lat: number; lon: number; label: string } | undefined) => {
-  const apiAnswers: Array<{ taxonomy: string; value: string } | { taxonomy: string; params: object }> = [];
+// Règles de sérialisation par type :
+//   - "params"  → { taxonomy, params } (chaque step inscrit sa propre taxonomy)
+//   - "options" → une entrée { taxonomy, value } par option_id (split sur le premier ".")
+//   - autres    → non envoyés (numeric = conditions UI, text = champs libres non scorés)
+// "handicap" est exclu : sa sémantique est déjà capturée dans answers["tranche_age"].params.handicap.
+export const buildPayload = (answers: QuizAnswers) => {
+  const apiAnswers: Array<{ taxonomy: string; value: string } | { taxonomy: string; params: Record<string, unknown> }> = [];
 
   for (const [stepId, answer] of Object.entries(answers)) {
-    if (stepId === "age" || stepId === "handicap") continue;
-    if (answer?.type === "age_params") {
-      apiAnswers.push({ taxonomy: "tranche_age", params: { age: answer.age, handicap: answer.handicap } });
+    if (stepId === "handicap") continue;
+    if (answer?.type === "params") {
+      apiAnswers.push({ taxonomy: answer.taxonomy, params: answer.params });
     } else if (answer?.type === "options") {
       for (const optionId of answer.option_ids) {
-        const dotIndex = optionId.indexOf(".");
-        const taxonomy = optionId.slice(0, dotIndex);
-        const value = optionId.slice(dotIndex + 1);
-        apiAnswers.push({ taxonomy, value });
+        const dot = optionId.indexOf(".");
+        apiAnswers.push({ taxonomy: optionId.slice(0, dot), value: optionId.slice(dot + 1) });
       }
     }
-  }
-
-  if (geo) {
-    apiAnswers.push({ taxonomy: "location", params: { lat: geo.lat, lon: geo.lon, label: geo.label } });
   }
 
   return { answers: apiAnswers };


### PR DESCRIPTION
## Description

Refactoring du contrat du payload envoyé à l'endpoint `/user-scoring` côté plateform (front uniquement — la mise à jour API sera faite dans une PR séparée).

### Nouveau format des réponses

Avant :
```json
{ "answers": [{ "taxonomy_value_key": "domaine.sante_soins" }], "geo": { "lat": 48.8, "lon": 2.3 } }
```

Après :
```json
{
  "answers": [
    { "taxonomy": "domaine", "value": "sante_soins" },
    { "taxonomy": "tranche_age", "params": { "age": 18, "handicap": false } },
    { "taxonomy": "location", "params": { "lat": 48.8, "lon": 2.3, "label": "Paris" } }
  ]
}
```

### Changements principaux

- **`ScreenAnswer.options`** : ajout du champ `taxonomy` directement dans la réponse stockée — `buildPayload` lit la taxonomy sans avoir à parser les clés `taxonomy.value`
- **`StepOption`** : `taxonomyKey` (format `"statut.lyceen"`) remplacé par `taxonomy` + `value` séparés — les composants de sélection passent désormais `o.value` à `onChange`
- **`buildPayload`** : logique unifiée et sans parsing de chaîne — `options` → `{ taxonomy, value }`, `params` → `{ taxonomy, params }`
- **`geo` supprimé du store** : la localisation est maintenant stockée comme une réponse `params` classique (`answers["localisation"]`), alignée avec les autres steps
- **`tranche_age`** : nouvel answer virtuel (non lié à une route) qui combine l'âge saisi et la réponse handicap — mis à jour par `age.tsx` et `handicap.tsx`
- **Conditions** : les `screenAnswer(stepId, "taxonomy.value")` passent à `screenAnswer(stepId, "value")` dans `quiz-flow.ts` et `motivation.tsx`
- **Store** : version bumped `3 → 5` pour invalider le localStorage existant

## Type de changement

- [x] Refactoring

## Checklist

- [x] Code testé localement
- [x] Respect des standards de code (ESLint)
