### PR TITLE
refactor(api): brevo secure webhook

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -21,6 +21,8 @@ export const ASSOS_INDEX = "association";
 export const STATS_INDEX = "stats";
 
 export const SENDINBLUE_APIKEY = process.env.SENDINBLUE_APIKEY;
+export const BREVO_WEBHOOK_TOKEN = process.env.BREVO_WEBHOOK_TOKEN;
+export const BREVO_WEBHOOK_IP_ALLOWLIST = process.env.BREVO_WEBHOOK_IP_ALLOWLIST || "1.179.112.0/20,172.246.240.0/20";
 
 export const SENTRY_DSN_API = process.env.SENTRY_DSN_API;
 export const SENTRY_DSN_JOBS = process.env.SENTRY_DSN_JOBS;

--- a/api/src/controllers/brevo-webhook/controller.ts
+++ b/api/src/controllers/brevo-webhook/controller.ts
@@ -1,13 +1,45 @@
-import { Router } from "express";
-import { INVALID_BODY } from "@/error";
-import { emailService } from "@/services/email";
-import { BrevoInboundEmail } from "@/types/brevo";
-import { EmailCreateInput } from "@/types/email";
-import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { downloadFile } from "@/controllers/brevo-webhook/helpers/download-file";
+import { INVALID_BODY } from "@/error";
+import { brevoWebhookSecurity } from "@/middlewares/brevo-webhook";
+import { publisherRateLimiter } from "@/middlewares/rate-limit";
+import { emailService } from "@/services/email";
+import { EmailCreateInput } from "@/types/email";
+import { Router } from "express";
+import { z } from "zod";
 
 const router = Router();
 router.use(publisherRateLimiter);
+router.use(brevoWebhookSecurity);
+
+const mailboxSchema = z.object({
+  Name: z.string(),
+  Address: z.string().email(),
+});
+
+const attachmentSchema = z.object({
+  Name: z.string(),
+  ContentType: z.string(),
+  ContentLength: z.number(),
+  ContentId: z.string(),
+  DownloadToken: z.string(),
+});
+
+const brevoInboundEmailSchema = z.object({
+  MessageId: z.string(),
+  InReplyTo: z.string().optional(),
+  From: mailboxSchema,
+  To: z.array(mailboxSchema),
+  SentAtDate: z.string(),
+  Subject: z.string(),
+  RawHtmlBody: z.string().optional(),
+  RawTextBody: z.string().optional(),
+  ExtractedMarkdownMessage: z.string().optional(),
+  Attachments: z.array(attachmentSchema),
+});
+
+const brevoWebhookSchema = z.object({
+  items: z.array(brevoInboundEmailSchema).min(1),
+});
 
 /**
  * Webhook for Brevo
@@ -17,14 +49,14 @@ router.use(publisherRateLimiter);
  */
 router.post("/", async (req, res, next) => {
   try {
-    const body = req.body as { items: BrevoInboundEmail[] };
+    const body = brevoWebhookSchema.safeParse(req.body);
 
-    if (!body.items || !Array.isArray(body.items)) {
+    if (!body.success) {
       return res.status(400).send({ ok: false, code: INVALID_BODY, message: "Invalid body" });
     }
 
-    for (let i = 0; i < body.items.length; i++) {
-      const item = body.items[i];
+    for (let i = 0; i < body.data.items.length; i++) {
+      const item = body.data.items[i];
 
       if (!item["Subject"].includes("Rapport LinkedIn")) {
         continue;

--- a/api/src/middlewares/__tests__/brevo-webhook.test.ts
+++ b/api/src/middlewares/__tests__/brevo-webhook.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadMiddleware = async ({ token = "test-token", allowlist = "1.179.112.0/20" } = {}) => {
+  vi.resetModules();
+  process.env.BREVO_WEBHOOK_TOKEN = token;
+  process.env.BREVO_WEBHOOK_IP_ALLOWLIST = allowlist;
+
+  const { brevoWebhookSecurity } = await import("@/middlewares/brevo-webhook");
+  return brevoWebhookSecurity;
+};
+
+const callMiddleware = async ({ authorization, ip = "1.179.112.1" }: { authorization?: string; ip?: string }) => {
+  const brevoWebhookSecurity = await loadMiddleware();
+  const req = {
+    header: (name: string) => (name.toLowerCase() === "authorization" ? authorization : undefined),
+    ip,
+    originalUrl: "/brevo-webhook",
+  } as any;
+  const res = {
+    body: undefined as unknown,
+    statusCode: undefined as number | undefined,
+    status: vi.fn(function (this: any, statusCode: number) {
+      this.statusCode = statusCode;
+      return this;
+    }),
+    send: vi.fn(function (this: any, body: unknown) {
+      this.body = body;
+      return this;
+    }),
+  };
+  const next = vi.fn();
+
+  brevoWebhookSecurity(req, res as any, next);
+
+  return { next, res };
+};
+
+describe("brevoWebhookSecurity", () => {
+  beforeEach(() => {
+    delete process.env.BREVO_WEBHOOK_TOKEN;
+    delete process.env.BREVO_WEBHOOK_IP_ALLOWLIST;
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const { res } = await callMiddleware({});
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ ok: false, code: "ACCESS_DENIED" });
+  });
+
+  it("returns 401 when bearer token is invalid", async () => {
+    const { res } = await callMiddleware({ authorization: "Bearer wrong-token" });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ ok: false, code: "ACCESS_DENIED" });
+  });
+
+  it("returns 403 when source IP is not allowlisted", async () => {
+    const { res } = await callMiddleware({ authorization: "Bearer test-token", ip: "203.0.113.10" });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toMatchObject({ ok: false, code: "FORBIDDEN" });
+  });
+
+  it("accepts a valid bearer token from an allowlisted Brevo IP", async () => {
+    const { next, res } = await callMiddleware({ authorization: "Bearer test-token" });
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts IPv4-mapped IPv6 addresses when the IPv4 is allowlisted", async () => {
+    const { next, res } = await callMiddleware({ authorization: "Bearer test-token", ip: "::ffff:1.179.112.1" });
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/api/src/middlewares/brevo-webhook.ts
+++ b/api/src/middlewares/brevo-webhook.ts
@@ -1,0 +1,117 @@
+import { timingSafeEqual } from "crypto";
+import { NextFunction, Request, Response } from "express";
+
+import { BREVO_WEBHOOK_IP_ALLOWLIST, BREVO_WEBHOOK_TOKEN } from "@/config";
+import { ACCESS_DENIED, FORBIDDEN } from "@/error";
+import { appendAuditEvent } from "@/utils/audit-log";
+
+const normalizeIpv4 = (ip?: string) => {
+  if (!ip) {
+    return null;
+  }
+
+  if (ip.startsWith("::ffff:")) {
+    return ip.slice("::ffff:".length);
+  }
+
+  return ip;
+};
+
+const ipv4ToNumber = (ip: string) => {
+  const parts = ip.split(".");
+  if (parts.length !== 4) {
+    return null;
+  }
+
+  let value = 0;
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) {
+      return null;
+    }
+    const parsed = Number(part);
+    if (parsed < 0 || parsed > 255) {
+      return null;
+    }
+    value = (value << 8) + parsed;
+  }
+
+  return value >>> 0;
+};
+
+export const isIpInCidr = (ip: string, cidr: string) => {
+  const normalizedIp = normalizeIpv4(ip);
+  if (!normalizedIp) {
+    return false;
+  }
+
+  const [rangeIp, prefixLengthRaw] = cidr.trim().split("/");
+  const prefixLength = Number(prefixLengthRaw);
+  if (!rangeIp || !Number.isInteger(prefixLength) || prefixLength < 0 || prefixLength > 32) {
+    return false;
+  }
+
+  const ipNumber = ipv4ToNumber(normalizedIp);
+  const rangeNumber = ipv4ToNumber(rangeIp);
+  if (ipNumber === null || rangeNumber === null) {
+    return false;
+  }
+
+  const mask = prefixLength === 0 ? 0 : (0xffffffff << (32 - prefixLength)) >>> 0;
+  return (ipNumber & mask) === (rangeNumber & mask);
+};
+
+const isTokenValid = (authorizationHeader?: string) => {
+  if (!BREVO_WEBHOOK_TOKEN) {
+    return false;
+  }
+
+  const parts = authorizationHeader?.split(" ") ?? [];
+  if (parts.length !== 2) {
+    return false;
+  }
+
+  const [scheme, token] = parts;
+  if (scheme !== "Bearer" || !token) {
+    return false;
+  }
+
+  const expected = Buffer.from(BREVO_WEBHOOK_TOKEN);
+  const received = Buffer.from(token);
+  if (expected.length !== received.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expected, received);
+};
+
+const isIpAllowed = (ip?: string) => {
+  const normalizedIp = normalizeIpv4(ip);
+  if (!normalizedIp) {
+    return false;
+  }
+
+  return BREVO_WEBHOOK_IP_ALLOWLIST.split(",").some((cidr) => isIpInCidr(normalizedIp, cidr));
+};
+
+export const brevoWebhookSecurity = (req: Request, res: Response, next: NextFunction) => {
+  if (!isTokenValid(req.header("authorization"))) {
+    appendAuditEvent(req, {
+      action: "webhook.brevo.invalid_token",
+      outcome: "denied",
+    });
+    return res.status(401).send({ ok: false, code: ACCESS_DENIED, message: "Not allowed" });
+  }
+
+  if (!isIpAllowed(req.ip)) {
+    appendAuditEvent(req, {
+      action: "webhook.brevo.ip_not_allowed",
+      outcome: "denied",
+      metadata: {
+        ip: req.ip,
+      },
+    });
+    return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Not allowed" });
+  }
+
+  next();
+};

--- a/api/src/utils/audit-log.ts
+++ b/api/src/utils/audit-log.ts
@@ -8,7 +8,9 @@ export type AuditAction =
   | "publisher.api_key.regenerate"
   | "publisher.update"
   | "widget.update"
-  | "organization.update";
+  | "organization.update"
+  | "webhook.brevo.invalid_token"
+  | "webhook.brevo.ip_not_allowed";
 
 export type AuditOutcome = "success" | "denied";
 

--- a/terraform/containers.tf
+++ b/terraform/containers.tf
@@ -51,6 +51,7 @@ resource "scaleway_container" "api" {
     "DATABASE_URL_CORE"      = local.secrets.DATABASE_URL_CORE
     "SENTRY_DSN_API"         = local.secrets.SENTRY_DSN_API
     "SENDINBLUE_APIKEY"      = local.secrets.SENDINBLUE_APIKEY
+    "BREVO_WEBHOOK_TOKEN"    = local.secrets.BREVO_WEBHOOK_TOKEN
     "SLACK_TOKEN"            = local.secrets.SLACK_TOKEN
     "SCW_ACCESS_KEY"         = local.secrets.SCW_ACCESS_KEY
     "SCW_SECRET_KEY"         = local.secrets.SCW_SECRET_KEY


### PR DESCRIPTION
## Description

Cette Pull Request sécurise le webhook Brevo public `/brevo-webhook`.

Elle ajoute :
- une authentification par bearer token via `BREVO_WEBHOOK_TOKEN`
- une allowlist IP Brevo configurable via `BREVO_WEBHOOK_IP_ALLOWLIST`
- une journalisation explicite des rejets de webhook
- une validation `zod` du payload reçu


## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/S-curisation-webhook-Brevo-35972a322d5080ae80a7e37fa8e10ef7?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Processus de mis à jour du webhook Brevo pendant le deploiement.

### staging
```
curl -X PUT https://api.brevo.com/v3/webhooks/1168900 \
     -H "api-key:  ${BREVO_TOKEN}" \
     -H "Content-Type: application/json" \
     -d '{
  "auth": {
    "type": "bearer",
    "token": "${BREVO_WEBHOOK_TOKEN}"
  }
}'
```

### production
```
curl -X PUT https://api.brevo.com/v3/webhooks/1174541 \
     -H "api-key:  ${BREVO_TOKEN}" \
     -H "Content-Type: application/json" \
     -d '{
  "auth": {
    "type": "bearer",
    "token": "${BREVO_WEBHOOK_TOKEN}"
  }
}'
```
