### PR TITLE
fix(api,app): require comment when refusing missions

### DIFF
--- a/api/src/controllers/moderation.ts
+++ b/api/src/controllers/moderation.ts
@@ -4,6 +4,7 @@ import zod from "zod";
 
 import { PUBLISHER_IDS } from "@/config";
 import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { missionModerationStatusService } from "@/services/mission-moderation-status";
 import { moderationEventService } from "@/services/moderation-event";
 import { publisherService } from "@/services/publisher";
@@ -11,7 +12,6 @@ import publisherOrganizationService from "@/services/publisher-organization";
 import { UserRecord } from "@/types";
 import { MissionModerationRecord, ModerationFilters } from "@/types/mission-moderation-status";
 import type { UserRequest } from "@/types/passport";
-import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { getModerationEvents, getModerationUpdates, getOrganizationUpdates } from "@/utils/mission-moderation-status";
 
 const router = Router();
@@ -204,12 +204,17 @@ router.put("/many", passport.authenticate("user", { session: false }), async (re
           organizationId: zod.string().optional(),
           status: zod.enum(["PENDING"]).optional(),
         }),
-        update: zod.object({
-          status: zod.enum(["ACCEPTED", "REFUSED", "PENDING", "ONGOING"]).optional(),
-          comment: zod.string().nullable().optional(),
-          note: zod.string().nullable().optional(),
-          title: zod.string().nullable().optional(),
-        }),
+        update: zod
+          .object({
+            status: zod.enum(["ACCEPTED", "REFUSED", "PENDING", "ONGOING"]).optional(),
+            comment: zod.string().nullable().optional(),
+            note: zod.string().nullable().optional(),
+            title: zod.string().nullable().optional(),
+          })
+          .refine((data) => data.status !== "REFUSED" || !!data.comment, {
+            message: "comment is required when status is REFUSED",
+            path: ["comment"],
+          }),
       })
       .safeParse(req.body);
 

--- a/app/src/scenes/broadcast/moderation/components/OrganizationRefusedModal.jsx
+++ b/app/src/scenes/broadcast/moderation/components/OrganizationRefusedModal.jsx
@@ -13,6 +13,11 @@ const OrganizationRefusedModal = ({ open, onClose, data, update, onChange, total
   const [loading, setLoading] = useState(false);
 
   const handleSubmit = async () => {
+    if (!update.comment) {
+      toast.error("Un motif est requis pour refuser des missions", { position: "bottom-right" });
+      return;
+    }
+
     setLoading(true);
     try {
       const where = { moderatorId: publisher.id, organizationId: data.missionPublisherOrganizationId, status: "PENDING" };


### PR DESCRIPTION
## Description

S'assure qu'un commentaire (motif) est requis pour passer une mission en `REFUSED`, à la fois en validation côté API et avec un retour utilisateur clair côté back-office.

**Changements** :

- **API** : ajout d'un `.refine()` sur le schéma `update` de `PUT /moderation/many` pour rejeter un statut `REFUSED` sans `comment`, alignant l'endpoint bulk sur `PUT /moderation/:id` qui appliquait déjà cette règle.
- **App** : guard dans `OrganizationRefusedModal` qui affiche un `toast.error` ("Un motif est requis pour refuser des missions") avant d'appeler l'API si `update.comment` est vide.

## Liens utiles

- 📝 Ticket Notion : [lien](https://www.notion.so/jeveuxaider/Les-motifs-de-refus-ne-sont-pas-bien-affich-s-dans-la-page-de-d-tails-35e72a322d5080a3bdcadb8bad820134?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Comble une asymétrie de validation : `PUT /moderation/:id` exigeait déjà un `comment` pour `REFUSED`, mais `PUT /moderation/many` permettait de refuser en masse sans motif — ce qui pouvait laisser remonter des refus sans label côté UI.
- Côté front, la garde affiche un message clair plutôt que de remonter une erreur générique via Sentry/captureError quand le motif est vide.