### PR TITLE
refactor(api): report access rules

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@aws-sdk/client-s3": "3.1036.0",
                 "@aws-sdk/lib-storage": "3.1036.0",
+                "@aws-sdk/s3-request-presigner": "3.1036.0",
                 "@opentelemetry/exporter-metrics-otlp-http": "0.215.0",
                 "@opentelemetry/resources": "2.7.0",
                 "@opentelemetry/sdk-metrics": "2.7.0",
@@ -824,6 +825,25 @@
                 "node": ">=20.0.0"
             }
         },
+        "node_modules/@aws-sdk/s3-request-presigner": {
+            "version": "3.1036.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1036.0.tgz",
+            "integrity": "sha512-5LEXxcZrrCrPvd7/zIyadEIBsMeXyT6sg9tn3OkkwZ9Rl6Wfq7gxOI82Ei30cj0QXvzJwjcizpskmPh8M5QNtQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/signature-v4-multi-region": "^3.996.22",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-format-url": "^3.972.10",
+                "@smithy/middleware-endpoint": "^4.4.32",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
             "version": "3.996.24",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.24.tgz",
@@ -894,6 +914,21 @@
                 "@smithy/types": "^4.14.1",
                 "@smithy/url-parser": "^4.2.14",
                 "@smithy/util-endpoints": "^3.4.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-format-url": {
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+            "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/querystring-builder": "^4.2.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {

--- a/api/package.json
+++ b/api/package.json
@@ -25,6 +25,7 @@
     "dependencies": {
         "@aws-sdk/client-s3": "3.1036.0",
         "@aws-sdk/lib-storage": "3.1036.0",
+        "@aws-sdk/s3-request-presigner": "3.1036.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.215.0",
         "@opentelemetry/resources": "2.7.0",
         "@opentelemetry/sdk-metrics": "2.7.0",

--- a/api/src/controllers/report.ts
+++ b/api/src/controllers/report.ts
@@ -1,15 +1,18 @@
 import { NextFunction, Request, Response, Router } from "express";
 import zod from "zod";
 
-import { captureException, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
+import { captureException, FORBIDDEN, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
+import passport from "@/middlewares/passport";
 import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { reportService } from "@/services/report";
+import { getPresignedUrl } from "@/services/s3";
+import type { UserRecord } from "@/types/user";
 
 const router = Router();
 router.use(ipRateLimiter);
 
 // Keep because old version of the report
-router.get("/pdf/:publisherId", async (req: Request, res: Response, next: NextFunction) => {
+router.get("/pdf/:publisherId", passport.authenticate("user", { session: false }), async (req: Request, res: Response, next: NextFunction) => {
   try {
     const params = zod
       .object({
@@ -31,6 +34,11 @@ router.get("/pdf/:publisherId", async (req: Request, res: Response, next: NextFu
       return res.status(400).send({ ok: false, code: INVALID_QUERY, message: query.error });
     }
 
+    const user = req.user as UserRecord;
+    if (user.role !== "admin" && !user.publishers.includes(params.data.publisherId)) {
+      return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Forbidden" });
+    }
+
     const report = await reportService.findOneReportByPublisherAndPeriod(params.data.publisherId, query.data.year, query.data.month);
     if (!report) {
       return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Report not found" });
@@ -38,6 +46,11 @@ router.get("/pdf/:publisherId", async (req: Request, res: Response, next: NextFu
     if (!report.url) {
       captureException(new Error(`Report ${report.id} has no url`), `Report ${report.id} has no url`);
       return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Report not found" });
+    }
+
+    if (report.objectName) {
+      const signedUrl = await getPresignedUrl(report.objectName);
+      return res.redirect(signedUrl);
     }
     res.redirect(report.url);
   } catch (error) {
@@ -66,6 +79,10 @@ router.get("/:id", async (req: Request, res: Response, next: NextFunction) => {
       return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Report not found" });
     }
 
+    if (report.objectName) {
+      const signedUrl = await getPresignedUrl(report.objectName);
+      return res.redirect(signedUrl);
+    }
     res.redirect(report.url);
   } catch (error) {
     next(error);

--- a/api/src/controllers/report.ts
+++ b/api/src/controllers/report.ts
@@ -1,62 +1,13 @@
 import { NextFunction, Request, Response, Router } from "express";
 import zod from "zod";
 
-import { captureException, FORBIDDEN, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
-import passport from "@/middlewares/passport";
+import { captureException, INVALID_PARAMS, NOT_FOUND } from "@/error";
 import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { reportService } from "@/services/report";
 import { getPresignedUrl } from "@/services/s3";
-import type { UserRecord } from "@/types/user";
 
 const router = Router();
 router.use(ipRateLimiter);
-
-// Keep because old version of the report
-router.get("/pdf/:publisherId", passport.authenticate("user", { session: false }), async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const params = zod
-      .object({
-        publisherId: zod.string(),
-      })
-      .safeParse(req.params);
-
-    const query = zod
-      .object({
-        year: zod.coerce.number().default(new Date().getFullYear()),
-        month: zod.coerce.number().default(new Date().getMonth()),
-      })
-      .safeParse(req.query);
-
-    if (!params.success) {
-      return res.status(400).send({ ok: false, code: INVALID_PARAMS, message: params.error });
-    }
-    if (!query.success) {
-      return res.status(400).send({ ok: false, code: INVALID_QUERY, message: query.error });
-    }
-
-    const user = req.user as UserRecord;
-    if (user.role !== "admin" && !user.publishers.includes(params.data.publisherId)) {
-      return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Forbidden" });
-    }
-
-    const report = await reportService.findOneReportByPublisherAndPeriod(params.data.publisherId, query.data.year, query.data.month);
-    if (!report) {
-      return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Report not found" });
-    }
-    if (!report.url) {
-      captureException(new Error(`Report ${report.id} has no url`), `Report ${report.id} has no url`);
-      return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Report not found" });
-    }
-
-    if (report.objectName) {
-      const signedUrl = await getPresignedUrl(report.objectName);
-      return res.redirect(signedUrl);
-    }
-    res.redirect(report.url);
-  } catch (error) {
-    next(error);
-  }
-});
 
 router.get("/:id", async (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/api/src/jobs/report/generate/index.ts
+++ b/api/src/jobs/report/generate/index.ts
@@ -96,7 +96,7 @@ export const generateReport = async (publisher: PublisherRecord, year: number, m
     // Save and upload file
     const objectName = `publishers/${publisher.id}/reports/${year}${month + 1 < 10 ? `0${month + 1}` : month + 1}.pdf`;
     const buffer = Buffer.from(doc.output("arraybuffer"));
-    await putObject(objectName, buffer, { ACL: OBJECT_ACL.PUBLIC_READ });
+    await putObject(objectName, buffer, { ACL: OBJECT_ACL.PRIVATE });
 
     return {
       data,

--- a/api/src/jobs/report/generate/report-stats-source.ts
+++ b/api/src/jobs/report/generate/report-stats-source.ts
@@ -223,17 +223,16 @@ async function getMonthlyBuckets(
 async function getTopPublishers(publisherId: string, columns: ReportColumnDefinitions, start: Date, end: Date) {
   const rows = await prisma.$queryRaw<{ key: string | null; doc_count: bigint }[]>(
     Prisma.sql`
-      SELECT ${columns.publisherNameColumnSql} AS key,
+      SELECT p."name" AS key,
              COUNT(*)::bigint AS doc_count
       FROM "stat_event"
-      WHERE is_bot is NOT true
+      JOIN "publisher" p ON p."id" = ${columns.peerPublisherIdColumnSql}
+      WHERE "stat_event"."is_bot" IS NOT TRUE
         AND ${columns.publisherIdColumnSql} = ${publisherId}
-        AND type = 'click'
-        AND created_at >= ${start}
-        AND created_at < ${end}
-        AND ${columns.publisherNameColumnSql} IS NOT NULL
-        AND ${columns.publisherNameColumnSql} <> ''
-      GROUP BY ${columns.publisherNameColumnSql}
+        AND "stat_event"."type" = 'click'
+        AND "stat_event"."created_at" >= ${start}
+        AND "stat_event"."created_at" < ${end}
+      GROUP BY p."name"
       ORDER BY doc_count DESC
       LIMIT 5
     `
@@ -250,11 +249,11 @@ async function getTopOrganizations(publisherId: string, columns: ReportColumnDef
       FROM "stat_event"
       JOIN "mission" m ON m."id" = "stat_event"."mission_id"
       JOIN "publisher_organization" po ON po."id" = m."publisher_organization_id"
-      WHERE is_bot is NOT true
+      WHERE "stat_event"."is_bot" IS NOT TRUE
         AND ${columns.publisherIdColumnSql} = ${publisherId}
-        AND type = 'click'
-        AND created_at >= ${start}
-        AND created_at < ${end}
+        AND "stat_event"."type" = 'click'
+        AND "stat_event"."created_at" >= ${start}
+        AND "stat_event"."created_at" < ${end}
         AND po."name" IS NOT NULL
         AND po."name" <> ''
       GROUP BY po."name"
@@ -300,17 +299,17 @@ async function getLastSixMonthsBuckets({
   const perOrg = topKeys.length
     ? await prisma.$queryRaw<{ month: Date; key: string | null; doc_count: bigint }[]>(
         Prisma.sql`
-          SELECT date_trunc('month', created_at) AS month,
+          SELECT date_trunc('month', "stat_event"."created_at") AS month,
                  po."name" AS key,
                  COUNT(*)::bigint AS doc_count
           FROM "stat_event"
           JOIN "mission" m ON m."id" = "stat_event"."mission_id"
           JOIN "publisher_organization" po ON po."id" = m."publisher_organization_id"
-          WHERE is_bot IS NOT TRUE
+          WHERE "stat_event"."is_bot" IS NOT TRUE
             AND ${columns.publisherIdColumnSql} = ${publisherId}
-            AND type = 'click'
-            AND created_at >= ${start}
-            AND created_at < ${end}
+            AND "stat_event"."type" = 'click'
+            AND "stat_event"."created_at" >= ${start}
+            AND "stat_event"."created_at" < ${end}
             AND po."name" = ANY(${Prisma.sql`ARRAY[${Prisma.join(topKeys)}]`})
           GROUP BY month, po."name"
           ORDER BY month
@@ -367,25 +366,22 @@ function isSameMonth(a: Date, b: Date) {
 
 interface ReportColumnDefinitions {
   publisherIdField: "from_publisher_id" | "to_publisher_id";
-  publisherNameField: "from_publisher_name" | "to_publisher_name";
   publisherIdColumnSql: Sql;
-  publisherNameColumnSql: Sql;
+  peerPublisherIdColumnSql: Sql;
 }
 
 function getReportColumnDefinitions(flux: ReportFlux): ReportColumnDefinitions {
   if (flux === "to") {
     return {
       publisherIdField: "to_publisher_id",
-      publisherNameField: "from_publisher_name",
       publisherIdColumnSql: Prisma.sql`"to_publisher_id"`,
-      publisherNameColumnSql: Prisma.sql`"from_publisher_name"`,
+      peerPublisherIdColumnSql: Prisma.sql`"from_publisher_id"`,
     };
   }
   return {
     publisherIdField: "from_publisher_id",
-    publisherNameField: "to_publisher_name",
     publisherIdColumnSql: Prisma.sql`"from_publisher_id"`,
-    publisherNameColumnSql: Prisma.sql`"to_publisher_name"`,
+    peerPublisherIdColumnSql: Prisma.sql`"to_publisher_id"`,
   };
 }
 

--- a/api/src/services/report.ts
+++ b/api/src/services/report.ts
@@ -175,11 +175,8 @@ export const reportService = {
     if ("objectName" in patch) {
       data.objectName = patch.objectName ?? undefined;
     }
-    if ("publisherId" in patch) {
-      data.publisherId = patch.publisherId ?? undefined;
-    }
-    if ("publisherName" in patch) {
-      data.publisherName = patch.publisherName ?? undefined;
+    if ("publisherId" in patch && patch.publisherId) {
+      data.publisher = { connect: { id: patch.publisherId } };
     }
     if ("dataTemplate" in patch) {
       data.dataTemplate = patch.dataTemplate ?? undefined;

--- a/api/src/services/s3.ts
+++ b/api/src/services/s3.ts
@@ -2,6 +2,7 @@ import { Readable } from "stream";
 
 import { CompleteMultipartUploadCommandOutput, DeleteObjectCommand, GetObjectCommand, ObjectCannedACL, S3Client } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 import { BUCKET_NAME, REGION, SCW_ACCESS_KEY, SCW_HOST, SCW_SECRET_KEY } from "@/config";
 
@@ -63,4 +64,9 @@ export const getObject = async (objectName: string, bucketName = BUCKET_NAME): P
 
 export const deleteObject = async (objectName: string, bucketName = BUCKET_NAME): Promise<void> => {
   await bucket.send(new DeleteObjectCommand({ Bucket: bucketName, Key: objectName }));
+};
+
+export const getPresignedUrl = async (objectName: string, expiresIn = 900): Promise<string> => {
+  const command = new GetObjectCommand({ Bucket: BUCKET_NAME, Key: objectName });
+  return getSignedUrl(bucket, command, { expiresIn });
 };

--- a/api/tests/fixtures/report.ts
+++ b/api/tests/fixtures/report.ts
@@ -8,6 +8,7 @@ export const createTestReport = async (data: Partial<ReportCreateInput> & { publ
     year: new Date().getFullYear(),
     url: `https://bucket.example.com/publishers/${data.publisherId}/reports/test.pdf`,
     objectName: `publishers/${data.publisherId}/reports/test.pdf`,
+    publisherId: data.publisherId,
     publisherName: "Test Publisher",
     dataTemplate: null,
     sentAt: null,

--- a/api/tests/fixtures/report.ts
+++ b/api/tests/fixtures/report.ts
@@ -1,0 +1,20 @@
+import { reportService } from "@/services/report";
+import type { ReportCreateInput, ReportRecord } from "@/types/report";
+
+export const createTestReport = async (data: Partial<ReportCreateInput> & { publisherId: string }): Promise<ReportRecord> => {
+  const defaultData: ReportCreateInput = {
+    name: "Test Report",
+    month: 0,
+    year: new Date().getFullYear(),
+    url: `https://bucket.example.com/publishers/${data.publisherId}/reports/test.pdf`,
+    objectName: `publishers/${data.publisherId}/reports/test.pdf`,
+    publisherName: "Test Publisher",
+    dataTemplate: null,
+    sentAt: null,
+    sentTo: [],
+    status: "GENERATED",
+    data: {},
+  };
+
+  return reportService.createReport({ ...defaultData, ...data });
+};

--- a/api/tests/integration/api/report.test.ts
+++ b/api/tests/integration/api/report.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 
 import { createTestPublisher } from "../../fixtures";
 import { createTestReport } from "../../fixtures/report";
-import { createTestUser } from "../../fixtures/user";
 import { createTestApp } from "../../testApp";
 
 const app = createTestApp();
@@ -43,57 +42,6 @@ describe("Report endpoints (integration)", () => {
       const res = await request(app).get("/report/not-a-uuid");
 
       expect(res.status).toBe(400);
-    });
-  });
-
-  describe("GET /report/pdf/:publisherId", () => {
-    it("returns 401 without a JWT token", async () => {
-      const publisher = await createTestPublisher();
-
-      const res = await request(app).get(`/report/pdf/${publisher.id}`);
-
-      expect(res.status).toBe(401);
-    });
-
-    it("returns 403 when the user does not belong to the publisher", async () => {
-      const publisher = await createTestPublisher();
-      const { token } = await createTestUser({ publishers: [] });
-      await createTestReport({ publisherId: publisher.id, month: new Date().getMonth(), year: new Date().getFullYear() });
-
-      const res = await request(app).get(`/report/pdf/${publisher.id}`).set("Authorization", `jwt ${token}`);
-
-      expect(res.status).toBe(403);
-    });
-
-    it("redirects to a presigned URL when the user belongs to the publisher", async () => {
-      const publisher = await createTestPublisher();
-      const { token } = await createTestUser({ publishers: [publisher.id] });
-      await createTestReport({ publisherId: publisher.id, month: new Date().getMonth(), year: new Date().getFullYear() });
-
-      const res = await request(app).get(`/report/pdf/${publisher.id}`).set("Authorization", `jwt ${token}`).redirects(0);
-
-      expect(res.status).toBe(302);
-      expect(res.headers.location).toBe(SIGNED_URL);
-    });
-
-    it("redirects to a presigned URL when the user is admin", async () => {
-      const publisher = await createTestPublisher();
-      const { token } = await createTestUser({ role: "admin", publishers: [] });
-      await createTestReport({ publisherId: publisher.id, month: new Date().getMonth(), year: new Date().getFullYear() });
-
-      const res = await request(app).get(`/report/pdf/${publisher.id}`).set("Authorization", `jwt ${token}`).redirects(0);
-
-      expect(res.status).toBe(302);
-      expect(res.headers.location).toBe(SIGNED_URL);
-    });
-
-    it("returns 404 when no report exists for the publisher and period", async () => {
-      const publisher = await createTestPublisher();
-      const { token } = await createTestUser({ publishers: [publisher.id] });
-
-      const res = await request(app).get(`/report/pdf/${publisher.id}?year=2000&month=0`).set("Authorization", `jwt ${token}`);
-
-      expect(res.status).toBe(404);
     });
   });
 });

--- a/api/tests/integration/api/report.test.ts
+++ b/api/tests/integration/api/report.test.ts
@@ -1,0 +1,99 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+import { createTestPublisher } from "../../fixtures";
+import { createTestReport } from "../../fixtures/report";
+import { createTestUser } from "../../fixtures/user";
+import { createTestApp } from "../../testApp";
+
+const app = createTestApp();
+
+const SIGNED_URL = "https://mock-bucket.example.com/signed-url?token=mock";
+
+describe("Report endpoints (integration)", () => {
+  describe("GET /report/:id", () => {
+    it("redirects to a presigned URL when objectName is set", async () => {
+      const publisher = await createTestPublisher();
+      const report = await createTestReport({ publisherId: publisher.id, objectName: `publishers/${publisher.id}/reports/202501.pdf` });
+
+      const res = await request(app).get(`/report/${report.id}`).redirects(0);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe(SIGNED_URL);
+    });
+
+    it("redirects to report.url when objectName is null (legacy fallback)", async () => {
+      const publisher = await createTestPublisher();
+      const legacyUrl = `https://bucket.example.com/publishers/${publisher.id}/reports/202501.pdf`;
+      const report = await createTestReport({ publisherId: publisher.id, objectName: null, url: legacyUrl });
+
+      const res = await request(app).get(`/report/${report.id}`).redirects(0);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe(legacyUrl);
+    });
+
+    it("returns 404 when the report does not exist", async () => {
+      const res = await request(app).get("/report/00000000-0000-0000-0000-000000000000");
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 for an invalid UUID", async () => {
+      const res = await request(app).get("/report/not-a-uuid");
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /report/pdf/:publisherId", () => {
+    it("returns 401 without a JWT token", async () => {
+      const publisher = await createTestPublisher();
+
+      const res = await request(app).get(`/report/pdf/${publisher.id}`);
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 403 when the user does not belong to the publisher", async () => {
+      const publisher = await createTestPublisher();
+      const { token } = await createTestUser({ publishers: [] });
+      await createTestReport({ publisherId: publisher.id, month: new Date().getMonth(), year: new Date().getFullYear() });
+
+      const res = await request(app).get(`/report/pdf/${publisher.id}`).set("Authorization", `jwt ${token}`);
+
+      expect(res.status).toBe(403);
+    });
+
+    it("redirects to a presigned URL when the user belongs to the publisher", async () => {
+      const publisher = await createTestPublisher();
+      const { token } = await createTestUser({ publishers: [publisher.id] });
+      await createTestReport({ publisherId: publisher.id, month: new Date().getMonth(), year: new Date().getFullYear() });
+
+      const res = await request(app).get(`/report/pdf/${publisher.id}`).set("Authorization", `jwt ${token}`).redirects(0);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe(SIGNED_URL);
+    });
+
+    it("redirects to a presigned URL when the user is admin", async () => {
+      const publisher = await createTestPublisher();
+      const { token } = await createTestUser({ role: "admin", publishers: [] });
+      await createTestReport({ publisherId: publisher.id, month: new Date().getMonth(), year: new Date().getFullYear() });
+
+      const res = await request(app).get(`/report/pdf/${publisher.id}`).set("Authorization", `jwt ${token}`).redirects(0);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe(SIGNED_URL);
+    });
+
+    it("returns 404 when no report exists for the publisher and period", async () => {
+      const publisher = await createTestPublisher();
+      const { token } = await createTestUser({ publishers: [publisher.id] });
+
+      const res = await request(app).get(`/report/pdf/${publisher.id}?year=2000&month=0`).set("Authorization", `jwt ${token}`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/api/tests/integration/jobs/report/report.handler.test.ts
+++ b/api/tests/integration/jobs/report/report.handler.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { ReportHandler } from "@/jobs/report/handler";
+import { reportService } from "@/services/report";
+import { createTestPublisher } from "../../../fixtures";
+
+describe("Report job handler (integration)", () => {
+  const handler = new ReportHandler();
+
+  it("runs to completion with no stat_event data and creates a NOT_GENERATED_NO_DATA report", { timeout: 30000 }, async () => {
+    const publisher = await createTestPublisher({
+      sendReport: true,
+      hasApiRights: true,
+    });
+
+    const result = await handler.handle({ dryRun: true, publisherId: publisher.id });
+
+    expect(result.success).toBe(true);
+
+    const report = await reportService.findOneReportByPublisherAndPeriod(
+      publisher.id,
+      new Date().getMonth() !== 0 ? new Date().getFullYear() : new Date().getFullYear() - 1,
+      new Date().getMonth() !== 0 ? new Date().getMonth() - 1 : 11
+    );
+
+    expect(report).not.toBeNull();
+    expect(report!.status).toBe("NOT_GENERATED_NO_DATA");
+  });
+});

--- a/api/tests/mocks/s3Mock.ts
+++ b/api/tests/mocks/s3Mock.ts
@@ -14,6 +14,7 @@ const s3Mock = {
   putObject: vi.fn().mockResolvedValue({}),
   getObject: vi.fn().mockResolvedValue({}),
   deleteObject: vi.fn().mockResolvedValue({}),
+  getPresignedUrl: vi.fn().mockResolvedValue("https://mock-bucket.example.com/signed-url?token=mock"),
 };
 
 export default s3Mock;

--- a/api/tests/testApp.ts
+++ b/api/tests/testApp.ts
@@ -10,6 +10,7 @@ import MissionController from "@/controllers/mission";
 import ModerationController from "@/controllers/moderation";
 import PublisherController from "@/controllers/publisher";
 import RedirectController from "@/controllers/redirect";
+import ReportController from "@/controllers/report";
 import StatsController from "@/controllers/stats";
 import UserController from "@/controllers/user";
 import WarningController from "@/controllers/warning";
@@ -49,6 +50,7 @@ export const createTestApp = ({ metricsRecorder }: { metricsRecorder?: HttpMetri
   app.use("/mission", MissionController);
   app.use("/moderation", ModerationController);
   app.use("/import", ImportController);
+  app.use("/report", ReportController);
   app.use("/stats", StatsController);
   app.use("/warning", WarningController);
   app.use("/v0/myorganization", MyOrganizationV0Controller);

--- a/api/tests/vitest/integration.setup.ts
+++ b/api/tests/vitest/integration.setup.ts
@@ -22,6 +22,7 @@ beforeEach(async () => {
     prisma.missionAddress.deleteMany({}),
     prisma.missionEvent.deleteMany({}),
     prisma.mission.deleteMany({}),
+    prisma.report.deleteMany({}),
     prisma.publisherOrganization.deleteMany({}),
     prisma.organization.deleteMany({}),
     prisma.publisherDiffusion.deleteMany({}),

--- a/app/src/scenes/admin-report/index.jsx
+++ b/app/src/scenes/admin-report/index.jsx
@@ -6,6 +6,7 @@ import Select from "@/components/Select";
 import Table from "@/components/Table";
 import { MONTHS, REPORT_STATUS, YEARS } from "@/constants";
 import api from "@/services/api";
+import { API_URL } from "@/services/config";
 import { captureError } from "@/services/error";
 import { RiDownload2Line } from "react-icons/ri";
 
@@ -141,19 +142,27 @@ const AdminReport = () => {
                     {item.data?.receive !== undefined && item.data?.receive.general !== undefined && <p className="text-xs">Pas de statistiques disponibles</p>}
                     {item.data?.receive !== undefined && (
                       <>
-                        <p className="text-xs">Redirections reçues : <span className="font-bold">{(item.data.receive.general?.traffic || item.data.receive.click || 0).toLocaleString("fr")}</span></p>
-                        <p className="text-xs">Candidatures reçues : <span className="font-bold">{(item.data.receive.general?.apply || item.data.receive.apply || 0).toLocaleString("fr")}</span></p>
+                        <p className="text-xs">
+                          Redirections reçues : <span className="font-bold">{(item.data.receive.general?.traffic || item.data.receive.click || 0).toLocaleString("fr")}</span>
+                        </p>
+                        <p className="text-xs">
+                          Candidatures reçues : <span className="font-bold">{(item.data.receive.general?.apply || item.data.receive.apply || 0).toLocaleString("fr")}</span>
+                        </p>
                       </>
                     )}
                     {item.data?.send !== undefined && (
                       <>
-                        <p className="text-xs">Redirections envoyées : <span className="font-bold">{(item.data.send.general?.traffic || item.data.send.click || 0).toLocaleString("fr")}</span></p>
-                        <p className="text-xs">Candidatures envoyées : <span className="font-bold">{(item.data.send.general?.apply || item.data.send.apply || 0).toLocaleString("fr")}</span></p>
+                        <p className="text-xs">
+                          Redirections envoyées : <span className="font-bold">{(item.data.send.general?.traffic || item.data.send.click || 0).toLocaleString("fr")}</span>
+                        </p>
+                        <p className="text-xs">
+                          Candidatures envoyées : <span className="font-bold">{(item.data.send.general?.apply || item.data.send.apply || 0).toLocaleString("fr")}</span>
+                        </p>
                       </>
                     )}
                   </div>
-                  {item.url !== null && (
-                    <a className="border-blue-france text-blue-france shrink-0 border p-2" href={item.url} target="_blank" rel="noreferrer">
+                  {item.id && (
+                    <a className="border-blue-france text-blue-france shrink-0 border p-2" href={`${API_URL}/report/${item.id}`} target="_blank" rel="noreferrer">
                       <RiDownload2Line className="text-blue-france" role="img" aria-label="Télécharger le rapport" />
                     </a>
                   )}


### PR DESCRIPTION
## Description

Cette PR regroupe plusieurs corrections sur la feature de rapports d'impact partenaires.

### Sécurité — rapports accessibles sans authentification

Les rapports mensuels (PDFs de business intelligence) étaient stockés en `public-read` sur Scaleway Object Storage et servis par des endpoints sans authentification.

- Les nouveaux PDFs sont uploadés en ACL **privée** (`OBJECT_ACL.PRIVATE`)
- `GET /report/:id` (flux email) redirige vers une **URL signée** à durée limitée (15 min) via `@aws-sdk/s3-request-presigner`, avec fallback vers l'URL directe pour les rapports sans `objectName` (legacy)
- `GET /report/pdf/:publisherId` **supprimé** — route legacy inutilisée nulle part dans le code applicatif, présentant le risque le plus élevé (publisherId prévisible)

### Bugs SQL dans le job de génération

Plusieurs requêtes brutes (`$queryRaw`) dans `report-stats-source.ts` étaient cassées :

- `getTopPublishers` : référençait les colonnes `from_publisher_name` / `to_publisher_name` qui n'existent pas dans `stat_event`. Corrigé par un `JOIN "publisher"` sur l'ID du publisher pair
- `getTopOrganizations` et `getLastSixMonthsBuckets` : colonnes `is_bot`, `type`, `created_at` non qualifiées avec le nom de table, causant des ambiguïtés PostgreSQL (code 42702) en présence des JOINs sur `mission` et `publisher_organization`

### Bugs Prisma dans le service de rapport

`updateReport` dans `services/report.ts` tentait de passer deux champs inexistants en base directement dans le `data` Prisma :

- `publisherId` → converti en `publisher: { connect: { id } }` (syntaxe relation Prisma)
- `publisherName` → supprimé (champ calculé via JOIN, non stocké en base)

### Tests

- 4 tests d'intégration sur l'endpoint `GET /report/:id` (presigned URL, fallback legacy, 404, UUID invalide)
- 1 test d'intégration sur le job handler : lance le job en `dryRun` et vérifie qu'il se termine sans erreur

## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Rapports-d-impact-des-partenaires-accessibles-publiquement-35972a322d508086a64ac4b30aa3cef0?source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests d'intégration ajoutés
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**⚠️ Migration manuelle requise (hors périmètre) :** les PDFs déjà uploadés en `public-read` sur Scaleway restent accessibles directement. Une migration des ACL S3 sur les objets existants (`publishers/*/reports/*.pdf`) est nécessaire pour couvrir l'historique.

**Compatibilité :** le champ `report.url` en base n'est pas modifié. Les rapports sans `objectName` continuent de fonctionner via le fallback vers `report.url`.

**À valider en staging :** les URLs signées Scaleway via `@aws-sdk/s3-request-presigner` sont compatibles avec l'API S3-compatible de Scaleway — à confirmer au déclenchement du prochain job report.