### PR TITLE
feat(app,api): self hosted scripts

### DIFF
--- a/api/prisma/migrations/20260518000000_add_publisher_self_hosted_script/migration.sql
+++ b/api/prisma/migrations/20260518000000_add_publisher_self_hosted_script/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "publisher" ADD COLUMN "self_hosted_script" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -327,6 +327,7 @@ model Publisher {
   description        String       @default("") @map("description")
   missionType        MissionType? @map("mission_type")
   isAnnonceur        Boolean      @default(false) @map("is_annonceur")
+  selfHostedScript   Boolean      @default(false) @map("self_hosted_script")
   hasApiRights       Boolean      @default(false) @map("has_api_rights")
   hasWidgetRights    Boolean      @default(false) @map("has_widget_rights")
   hasCampaignRights  Boolean      @default(false) @map("has_campaign_rights")

--- a/api/src/controllers/publisher.ts
+++ b/api/src/controllers/publisher.ts
@@ -146,6 +146,7 @@ router.post("/", passport.authenticate("admin", { session: false }), async (req:
         sendReport: zod.boolean().default(false),
         sendReportTo: zod.array(zod.string()).default([]),
         isAnnonceur: zod.boolean().default(false),
+        selfHostedScript: zod.boolean().default(false),
         missionType: zod.enum(PublisherMissionType).nullable().default(null),
         hasApiRights: zod.boolean().default(false),
         hasWidgetRights: zod.boolean().default(false),
@@ -185,6 +186,7 @@ router.post("/", passport.authenticate("admin", { session: false }), async (req:
       sendReport: body.data.sendReport,
       sendReportTo: body.data.sendReportTo,
       isAnnonceur: body.data.isAnnonceur,
+      selfHostedScript: body.data.selfHostedScript,
       missionType: body.data.missionType,
       hasApiRights: body.data.hasApiRights,
       hasWidgetRights: body.data.hasWidgetRights,
@@ -242,36 +244,31 @@ router.post(
   }
 );
 
-router.post(
-  "/:id/apikey",
-  passport.authenticate("user", { session: false }),
-  requirePublisherWriteAccess,
-  async (req: UserRequest, res: Response, next: NextFunction) => {
-    try {
-      const publisherId = readRequiredParam(req, res, "id");
-      if (!publisherId) {
-        return;
-      }
-
-      try {
-        const { apikey } = await publisherService.regenerateApiKey(publisherId);
-        appendAuditEvent(req, {
-          action: "publisher.api_key.regenerate",
-          outcome: "success",
-          target: { type: "publisher", id: publisherId },
-        });
-        return res.status(200).send({ ok: true, data: apikey });
-      } catch (error) {
-        if (error instanceof PublisherNotFoundError) {
-          return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Publisher not found" });
-        }
-        throw error;
-      }
-    } catch (error) {
-      next(error);
+router.post("/:id/apikey", passport.authenticate("user", { session: false }), requirePublisherWriteAccess, async (req: UserRequest, res: Response, next: NextFunction) => {
+  try {
+    const publisherId = readRequiredParam(req, res, "id");
+    if (!publisherId) {
+      return;
     }
+
+    try {
+      const { apikey } = await publisherService.regenerateApiKey(publisherId);
+      appendAuditEvent(req, {
+        action: "publisher.api_key.regenerate",
+        outcome: "success",
+        target: { type: "publisher", id: publisherId },
+      });
+      return res.status(200).send({ ok: true, data: apikey });
+    } catch (error) {
+      if (error instanceof PublisherNotFoundError) {
+        return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Publisher not found" });
+      }
+      throw error;
+    }
+  } catch (error) {
+    next(error);
   }
-);
+});
 
 router.put("/:id", passport.authenticate("admin", { session: false }), async (req: UserRequest, res: Response, next: NextFunction) => {
   try {
@@ -287,6 +284,7 @@ router.put("/:id", passport.authenticate("admin", { session: false }), async (re
         sendReport: zod.boolean().optional(),
         sendReportTo: zod.array(zod.string()).optional(),
         isAnnonceur: zod.boolean().optional(),
+        selfHostedScript: zod.boolean().optional(),
         missionType: zod.enum(PublisherMissionType).nullable().optional(),
         hasApiRights: zod.boolean().optional(),
         hasWidgetRights: zod.boolean().optional(),
@@ -323,6 +321,7 @@ router.put("/:id", passport.authenticate("admin", { session: false }), async (re
       sendReport: body.data.sendReport,
       sendReportTo: body.data.sendReportTo,
       isAnnonceur: body.data.isAnnonceur,
+      selfHostedScript: body.data.selfHostedScript,
       missionType: body.data.missionType,
       hasApiRights: body.data.hasApiRights,
       hasWidgetRights: body.data.hasWidgetRights,

--- a/api/src/jobs/import-missions/utils/__tests__/factories.ts
+++ b/api/src/jobs/import-missions/utils/__tests__/factories.ts
@@ -27,6 +27,7 @@ export const buildPublisher = (overrides: Partial<PublisherRecord> = {}): Publis
   description: "",
   missionType: PublisherMissionType.BENEVOLAT,
   isAnnonceur: true,
+  selfHostedScript: false,
   hasApiRights: false,
   hasWidgetRights: false,
   hasCampaignRights: false,

--- a/api/src/services/publisher.ts
+++ b/api/src/services/publisher.ts
@@ -60,6 +60,7 @@ export const publisherService = (() => {
     description: publisher.description ?? "",
     missionType: (publisher.missionType as PublisherMissionType) ?? null,
     isAnnonceur: publisher.isAnnonceur,
+    selfHostedScript: publisher.selfHostedScript,
     hasApiRights: publisher.hasApiRights,
     hasWidgetRights: publisher.hasWidgetRights,
     hasCampaignRights: publisher.hasCampaignRights,
@@ -189,6 +190,7 @@ export const publisherService = (() => {
       description: normalizeOptionalString(input.description) ?? "",
       missionType: (normalizeOptionalString(input.missionType) as PublisherMissionType) ?? null,
       isAnnonceur: input.isAnnonceur ?? false,
+      selfHostedScript: input.selfHostedScript ?? false,
       hasApiRights: input.hasApiRights ?? false,
       hasWidgetRights: input.hasWidgetRights ?? false,
       hasCampaignRights: input.hasCampaignRights ?? false,
@@ -372,6 +374,9 @@ export const publisherService = (() => {
     }
     if (patch.isAnnonceur !== undefined) {
       data.isAnnonceur = patch.isAnnonceur;
+    }
+    if (patch.selfHostedScript !== undefined) {
+      data.selfHostedScript = patch.selfHostedScript;
     }
     if (patch.hasApiRights !== undefined) {
       data.hasApiRights = patch.hasApiRights;

--- a/api/src/types/publisher.ts
+++ b/api/src/types/publisher.ts
@@ -49,6 +49,7 @@ export interface PublisherRecord {
   description: string;
   missionType: PublisherMissionType | null;
   isAnnonceur: boolean;
+  selfHostedScript: boolean;
   hasApiRights: boolean;
   hasWidgetRights: boolean;
   hasCampaignRights: boolean;
@@ -96,6 +97,7 @@ export interface PublisherCreateInput {
   apikey?: string | null;
   missionType?: PublisherMissionType | null;
   isAnnonceur?: boolean;
+  selfHostedScript?: boolean;
   hasApiRights?: boolean;
   hasWidgetRights?: boolean;
   hasCampaignRights?: boolean;

--- a/app/public/jstag.js
+++ b/app/public/jstag.js
@@ -8,10 +8,10 @@
  * Incrémenter le numéro de version (v1, v2, v3…) à chaque changement notable.
  */
 "use strict";
-(window._apieng = window._apieng || {}),
+((window._apieng = window._apieng || {}),
   (window.apieng = window.apieng || {}),
   (function () {
-    (window._apieng.cookieDomain = "www." === window.location.hostname.slice(0, 4) ? window.location.hostname.slice(4) : window.location.hostname),
+    ((window._apieng.cookieDomain = "www." === window.location.hostname.slice(0, 4) ? window.location.hostname.slice(4) : window.location.hostname),
       (window._apieng.eventHost = "https://api.api-engagement.beta.gouv.fr"),
       // Configuration
       (window._apieng.config = function (e) {
@@ -224,7 +224,7 @@
         if (i) o.append("clientEventId", i);
         fetch(window._apieng.eventHost + n + "?" + o);
       }),
-      (window.apieng.q = window.apieng.q || []);
+      (window.apieng.q = window.apieng.q || []));
 
     // Setup interaction tracking
     window._apieng.setupInteractionTracking();
@@ -243,4 +243,4 @@
     };
     let e = window._apieng.getQueryParameter("apiengagement_id");
     null != e && window._apieng.setCookieValue("apiengagement", e);
-  })();
+  })());

--- a/app/public/jstag.js
+++ b/app/public/jstag.js
@@ -1,8 +1,17 @@
+/* jstag v1
+ *
+ * ATTENTION — Partenaires auto-hébergeurs
+ * Ce script est auto-hébergé par certains partenaires annonceurs.
+ * Toute modification ici ne leur sera PAS automatiquement répercutée.
+ * Avant de modifier ce fichier, vérifier la liste des partenaires avec
+ * selfHostedScript = true et les en informer manuellement.
+ * Incrémenter le numéro de version (v1, v2, v3…) à chaque changement notable.
+ */
 "use strict";
-((window._apieng = window._apieng || {}),
+(window._apieng = window._apieng || {}),
   (window.apieng = window.apieng || {}),
   (function () {
-    ((window._apieng.cookieDomain = "www." === window.location.hostname.slice(0, 4) ? window.location.hostname.slice(4) : window.location.hostname),
+    (window._apieng.cookieDomain = "www." === window.location.hostname.slice(0, 4) ? window.location.hostname.slice(4) : window.location.hostname),
       (window._apieng.eventHost = "https://api.api-engagement.beta.gouv.fr"),
       // Configuration
       (window._apieng.config = function (e) {
@@ -215,7 +224,7 @@
         if (i) o.append("clientEventId", i);
         fetch(window._apieng.eventHost + n + "?" + o);
       }),
-      (window.apieng.q = window.apieng.q || []));
+      (window.apieng.q = window.apieng.q || []);
 
     // Setup interaction tracking
     window._apieng.setupInteractionTracking();
@@ -234,4 +243,4 @@
     };
     let e = window._apieng.getQueryParameter("apiengagement_id");
     null != e && window._apieng.setCookieValue("apiengagement", e);
-  })());
+  })();

--- a/app/src/scenes/publisher/Create.jsx
+++ b/app/src/scenes/publisher/Create.jsx
@@ -1,14 +1,14 @@
+import { toast } from "@/services/toast";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { toast } from "@/services/toast";
 
-import { RiArrowLeftLine } from "react-icons/ri";
-import api from "@/services/api";
-import { captureError } from "@/services/error";
-import { buildPublisherPayload } from "@/utils/publisher";
 import AnnonceurCreation from "@/scenes/publisher/components/AnnonceurCreation";
 import DiffuseurCreation from "@/scenes/publisher/components/DiffuseurCreation";
 import Informations from "@/scenes/publisher/components/Informations";
+import api from "@/services/api";
+import { captureError } from "@/services/error";
+import { buildPublisherPayload } from "@/utils/publisher";
+import { RiArrowLeftLine } from "react-icons/ri";
 
 const canSubmit = (values) => {
   if (values.name === "") return false;
@@ -32,6 +32,7 @@ const Create = () => {
     documentation: "",
     name: "",
     isAnnonceur: false,
+    selfHostedScript: false,
     isDiffuseur: false, // No in the model
     missionType: null,
     category: null,

--- a/app/src/scenes/publisher/Edit.jsx
+++ b/app/src/scenes/publisher/Edit.jsx
@@ -34,6 +34,7 @@ const Edit = () => {
     missionType: null,
     category: null,
     isAnnonceur: false,
+    selfHostedScript: false,
     isDiffuseur: false,
     hasApiRights: false,
     hasWidgetRights: false,

--- a/app/src/scenes/publisher/components/Annonceur.jsx
+++ b/app/src/scenes/publisher/components/Annonceur.jsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from "react";
+import { RiInformationLine } from "react-icons/ri";
 
 import ExportSvg from "@/assets/svg/export-icon.svg?react";
+import Checkbox from "@/components/form/Checkbox";
 import RadioInput from "@/components/form/RadioInput";
 import Modal from "@/components/Modal";
 import Table from "@/components/Table";
 import Toggle from "@/components/Toggle";
+import Tooltip from "@/components/Tooltip";
 import { MISSION_TYPES } from "@/constants";
 import api from "@/services/api";
 import { captureError } from "@/services/error";
@@ -81,7 +84,7 @@ const Annonceur = ({ values, onChange, errors, setErrors }) => {
           <div className="flex items-center gap-2">
             <Checkbox
               id="self-hosted-script"
-              label="Script de tracking des conversions auto-hébergé"
+              label="Script de tracking auto-hébergé"
               value={values.selfHostedScript}
               onChange={(e) => onChange({ ...values, selfHostedScript: e.target.checked })}
             />

--- a/app/src/scenes/publisher/components/Annonceur.jsx
+++ b/app/src/scenes/publisher/components/Annonceur.jsx
@@ -77,6 +77,22 @@ const Annonceur = ({ values, onChange, errors, setErrors }) => {
             ))}
           </Table>
           <DiffuseurModal data={data} />
+          <div className="h-px w-full bg-gray-900" />
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="self-hosted-script"
+              label="Script de tracking des conversions auto-hébergé"
+              value={values.selfHostedScript}
+              onChange={(e) => onChange({ ...values, selfHostedScript: e.target.checked })}
+            />
+            <Tooltip
+              id="tooltip-self-hosted-script"
+              ariaLabel="En savoir plus sur l'auto-hébergement du script"
+              content="Par défaut ce paramètre doit rester décoché. Le partenaire n'auto-héberge pas le script. Se rapprocher de l'équipe technique pour en savoir plus."
+            >
+              <RiInformationLine className="h-4 w-4 text-gray-500" aria-hidden="true" />
+            </Tooltip>
+          </div>
         </>
       )}
     </div>

--- a/app/src/scenes/publisher/components/AnnonceurCreation.jsx
+++ b/app/src/scenes/publisher/components/AnnonceurCreation.jsx
@@ -1,5 +1,9 @@
+import { RiInformationLine } from "react-icons/ri";
+
+import Checkbox from "@/components/form/Checkbox";
 import RadioInput from "@/components/form/RadioInput";
 import Toggle from "@/components/Toggle";
+import Tooltip from "@/components/Tooltip";
 import { MISSION_TYPES } from "@/constants";
 
 const AnnonceurCreation = ({ values, onChange }) => {
@@ -11,7 +15,7 @@ const AnnonceurCreation = ({ values, onChange }) => {
         <Toggle
           aria-label={isAnnonceur ? "Désactiver le mode annonceur" : "Activer le mode annonceur"}
           value={isAnnonceur}
-          onChange={(e) => onChange({ ...values, isAnnonceur: e, missionType: null })}
+          onChange={(e) => onChange({ ...values, isAnnonceur: e, missionType: null, selfHostedScript: false })}
         />
       </div>
       {isAnnonceur && (
@@ -30,6 +34,22 @@ const AnnonceurCreation = ({ values, onChange }) => {
                 onChange={() => onChange({ ...values, missionType: type.slug })}
               />
             ))}
+          </div>
+          <div className="h-px w-full bg-gray-900" />
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="self-hosted-script"
+              label="Script de tracking auto-hébergé"
+              value={values.selfHostedScript}
+              onChange={(e) => onChange({ ...values, selfHostedScript: e.target.checked })}
+            />
+            <Tooltip
+              id="tooltip-self-hosted-script"
+              ariaLabel="En savoir plus sur l'auto-hébergement du script"
+              content="Par défaut ce paramètre doit rester décoché. Le partenaire n'auto-héberge pas le script. Se rapprocher de l'équipe technique pour en savoir plus."
+            >
+              <RiInformationLine className="h-4 w-4 text-gray-500" aria-hidden="true" />
+            </Tooltip>
           </div>
         </>
       )}

--- a/app/src/utils/publisher.js
+++ b/app/src/utils/publisher.js
@@ -24,6 +24,7 @@ export const buildPublisherPayload = (values) => ({
   sendReport: Boolean(values.sendReport),
   sendReportTo: values.sendReportTo ?? [],
   isAnnonceur: Boolean(values.isAnnonceur),
+  selfHostedScript: values.isAnnonceur ? Boolean(values.selfHostedScript) : false,
   missionType: values.isAnnonceur ? values.missionType : null,
   hasApiRights: Boolean(values.hasApiRights),
   hasWidgetRights: Boolean(values.hasWidgetRights),


### PR DESCRIPTION
## Description

Certains partenaires annonceurs souhaitent auto-héberger le script de tracking (`jstag.js`) plutôt que de le charger depuis nos serveurs. Cette PR introduit un mécanisme pour les identifier et avertit les développeurs qu'une modification du script ne leur sera pas automatiquement répercutée.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Identifier-les-partenaires-auto-h-berg-s-pour-volution-technique-du-JSTag-35972a322d5080269b81ca72761d8245?source=copy_link)

## Type de changement

- [x] Nouvelle fonctionnalité

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire