### PR TITLE
fix(api): job build

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -42,7 +42,6 @@
                 "pg": "8.20.0",
                 "prisma": "7.8.0",
                 "sharp": "0.34.5",
-                "uuid": "14.0.0",
                 "xlsx": "0.18.5",
                 "zod": "4.3.6"
             },
@@ -64,7 +63,6 @@
                 "@types/passport-jwt": "4.0.1",
                 "@types/pg": "8.20.0",
                 "@types/supertest": "7.2.0",
-                "@types/uuid": "10.0.0",
                 "@types/yauzl": "2.10.3",
                 "@typescript-eslint/eslint-plugin": "8.59.0",
                 "@typescript-eslint/parser": "8.59.0",
@@ -4863,13 +4861,6 @@
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
             "license": "MIT",
             "optional": true
-        },
-        "node_modules/@types/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@types/yauzl": {
             "version": "2.10.3",
@@ -12113,19 +12104,6 @@
             "optional": true,
             "dependencies": {
                 "base64-arraybuffer": "^1.0.2"
-            }
-        },
-        "node_modules/uuid": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist-node/bin/uuid"
             }
         },
         "node_modules/v8-compile-cache-lib": {

--- a/api/package.json
+++ b/api/package.json
@@ -57,7 +57,6 @@
         "pg": "8.20.0",
         "prisma": "7.8.0",
         "sharp": "0.34.5",
-        "uuid": "14.0.0",
         "xlsx": "0.18.5",
         "zod": "4.3.6"
     },
@@ -79,7 +78,6 @@
         "@types/passport-jwt": "4.0.1",
         "@types/pg": "8.20.0",
         "@types/supertest": "7.2.0",
-        "@types/uuid": "10.0.0",
         "@types/yauzl": "2.10.3",
         "@typescript-eslint/eslint-plugin": "8.59.0",
         "@typescript-eslint/parser": "8.59.0",

--- a/api/src/services/publisher.ts
+++ b/api/src/services/publisher.ts
@@ -1,5 +1,4 @@
-import { randomBytes } from "crypto";
-import { v4 as uuid } from "uuid";
+import { randomBytes, randomUUID } from "crypto";
 
 import { MissionType, Prisma, Publisher, PublisherDiffusion, PublisherDiffusionExclusion } from "@/db/core";
 import { publisherRepository } from "@/repositories/publisher";
@@ -289,7 +288,7 @@ export const publisherService = (() => {
   };
 
   const regenerateApiKey = async (id: string): Promise<{ apikey: string; publisher: PublisherRecord }> => {
-    const apikey = uuid();
+    const apikey = randomUUID();
     const updated = await publisherRepository.update({
       where: { id },
       data: { apikey },

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -16,6 +16,8 @@
     "target": "es2021",
     "module": "commonjs",
     "sourceMap": true,
+    "rootDir": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
## Description

Corrige l'exécution des jobs API avec TypeScript 6 et `ts-node`.

- Ajoute un `rootDir` explicite dans le `tsconfig` API afin d'éviter que TypeScript déduise `src/jobs` comme racine commune lors de l'exécution de `npm run job`.
- Ajoute `ignoreDeprecations: "6.0"` pour conserver temporairement la résolution de modules actuelle sans bloquer la compilation avec TypeScript 6.
- Remplace l'utilisation du package `uuid` par `crypto.randomUUID()` pour éviter l'erreur runtime liée à `uuid@14` en ESM-only dans le contexte CommonJS de `ts-node`.
- Retire les dépendances directes `uuid` et `@types/uuid`, devenues inutiles côté API.

## Liens utiles

- Ticket Notion : non renseigné

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Validations locales effectuées :

- `npm run job -- __missing_job__` : le runner compile et sort bien sur le job absent.
- `npx ts-node -e "import('./src/jobs/import-missions/handler').then(() => console.log('handler loaded'))"` : le handler `import-missions` se charge correctement.
- `npx tsc --noEmit -p tsconfig.build.json` : compilation build OK.

Le job `import-missions` complet n'a pas été relancé après correction pour éviter de déclencher un import réel.