### PR TITLE
feat(api): add audit logs

### DIFF
--- a/api/src/controllers/organization.ts
+++ b/api/src/controllers/organization.ts
@@ -7,6 +7,7 @@ import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { organizationService } from "@/services/organization";
 import { OrganizationUpdatePatch } from "@/types/organization";
 import { UserRequest } from "@/types/passport";
+import { appendAuditEvent } from "@/utils/audit-log";
 import { slugify } from "@/utils/string";
 
 const router = Router();
@@ -121,6 +122,15 @@ router.put("/:id", passport.authenticate("admin", { session: false }), async (re
     }
 
     const data = await organizationService.updateOrganization(organization.id, patch);
+
+    appendAuditEvent(req, {
+      action: "organization.update",
+      outcome: "success",
+      target: { type: "organization", id: organization.id },
+      metadata: {
+        fields: Object.keys(patch),
+      },
+    });
 
     return res.status(200).send({ ok: true, data });
   } catch (error: any) {

--- a/api/src/controllers/publisher.ts
+++ b/api/src/controllers/publisher.ts
@@ -13,6 +13,7 @@ import { OBJECT_ACL, putObject } from "@/services/s3";
 import { userService } from "@/services/user";
 import { UserRequest } from "@/types/passport";
 import { PublisherMissionType, type PublisherDiffusionInput, type PublisherRoleFilter } from "@/types/publisher";
+import { appendAuditEvent } from "@/utils/audit-log";
 import { readRequiredParam } from "@/utils/publisher-access";
 
 const upload = multer();
@@ -254,6 +255,11 @@ router.post(
 
       try {
         const { apikey } = await publisherService.regenerateApiKey(publisherId);
+        appendAuditEvent(req, {
+          action: "publisher.api_key.regenerate",
+          outcome: "success",
+          target: { type: "publisher", id: publisherId },
+        });
         return res.status(200).send({ ok: true, data: apikey });
       } catch (error) {
         if (error instanceof PublisherNotFoundError) {
@@ -334,6 +340,14 @@ router.put("/:id", passport.authenticate("admin", { session: false }), async (re
 
     try {
       const updated = await publisherService.updatePublisher(params.data.id, patch);
+      appendAuditEvent(req, {
+        action: "publisher.update",
+        outcome: "success",
+        target: { type: "publisher", id: params.data.id },
+        metadata: {
+          fields: Object.keys(patch).filter((key) => patch[key as keyof typeof patch] !== undefined),
+        },
+      });
       res.status(200).send({ ok: true, data: updated });
     } catch (error) {
       if (error instanceof PublisherNotFoundError) {

--- a/api/src/controllers/user.ts
+++ b/api/src/controllers/user.ts
@@ -11,6 +11,7 @@ import { loginHistoryService } from "@/services/login-history";
 import { publisherService } from "@/services/publisher";
 import { userService } from "@/services/user";
 import { UserRequest } from "@/types/passport";
+import { appendAuditEvent } from "@/utils/audit-log";
 import type { UserUpdatePatch } from "@/types/user";
 import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { hasLetter, hasNumber, hasSpecialChar } from "@/utils";
@@ -133,6 +134,14 @@ router.get("/loginas/:id", passport.authenticate("admin", { session: false }), a
 
     const token = jwt.sign({ _id: user.id }, SECRET, {
       expiresIn: AUTH_TOKEN_EXPIRATION,
+    });
+    appendAuditEvent(req, {
+      action: "user.login_as",
+      outcome: "success",
+      target: { type: "user", id: user.id },
+      metadata: {
+        publisherId: publisher.id,
+      },
     });
     return res.status(200).send({ ok: true, data: { user, publisher, token } });
   } catch (error) {

--- a/api/src/controllers/widget.ts
+++ b/api/src/controllers/widget.ts
@@ -9,6 +9,7 @@ import { publisherService } from "@/services/publisher";
 import { widgetService } from "@/services/widget";
 import { UserRequest } from "@/types/passport";
 import type { WidgetCreateInput, WidgetSearchParams } from "@/types/widget";
+import { appendAuditEvent } from "@/utils/audit-log";
 import { readRequiredParam } from "@/utils/publisher-access";
 
 const router = Router();
@@ -293,6 +294,16 @@ router.put("/:id", passport.authenticate("admin", { session: false }), async (re
       publishers: body.data.publishers,
       jvaModeration: body.data.jvaModeration,
       location: body.data.location,
+    });
+
+    appendAuditEvent(req, {
+      action: "widget.update",
+      outcome: "success",
+      target: { type: "widget", id: params.data.id },
+      metadata: {
+        fields: Object.keys(body.data),
+        fromPublisherId: widget.fromPublisherId,
+      },
     });
 
     return res.status(200).json({ ok: true, data: updated });

--- a/api/src/middlewares/logger.ts
+++ b/api/src/middlewares/logger.ts
@@ -1,10 +1,11 @@
-import { Request, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 import morgan from "morgan";
+import { buildAuditLog, getAuditEvents } from "@/utils/audit-log";
 import { REQUEST_ID_HEADER } from "@/utils/request-id";
 
 const SENSITIVE_FIELDS = ["password", "apikey"];
 
-const logger = morgan<Request, Response>(
+const httpLogger = morgan<Request, Response>(
   (tokens, req, res) => {
     const user = req.user as any;
     const isUser = user ? "firstname" in user : false;
@@ -46,5 +47,30 @@ const logger = morgan<Request, Response>(
     skip: (req) => req.method === "HEAD",
   }
 );
+
+export const auditLogger = (req: Request, res: Response, next: NextFunction) => {
+  res.once("finish", () => {
+    const events = [...getAuditEvents(req)];
+
+    if (res.statusCode === 403) {
+      events.unshift({
+        action: "access.denied",
+        outcome: "denied",
+        target: {
+          type: "route",
+          id: req.route ? req.baseUrl + req.route.path : req.originalUrl.split("?")[0],
+        },
+      });
+    }
+
+    events.forEach((event) => {
+      console.info(JSON.stringify(buildAuditLog(req, res, event)));
+    });
+  });
+
+  next();
+};
+
+const logger = [auditLogger, httpLogger];
 
 export default logger;

--- a/api/src/utils/__tests__/audit-log.test.ts
+++ b/api/src/utils/__tests__/audit-log.test.ts
@@ -1,0 +1,93 @@
+import { Request, Response } from "express";
+import { describe, expect, it } from "vitest";
+
+import { appendAuditEvent, buildAuditActor, buildAuditLog, getAuditEvents, redactAuditMetadata } from "@/utils/audit-log";
+
+const buildRequest = (overrides: Partial<Request> & { requestId?: string; user?: unknown } = {}) =>
+  ({
+    method: "POST",
+    originalUrl: "/publisher/123/apikey?debug=true",
+    header: (name: string) => (name === "x-request-id" ? "header-request-id" : undefined),
+    ...overrides,
+  }) as Request;
+
+const buildResponse = (statusCode = 200) =>
+  ({
+    statusCode,
+  }) as Response;
+
+describe("audit-log utils", () => {
+  it("normalise un acteur utilisateur", () => {
+    const req = buildRequest({ user: { id: "user-1", firstname: "Jane", role: "admin" } });
+
+    expect(buildAuditActor(req)).toEqual({ type: "user", id: "user-1", role: "admin" });
+  });
+
+  it("normalise un acteur publisher", () => {
+    const req = buildRequest({ user: { id: "publisher-1", name: "Publisher" } });
+
+    expect(buildAuditActor(req)).toEqual({ type: "publisher", id: "publisher-1" });
+  });
+
+  it("stocke les événements d'audit sur la requête", () => {
+    const req = buildRequest();
+
+    appendAuditEvent(req, {
+      action: "publisher.api_key.regenerate",
+      outcome: "success",
+      target: { type: "publisher", id: "publisher-1" },
+    });
+
+    expect(getAuditEvents(req)).toEqual([
+      {
+        action: "publisher.api_key.regenerate",
+        outcome: "success",
+        target: { type: "publisher", id: "publisher-1" },
+      },
+    ]);
+  });
+
+  it("construit un log d'audit avec request_id, chemin et statut", () => {
+    const req = buildRequest({ requestId: "request-1", user: { id: "user-1", firstname: "Jane", role: "admin" } });
+    const res = buildResponse(403);
+
+    expect(
+      buildAuditLog(req, res, {
+        action: "access.denied",
+        outcome: "denied",
+        target: { type: "route", id: "/publisher/:id" },
+      })
+    ).toEqual({
+      type: "security_audit",
+      action: "access.denied",
+      outcome: "denied",
+      actor: { type: "user", id: "user-1", role: "admin" },
+      target: { type: "route", id: "/publisher/:id" },
+      request_id: "request-1",
+      method: "POST",
+      path: "/publisher/123/apikey",
+      status: 403,
+      metadata: undefined,
+    });
+  });
+
+  it("redige les champs sensibles dans les metadata", () => {
+    expect(
+      redactAuditMetadata({
+        apikey: "secret-api-key",
+        password: "secret-password",
+        nested: {
+          token: "secret-token",
+          kept: "value",
+        },
+      })
+    ).toEqual({
+      apikey: "****",
+      password: "****",
+      nested: {
+        token: "****",
+        kept: "value",
+      },
+    });
+  });
+});

--- a/api/src/utils/audit-log.ts
+++ b/api/src/utils/audit-log.ts
@@ -1,0 +1,118 @@
+import { Request, Response } from "express";
+
+import { REQUEST_ID_HEADER } from "@/utils/request-id";
+
+export type AuditAction =
+  | "access.denied"
+  | "user.login_as"
+  | "publisher.api_key.regenerate"
+  | "publisher.update"
+  | "widget.update"
+  | "organization.update";
+
+export type AuditOutcome = "success" | "denied";
+
+export type AuditActor = {
+  type: "anonymous" | "publisher" | "user";
+  id?: string;
+  role?: string;
+};
+
+export type AuditTarget = {
+  type: string;
+  id?: string;
+};
+
+export type AuditEvent = {
+  action: AuditAction;
+  outcome: AuditOutcome;
+  target?: AuditTarget;
+  metadata?: Record<string, unknown>;
+};
+
+export type AuditLog = AuditEvent & {
+  type: "security_audit";
+  actor: AuditActor;
+  request_id?: string;
+  method: string;
+  path: string;
+  status: number;
+};
+
+const AUDIT_EVENTS_KEY = "__auditEvents";
+const SENSITIVE_KEYS = new Set(["apikey", "api_key", "apiKey", "authorization", "cookie", "password", "secret", "token"]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
+
+const redactSensitiveValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(redactSensitiveValue);
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return Object.entries(value).reduce<Record<string, unknown>>((acc, [key, nestedValue]) => {
+    if (nestedValue === undefined) {
+      return acc;
+    }
+
+    acc[key] = SENSITIVE_KEYS.has(key) ? "****" : redactSensitiveValue(nestedValue);
+    return acc;
+  }, {});
+};
+
+export const redactAuditMetadata = (metadata?: Record<string, unknown>): Record<string, unknown> | undefined => {
+  if (!metadata) {
+    return undefined;
+  }
+
+  return redactSensitiveValue(metadata) as Record<string, unknown>;
+};
+
+export const getAuditEvents = (req: Request): AuditEvent[] => {
+  return ((req as unknown as Record<string, AuditEvent[]>)[AUDIT_EVENTS_KEY] ?? []) as AuditEvent[];
+};
+
+export const appendAuditEvent = (req: Request, event: AuditEvent) => {
+  const requestWithAudit = req as unknown as Record<string, AuditEvent[]>;
+  requestWithAudit[AUDIT_EVENTS_KEY] = [...getAuditEvents(req), event];
+};
+
+export const buildAuditActor = (req: Request): AuditActor => {
+  const user = req.user as { firstname?: unknown; id?: string; role?: string } | undefined;
+  if (!user) {
+    return { type: "anonymous" };
+  }
+
+  if ("firstname" in user) {
+    return {
+      type: "user",
+      id: user.id,
+      role: user.role,
+    };
+  }
+
+  return {
+    type: "publisher",
+    id: user.id,
+  };
+};
+
+export const buildAuditLog = (req: Request, res: Response, event: AuditEvent): AuditLog => {
+  const requestId = (req as unknown as { requestId?: string }).requestId ?? req.header(REQUEST_ID_HEADER);
+
+  return {
+    type: "security_audit",
+    action: event.action,
+    outcome: event.outcome,
+    actor: buildAuditActor(req),
+    target: event.target,
+    request_id: requestId,
+    method: req.method,
+    path: req.originalUrl.split("?")[0],
+    status: res.statusCode,
+    metadata: redactAuditMetadata(event.metadata),
+  };
+};

--- a/api/tests/integration/api/endpoints/organization.test.ts
+++ b/api/tests/integration/api/endpoints/organization.test.ts
@@ -1,23 +1,32 @@
 import request from "supertest";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { organizationService } from "@/services/organization";
 import { createTestPublisher } from "../../../fixtures";
 import { createTestUser } from "../../../fixtures/user";
 import { createTestApp } from "../../../testApp";
 
-const app = createTestApp();
+const app = createTestApp({ auditLogs: true });
+
+const getAuditLogs = (spy: ReturnType<typeof vi.spyOn>) =>
+  spy.mock.calls.map((call: unknown[]) => JSON.parse(String(call[0]))).filter((log: { type?: string }) => log.type === "security_audit");
 
 describe("Dashboard organization controller", () => {
+  let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
   let token: string;
 
   beforeEach(async () => {
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
     const publisher = await createTestPublisher({ moderator: true });
     const { token: userToken } = await createTestUser({ role: "user", publishers: [publisher.id] });
     token = userToken;
   });
 
   const authHeader = () => ({ Authorization: `jwt ${token}` });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it("rejects GET /organization/:id for a non-admin user", async () => {
     const organization = await organizationService.createOrganization({ title: "Test organization" });
@@ -33,5 +42,28 @@ describe("Dashboard organization controller", () => {
     const res = await request(app).put(`/organization/${organization.id}`).set(authHeader()).send({ rna: "W123456789" });
 
     expect([401, 403]).toContain(res.status);
+  });
+
+  it("logs an audit event when updating an organization", async () => {
+    const { token: adminToken } = await createTestUser({ role: "admin" });
+    const organization = await organizationService.createOrganization({ title: "Test organization" });
+
+    const res = await request(app).put(`/organization/${organization.id}`).set({ Authorization: `jwt ${adminToken}` }).set("x-request-id", "request-organization-update").send({
+      rna: "W123456789",
+    });
+
+    expect(res.status).toBe(200);
+    expect(getAuditLogs(consoleInfoSpy)).toContainEqual(
+      expect.objectContaining({
+        type: "security_audit",
+        action: "organization.update",
+        outcome: "success",
+        actor: expect.objectContaining({ type: "user", role: "admin" }),
+        target: { type: "organization", id: organization.id },
+        request_id: "request-organization-update",
+        status: 200,
+        metadata: { fields: ["rna"] },
+      })
+    );
   });
 });

--- a/api/tests/integration/api/endpoints/publisher.test.ts
+++ b/api/tests/integration/api/endpoints/publisher.test.ts
@@ -1,17 +1,22 @@
 import request from "supertest";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createTestPublisher } from "../../../fixtures";
 import { createTestUser } from "../../../fixtures/user";
 import { createTestApp } from "../../../testApp";
 
-const app = createTestApp();
+const app = createTestApp({ auditLogs: true });
+
+const getAuditLogs = (spy: ReturnType<typeof vi.spyOn>) =>
+  spy.mock.calls.map((call: unknown[]) => JSON.parse(String(call[0]))).filter((log: { type?: string }) => log.type === "security_audit");
 
 describe("Dashboard publisher controller", () => {
+  let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
   let token: string;
   let publisherId: string;
 
   beforeEach(async () => {
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
     const publisher = await createTestPublisher({ moderator: true });
     publisherId = publisher.id;
     const { token: userToken } = await createTestUser({ role: "user", publishers: [publisherId] });
@@ -19,6 +24,10 @@ describe("Dashboard publisher controller", () => {
   });
 
   const authHeader = () => ({ Authorization: `jwt ${token}` });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it("allows POST /publisher/search for an authenticated user", async () => {
     const res = await request(app).post("/publisher/search").set(authHeader()).send({});
@@ -64,5 +73,45 @@ describe("Dashboard publisher controller", () => {
     const res = await request(app).get(`/publisher/${otherPublisher.id}/moderated`).set(authHeader());
 
     expect(res.status).toBe(403);
+  });
+
+  it("logs an audit event when regenerating a publisher API key", async () => {
+    const res = await request(app).post(`/publisher/${publisherId}/apikey`).set(authHeader()).set("x-request-id", "request-api-key");
+
+    expect(res.status).toBe(200);
+    expect(JSON.stringify(getAuditLogs(consoleInfoSpy))).not.toContain(res.body.data);
+    expect(getAuditLogs(consoleInfoSpy)).toContainEqual(
+      expect.objectContaining({
+        type: "security_audit",
+        action: "publisher.api_key.regenerate",
+        outcome: "success",
+        actor: expect.objectContaining({ type: "user" }),
+        target: { type: "publisher", id: publisherId },
+        request_id: "request-api-key",
+        status: 200,
+      })
+    );
+  });
+
+  it("logs an audit event when updating a publisher", async () => {
+    const { token: adminToken } = await createTestUser({ role: "admin" });
+
+    const res = await request(app).put(`/publisher/${publisherId}`).set({ Authorization: `jwt ${adminToken}` }).set("x-request-id", "request-publisher-update").send({
+      name: "Updated publisher",
+    });
+
+    expect(res.status).toBe(200);
+    expect(getAuditLogs(consoleInfoSpy)).toContainEqual(
+      expect.objectContaining({
+        type: "security_audit",
+        action: "publisher.update",
+        outcome: "success",
+        actor: expect.objectContaining({ type: "user", role: "admin" }),
+        target: { type: "publisher", id: publisherId },
+        request_id: "request-publisher-update",
+        status: 200,
+        metadata: { fields: ["name"] },
+      })
+    );
   });
 });

--- a/api/tests/integration/api/endpoints/user.test.ts
+++ b/api/tests/integration/api/endpoints/user.test.ts
@@ -1,17 +1,22 @@
 import request from "supertest";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createTestPublisher } from "../../../fixtures";
 import { createTestUser } from "../../../fixtures/user";
 import { createTestApp } from "../../../testApp";
 
-const app = createTestApp();
+const app = createTestApp({ auditLogs: true });
+
+const getAuditLogs = (spy: ReturnType<typeof vi.spyOn>) =>
+  spy.mock.calls.map((call: unknown[]) => JSON.parse(String(call[0]))).filter((log: { type?: string }) => log.type === "security_audit");
 
 describe("Dashboard user controller", () => {
+  let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
   let token: string;
   let publisherId: string;
 
   beforeEach(async () => {
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
     const publisher = await createTestPublisher({ moderator: true });
     publisherId = publisher.id;
     const { token: userToken } = await createTestUser({ role: "user", publishers: [publisherId] });
@@ -19,6 +24,10 @@ describe("Dashboard user controller", () => {
   });
 
   const authHeader = () => ({ Authorization: `jwt ${token}` });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it("allows GET /user/refresh for an authenticated user", async () => {
     const res = await request(app).get(`/user/refresh?publisherId=${publisherId}`).set(authHeader());
@@ -32,5 +41,45 @@ describe("Dashboard user controller", () => {
 
     expect(res.status).not.toBe(401);
     expect(res.status).not.toBe(403);
+  });
+
+  it("logs an audit event when a user access is denied", async () => {
+    const { user: otherUser } = await createTestUser();
+
+    const res = await request(app).get(`/user/${otherUser.id}`).set(authHeader()).set("x-request-id", "request-user-denied");
+
+    expect(res.status).toBe(403);
+    expect(getAuditLogs(consoleInfoSpy)).toContainEqual(
+      expect.objectContaining({
+        type: "security_audit",
+        action: "access.denied",
+        outcome: "denied",
+        actor: expect.objectContaining({ type: "user" }),
+        request_id: "request-user-denied",
+        status: 403,
+      })
+    );
+  });
+
+  it("logs an audit event when an admin uses loginas", async () => {
+    const publisher = await createTestPublisher();
+    const { token: adminToken } = await createTestUser({ role: "admin" });
+    const { user: targetUser } = await createTestUser({ publishers: [publisher.id] });
+
+    const res = await request(app).get(`/user/loginas/${targetUser.id}`).set({ Authorization: `jwt ${adminToken}` }).set("x-request-id", "request-loginas");
+
+    expect(res.status).toBe(200);
+    expect(getAuditLogs(consoleInfoSpy)).toContainEqual(
+      expect.objectContaining({
+        type: "security_audit",
+        action: "user.login_as",
+        outcome: "success",
+        actor: expect.objectContaining({ type: "user", role: "admin" }),
+        target: { type: "user", id: targetUser.id },
+        request_id: "request-loginas",
+        status: 200,
+        metadata: { publisherId: publisher.id },
+      })
+    );
   });
 });

--- a/api/tests/integration/api/endpoints/widget.test.ts
+++ b/api/tests/integration/api/endpoints/widget.test.ts
@@ -1,17 +1,22 @@
 import request from "supertest";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createTestPublisher, createTestWidget } from "../../../fixtures";
 import { createTestUser } from "../../../fixtures/user";
 import { createTestApp } from "../../../testApp";
 
-const app = createTestApp();
+const app = createTestApp({ auditLogs: true });
+
+const getAuditLogs = (spy: ReturnType<typeof vi.spyOn>) =>
+  spy.mock.calls.map((call: unknown[]) => JSON.parse(String(call[0]))).filter((log: { type?: string }) => log.type === "security_audit");
 
 describe("Dashboard widget controller", () => {
+  let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
   let token: string;
   let publisherId: string;
 
   beforeEach(async () => {
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
     const publisher = await createTestPublisher({ moderator: true });
     publisherId = publisher.id;
     const { token: userToken } = await createTestUser({ role: "user", publishers: [publisherId] });
@@ -19,6 +24,10 @@ describe("Dashboard widget controller", () => {
   });
 
   const authHeader = () => ({ Authorization: `jwt ${token}` });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it("allows POST /widget/search for an authenticated user", async () => {
     const res = await request(app).post("/widget/search").set(authHeader()).send({});
@@ -34,5 +43,30 @@ describe("Dashboard widget controller", () => {
     const res = await request(app).get(`/widget/${widget.id}`).set(authHeader());
 
     expect(res.status).toBe(403);
+  });
+
+  it("logs an audit event when updating a widget", async () => {
+    const publisher = await createTestPublisher();
+    const widget = await createTestWidget({ fromPublisher: publisher });
+    const { token: adminToken } = await createTestUser({ role: "admin" });
+
+    const res = await request(app).put(`/widget/${widget.id}`).set({ Authorization: `jwt ${adminToken}` }).set("x-request-id", "request-widget-update").send({
+      name: "Updated widget",
+      active: false,
+    });
+
+    expect(res.status).toBe(200);
+    expect(getAuditLogs(consoleInfoSpy)).toContainEqual(
+      expect.objectContaining({
+        type: "security_audit",
+        action: "widget.update",
+        outcome: "success",
+        actor: expect.objectContaining({ type: "user", role: "admin" }),
+        target: { type: "widget", id: widget.id },
+        request_id: "request-widget-update",
+        status: 200,
+        metadata: { fields: ["name", "active"], fromPublisherId: publisher.id },
+      })
+    );
   });
 });

--- a/api/tests/testApp.ts
+++ b/api/tests/testApp.ts
@@ -16,6 +16,7 @@ import UserController from "@/controllers/user";
 import WarningController from "@/controllers/warning";
 import WidgetController from "@/controllers/widget";
 import bodyParserErrorHandler from "@/middlewares/body-parser-error-handler";
+import { auditLogger } from "@/middlewares/logger";
 import passport from "@/middlewares/passport";
 import requestId from "@/middlewares/request-id";
 import { createHttpMetricsMiddleware, HttpMetricsRecorder } from "@/services/observability/metrics";
@@ -27,7 +28,7 @@ import ActivityV2Controller from "@/v2/activity";
 import MissionV2WriteController from "@/v2/mission/controller";
 
 // Create a test Express app with minimal configuration
-export const createTestApp = ({ metricsRecorder }: { metricsRecorder?: HttpMetricsRecorder } = {}) => {
+export const createTestApp = ({ auditLogs = false, metricsRecorder }: { auditLogs?: boolean; metricsRecorder?: HttpMetricsRecorder } = {}) => {
   const app = express();
 
   app.set("trust proxy", true);
@@ -40,6 +41,9 @@ export const createTestApp = ({ metricsRecorder }: { metricsRecorder?: HttpMetri
   app.use(cookieParser());
   app.use(requestId);
   app.use(createHttpMetricsMiddleware(metricsRecorder));
+  if (auditLogs) {
+    app.use(auditLogger);
+  }
   app.use(passport.initialize());
 
   // Mount the controllers


### PR DESCRIPTION
## Description

Cette PR ajoute une journalisation d’audit sécurité côté API, distincte des logs HTTP techniques existants.

Périmètre couvert :

- journalisation automatique des refus d’accès `403` avec un événement `access.denied` ;
- journalisation des actions sensibles suivantes :
  - impersonation admin via `GET /user/loginas/:id` ;
  - régénération de clé API publisher via `POST /publisher/:id/apikey` ;
  - modification de publisher via `PUT /publisher/:id` ;
  - modification de widget via `PUT /widget/:id` ;
  - modification d’organisation via `PUT /organization/:id` ;
- ajout d’un helper `api/src/utils/audit-log.ts` pour construire des événements structurés avec `actor`, `target`, `action`, `outcome`, `request_id`, `status` et métadonnées métier ;
- redaction des champs sensibles dans les métadonnées d’audit ;
- adaptation de `createTestApp` pour activer uniquement le middleware d’audit dans les tests qui en ont besoin, sans bruit Morgan pendant les tests d’intégration.

Aucun changement de contrat HTTP ni migration de données.

## Liens utiles

- 📝 Ticket Notion :  https://www.notion.so/jeveuxaider/Log-des-actions-sensibles-35972a322d50801b9c29f5bd502026a0?source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire