### PR TITLE
refactor(api): apply taxonomy transformers

### DIFF
--- a/api/src/controllers/user-scoring.ts
+++ b/api/src/controllers/user-scoring.ts
@@ -20,32 +20,19 @@ const distinctIdSchema = zod.string().trim().min(1);
 
 const bodySchema = zod.object({
   answers: answersSchema,
-  geo: zod
-    .object({
-      lat: zod.number().min(-90).max(90),
-      lon: zod.number().min(-180).max(180),
-      radius_km: zod.number().positive().optional(),
-    })
-    .optional(),
   distinctId: distinctIdSchema.optional(),
   missionAlertEnabled: zod.boolean().default(false),
-});
+}).strict();
 
 const updateBodySchema = zod
   .object({
     answers: answersSchema.optional(),
     distinctId: distinctIdSchema,
-    geo: zod
-      .object({
-        lat: zod.number().min(-90).max(90),
-        lon: zod.number().min(-180).max(180),
-        radius_km: zod.number().positive().optional(),
-      })
-      .optional(),
     missionAlertEnabled: zod.boolean().optional(),
   })
-  .refine((body) => body.answers !== undefined || body.geo !== undefined || body.missionAlertEnabled !== undefined, {
-    message: "answers, geo or missionAlertEnabled is required",
+  .strict()
+  .refine((body) => body.answers !== undefined || body.missionAlertEnabled !== undefined, {
+    message: "answers or missionAlertEnabled is required",
   });
 
 const userScoringParamsSchema = zod.object({
@@ -86,7 +73,6 @@ router.put("/:userScoringId", async (req, res, next) => {
       userScoringId: params.data.userScoringId,
       distinctId: body.data.distinctId,
       answers: body.data.answers,
-      geo: body.data.geo,
       missionAlertEnabled: body.data.missionAlertEnabled,
     });
 

--- a/api/src/controllers/user-scoring.ts
+++ b/api/src/controllers/user-scoring.ts
@@ -1,14 +1,21 @@
 import { Router } from "express";
 import zod from "zod";
 
-import { isValidTaxonomyValueKey } from "@engagement/taxonomy";
-
 import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, NOT_FOUND } from "@/error";
-import { userScoringService } from "@/services/user-scoring";
+import { UserScoringAnswerValidationError, userScoringService } from "@/services/user-scoring";
 
 const router = Router();
 
-const answersSchema = zod.array(zod.object({ taxonomy_value_key: zod.string() })).min(1);
+const answerSchema = zod
+  .object({
+    taxonomy: zod.string().trim().min(1),
+    value: zod.string().trim().min(1).optional(),
+    params: zod.record(zod.string(), zod.unknown()).optional(),
+  })
+  .refine((answer) => (answer.value === undefined) !== (answer.params === undefined), {
+    message: "Exactly one of value or params is required",
+  });
+const answersSchema = zod.array(answerSchema).min(1);
 const distinctIdSchema = zod.string().trim().min(1);
 
 const bodySchema = zod.object({
@@ -52,16 +59,13 @@ router.post("/", async (req, res, next) => {
       return res.status(400).send({ ok: false, code: INVALID_BODY, error: body.error });
     }
 
-    // Silently discard unknown or malformed keys — only valid taxonomy values are persisted.
-    // Return 400 only if *all* answers are invalid (nothing to score).
-    const validAnswers = body.data.answers.filter((a) => isValidTaxonomyValueKey(a.taxonomy_value_key));
-    if (validAnswers.length === 0) {
-      return res.status(400).send({ ok: false, code: INVALID_BODY, message: "No valid taxonomy_value_key provided" });
-    }
-
-    const data = await userScoringService.create({ ...body.data, answers: validAnswers });
+    const data = await userScoringService.create(body.data);
     return res.status(201).send({ ok: true, data });
   } catch (error) {
+    if (error instanceof UserScoringAnswerValidationError) {
+      return res.status(400).send({ ok: false, code: INVALID_BODY, message: error.message });
+    }
+
     next(error);
   }
 });
@@ -78,15 +82,10 @@ router.put("/:userScoringId", async (req, res, next) => {
       return res.status(400).send({ ok: false, code: INVALID_BODY, error: body.error });
     }
 
-    const validAnswers = body.data.answers?.filter((a) => isValidTaxonomyValueKey(a.taxonomy_value_key));
-    if (body.data.answers && validAnswers?.length === 0) {
-      return res.status(400).send({ ok: false, code: INVALID_BODY, message: "No valid taxonomy_value_key provided" });
-    }
-
     const data = await userScoringService.update({
       userScoringId: params.data.userScoringId,
       distinctId: body.data.distinctId,
-      answers: validAnswers,
+      answers: body.data.answers,
       geo: body.data.geo,
       missionAlertEnabled: body.data.missionAlertEnabled,
     });
@@ -101,6 +100,10 @@ router.put("/:userScoringId", async (req, res, next) => {
 
     return res.status(200).send({ ok: true, data: data.data });
   } catch (error) {
+    if (error instanceof UserScoringAnswerValidationError) {
+      return res.status(400).send({ ok: false, code: INVALID_BODY, message: error.message });
+    }
+
     next(error);
   }
 });

--- a/api/src/repositories/user-scoring.ts
+++ b/api/src/repositories/user-scoring.ts
@@ -53,10 +53,27 @@ export const userScoringRepository = {
   update(params: {
     userScoringId: string;
     values: Array<{ taxonomyKey: string; valueKey: string; score?: number }>;
+    replaceAnswers: boolean;
     geo?: { lat: number; lon: number; radiusKm?: number; countryCode?: string };
     missionAlertEnabled?: boolean;
   }): Promise<{ createdCount: number; missionAlertEnabled: boolean }> {
     return prisma.$transaction(async (tx) => {
+      if (params.replaceAnswers) {
+        await tx.userScoringValue.deleteMany({
+          where: {
+            userScoringId: params.userScoringId,
+          },
+        });
+
+        if (!params.geo) {
+          await tx.userScoringGeo.deleteMany({
+            where: {
+              userScoringId: params.userScoringId,
+            },
+          });
+        }
+      }
+
       const createdValues = params.values.length
         ? await tx.userScoringValue.createMany({
             data: params.values.map((value) => ({

--- a/api/src/repositories/user-scoring.ts
+++ b/api/src/repositories/user-scoring.ts
@@ -12,7 +12,7 @@ export const userScoringRepository = {
   create(params: {
     expiresAt: Date;
     values: Array<{ taxonomyKey: string; valueKey: string; score?: number }>;
-    geo?: { lat: number; lon: number; radiusKm?: number };
+    geo?: { lat: number; lon: number; radiusKm?: number; countryCode?: string };
     distinctId?: string;
     missionAlertEnabled: boolean;
   }): Promise<UserScoring> {
@@ -21,15 +21,19 @@ export const userScoringRepository = {
         expiresAt: params.expiresAt,
         distinctId: params.distinctId,
         missionAlertEnabled: params.missionAlertEnabled,
-        values: {
-          createMany: {
-            data: params.values.map((value) => ({
-              taxonomyKey: value.taxonomyKey,
-              valueKey: value.valueKey,
-              score: value.score ?? 1.0,
-            })),
-          },
-        },
+        ...(params.values.length
+          ? {
+              values: {
+                createMany: {
+                  data: params.values.map((value) => ({
+                    taxonomyKey: value.taxonomyKey,
+                    valueKey: value.valueKey,
+                    score: value.score ?? 1.0,
+                  })),
+                },
+              },
+            }
+          : {}),
         ...(params.geo
           ? {
               geo: {
@@ -37,6 +41,7 @@ export const userScoringRepository = {
                   lat: params.geo.lat,
                   lon: params.geo.lon,
                   radiusKm: params.geo.radiusKm,
+                  countryCode: params.geo.countryCode,
                 },
               },
             }
@@ -48,7 +53,7 @@ export const userScoringRepository = {
   update(params: {
     userScoringId: string;
     values: Array<{ taxonomyKey: string; valueKey: string; score?: number }>;
-    geo?: { lat: number; lon: number; radiusKm?: number };
+    geo?: { lat: number; lon: number; radiusKm?: number; countryCode?: string };
     missionAlertEnabled?: boolean;
   }): Promise<{ createdCount: number; missionAlertEnabled: boolean }> {
     return prisma.$transaction(async (tx) => {
@@ -76,11 +81,13 @@ export const userScoringRepository = {
                       lat: params.geo.lat,
                       lon: params.geo.lon,
                       radiusKm: params.geo.radiusKm,
+                      countryCode: params.geo.countryCode,
                     },
                     update: {
                       lat: params.geo.lat,
                       lon: params.geo.lon,
                       radiusKm: params.geo.radiusKm,
+                      countryCode: params.geo.countryCode,
                     },
                   },
                 },

--- a/api/src/services/user-scoring/index.ts
+++ b/api/src/services/user-scoring/index.ts
@@ -1,11 +1,22 @@
-import { parseTaxonomyValueKey } from "@engagement/taxonomy";
+import { TAXONOMY } from "@engagement/taxonomy";
 
 import { userScoringRepository } from "@/repositories/user-scoring";
 
 const USER_SCORING_TTL_DAYS = 7;
 
+type UserScoringAnswerInput = {
+  taxonomy: string;
+  value?: string;
+  params?: Record<string, unknown>;
+};
+
+type TaxonomyDefinitionWithTransformer = {
+  values: Record<string, unknown>;
+  transformer?: (params: unknown) => string[];
+};
+
 interface CreateUserScoringInput {
-  answers: Array<{ taxonomy_value_key: string }>;
+  answers: UserScoringAnswerInput[];
   geo?: {
     lat: number;
     lon: number;
@@ -18,7 +29,7 @@ interface CreateUserScoringInput {
 interface UpdateUserScoringInput {
   userScoringId: string;
   distinctId: string;
-  answers?: Array<{ taxonomy_value_key: string }>;
+  answers?: UserScoringAnswerInput[];
   geo?: {
     lat: number;
     lon: number;
@@ -27,20 +38,74 @@ interface UpdateUserScoringInput {
   missionAlertEnabled?: boolean;
 }
 
-const buildValuesToPersist = (answers: Array<{ taxonomy_value_key: string }>) => {
-  const seen = new Set<string>();
-  const uniqueKeys: string[] = [];
-  for (const answer of answers) {
-    const key = answer.taxonomy_value_key;
-    if (!seen.has(key)) {
-      seen.add(key);
-      uniqueKeys.push(key);
+export class UserScoringAnswerValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UserScoringAnswerValidationError";
+  }
+}
+
+const getTaxonomyDefinition = (taxonomyKey: string): TaxonomyDefinitionWithTransformer | null => {
+  if (!Object.prototype.hasOwnProperty.call(TAXONOMY, taxonomyKey)) {
+    return null;
+  }
+
+  return TAXONOMY[taxonomyKey as keyof typeof TAXONOMY] as TaxonomyDefinitionWithTransformer;
+};
+
+const resolveAnswerValueKeys = (answer: UserScoringAnswerInput): string[] => {
+  const taxonomy = getTaxonomyDefinition(answer.taxonomy);
+  if (!taxonomy) {
+    throw new UserScoringAnswerValidationError(`Unknown taxonomy: ${answer.taxonomy}`);
+  }
+
+  if (answer.value !== undefined) {
+    if (!Object.prototype.hasOwnProperty.call(taxonomy.values, answer.value)) {
+      throw new UserScoringAnswerValidationError(`Unknown taxonomy value: ${answer.taxonomy}.${answer.value}`);
+    }
+
+    return [answer.value];
+  }
+
+  if (!taxonomy.transformer) {
+    throw new UserScoringAnswerValidationError(`No transformer configured for taxonomy: ${answer.taxonomy}`);
+  }
+
+  let resolvedValues: string[];
+  try {
+    resolvedValues = taxonomy.transformer(answer.params);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Invalid taxonomy params";
+    throw new UserScoringAnswerValidationError(message);
+  }
+
+  for (const value of resolvedValues) {
+    if (!Object.prototype.hasOwnProperty.call(taxonomy.values, value)) {
+      throw new UserScoringAnswerValidationError(`Transformer returned unknown taxonomy value: ${answer.taxonomy}.${value}`);
     }
   }
 
-  // Caller (controller) is responsible for filtering invalid keys before reaching here.
-  const pairs = uniqueKeys.map((key) => parseTaxonomyValueKey(key)!);
-  return pairs.map(({ taxonomyKey, valueKey }) => ({
+  return resolvedValues;
+};
+
+const buildValuesToPersist = (answers: UserScoringAnswerInput[]) => {
+  const seen = new Set<string>();
+  const uniquePairs: Array<{ taxonomyKey: string; valueKey: string }> = [];
+  for (const answer of answers) {
+    for (const valueKey of resolveAnswerValueKeys(answer)) {
+      const key = `${answer.taxonomy}.${valueKey}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        uniquePairs.push({ taxonomyKey: answer.taxonomy, valueKey });
+      }
+    }
+  }
+
+  if (uniquePairs.length === 0) {
+    throw new UserScoringAnswerValidationError("No taxonomy value resolved from answers");
+  }
+
+  return uniquePairs.map(({ taxonomyKey, valueKey }) => ({
     taxonomyKey,
     valueKey,
     score: 1.0,

--- a/api/src/services/user-scoring/index.ts
+++ b/api/src/services/user-scoring/index.ts
@@ -10,18 +10,27 @@ type UserScoringAnswerInput = {
   params?: Record<string, unknown>;
 };
 
+type UserScoringGeoInput = {
+  lat: number;
+  lon: number;
+  radiusKm?: number;
+  countryCode?: string;
+};
+
+type TaxonomyTransformerResult =
+  | string[]
+  | {
+      values?: string[];
+      geo?: UserScoringGeoInput;
+    };
+
 type TaxonomyDefinitionWithTransformer = {
   values: Record<string, unknown>;
-  transformer?: (params: unknown) => string[];
+  transformer?: (params: unknown) => TaxonomyTransformerResult;
 };
 
 interface CreateUserScoringInput {
   answers: UserScoringAnswerInput[];
-  geo?: {
-    lat: number;
-    lon: number;
-    radius_km?: number;
-  };
   distinctId?: string;
   missionAlertEnabled: boolean;
 }
@@ -30,11 +39,6 @@ interface UpdateUserScoringInput {
   userScoringId: string;
   distinctId: string;
   answers?: UserScoringAnswerInput[];
-  geo?: {
-    lat: number;
-    lon: number;
-    radius_km?: number;
-  };
   missionAlertEnabled?: boolean;
 }
 
@@ -53,7 +57,23 @@ const getTaxonomyDefinition = (taxonomyKey: string): TaxonomyDefinitionWithTrans
   return TAXONOMY[taxonomyKey as keyof typeof TAXONOMY] as TaxonomyDefinitionWithTransformer;
 };
 
-const resolveAnswerValueKeys = (answer: UserScoringAnswerInput): string[] => {
+type ResolvedAnswer = {
+  values: string[];
+  geo?: UserScoringGeoInput;
+};
+
+const normalizeTransformerResult = (result: TaxonomyTransformerResult): ResolvedAnswer => {
+  if (Array.isArray(result)) {
+    return { values: result };
+  }
+
+  return {
+    values: result.values ?? [],
+    geo: result.geo,
+  };
+};
+
+const resolveAnswer = (answer: UserScoringAnswerInput): ResolvedAnswer => {
   const taxonomy = getTaxonomyDefinition(answer.taxonomy);
   if (!taxonomy) {
     throw new UserScoringAnswerValidationError(`Unknown taxonomy: ${answer.taxonomy}`);
@@ -64,35 +84,44 @@ const resolveAnswerValueKeys = (answer: UserScoringAnswerInput): string[] => {
       throw new UserScoringAnswerValidationError(`Unknown taxonomy value: ${answer.taxonomy}.${answer.value}`);
     }
 
-    return [answer.value];
+    return { values: [answer.value] };
   }
 
   if (!taxonomy.transformer) {
     throw new UserScoringAnswerValidationError(`No transformer configured for taxonomy: ${answer.taxonomy}`);
   }
 
-  let resolvedValues: string[];
+  let resolvedAnswer: ResolvedAnswer;
   try {
-    resolvedValues = taxonomy.transformer(answer.params);
+    resolvedAnswer = normalizeTransformerResult(taxonomy.transformer(answer.params));
   } catch (error) {
     const message = error instanceof Error ? error.message : "Invalid taxonomy params";
     throw new UserScoringAnswerValidationError(message);
   }
 
-  for (const value of resolvedValues) {
+  for (const value of resolvedAnswer.values) {
     if (!Object.prototype.hasOwnProperty.call(taxonomy.values, value)) {
       throw new UserScoringAnswerValidationError(`Transformer returned unknown taxonomy value: ${answer.taxonomy}.${value}`);
     }
   }
 
-  return resolvedValues;
+  return resolvedAnswer;
 };
 
 const buildValuesToPersist = (answers: UserScoringAnswerInput[]) => {
   const seen = new Set<string>();
   const uniquePairs: Array<{ taxonomyKey: string; valueKey: string }> = [];
+  let geo: UserScoringGeoInput | undefined;
   for (const answer of answers) {
-    for (const valueKey of resolveAnswerValueKeys(answer)) {
+    const resolvedAnswer = resolveAnswer(answer);
+    if (resolvedAnswer.geo) {
+      if (geo) {
+        throw new UserScoringAnswerValidationError("Multiple location answers are not supported");
+      }
+      geo = resolvedAnswer.geo;
+    }
+
+    for (const valueKey of resolvedAnswer.values) {
       const key = `${answer.taxonomy}.${valueKey}`;
       if (!seen.has(key)) {
         seen.add(key);
@@ -101,26 +130,29 @@ const buildValuesToPersist = (answers: UserScoringAnswerInput[]) => {
     }
   }
 
-  if (uniquePairs.length === 0) {
+  if (uniquePairs.length === 0 && !geo) {
     throw new UserScoringAnswerValidationError("No taxonomy value resolved from answers");
   }
 
-  return uniquePairs.map(({ taxonomyKey, valueKey }) => ({
-    taxonomyKey,
-    valueKey,
-    score: 1.0,
-  }));
+  return {
+    values: uniquePairs.map(({ taxonomyKey, valueKey }) => ({
+      taxonomyKey,
+      valueKey,
+      score: 1.0,
+    })),
+    geo,
+  };
 };
 
 export const userScoringService = {
   async create(input: CreateUserScoringInput) {
-    const valuesToPersist = buildValuesToPersist(input.answers);
+    const scoringData = buildValuesToPersist(input.answers);
     const expiresAt = new Date(Date.now() + USER_SCORING_TTL_DAYS * 24 * 60 * 60 * 1000);
 
     const userScoring = await userScoringRepository.create({
       expiresAt,
-      values: valuesToPersist,
-      geo: input.geo ? { lat: input.geo.lat, lon: input.geo.lon, radiusKm: input.geo.radius_km } : undefined,
+      values: scoringData.values,
+      geo: scoringData.geo,
       distinctId: input?.distinctId,
       missionAlertEnabled: input.missionAlertEnabled,
     });
@@ -138,11 +170,11 @@ export const userScoringService = {
       return { status: "forbidden" as const };
     }
 
-    const valuesToPersist = input.answers ? buildValuesToPersist(input.answers) : [];
+    const scoringData = input.answers ? buildValuesToPersist(input.answers) : { values: [], geo: undefined };
     const result = await userScoringRepository.update({
       userScoringId: input.userScoringId,
-      values: valuesToPersist,
-      geo: input.geo ? { lat: input.geo.lat, lon: input.geo.lon, radiusKm: input.geo.radius_km } : undefined,
+      values: scoringData.values,
+      geo: scoringData.geo,
       missionAlertEnabled: input.missionAlertEnabled,
     });
 

--- a/api/src/services/user-scoring/index.ts
+++ b/api/src/services/user-scoring/index.ts
@@ -174,6 +174,7 @@ export const userScoringService = {
     const result = await userScoringRepository.update({
       userScoringId: input.userScoringId,
       values: scoringData.values,
+      replaceAnswers: input.answers !== undefined,
       geo: scoringData.geo,
       missionAlertEnabled: input.missionAlertEnabled,
     });

--- a/api/tests/integration/api/user-scoring.test.ts
+++ b/api/tests/integration/api/user-scoring.test.ts
@@ -42,12 +42,11 @@ describe("POST /user-scoring", () => {
     expect(geo).toBeNull();
   });
 
-  it("should create a user scoring with geo (lat/lon only)", async () => {
+  it("should create a user scoring with location params (lat/lon only)", async () => {
     const res = await request(app)
       .post("/user-scoring")
       .send({
-        answers: [taxonomyAnswer],
-        geo: { lat: 48.8566, lon: 2.3522 },
+        answers: [taxonomyAnswer, { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } }],
       });
 
     expect(res.status).toBe(201);
@@ -61,12 +60,11 @@ describe("POST /user-scoring", () => {
     expect(geo!.radiusKm).toBeNull();
   });
 
-  it("should create a user scoring with geo including radius_km", async () => {
+  it("should create a user scoring with location params including radius_km and country_code", async () => {
     const res = await request(app)
       .post("/user-scoring")
       .send({
-        answers: [taxonomyAnswer],
-        geo: { lat: 48.8566, lon: 2.3522, radius_km: 50 },
+        answers: [taxonomyAnswer, { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522, radius_km: 50, country_code: "fr" } }],
       });
 
     expect(res.status).toBe(201);
@@ -75,6 +73,29 @@ describe("POST /user-scoring", () => {
       where: { userScoringId: res.body.data.id },
     });
     expect(geo!.radiusKm).toBe(50);
+    expect(geo!.countryCode).toBe("FR");
+  });
+
+  it("should create a user scoring with only location params", async () => {
+    const res = await request(app)
+      .post("/user-scoring")
+      .send({
+        answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } }],
+      });
+
+    expect(res.status).toBe(201);
+
+    const values = await prisma.userScoringValue.findMany({
+      where: { userScoringId: res.body.data.id },
+    });
+    expect(values).toHaveLength(0);
+
+    const geo = await prisma.userScoringGeo.findUnique({
+      where: { userScoringId: res.body.data.id },
+    });
+    expect(geo).not.toBeNull();
+    expect(geo!.lat).toBe(48.8566);
+    expect(geo!.lon).toBe(2.3522);
   });
 
   it("should create a user scoring with multiple answers", async () => {
@@ -268,24 +289,97 @@ describe("POST /user-scoring", () => {
     expect(responses.every((res) => res.body.ok === false)).toBe(true);
   });
 
-  it("should return 400 when geo.lat is out of range", async () => {
+  it("should create a user scoring with direct values, tranche_age and location params", async () => {
     const res = await request(app)
       .post("/user-scoring")
       .send({
-        answers: [taxonomyAnswer],
-        geo: { lat: 999, lon: 2.3522 },
+        answers: [
+          taxonomyAnswer,
+          { taxonomy: "tranche_age", params: { age: 18, handicap: false } },
+          { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } },
+        ],
+      });
+
+    expect(res.status).toBe(201);
+
+    const values = await prisma.userScoringValue.findMany({
+      where: { userScoringId: res.body.data.id },
+    });
+    expect(values).toHaveLength(4);
+
+    const geo = await prisma.userScoringGeo.findUnique({
+      where: { userScoringId: res.body.data.id },
+    });
+    expect(geo).not.toBeNull();
+  });
+
+  it("should return 400 when location lat is out of range", async () => {
+    const res = await request(app)
+      .post("/user-scoring")
+      .send({
+        answers: [{ taxonomy: "location", params: { lat: 999, lon: 2.3522 } }],
       });
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
   });
 
-  it("should return 400 when geo.lon is out of range", async () => {
+  it("should return 400 when location lon is out of range", async () => {
+    const res = await request(app)
+      .post("/user-scoring")
+      .send({
+        answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 999 } }],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("should return 400 when location radius_km is invalid", async () => {
+    const res = await request(app)
+      .post("/user-scoring")
+      .send({
+        answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 2.3522, radius_km: 0 } }],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("should return 400 when location country_code is invalid", async () => {
+    const res = await request(app)
+      .post("/user-scoring")
+      .send({
+        answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 2.3522, country_code: "FRA" } }],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("should return 400 when location uses a value or is duplicated", async () => {
+    const responses = await Promise.all([
+      request(app)
+        .post("/user-scoring")
+        .send({ answers: [{ taxonomy: "location", value: "paris" }] }),
+      request(app)
+        .post("/user-scoring")
+        .send({
+          answers: [
+            { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } },
+            { taxonomy: "location", params: { lat: 45.764, lon: 4.8357 } },
+          ],
+        }),
+    ]);
+
+    expect(responses.map((res) => res.status)).toEqual([400, 400]);
+    expect(responses.every((res) => res.body.ok === false)).toBe(true);
+  });
+
+  it("should return 400 when top-level geo is provided", async () => {
     const res = await request(app)
       .post("/user-scoring")
       .send({
         answers: [taxonomyAnswer],
-        geo: { lat: 48.8566, lon: 999 },
+        geo: { lat: 48.8566, lon: 2.3522 },
       });
+
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
   });
@@ -419,6 +513,46 @@ describe("PUT /user-scoring/:userScoringId", () => {
     expect(values).toHaveLength(4);
   });
 
+  it("should update geo from location params", async () => {
+    const userScoringId = await createUserScoring();
+
+    const res = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({
+        distinctId,
+        answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 2.3522, radius_km: 25, country_code: "FR" } }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.created_count).toBe(0);
+
+    const geo = await prisma.userScoringGeo.findUnique({
+      where: { userScoringId },
+    });
+    expect(geo).not.toBeNull();
+    expect(geo!.lat).toBe(48.8566);
+    expect(geo!.lon).toBe(2.3522);
+    expect(geo!.radiusKm).toBe(25);
+    expect(geo!.countryCode).toBe("FR");
+  });
+
+  it("should accept an update with only location params", async () => {
+    const userScoringId = await createUserScoring();
+
+    const res = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({
+        distinctId,
+        answers: [{ taxonomy: "location", params: { lat: 45.764, lon: 4.8357 } }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: { user_scoring_id: userScoringId, created_count: 0, mission_alert_enabled: false },
+    });
+  });
+
   it("should return 400 when added answers are invalid", async () => {
     const userScoringId = await createUserScoring();
 
@@ -434,6 +568,17 @@ describe("PUT /user-scoring/:userScoringId", () => {
     const userScoringId = await createUserScoring();
 
     const res = await request(app).put(`/user-scoring/${userScoringId}`).send({ distinctId });
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("should return 400 when top-level geo is provided on update", async () => {
+    const userScoringId = await createUserScoring();
+
+    const res = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({ distinctId, geo: { lat: 48.8566, lon: 2.3522 } });
 
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);

--- a/api/tests/integration/api/user-scoring.test.ts
+++ b/api/tests/integration/api/user-scoring.test.ts
@@ -395,16 +395,21 @@ describe("PUT /user-scoring/:userScoringId", () => {
     secondaryTaxonomyAnswer = { taxonomy: "type_mission", value: "ponctuelle" };
   });
 
-  const createUserScoring = async (params: { distinctId?: string } = { distinctId }) => {
+  const createUserScoring = async (
+    params: {
+      distinctId?: string;
+      answers?: Array<{ taxonomy: string; value?: string; params?: Record<string, unknown> }>;
+    } = { distinctId },
+  ) => {
     const res = await request(app)
       .post("/user-scoring")
-      .send({ answers: [taxonomyAnswer], distinctId: params.distinctId });
+      .send({ answers: params.answers ?? [taxonomyAnswer], distinctId: params.distinctId });
 
     expect(res.status).toBe(201);
     return res.body.data.id as string;
   };
 
-  it("should add answers to an existing user scoring", async () => {
+  it("should replace existing answers on an existing user scoring", async () => {
     const userScoringId = await createUserScoring();
 
     const res = await request(app)
@@ -421,8 +426,8 @@ describe("PUT /user-scoring/:userScoringId", () => {
       where: { userScoringId },
       orderBy: [{ taxonomyKey: "asc" }, { valueKey: "asc" }],
     });
-    expect(values).toHaveLength(2);
-    expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual(["domaine.social_solidarite", "type_mission.ponctuelle"]);
+    expect(values).toHaveLength(1);
+    expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual(["type_mission.ponctuelle"]);
   });
 
   it("should update missionAlertEnabled without adding answers", async () => {
@@ -447,7 +452,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
     expect(values).toHaveLength(1);
   });
 
-  it("should add answers and update missionAlertEnabled in the same request", async () => {
+  it("should replace answers and update missionAlertEnabled in the same request", async () => {
     const userScoringId = await createUserScoring();
 
     const res = await request(app)
@@ -472,10 +477,10 @@ describe("PUT /user-scoring/:userScoringId", () => {
     const values = await prisma.userScoringValue.findMany({
       where: { userScoringId },
     });
-    expect(values).toHaveLength(2);
+    expect(values).toHaveLength(1);
   });
 
-  it("should skip duplicate answers when adding answers", async () => {
+  it("should replace all existing values with payload values and deduplicate answers", async () => {
     const userScoringId = await createUserScoring();
 
     const res = await request(app)
@@ -486,15 +491,38 @@ describe("PUT /user-scoring/:userScoringId", () => {
       });
 
     expect(res.status).toBe(200);
+    expect(res.body.data.created_count).toBe(2);
+
+    const values = await prisma.userScoringValue.findMany({
+      where: { userScoringId },
+      orderBy: [{ taxonomyKey: "asc" }, { valueKey: "asc" }],
+    });
+    expect(values).toHaveLength(2);
+    expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual(["domaine.social_solidarite", "type_mission.ponctuelle"]);
+  });
+
+  it("should replace existing values for a direct taxonomy", async () => {
+    const userScoringId = await createUserScoring();
+
+    const res = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({
+        distinctId,
+        answers: [{ taxonomy: "domaine", value: "sante_soins" }],
+      });
+
+    expect(res.status).toBe(200);
     expect(res.body.data.created_count).toBe(1);
 
     const values = await prisma.userScoringValue.findMany({
       where: { userScoringId },
     });
-    expect(values).toHaveLength(2);
+    expect(values).toHaveLength(1);
+    expect(values[0].taxonomyKey).toBe("domaine");
+    expect(values[0].valueKey).toBe("sante_soins");
   });
 
-  it("should add resolved tranche_age answers", async () => {
+  it("should replace existing values with resolved tranche_age answers", async () => {
     const userScoringId = await createUserScoring();
 
     const res = await request(app)
@@ -510,7 +538,76 @@ describe("PUT /user-scoring/:userScoringId", () => {
     const values = await prisma.userScoringValue.findMany({
       where: { userScoringId },
     });
-    expect(values).toHaveLength(4);
+    expect(values).toHaveLength(3);
+  });
+
+  it("should replace existing tranche_age values when age changes", async () => {
+    const userScoringId = await createUserScoring();
+
+    const firstRes = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({
+        distinctId,
+        answers: [{ taxonomy: "tranche_age", params: { age: 18, handicap: false } }],
+      });
+    expect(firstRes.status).toBe(200);
+    expect(firstRes.body.data.created_count).toBe(3);
+
+    const secondRes = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({
+        distinctId,
+        answers: [{ taxonomy: "tranche_age", params: { age: 70, handicap: false } }],
+      });
+
+    expect(secondRes.status).toBe(200);
+    expect(secondRes.body.data.created_count).toBe(1);
+
+    const values = await prisma.userScoringValue.findMany({
+      where: { userScoringId },
+      orderBy: [{ taxonomyKey: "asc" }, { valueKey: "asc" }],
+    });
+    expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual(["tranche_age.entre_17_72_ans"]);
+  });
+
+  it("should delete existing geo when answers do not include location", async () => {
+    const userScoringId = await createUserScoring({
+      distinctId,
+      answers: [taxonomyAnswer, { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } }],
+    });
+
+    const res = await request(app)
+      .put(`/user-scoring/${userScoringId}`)
+      .send({
+        distinctId,
+        answers: [secondaryTaxonomyAnswer],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.created_count).toBe(1);
+
+    const geo = await prisma.userScoringGeo.findUnique({
+      where: { userScoringId },
+    });
+    expect(geo).toBeNull();
+  });
+
+  it("should keep existing geo when update does not include answers", async () => {
+    const userScoringId = await createUserScoring({
+      distinctId,
+      answers: [taxonomyAnswer, { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } }],
+    });
+
+    const res = await request(app).put(`/user-scoring/${userScoringId}`).send({ distinctId, missionAlertEnabled: true });
+
+    expect(res.status).toBe(200);
+
+    const geo = await prisma.userScoringGeo.findUnique({
+      where: { userScoringId },
+    });
+    expect(geo).not.toBeNull();
+    expect(geo!.lat).toBe(48.8566);
+    expect(geo!.lon).toBe(2.3522);
   });
 
   it("should update geo from location params", async () => {
@@ -534,6 +631,11 @@ describe("PUT /user-scoring/:userScoringId", () => {
     expect(geo!.lon).toBe(2.3522);
     expect(geo!.radiusKm).toBe(25);
     expect(geo!.countryCode).toBe("FR");
+
+    const values = await prisma.userScoringValue.findMany({
+      where: { userScoringId },
+    });
+    expect(values).toHaveLength(0);
   });
 
   it("should accept an update with only location params", async () => {

--- a/api/tests/integration/api/user-scoring.test.ts
+++ b/api/tests/integration/api/user-scoring.test.ts
@@ -2,18 +2,17 @@ import request from "supertest";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { prisma } from "@/db/postgres";
-import { type TaxonomyValueKey } from "@engagement/taxonomy";
 import { createTestApp } from "../../testApp";
 
 const app = createTestApp();
 
 describe("POST /user-scoring", () => {
-  let taxonomyValueKey: string;
-  let secondaryTaxonomyValueKey: string;
+  let taxonomyAnswer: { taxonomy: string; value: string };
+  let secondaryTaxonomyAnswer: { taxonomy: string; value: string };
 
   beforeEach(async () => {
-    taxonomyValueKey = "domaine.social_solidarite" satisfies TaxonomyValueKey;
-    secondaryTaxonomyValueKey = "type_mission.ponctuelle" satisfies TaxonomyValueKey;
+    taxonomyAnswer = { taxonomy: "domaine", value: "social_solidarite" };
+    secondaryTaxonomyAnswer = { taxonomy: "type_mission", value: "ponctuelle" };
   });
 
   // ─── Success cases ──────────────────────────────────────────────────────────
@@ -21,7 +20,7 @@ describe("POST /user-scoring", () => {
   it("should create a user scoring with one answer (no geo)", async () => {
     const res = await request(app)
       .post("/user-scoring")
-      .send({ answers: [{ taxonomy_value_key: taxonomyValueKey }] });
+      .send({ answers: [taxonomyAnswer] });
 
     expect(res.status).toBe(201);
     expect(res.body.ok).toBe(true);
@@ -47,7 +46,7 @@ describe("POST /user-scoring", () => {
     const res = await request(app)
       .post("/user-scoring")
       .send({
-        answers: [{ taxonomy_value_key: taxonomyValueKey }],
+        answers: [taxonomyAnswer],
         geo: { lat: 48.8566, lon: 2.3522 },
       });
 
@@ -66,7 +65,7 @@ describe("POST /user-scoring", () => {
     const res = await request(app)
       .post("/user-scoring")
       .send({
-        answers: [{ taxonomy_value_key: taxonomyValueKey }],
+        answers: [taxonomyAnswer],
         geo: { lat: 48.8566, lon: 2.3522, radius_km: 50 },
       });
 
@@ -82,7 +81,7 @@ describe("POST /user-scoring", () => {
     const res = await request(app)
       .post("/user-scoring")
       .send({
-        answers: [{ taxonomy_value_key: taxonomyValueKey }, { taxonomy_value_key: secondaryTaxonomyValueKey }],
+        answers: [taxonomyAnswer, secondaryTaxonomyAnswer],
       });
 
     expect(res.status).toBe(201);
@@ -99,7 +98,7 @@ describe("POST /user-scoring", () => {
     const res = await request(app)
       .post("/user-scoring")
       .send({
-        answers: [{ taxonomy_value_key: taxonomyValueKey }],
+        answers: [taxonomyAnswer],
         distinctId: "distinct-user-1",
         missionAlertEnabled: true,
       });
@@ -113,11 +112,11 @@ describe("POST /user-scoring", () => {
     expect(userScoring.missionAlertEnabled).toBe(true);
   });
 
-  it("should deduplicate answers with repeated taxonomy_value_key", async () => {
+  it("should deduplicate repeated answers", async () => {
     const res = await request(app)
       .post("/user-scoring")
       .send({
-        answers: [{ taxonomy_value_key: taxonomyValueKey }, { taxonomy_value_key: taxonomyValueKey }],
+        answers: [taxonomyAnswer, taxonomyAnswer],
       });
 
     expect(res.status).toBe(201);
@@ -132,7 +131,7 @@ describe("POST /user-scoring", () => {
     const before = Date.now();
     const res = await request(app)
       .post("/user-scoring")
-      .send({ answers: [{ taxonomy_value_key: taxonomyValueKey }] });
+      .send({ answers: [taxonomyAnswer] });
 
     const userScoring = await prisma.userScoring.findUniqueOrThrow({
       where: { id: res.body.data.id },
@@ -159,11 +158,54 @@ describe("POST /user-scoring", () => {
     expect(res.body.ok).toBe(false);
   });
 
-  it("should silently skip invalid answers and return 201 when at least one is valid", async () => {
+  it("should create a user scoring from tranche_age params", async () => {
     const res = await request(app)
       .post("/user-scoring")
       .send({
-        answers: [{ taxonomy_value_key: taxonomyValueKey }, { taxonomy_value_key: "domaine.does_not_exist" }, { taxonomy_value_key: "nodotinkey" }],
+        answers: [{ taxonomy: "tranche_age", params: { age: 18, handicap: false } }],
+      });
+
+    expect(res.status).toBe(201);
+
+    const values = await prisma.userScoringValue.findMany({
+      where: { userScoringId: res.body.data.id },
+      orderBy: [{ valueKey: "asc" }],
+    });
+    expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual([
+      "tranche_age.entre_16_67_ans",
+      "tranche_age.entre_17_72_ans",
+      "tranche_age.moins_26_ans",
+    ]);
+  });
+
+  it("should create a user scoring with handicap tranche_age params", async () => {
+    const res = await request(app)
+      .post("/user-scoring")
+      .send({
+        answers: [{ taxonomy: "tranche_age", params: { age: 30, handicap: true } }],
+      });
+
+    expect(res.status).toBe(201);
+
+    const values = await prisma.userScoringValue.findMany({
+      where: { userScoringId: res.body.data.id },
+      orderBy: [{ valueKey: "asc" }],
+    });
+    expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual([
+      "tranche_age.entre_16_67_ans",
+      "tranche_age.entre_17_72_ans",
+      "tranche_age.moins_31_ans_handicap",
+    ]);
+  });
+
+  it("should deduplicate direct and resolved answers", async () => {
+    const res = await request(app)
+      .post("/user-scoring")
+      .send({
+        answers: [
+          { taxonomy: "tranche_age", value: "moins_26_ans" },
+          { taxonomy: "tranche_age", params: { age: 18, handicap: false } },
+        ],
       });
 
     expect(res.status).toBe(201);
@@ -171,35 +213,55 @@ describe("POST /user-scoring", () => {
     const values = await prisma.userScoringValue.findMany({
       where: { userScoringId: res.body.data.id },
     });
-    expect(values).toHaveLength(1);
-    expect(values[0].taxonomyKey).toBe("domaine");
-    expect(values[0].valueKey).toBe("social_solidarite");
+    expect(values).toHaveLength(3);
   });
 
-  it("should return 400 when all answers are invalid (no dot separator)", async () => {
+  it("should return 400 when taxonomy is unknown", async () => {
     const res = await request(app)
       .post("/user-scoring")
-      .send({ answers: [{ taxonomy_value_key: "nodotinkey" }] });
+      .send({ answers: [{ taxonomy: "unknown", value: "sante_soins" }] });
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
   });
 
-  it("should return 400 when all answers reference unknown taxonomy values", async () => {
+  it("should return 400 when taxonomy value is unknown", async () => {
     const res = await request(app)
       .post("/user-scoring")
-      .send({ answers: [{ taxonomy_value_key: "domaine.does_not_exist" }] });
+      .send({ answers: [{ taxonomy: "domaine", value: "does_not_exist" }] });
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
   });
 
-  it("should return 400 when taxonomy_value_key targets inherited object properties", async () => {
+  it("should return 400 when params target a taxonomy without transformer", async () => {
+    const res = await request(app)
+      .post("/user-scoring")
+      .send({ answers: [{ taxonomy: "domaine", params: { age: 18 } }] });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("should return 400 when tranche_age params are invalid", async () => {
     const responses = await Promise.all([
       request(app)
         .post("/user-scoring")
-        .send({ answers: [{ taxonomy_value_key: "domaine.toString" }] }),
+        .send({ answers: [{ taxonomy: "tranche_age", params: { age: 121, handicap: false } }] }),
       request(app)
         .post("/user-scoring")
-        .send({ answers: [{ taxonomy_value_key: "__proto__.x" }] }),
+        .send({ answers: [{ taxonomy: "tranche_age", params: { age: 18, handicap: "false" } }] }),
+    ]);
+
+    expect(responses.map((res) => res.status)).toEqual([400, 400]);
+    expect(responses.every((res) => res.body.ok === false)).toBe(true);
+  });
+
+  it("should return 400 when answer has both value and params or neither", async () => {
+    const responses = await Promise.all([
+      request(app)
+        .post("/user-scoring")
+        .send({ answers: [{ taxonomy: "domaine", value: "social_solidarite", params: { age: 18 } }] }),
+      request(app)
+        .post("/user-scoring")
+        .send({ answers: [{ taxonomy: "domaine" }] }),
     ]);
 
     expect(responses.map((res) => res.status)).toEqual([400, 400]);
@@ -210,7 +272,7 @@ describe("POST /user-scoring", () => {
     const res = await request(app)
       .post("/user-scoring")
       .send({
-        answers: [{ taxonomy_value_key: taxonomyValueKey }],
+        answers: [taxonomyAnswer],
         geo: { lat: 999, lon: 2.3522 },
       });
     expect(res.status).toBe(400);
@@ -221,7 +283,7 @@ describe("POST /user-scoring", () => {
     const res = await request(app)
       .post("/user-scoring")
       .send({
-        answers: [{ taxonomy_value_key: taxonomyValueKey }],
+        answers: [taxonomyAnswer],
         geo: { lat: 48.8566, lon: 999 },
       });
     expect(res.status).toBe(400);
@@ -231,18 +293,18 @@ describe("POST /user-scoring", () => {
 
 describe("PUT /user-scoring/:userScoringId", () => {
   const distinctId = "distinct-user-1";
-  let taxonomyValueKey: string;
-  let secondaryTaxonomyValueKey: string;
+  let taxonomyAnswer: { taxonomy: string; value: string };
+  let secondaryTaxonomyAnswer: { taxonomy: string; value: string };
 
   beforeEach(async () => {
-    taxonomyValueKey = "domaine.social_solidarite" satisfies TaxonomyValueKey;
-    secondaryTaxonomyValueKey = "type_mission.ponctuelle" satisfies TaxonomyValueKey;
+    taxonomyAnswer = { taxonomy: "domaine", value: "social_solidarite" };
+    secondaryTaxonomyAnswer = { taxonomy: "type_mission", value: "ponctuelle" };
   });
 
   const createUserScoring = async (params: { distinctId?: string } = { distinctId }) => {
     const res = await request(app)
       .post("/user-scoring")
-      .send({ answers: [{ taxonomy_value_key: taxonomyValueKey }], distinctId: params.distinctId });
+      .send({ answers: [taxonomyAnswer], distinctId: params.distinctId });
 
     expect(res.status).toBe(201);
     return res.body.data.id as string;
@@ -253,7 +315,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
 
     const res = await request(app)
       .put(`/user-scoring/${userScoringId}`)
-      .send({ distinctId, answers: [{ taxonomy_value_key: secondaryTaxonomyValueKey }] });
+      .send({ distinctId, answers: [secondaryTaxonomyAnswer] });
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
@@ -299,7 +361,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
       .send({
         distinctId,
         missionAlertEnabled: true,
-        answers: [{ taxonomy_value_key: secondaryTaxonomyValueKey }],
+        answers: [secondaryTaxonomyAnswer],
       });
 
     expect(res.status).toBe(200);
@@ -326,7 +388,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
       .put(`/user-scoring/${userScoringId}`)
       .send({
         distinctId,
-        answers: [{ taxonomy_value_key: taxonomyValueKey }, { taxonomy_value_key: secondaryTaxonomyValueKey }, { taxonomy_value_key: secondaryTaxonomyValueKey }],
+        answers: [taxonomyAnswer, secondaryTaxonomyAnswer, secondaryTaxonomyAnswer],
       });
 
     expect(res.status).toBe(200);
@@ -338,26 +400,31 @@ describe("PUT /user-scoring/:userScoringId", () => {
     expect(values).toHaveLength(2);
   });
 
-  it("should silently skip invalid answers when adding answers", async () => {
+  it("should add resolved tranche_age answers", async () => {
     const userScoringId = await createUserScoring();
 
     const res = await request(app)
       .put(`/user-scoring/${userScoringId}`)
       .send({
         distinctId,
-        answers: [{ taxonomy_value_key: secondaryTaxonomyValueKey }, { taxonomy_value_key: "domaine.does_not_exist" }],
+        answers: [{ taxonomy: "tranche_age", params: { age: 18, handicap: false } }],
       });
 
     expect(res.status).toBe(200);
-    expect(res.body.data.created_count).toBe(1);
+    expect(res.body.data.created_count).toBe(3);
+
+    const values = await prisma.userScoringValue.findMany({
+      where: { userScoringId },
+    });
+    expect(values).toHaveLength(4);
   });
 
-  it("should return 400 when all added answers are invalid", async () => {
+  it("should return 400 when added answers are invalid", async () => {
     const userScoringId = await createUserScoring();
 
     const res = await request(app)
       .put(`/user-scoring/${userScoringId}`)
-      .send({ distinctId, answers: [{ taxonomy_value_key: "domaine.does_not_exist" }] });
+      .send({ distinctId, answers: [{ taxonomy: "domaine", value: "does_not_exist" }] });
 
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
@@ -377,7 +444,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
 
     const res = await request(app)
       .put(`/user-scoring/${userScoringId}`)
-      .send({ answers: [{ taxonomy_value_key: secondaryTaxonomyValueKey }] });
+      .send({ answers: [secondaryTaxonomyAnswer] });
 
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
@@ -388,7 +455,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
 
     const res = await request(app)
       .put(`/user-scoring/${userScoringId}`)
-      .send({ distinctId: "another-distinct-user", answers: [{ taxonomy_value_key: secondaryTaxonomyValueKey }] });
+      .send({ distinctId: "another-distinct-user", answers: [secondaryTaxonomyAnswer] });
 
     expect(res.status).toBe(403);
     expect(res.body.ok).toBe(false);
@@ -404,7 +471,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
 
     const res = await request(app)
       .put(`/user-scoring/${userScoringId}`)
-      .send({ distinctId, answers: [{ taxonomy_value_key: secondaryTaxonomyValueKey }] });
+      .send({ distinctId, answers: [secondaryTaxonomyAnswer] });
 
     expect(res.status).toBe(403);
     expect(res.body.ok).toBe(false);
@@ -413,7 +480,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should return 400 when userScoringId is not a uuid", async () => {
     const res = await request(app)
       .put("/user-scoring/not-a-uuid")
-      .send({ distinctId, answers: [{ taxonomy_value_key: taxonomyValueKey }] });
+      .send({ distinctId, answers: [taxonomyAnswer] });
 
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
@@ -422,7 +489,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should return 404 when user scoring does not exist", async () => {
     const res = await request(app)
       .put("/user-scoring/00000000-0000-4000-8000-000000000000")
-      .send({ distinctId, answers: [{ taxonomy_value_key: taxonomyValueKey }] });
+      .send({ distinctId, answers: [taxonomyAnswer] });
 
     expect(res.status).toBe(404);
     expect(res.body.ok).toBe(false);

--- a/packages/taxonomy/src/taxonomy.ts
+++ b/packages/taxonomy/src/taxonomy.ts
@@ -5,13 +5,16 @@
 //   label     — libellé affiché en UI / logs
 //   type      — "multi_value" | "categorical" | "gate" (correspond au TaxonomyType Prisma)
 //   enrichable — true si la taxonomy est classifiée par le LLM (mission-enrichment)
-//   gate       — true si la taxonomy est un filtre dur dans le matching engine
+//   gate        — true si la taxonomy est un filtre dur dans le matching engine
+//   transformer — fonction optionnelle qui calcule des value keys depuis des params utilisateur
 //
 // Champs par valeur :
 //   label      — libellé affiché
 //   sublabel   — aide contextuelle optionnelle pour les UIs
 //   icon       — emoji optionnel
 //   enrichable — false pour les valeurs exclues de l'enrichissement (ex : je_ne_sais_pas)
+
+import { resolveTrancheAgeValues } from "./transformers/tranche-age";
 
 export const TAXONOMY = {
   // ─── Taxonomies enrichissables ────────────────────────────────────────────
@@ -286,11 +289,12 @@ export const TAXONOMY = {
     type: "gate",
     enrichable: false, // pas enrichie par le LLM — calculée côté client (âge saisi)
     gate: true,
+    transformer: resolveTrancheAgeValues,
     values: {
       moins_26_ans: { label: "Moins de 26 ans", icon: null, enrichable: false },
       moins_31_ans_handicap: { label: "Moins de 31 ans — situation de handicap", icon: null, enrichable: false },
       entre_17_72_ans: { label: "Être âgé de 17 à 72 ans", icon: null, enrichable: false },
-      entre_16_67_ans: { label: "Avoir au minimum 16 ans (avec autorisation parentale pour les mineurs) et moins de 67 ans", icon: null, enrichable: false }
+      entre_16_67_ans: { label: "Avoir au minimum 16 ans (avec autorisation parentale pour les mineurs) et moins de 67 ans", icon: null, enrichable: false },
     },
   },
 } as const;

--- a/packages/taxonomy/src/taxonomy.ts
+++ b/packages/taxonomy/src/taxonomy.ts
@@ -3,7 +3,7 @@
 //
 // Champs par taxonomy :
 //   label     — libellé affiché en UI / logs
-//   type      — "multi_value" | "categorical" | "gate" (correspond au TaxonomyType Prisma)
+//   type      — "multi_value" | "categorical" | "gate" | "value"
 //   enrichable — true si la taxonomy est classifiée par le LLM (mission-enrichment)
 //   gate        — true si la taxonomy est un filtre dur dans le matching engine
 //   transformer — fonction optionnelle qui calcule des value keys depuis des params utilisateur
@@ -14,6 +14,7 @@
 //   icon       — emoji optionnel
 //   enrichable — false pour les valeurs exclues de l'enrichissement (ex : je_ne_sais_pas)
 
+import { resolveLocationValues } from "./transformers/location";
 import { resolveTrancheAgeValues } from "./transformers/tranche-age";
 
 export const TAXONOMY = {
@@ -280,6 +281,15 @@ export const TAXONOMY = {
       ne_sais_pas: { label: "Je ne sais pas", icon: null, enrichable: false },
       aucun: { label: "Aucun de ces choix", icon: null, enrichable: false },
     },
+  },
+
+  location: {
+    label: "Localisation",
+    type: "value",
+    enrichable: false,
+    gate: false,
+    transformer: resolveLocationValues,
+    values: {},
   },
 
   // ─── taxonomy gate (filtre dur dans le matching) ────────────────────────

--- a/packages/taxonomy/src/transformers/location.ts
+++ b/packages/taxonomy/src/transformers/location.ts
@@ -1,0 +1,46 @@
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
+
+export type LocationTransformerResult = {
+  geo: {
+    lat: number;
+    lon: number;
+    radiusKm?: number;
+    countryCode?: string;
+  };
+};
+
+export const resolveLocationValues = (params: unknown): LocationTransformerResult => {
+  if (!isRecord(params)) {
+    throw new Error("location params must be an object");
+  }
+
+  const lat = params.lat;
+  const lon = params.lon;
+  const radiusKm = params.radius_km;
+  const countryCode = params.country_code;
+
+  if (typeof lat !== "number" || lat < -90 || lat > 90) {
+    throw new Error("location.lat must be a number between -90 and 90");
+  }
+
+  if (typeof lon !== "number" || lon < -180 || lon > 180) {
+    throw new Error("location.lon must be a number between -180 and 180");
+  }
+
+  if (radiusKm !== undefined && (typeof radiusKm !== "number" || radiusKm <= 0)) {
+    throw new Error("location.radius_km must be a positive number");
+  }
+
+  if (countryCode !== undefined && (typeof countryCode !== "string" || !/^[a-zA-Z]{2}$/.test(countryCode))) {
+    throw new Error("location.country_code must be a two-letter country code");
+  }
+
+  return {
+    geo: {
+      lat,
+      lon,
+      ...(radiusKm === undefined ? {} : { radiusKm }),
+      ...(countryCode === undefined ? {} : { countryCode: countryCode.toUpperCase() }),
+    },
+  };
+};

--- a/packages/taxonomy/src/transformers/tranche-age.ts
+++ b/packages/taxonomy/src/transformers/tranche-age.ts
@@ -1,0 +1,40 @@
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
+
+type TrancheAgeValueKey = "moins_26_ans" | "moins_31_ans_handicap" | "entre_17_72_ans" | "entre_16_67_ans";
+
+export const resolveTrancheAgeValues = (params: unknown): TrancheAgeValueKey[] => {
+  if (!isRecord(params)) {
+    throw new Error("tranche_age params must be an object");
+  }
+
+  const age = params.age;
+  const handicap = params.handicap ?? false;
+
+  if (typeof age !== "number" || !Number.isInteger(age) || age < 0 || age > 120) {
+    throw new Error("tranche_age.age must be an integer between 0 and 120");
+  }
+
+  if (typeof handicap !== "boolean") {
+    throw new Error("tranche_age.handicap must be a boolean");
+  }
+
+  const values: TrancheAgeValueKey[] = [];
+
+  if (age < 26) {
+    values.push("moins_26_ans");
+  }
+
+  if (age < 31 && handicap) {
+    values.push("moins_31_ans_handicap");
+  }
+
+  if (age >= 17 && age <= 72) {
+    values.push("entre_17_72_ans");
+  }
+
+  if (age >= 16 && age < 67) {
+    values.push("entre_16_67_ans");
+  }
+
+  return values;
+};

--- a/packages/taxonomy/src/types.ts
+++ b/packages/taxonomy/src/types.ts
@@ -35,7 +35,7 @@ export type TaxonomyValueItem = {
 export type TaxonomyListItem = {
   key: TaxonomyKey;
   label: string;
-  type: "categorical" | "multi_value" | "gate";
+  type: "categorical" | "multi_value" | "gate" | "value";
   enrichable: boolean;
   gate: boolean;
   values: TaxonomyValueItem[];


### PR DESCRIPTION
## Description

Cette PR fait évoluer le payload `/user-scoring` pour gérer les réponses sous forme structurée `{ taxonomy, value }` ou `{ taxonomy, params }`.

Elle ajoute aussi des transformers de taxonomies :
- `tranche_age` transforme `{ age, handicap }` en valeurs de taxonomy.
- `location` transforme `{ lat, lon, radius_km?, country_code? }` en données `user_scoring_geo`.

Le champ top-level `geo` est supprimé du contrat API au profit de :
```json
{ "taxonomy": "location", "params": { "lat": 48.8566, "lon": 2.3522, "country_code": "FR" } }
```

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
