### PR TITLE
fix(api): update matching engine with OR logic for multiple values

### DIFF
--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -307,6 +307,49 @@ describe("matchingEngineService", () => {
       ]);
     });
 
+    it("uses bounded OR taxonomy scoring with multi-value bonus", async () => {
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            id: "user-scoring-or-taxonomy",
+            expires_at: null,
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            mission_id: "mission-1",
+            mission_scoring_id: "mission-scoring-1",
+            total_score: 0.866667,
+            taxonomy_score: 0.866667,
+            geo_score: null,
+            distance_km: null,
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            mission_scoring_id: "mission-scoring-1",
+            taxonomy_key: "tranche_age",
+            taxonomy_score: 0.866667,
+          },
+        ]);
+      missionMatchingResultRepositoryMock.createForUserScoringVersion.mockResolvedValue({
+        id: "mission-matching-result-or-taxonomy",
+      });
+
+      const result = await matchingEngineService.rankMissionsByUserScoring({
+        userScoringId: "user-scoring-or-taxonomy",
+      });
+
+      const rankingSql = getSqlText(prismaMock.$queryRaw.mock.calls[1][0]);
+      const taxonomyScoresSql = getSqlText(prismaMock.$queryRaw.mock.calls[2][0]);
+
+      expect(result.items[0].taxonomyScores.tranche_age).toBe(0.866667);
+      expect(rankingSql).toContain('COALESCE(SUM(COALESCE(dw."taxonomy_weight", 1.0)), 0) AS "taxonomy_total"');
+      expect(rankingSql).not.toContain('SUM(udt."taxonomy_total" * COALESCE(dw."taxonomy_weight", 1.0))');
+      expect(rankingSql).toContain('LEAST(mv."taxonomy_sum" / NULLIF(udt."taxonomy_total", 0), 1.0)');
+      expect(taxonomyScoresSql).toContain('LEAST(mv."taxonomy_sum" / udt."taxonomy_total", 1.0)');
+    });
+
     it("does not persist a snapshot when the caller requests an offset page", async () => {
       prismaMock.$queryRaw
         .mockResolvedValueOnce([

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -44,6 +44,7 @@ const MIN_TAXONOMY_CANDIDATE_LIMIT = 1000;
 const GEO_CANDIDATE_MULTIPLIER = 50;
 const MIN_GEO_CANDIDATE_LIMIT = 1000;
 const GEO_PREFILTER_RADIUS_MULTIPLIER = 6;
+const TAXONOMY_OR_BASE_SCORE = 0.8;
 
 const getTaxonomyCandidateLimit = (params: { limit: number; offset: number }): number =>
   Math.max(params.offset + params.limit, params.limit * TAXONOMY_CANDIDATE_MULTIPLIER, MIN_TAXONOMY_CANDIDATE_LIMIT);
@@ -106,7 +107,7 @@ const buildRanking = (params: {
   ),
   weighted_user_totals AS (
     SELECT
-      COALESCE(SUM(udt."taxonomy_total" * COALESCE(dw."taxonomy_weight", 1.0)), 0) AS "taxonomy_total"
+      COALESCE(SUM(COALESCE(dw."taxonomy_weight", 1.0)), 0) AS "taxonomy_total"
     FROM user_taxonomy_totals udt
     LEFT JOIN taxonomy_weights dw
       ON dw."taxonomy_key" = udt."taxonomy_key"
@@ -196,8 +197,15 @@ const buildRanking = (params: {
   taxonomy_scores AS (
     SELECT
       mv."mission_scoring_id",
-      SUM(mv."taxonomy_sum" * COALESCE(dw."taxonomy_weight", 1.0)) AS "weighted_sum"
+      SUM(
+        (
+          CAST(${TAXONOMY_OR_BASE_SCORE} AS double precision) +
+          ((1.0 - CAST(${TAXONOMY_OR_BASE_SCORE} AS double precision)) * LEAST(mv."taxonomy_sum" / NULLIF(udt."taxonomy_total", 0), 1.0))
+        ) * COALESCE(dw."taxonomy_weight", 1.0)
+      ) AS "weighted_sum"
     FROM matched_values mv
+    JOIN user_taxonomy_totals udt
+      ON udt."taxonomy_key" = mv."taxonomy_key"
     LEFT JOIN taxonomy_weights dw
       ON dw."taxonomy_key" = mv."taxonomy_key"
     GROUP BY mv."mission_scoring_id"
@@ -467,7 +475,9 @@ const buildTaxonomyScoresSql = (params: { userScoringId: string; missionScoringI
     mv."mission_scoring_id",
     mv."taxonomy_key",
     CASE
-      WHEN udt."taxonomy_total" > 0 THEN mv."taxonomy_sum" / udt."taxonomy_total"
+      WHEN udt."taxonomy_total" > 0 THEN
+        CAST(${TAXONOMY_OR_BASE_SCORE} AS double precision) +
+        ((1.0 - CAST(${TAXONOMY_OR_BASE_SCORE} AS double precision)) * LEAST(mv."taxonomy_sum" / udt."taxonomy_total", 1.0))
       ELSE 0
     END AS "taxonomy_score"
   FROM matched_values mv


### PR DESCRIPTION
## Description

Mettre à jour l’algorithme de matching pour interpréter plusieurs valeurs d’une même taxonomy comme un `OR`, et non comme une couverture obligatoire.

###  Changements

- Modification du scoring par taxonomy dans le matching engine.
- Une mission qui matche au moins une value d’une taxonomy obtient désormais un score fort.
- Les matches supplémentaires dans la même taxonomy ajoutent un bonus progressif jusqu’à `1`.
- Le score global n’est plus dilué par le nombre de values utilisateur dans une même taxonomy.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

