### PR TITLE
fix(app): display sandbox API URL in broadcaster curl example

### DIFF
--- a/app/src/scenes/broadcast/Api.jsx
+++ b/app/src/scenes/broadcast/Api.jsx
@@ -3,15 +3,18 @@ import { useEffect, useState } from "react";
 import { RiBookletFill, RiFileCopyFill } from "react-icons/ri";
 
 import api from "@/services/api";
+import { ENV } from "@/services/config";
 import { captureError } from "@/services/error";
 import useStore from "@/services/store";
 
+const API_PUBLIC_URL = ENV === "sandbox" ? "https://api.bac-a-sable.api-engagement.beta.gouv.fr" : "https://api.api-engagement.beta.gouv.fr";
+
 const Api = () => {
   const { publisher, setPublisher } = useStore();
-  const [curl, setCurl] = useState(`curl --location --request GET 'https://api.api-engagement.beta.gouv.fr/v0/mission' --header 'apikey: ${publisher.apikey || "<apikey>"}'`);
+  const [curl, setCurl] = useState(`curl --location --request GET '${API_PUBLIC_URL}/v0/mission' --header 'apikey: ${publisher.apikey || "<apikey>"}'`);
 
   useEffect(() => {
-    setCurl(`curl --location --request GET 'https://api.api-engagement.beta.gouv.fr/v0/mission' --header 'apikey: ${publisher.apikey || "<apikey>"}'`);
+    setCurl(`curl --location --request GET '${API_PUBLIC_URL}/v0/mission' --header 'apikey: ${publisher.apikey || "<apikey>"}'`);
   }, [publisher]);
 
   const handleNewApiKey = async () => {

--- a/app/src/scenes/broadcast/Api.jsx
+++ b/app/src/scenes/broadcast/Api.jsx
@@ -3,18 +3,16 @@ import { useEffect, useState } from "react";
 import { RiBookletFill, RiFileCopyFill } from "react-icons/ri";
 
 import api from "@/services/api";
-import { ENV } from "@/services/config";
+import { API_URL } from "@/services/config";
 import { captureError } from "@/services/error";
 import useStore from "@/services/store";
 
-const API_PUBLIC_URL = ENV === "sandbox" ? "https://api.bac-a-sable.api-engagement.beta.gouv.fr" : "https://api.api-engagement.beta.gouv.fr";
-
 const Api = () => {
   const { publisher, setPublisher } = useStore();
-  const [curl, setCurl] = useState(`curl --location --request GET '${API_PUBLIC_URL}/v0/mission' --header 'apikey: ${publisher.apikey || "<apikey>"}'`);
+  const [curl, setCurl] = useState(`curl --location --request GET '${API_URL}/v0/mission' --header 'apikey: ${publisher.apikey || "<apikey>"}'`);
 
   useEffect(() => {
-    setCurl(`curl --location --request GET '${API_PUBLIC_URL}/v0/mission' --header 'apikey: ${publisher.apikey || "<apikey>"}'`);
+    setCurl(`curl --location --request GET '${API_URL}/v0/mission' --header 'apikey: ${publisher.apikey || "<apikey>"}'`);
   }, [publisher]);
 
   const handleNewApiKey = async () => {


### PR DESCRIPTION
## Description

L'encadré "Exemple d'appel" de la page **Diffuser des missions partenaires par API** affichait l'URL de production en dur, y compris dans l'environnement bac à sable.

**Changement** : L'URL est maintenant choisie dynamiquement selon l'environnement (`VITE_ENV`) :
- `sandbox` → `https://api.bac-a-sable.api-engagement.beta.gouv.fr`
- autres → `https://api.api-engagement.beta.gouv.fr`

La variable `VITE_ENV=sandbox` est déjà injectée lors du build Docker sandbox, aucune variable supplémentaire n'est nécessaire.

## Liens utiles

- 📝 Ticket Notion : N/A

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Seul `app/src/scenes/broadcast/Api.jsx` est modifié.