### PR TITLE
fix(api): remove brevo ip validation

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -22,7 +22,6 @@ export const STATS_INDEX = "stats";
 
 export const SENDINBLUE_APIKEY = process.env.SENDINBLUE_APIKEY;
 export const BREVO_WEBHOOK_TOKEN = process.env.BREVO_WEBHOOK_TOKEN;
-export const BREVO_WEBHOOK_IP_ALLOWLIST = process.env.BREVO_WEBHOOK_IP_ALLOWLIST || "1.179.112.0/20,172.246.240.0/20";
 
 export const SENTRY_DSN_API = process.env.SENTRY_DSN_API;
 export const SENTRY_DSN_JOBS = process.env.SENTRY_DSN_JOBS;

--- a/api/src/middlewares/__tests__/brevo-webhook.test.ts
+++ b/api/src/middlewares/__tests__/brevo-webhook.test.ts
@@ -9,10 +9,25 @@ const loadMiddleware = async ({ token = "test-token", allowlist = "1.179.112.0/2
   return brevoWebhookSecurity;
 };
 
-const callMiddleware = async ({ authorization, ip = "1.179.112.1" }: { authorization?: string; ip?: string }) => {
+const callMiddleware = async ({
+  authorization,
+  ip = "1.179.112.1",
+  xForwardedFor,
+  xEnvoyExternalAddress,
+}: {
+  authorization?: string;
+  ip?: string;
+  xForwardedFor?: string;
+  xEnvoyExternalAddress?: string;
+}) => {
   const brevoWebhookSecurity = await loadMiddleware();
+  const headers: Record<string, string | undefined> = {
+    authorization,
+    "x-forwarded-for": xForwardedFor,
+    "x-envoy-external-address": xEnvoyExternalAddress,
+  };
   const req = {
-    header: (name: string) => (name.toLowerCase() === "authorization" ? authorization : undefined),
+    header: (name: string) => headers[name.toLowerCase()],
     ip,
     originalUrl: "/brevo-webhook",
   } as any;
@@ -55,22 +70,36 @@ describe("brevoWebhookSecurity", () => {
     expect(res.body).toMatchObject({ ok: false, code: "ACCESS_DENIED" });
   });
 
-  it("returns 403 when source IP is not allowlisted", async () => {
-    const { res } = await callMiddleware({ authorization: "Bearer test-token", ip: "203.0.113.10" });
+  it("returns 403 when X-Forwarded-For source IP is not allowlisted", async () => {
+    const { res } = await callMiddleware({ authorization: "Bearer test-token", ip: "100.96.0.53", xForwardedFor: "203.0.113.10" });
 
     expect(res.statusCode).toBe(403);
     expect(res.body).toMatchObject({ ok: false, code: "FORBIDDEN" });
   });
 
-  it("accepts a valid bearer token from an allowlisted Brevo IP", async () => {
-    const { next, res } = await callMiddleware({ authorization: "Bearer test-token" });
+  it("accepts a valid bearer token from an allowlisted X-Forwarded-For Brevo IP", async () => {
+    const { next, res } = await callMiddleware({ authorization: "Bearer test-token", ip: "100.96.0.53", xForwardedFor: "1.179.112.1" });
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the first IP from an X-Forwarded-For chain", async () => {
+    const { next, res } = await callMiddleware({ authorization: "Bearer test-token", ip: "100.96.0.53", xForwardedFor: "1.179.112.1, 100.96.0.53" });
 
     expect(res.status).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledTimes(1);
   });
 
   it("accepts IPv4-mapped IPv6 addresses when the IPv4 is allowlisted", async () => {
-    const { next, res } = await callMiddleware({ authorization: "Bearer test-token", ip: "::ffff:1.179.112.1" });
+    const { next, res } = await callMiddleware({ authorization: "Bearer test-token", ip: "100.96.0.53", xForwardedFor: "::ffff:1.179.112.1" });
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to req.ip when proxy headers are missing", async () => {
+    const { next, res } = await callMiddleware({ authorization: "Bearer test-token", ip: "1.179.112.1" });
 
     expect(res.status).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledTimes(1);

--- a/api/src/middlewares/__tests__/brevo-webhook.test.ts
+++ b/api/src/middlewares/__tests__/brevo-webhook.test.ts
@@ -1,34 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const loadMiddleware = async ({ token = "test-token", allowlist = "1.179.112.0/20" } = {}) => {
+const loadMiddleware = async ({ token = "test-token" } = {}) => {
   vi.resetModules();
   process.env.BREVO_WEBHOOK_TOKEN = token;
-  process.env.BREVO_WEBHOOK_IP_ALLOWLIST = allowlist;
 
   const { brevoWebhookSecurity } = await import("@/middlewares/brevo-webhook");
   return brevoWebhookSecurity;
 };
 
-const callMiddleware = async ({
-  authorization,
-  ip = "1.179.112.1",
-  xForwardedFor,
-  xEnvoyExternalAddress,
-}: {
-  authorization?: string;
-  ip?: string;
-  xForwardedFor?: string;
-  xEnvoyExternalAddress?: string;
-}) => {
+const callMiddleware = async ({ authorization }: { authorization?: string }) => {
   const brevoWebhookSecurity = await loadMiddleware();
-  const headers: Record<string, string | undefined> = {
-    authorization,
-    "x-forwarded-for": xForwardedFor,
-    "x-envoy-external-address": xEnvoyExternalAddress,
-  };
+  const headers: Record<string, string | undefined> = { authorization };
   const req = {
     header: (name: string) => headers[name.toLowerCase()],
-    ip,
     originalUrl: "/brevo-webhook",
   } as any;
   const res = {
@@ -53,7 +37,6 @@ const callMiddleware = async ({
 describe("brevoWebhookSecurity", () => {
   beforeEach(() => {
     delete process.env.BREVO_WEBHOOK_TOKEN;
-    delete process.env.BREVO_WEBHOOK_IP_ALLOWLIST;
   });
 
   it("returns 401 when Authorization header is missing", async () => {
@@ -70,36 +53,8 @@ describe("brevoWebhookSecurity", () => {
     expect(res.body).toMatchObject({ ok: false, code: "ACCESS_DENIED" });
   });
 
-  it("returns 403 when X-Forwarded-For source IP is not allowlisted", async () => {
-    const { res } = await callMiddleware({ authorization: "Bearer test-token", ip: "100.96.0.53", xForwardedFor: "203.0.113.10" });
-
-    expect(res.statusCode).toBe(403);
-    expect(res.body).toMatchObject({ ok: false, code: "FORBIDDEN" });
-  });
-
-  it("accepts a valid bearer token from an allowlisted X-Forwarded-For Brevo IP", async () => {
-    const { next, res } = await callMiddleware({ authorization: "Bearer test-token", ip: "100.96.0.53", xForwardedFor: "1.179.112.1" });
-
-    expect(res.status).not.toHaveBeenCalled();
-    expect(next).toHaveBeenCalledTimes(1);
-  });
-
-  it("uses the first IP from an X-Forwarded-For chain", async () => {
-    const { next, res } = await callMiddleware({ authorization: "Bearer test-token", ip: "100.96.0.53", xForwardedFor: "1.179.112.1, 100.96.0.53" });
-
-    expect(res.status).not.toHaveBeenCalled();
-    expect(next).toHaveBeenCalledTimes(1);
-  });
-
-  it("accepts IPv4-mapped IPv6 addresses when the IPv4 is allowlisted", async () => {
-    const { next, res } = await callMiddleware({ authorization: "Bearer test-token", ip: "100.96.0.53", xForwardedFor: "::ffff:1.179.112.1" });
-
-    expect(res.status).not.toHaveBeenCalled();
-    expect(next).toHaveBeenCalledTimes(1);
-  });
-
-  it("falls back to req.ip when proxy headers are missing", async () => {
-    const { next, res } = await callMiddleware({ authorization: "Bearer test-token", ip: "1.179.112.1" });
+  it("accepts a valid bearer token without checking the source IP", async () => {
+    const { next, res } = await callMiddleware({ authorization: "Bearer test-token" });
 
     expect(res.status).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledTimes(1);

--- a/api/src/middlewares/brevo-webhook.ts
+++ b/api/src/middlewares/brevo-webhook.ts
@@ -1,64 +1,9 @@
 import { timingSafeEqual } from "crypto";
 import { NextFunction, Request, Response } from "express";
 
-import { BREVO_WEBHOOK_IP_ALLOWLIST, BREVO_WEBHOOK_TOKEN } from "@/config";
-import { ACCESS_DENIED, FORBIDDEN } from "@/error";
+import { BREVO_WEBHOOK_TOKEN } from "@/config";
+import { ACCESS_DENIED } from "@/error";
 import { appendAuditEvent } from "@/utils/audit-log";
-
-const normalizeIpv4 = (ip?: string) => {
-  if (!ip) {
-    return null;
-  }
-
-  if (ip.startsWith("::ffff:")) {
-    return ip.slice("::ffff:".length);
-  }
-
-  return ip;
-};
-
-const ipv4ToNumber = (ip: string) => {
-  const parts = ip.split(".");
-  if (parts.length !== 4) {
-    return null;
-  }
-
-  let value = 0;
-  for (const part of parts) {
-    if (!/^\d+$/.test(part)) {
-      return null;
-    }
-    const parsed = Number(part);
-    if (parsed < 0 || parsed > 255) {
-      return null;
-    }
-    value = (value << 8) + parsed;
-  }
-
-  return value >>> 0;
-};
-
-export const isIpInCidr = (ip: string, cidr: string) => {
-  const normalizedIp = normalizeIpv4(ip);
-  if (!normalizedIp) {
-    return false;
-  }
-
-  const [rangeIp, prefixLengthRaw] = cidr.trim().split("/");
-  const prefixLength = Number(prefixLengthRaw);
-  if (!rangeIp || !Number.isInteger(prefixLength) || prefixLength < 0 || prefixLength > 32) {
-    return false;
-  }
-
-  const ipNumber = ipv4ToNumber(normalizedIp);
-  const rangeNumber = ipv4ToNumber(rangeIp);
-  if (ipNumber === null || rangeNumber === null) {
-    return false;
-  }
-
-  const mask = prefixLength === 0 ? 0 : (0xffffffff << (32 - prefixLength)) >>> 0;
-  return (ipNumber & mask) === (rangeNumber & mask);
-};
 
 const isTokenValid = (authorizationHeader?: string) => {
   if (!BREVO_WEBHOOK_TOKEN) {
@@ -84,30 +29,6 @@ const isTokenValid = (authorizationHeader?: string) => {
   return timingSafeEqual(expected, received);
 };
 
-const isIpAllowed = (ip?: string) => {
-  const normalizedIp = normalizeIpv4(ip);
-  if (!normalizedIp) {
-    return false;
-  }
-
-  return BREVO_WEBHOOK_IP_ALLOWLIST.split(",").some((cidr) => isIpInCidr(normalizedIp, cidr));
-};
-
-export const getBrevoWebhookSourceIp = (req: Request) => {
-  const xForwardedFor = req.header("x-forwarded-for");
-  const forwardedSourceIp = xForwardedFor?.split(",")[0]?.trim();
-  if (forwardedSourceIp) {
-    return normalizeIpv4(forwardedSourceIp);
-  }
-
-  const envoyExternalAddress = req.header("x-envoy-external-address")?.trim();
-  if (envoyExternalAddress) {
-    return normalizeIpv4(envoyExternalAddress);
-  }
-
-  return normalizeIpv4(req.ip);
-};
-
 export const brevoWebhookSecurity = (req: Request, res: Response, next: NextFunction) => {
   if (!isTokenValid(req.header("authorization"))) {
     appendAuditEvent(req, {
@@ -115,21 +36,6 @@ export const brevoWebhookSecurity = (req: Request, res: Response, next: NextFunc
       outcome: "denied",
     });
     return res.status(401).send({ ok: false, code: ACCESS_DENIED, message: "Not allowed" });
-  }
-
-  const sourceIp = getBrevoWebhookSourceIp(req);
-  if (!isIpAllowed(sourceIp ?? undefined)) {
-    appendAuditEvent(req, {
-      action: "webhook.brevo.ip_not_allowed",
-      outcome: "denied",
-      metadata: {
-        sourceIp,
-        proxyIp: req.ip,
-        xForwardedFor: req.header("x-forwarded-for"),
-        xEnvoyExternalAddress: req.header("x-envoy-external-address"),
-      },
-    });
-    return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Not allowed" });
   }
 
   next();

--- a/api/src/middlewares/brevo-webhook.ts
+++ b/api/src/middlewares/brevo-webhook.ts
@@ -93,6 +93,21 @@ const isIpAllowed = (ip?: string) => {
   return BREVO_WEBHOOK_IP_ALLOWLIST.split(",").some((cidr) => isIpInCidr(normalizedIp, cidr));
 };
 
+export const getBrevoWebhookSourceIp = (req: Request) => {
+  const xForwardedFor = req.header("x-forwarded-for");
+  const forwardedSourceIp = xForwardedFor?.split(",")[0]?.trim();
+  if (forwardedSourceIp) {
+    return normalizeIpv4(forwardedSourceIp);
+  }
+
+  const envoyExternalAddress = req.header("x-envoy-external-address")?.trim();
+  if (envoyExternalAddress) {
+    return normalizeIpv4(envoyExternalAddress);
+  }
+
+  return normalizeIpv4(req.ip);
+};
+
 export const brevoWebhookSecurity = (req: Request, res: Response, next: NextFunction) => {
   if (!isTokenValid(req.header("authorization"))) {
     appendAuditEvent(req, {
@@ -102,12 +117,16 @@ export const brevoWebhookSecurity = (req: Request, res: Response, next: NextFunc
     return res.status(401).send({ ok: false, code: ACCESS_DENIED, message: "Not allowed" });
   }
 
-  if (!isIpAllowed(req.ip)) {
+  const sourceIp = getBrevoWebhookSourceIp(req);
+  if (!isIpAllowed(sourceIp ?? undefined)) {
     appendAuditEvent(req, {
       action: "webhook.brevo.ip_not_allowed",
       outcome: "denied",
       metadata: {
-        ip: req.ip,
+        sourceIp,
+        proxyIp: req.ip,
+        xForwardedFor: req.header("x-forwarded-for"),
+        xEnvoyExternalAddress: req.header("x-envoy-external-address"),
       },
     });
     return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Not allowed" });

--- a/api/src/utils/audit-log.ts
+++ b/api/src/utils/audit-log.ts
@@ -9,8 +9,7 @@ export type AuditAction =
   | "publisher.update"
   | "widget.update"
   | "organization.update"
-  | "webhook.brevo.invalid_token"
-  | "webhook.brevo.ip_not_allowed";
+  | "webhook.brevo.invalid_token";
 
 export type AuditOutcome = "success" | "denied";
 


### PR DESCRIPTION
## Description

Le filtrage IP applicatif a volontairement été retiré : dans le contexte Scaleway Serverless Containers, req.ip peut être une IP interne et `X-Forwarded-For` peut être forgé côté client. La sécurité repose donc sur le bearer token.

## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/S-curisation-webhook-Brevo-35972a322d5080ae80a7e37fa8e10ef7?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
