### PR TITLE
chore(ci): deploy openapi spec on CI

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,18 @@
+name: Sync OpenAPI to GitBook
+
+on:
+  workflow_call:
+
+jobs:
+  publish-openapi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install GitBook CLI
+        run: npm install -g @gitbook/cli
+
+      - name: Publish OpenAPI spec to GitBook
+        run: gitbook openapi publish --spec ${{ secrets.GITBOOK_SPEC_NAME }} --organization ${{ secrets.GITBOOK_ORGANIZATION_ID }} api/docs/openapi.yaml
+        env:
+          GITBOOK_TOKEN: ${{ secrets.GITBOOK_TOKEN }}

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -68,3 +68,9 @@ jobs:
       branch: main
       environment: sandbox
     secrets: inherit
+
+  sync-docs:
+    needs: deploy
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/docs-sync.yml
+    secrets: inherit


### PR DESCRIPTION
## Description

La spec OpenAPI (`api/docs/openapi.yaml`) était jusqu'ici mise à jour dans git mais pas synchronisée automatiquement côté GitBook : le plugin GitHub Sync de GitBook gère les fichiers markdown, mais les specs OpenAPI doivent être publiées séparément via le CLI `@gitbook/cli`.

Ce PR ajoute un job `sync-docs` dans le pipeline principal qui publie automatiquement la spec après chaque déploiement réussi sur `main`.

## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Le-compensationAmountMax-n-est-pas-visible-dans-la-doc-35872a322d50802cb32af40e646d5d1f?source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Le job `sync-docs` dépend de `deploy` (terraform apply sur Scaleway) et ne tourne que sur `main` — la doc n'est publiée que si le déploiement s'est bien passé.
- La logique est extraite dans un workflow réutilisable `docs-sync.yml` (pattern cohérent avec le reste du pipeline).
- Les secrets `GITBOOK_TOKEN`, `GITBOOK_ORGANIZATION_ID` et `GITBOOK_SPEC_NAME` sont déjà configurés dans les settings GitHub du dépôt.