### PR TITLE
feat(app): add API key tab for annonceurs in settings

### DIFF
--- a/app/src/scenes/settings/ApiAnnonceur.jsx
+++ b/app/src/scenes/settings/ApiAnnonceur.jsx
@@ -1,0 +1,102 @@
+import { toast } from "@/services/toast";
+import { useEffect, useState } from "react";
+import { RiBookletFill, RiFileCopyFill } from "react-icons/ri";
+
+import api from "@/services/api";
+import { API_URL } from "@/services/config";
+import { captureError } from "@/services/error";
+import useStore from "@/services/store";
+
+const ApiAnnonceur = () => {
+  const { publisher, setPublisher } = useStore();
+  const [curl, setCurl] = useState(`curl --location --request POST '${API_URL}/v2/mission' --header 'apikey: ${publisher.apikey || "<apikey>"}'`);
+
+  useEffect(() => {
+    setCurl(`curl --location --request POST '${API_URL}/v2/mission' --header 'apikey: ${publisher.apikey || "<apikey>"}'`);
+  }, [publisher]);
+
+  const handleNewApiKey = async () => {
+    const confirm = window.confirm("Êtes-vous sûr de vouloir générer une nouvelle clé API ?");
+    if (!confirm) return;
+    try {
+      const res = await api.post(`/publisher/${publisher.id}/apikey`);
+      if (!res.ok) throw res;
+      setPublisher({ ...publisher, apikey: res.data });
+      toast.success("Nouvelle clé API générée");
+    } catch (error) {
+      captureError(error, { extra: { publisherId: publisher.id } });
+    }
+  };
+
+  const handleDelete = async () => {
+    const confirm = window.confirm("Êtes-vous sûr de vouloir supprimer la clé API ?");
+    if (!confirm) return;
+    try {
+      const res = await api.delete(`/publisher/${publisher.id}/apikey`);
+      if (!res.ok) throw res;
+      setPublisher({ ...publisher, apikey: undefined });
+      toast.success("Clé API supprimée");
+    } catch (error) {
+      captureError(error, { extra: { publisherId: publisher.id } });
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(publisher.apikey);
+    toast.success("Lien copié");
+  };
+
+  if (!publisher) return <p className="p-3">Chargement...</p>;
+
+  return (
+    <div className="space-y-12 p-4 sm:p-12">
+      <title>API Engagement - Flux API - Paramètres</title>
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-2">
+          <h2 className="text-3xl font-bold">Partager des missions par API</h2>
+          <p>Je partage mes missions avec mes partenaires diffuseurs via l'API</p>
+        </div>
+
+        <a href="https://doc.api-engagement.beta.gouv.fr/api-reference/mission-mission/creer-mettre-a-jour" className="secondary-btn flex items-center" target="_blank">
+          <RiBookletFill className="mr-2" aria-hidden="true" />
+          Documentation
+        </a>
+      </div>
+      <div className="border-grey-border border p-4 sm:p-6">
+        <div className="border-b-gray-925 flex flex-col gap-4 border-b pb-6">
+          <label htmlFor="apikey" className="font-semibold">
+            Votre clé API
+          </label>
+          <div className="flex items-center gap-4">
+            <input id="apikey" className="input min-w-0 flex-1" name="apikey" readOnly value={publisher.apikey || ""} />
+            <button className="secondary-btn flex h-10 w-10 shrink-0 items-center justify-center p-0" onClick={handleCopy}>
+              <RiFileCopyFill aria-hidden="true" />
+              <span className="sr-only">Copier la clé API</span>
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-4">
+            <button className="secondary-btn" onClick={handleNewApiKey}>
+              Générer une nouvelle clé
+            </button>
+            <button className="secondary-btn" onClick={handleDelete}>
+              Supprimer la clé
+            </button>
+          </div>
+        </div>
+        <div className="flex flex-col gap-4 pt-6">
+          <div className="flex items-center justify-between gap-4">
+            <p className="font-semibold sm:w-1/4">Exemple d'appel</p>
+          </div>
+          <textarea
+            className="border-blue-france-925 bg-blue-france-975 w-full rounded-none border px-4 py-2 font-mono text-sm read-only:opacity-80"
+            rows={2}
+            readOnly
+            value={curl}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ApiAnnonceur;

--- a/app/src/scenes/settings/index.jsx
+++ b/app/src/scenes/settings/index.jsx
@@ -2,6 +2,7 @@ import { Route, Routes, useLocation } from "react-router-dom";
 
 import Tabs from "@/components/Tabs";
 import useStore from "@/services/store";
+import ApiAnnonceur from "./ApiAnnonceur";
 import Flux from "./Flux";
 import RealTime from "./RealTime";
 import TrackingAnnounce from "./TrackingAnnounce";
@@ -18,6 +19,12 @@ const Settings = () => {
       label: "Flux de missions",
       route: "",
       isActive: currentRoute === "",
+    },
+    {
+      key: "api",
+      label: "Flux API",
+      route: "api",
+      isActive: currentRoute === "api",
     },
     {
       key: "tracking",
@@ -85,6 +92,7 @@ const Settings = () => {
         <section id="settings-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} className="bg-white shadow-lg">
           <Routes>
             <Route path="/" element={<Flux />} />
+            <Route path="/api" element={<ApiAnnonceur />} />
             <Route path="/tracking" element={<TrackingAnnounce />} />
             <Route path="/real-time" element={<RealTime />} />
           </Routes>


### PR DESCRIPTION
## Description

Ajout d'un onglet **Flux API** côté annonceur dans la page Paramètres, entre les onglets « Flux de missions » et « Tracking des événements ».

La clé API est partagée avec le côté diffuseur (mêmes endpoints `POST/DELETE /publisher/{id}/apikey`). L'annonceur peut générer, supprimer et copier sa clé API, qui reste synchronisée avec celle visible côté diffuseur.

Différences par rapport au composant diffuseur :
- Lien documentation → https://doc.api-engagement.beta.gouv.fr/api-reference/mission-mission/creer-mettre-a-jour
- Exemple curl : `POST /v2/mission` (création de mission) au lieu de `GET /v0/mission`

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Fichiers modifiés :
- `app/src/scenes/settings/ApiAnnonceur.jsx` (nouveau) — composant de gestion de clé API pour annonceurs
- `app/src/scenes/settings/index.jsx` — ajout de l'onglet et de la route `/settings/api` (uniquement pour `flux === "to"`, sans impact côté diffuseur)