### PR TITLE
refactor(api): define a mock provider for enrichment

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -56,6 +56,7 @@ export const DATA_SUBVENTION_TOKEN = process.env.DATA_SUBVENTION_TOKEN;
 // Albert API
 export const ALBERT_API_KEY = process.env.ALBERT_API_KEY;
 export const ALBERT_BASE_URL = process.env.ALBERT_BASE_URL || "https://albert.api.etalab.gouv.fr";
+export const MISSION_ENRICHMENT_PROVIDER = process.env.MISSION_ENRICHMENT_PROVIDER || "llm";
 
 // Rate limit
 export const RATE_LIMIT_PUBLISHER_MAX = Number(process.env.RATE_LIMIT_PUBLISHER_MAX) || 600;

--- a/api/src/services/mission-enrichment/__tests__/index.test.ts
+++ b/api/src/services/mission-enrichment/__tests__/index.test.ts
@@ -14,8 +14,8 @@ vi.mock("@/repositories/mission-enrichment", () => ({
   },
 }));
 
-vi.mock("ai", () => ({
-  generateObject: vi.fn(),
+vi.mock("@/services/mission-enrichment/providers", () => ({
+  getMissionEnrichmentProvider: vi.fn(),
 }));
 
 // Prevent loading @ai-sdk/mistral (not installed) and avoid real LLM model instantiation
@@ -44,7 +44,7 @@ import { missionRepository } from "@/repositories/mission";
 import { missionEnrichmentRepository } from "@/repositories/mission-enrichment";
 import { asyncTaskBus } from "@/services/async-task";
 import { missionEnrichmentService } from "@/services/mission-enrichment";
-import { generateObject } from "ai";
+import { getMissionEnrichmentProvider } from "@/services/mission-enrichment/providers";
 
 const baseMission = {
   id: "mission-1",
@@ -71,13 +71,20 @@ const baseMission = {
 };
 
 describe("missionEnrichmentService.enrich — chain propagation", () => {
+  const providerGenerate = vi.fn();
+
+  beforeEach(() => {
+    providerGenerate.mockReset();
+    (getMissionEnrichmentProvider as ReturnType<typeof vi.fn>).mockReturnValue({ generate: providerGenerate });
+  });
+
   it("stops the chain when mission is not found", async () => {
     (missionRepository.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
     await missionEnrichmentService.enrich("mission-1");
 
     expect(asyncTaskBus.publish).not.toHaveBeenCalled();
-    expect(generateObject).not.toHaveBeenCalled();
+    expect(providerGenerate).not.toHaveBeenCalled();
   });
 
   it("forwards to scoring without calling LLM when mission is deleted", async () => {
@@ -90,7 +97,7 @@ describe("missionEnrichmentService.enrich — chain propagation", () => {
       type: "mission.scoring",
       payload: { missionId: "mission-1" },
     });
-    expect(generateObject).not.toHaveBeenCalled();
+    expect(providerGenerate).not.toHaveBeenCalled();
   });
 
   it("stops the chain when a completed enrichment is already up-to-date", async () => {
@@ -104,7 +111,7 @@ describe("missionEnrichmentService.enrich — chain propagation", () => {
     await missionEnrichmentService.enrich("mission-1");
 
     expect(asyncTaskBus.publish).not.toHaveBeenCalled();
-    expect(generateObject).not.toHaveBeenCalled();
+    expect(providerGenerate).not.toHaveBeenCalled();
   });
 
   it("stops the chain when an enrichment is already in-flight (pending)", async () => {
@@ -118,7 +125,7 @@ describe("missionEnrichmentService.enrich — chain propagation", () => {
     await missionEnrichmentService.enrich("mission-1");
 
     expect(asyncTaskBus.publish).not.toHaveBeenCalled();
-    expect(generateObject).not.toHaveBeenCalled();
+    expect(providerGenerate).not.toHaveBeenCalled();
   });
 
   it("stops the chain when an enrichment is already in-flight (processing)", async () => {
@@ -132,7 +139,7 @@ describe("missionEnrichmentService.enrich — chain propagation", () => {
     await missionEnrichmentService.enrich("mission-1");
 
     expect(asyncTaskBus.publish).not.toHaveBeenCalled();
-    expect(generateObject).not.toHaveBeenCalled();
+    expect(providerGenerate).not.toHaveBeenCalled();
   });
 
   it("calls LLM and forwards to scoring after successful enrichment", async () => {
@@ -141,14 +148,18 @@ describe("missionEnrichmentService.enrich — chain propagation", () => {
     (missionEnrichmentRepository.create as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "enrichment-new" });
     (missionEnrichmentRepository.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
     (missionEnrichmentRepository.completeWithValues as ReturnType<typeof vi.fn>).mockResolvedValue({});
-    (generateObject as ReturnType<typeof vi.fn>).mockResolvedValue({
+    providerGenerate.mockResolvedValue({
       object: { classifications: [] },
       usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
     });
 
     await missionEnrichmentService.enrich("mission-1");
 
-    expect(generateObject).toHaveBeenCalled();
+    expect(providerGenerate).toHaveBeenCalledWith({
+      systemPrompt: "system",
+      userMessage: "user",
+      promptVersion: expect.objectContaining({ TEMPERATURE: 0 }),
+    });
     expect(asyncTaskBus.publish).toHaveBeenCalledOnce();
     expect(asyncTaskBus.publish).toHaveBeenCalledWith({
       type: "mission.scoring",

--- a/api/src/services/mission-enrichment/index.ts
+++ b/api/src/services/mission-enrichment/index.ts
@@ -1,16 +1,17 @@
 import { Prisma } from "@/db/core";
 import { prisma } from "@/db/postgres";
 import { ENRICHABLE_TAXONOMIES, TAXONOMY } from "@engagement/taxonomy";
-import { generateObject } from "ai";
 
 import { missionRepository } from "@/repositories/mission";
 import { missionEnrichmentRepository } from "@/repositories/mission-enrichment";
 import { asyncTaskBus } from "@/services/async-task";
 import type { MissionRecord, MissionSearchFilters } from "@/types/mission";
-import { CONFIDENCE_THRESHOLD, CURRENT_PROMPT_VERSION, LLM_MAX_RETRIES, LLM_NO_OBJECT_MAX_RETRIES } from "./config";
+import { CONFIDENCE_THRESHOLD, CURRENT_PROMPT_VERSION } from "./config";
 import { validateEnrichmentClassifications, type ClassificationInput, type TaxonomyLookup } from "./parser";
 import { buildMissionBlock, buildTaxonomyBlock, PROMPT_REGISTRY } from "./prompts";
 import type { MissionForPrompt, TaxonomyForPrompt } from "./prompts/types";
+import { getMissionEnrichmentProvider } from "./providers";
+import type { MissionEnrichmentProviderResult } from "./providers/types";
 
 const LOG_PREFIX = "[mission-enrichment]";
 
@@ -317,7 +318,7 @@ export const missionEnrichmentService = {
     }
 
     // Declared outside try/catch so the catch block can persist them on failure
-    let llmResult: Awaited<ReturnType<typeof generateObject>> | undefined;
+    let providerResult: MissionEnrichmentProviderResult | undefined;
 
     try {
       // 5. Mark as processing
@@ -331,38 +332,15 @@ export const missionEnrichmentService = {
       const systemPrompt = promptVersion.buildSystemPrompt(buildTaxonomyBlock(toTaxonomyForPrompt(taxonomies)));
       const userMessage = promptVersion.buildUserMessage(buildMissionBlock(toMissionForPrompt(mission)));
 
-      // 7. Call LLM with structured output (retry on AI_NoObjectGeneratedError)
-      for (let attempt = 1; attempt <= LLM_NO_OBJECT_MAX_RETRIES; attempt++) {
-        try {
-          llmResult = await generateObject({
-            model: promptVersion.MODEL,
-            schema: promptVersion.ENRICHMENT_SCHEMA,
-            system: systemPrompt,
-            prompt: userMessage,
-            maxRetries: LLM_MAX_RETRIES,
-            temperature: promptVersion.TEMPERATURE,
-          });
-          break;
-        } catch (error) {
-          const isNoObject = (error as { name?: string })?.name === "AI_NoObjectGeneratedError";
-          if (isNoObject && attempt < LLM_NO_OBJECT_MAX_RETRIES) {
-            console.warn(`${LOG_PREFIX} ${missionId}: AI_NoObjectGeneratedError — retry ${attempt}/${LLM_NO_OBJECT_MAX_RETRIES}`);
-            continue;
-          }
-          throw error;
-        }
-      }
+      // 7. Generate enrichment with the configured provider.
+      providerResult = await getMissionEnrichmentProvider().generate({ systemPrompt, userMessage, promptVersion });
 
-      if (!llmResult) {
-        throw new Error(`${LOG_PREFIX} ${missionId}: no LLM result after retries`);
-      }
-
-      const { inputTokens, outputTokens, totalTokens } = llmResult.usage;
-      console.log(`${LOG_PREFIX} ${missionId}: LLM response received — tokens: ${inputTokens} in / ${outputTokens} out / ${totalTokens} total`);
+      const { inputTokens, outputTokens, totalTokens } = providerResult.usage;
+      console.log(`${LOG_PREFIX} ${missionId}: enrichment provider response received — tokens: ${inputTokens} in / ${outputTokens} out / ${totalTokens} total`);
 
       // 8. Normalize + validate classifications against taxonomy rules
       const { valid, skipped } = validateEnrichmentClassifications(
-        (llmResult.object as { classifications: ClassificationInput[] }).classifications,
+        (providerResult.object as { classifications: ClassificationInput[] }).classifications,
         buildTaxonomyLookup(taxonomies),
         CONFIDENCE_THRESHOLD
       );
@@ -387,21 +365,21 @@ export const missionEnrichmentService = {
           enrichmentId: enrichment.id,
           missionId,
           promptVersion: CURRENT_PROMPT_VERSION,
-          rawResponse: JSON.stringify(llmResult.object),
+          rawResponse: JSON.stringify(providerResult.object),
           tokenUsage: { inputTokens, outputTokens, totalTokens },
           values: persistedValues,
         });
       } else {
-        await missionEnrichmentRepository.completeWithValues(enrichment.id, JSON.stringify(llmResult.object), { inputTokens, outputTokens, totalTokens }, persistedValues);
+        await missionEnrichmentRepository.completeWithValues(enrichment.id, JSON.stringify(providerResult.object), { inputTokens, outputTokens, totalTokens }, persistedValues);
       }
 
       console.log(`${LOG_PREFIX} ${missionId}: enrichment completed — ${valid.length} values persisted`);
     } catch (error) {
       // NoObjectGeneratedError (schema validation failure) exposes the raw LLM text and usage
-      // directly on the error — llmResult may never have been assigned in this case.
+      // directly on the error — providerResult may never have been assigned in this case.
       const errPayload = error as { text?: string; usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number } };
-      const rawResponse = llmResult ? JSON.stringify(llmResult.object) : (errPayload.text ?? null);
-      const usage = llmResult?.usage ?? errPayload.usage;
+      const rawResponse = providerResult ? JSON.stringify(providerResult.object) : (errPayload.text ?? null);
+      const usage = providerResult?.usage ?? errPayload.usage;
 
       await missionEnrichmentRepository
         .update({

--- a/api/src/services/mission-enrichment/providers/__tests__/mock.test.ts
+++ b/api/src/services/mission-enrichment/providers/__tests__/mock.test.ts
@@ -1,0 +1,11 @@
+import { mockMissionEnrichmentProvider } from "@/services/mission-enrichment/providers/mock";
+import { describe, expect, it } from "vitest";
+
+describe("mockMissionEnrichmentProvider", () => {
+  it("retourne un enrichissement vide sans appel externe", async () => {
+    await expect(mockMissionEnrichmentProvider.generate()).resolves.toEqual({
+      object: { classifications: [] },
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    });
+  });
+});

--- a/api/src/services/mission-enrichment/providers/index.ts
+++ b/api/src/services/mission-enrichment/providers/index.ts
@@ -1,0 +1,12 @@
+import { MISSION_ENRICHMENT_PROVIDER } from "@/config";
+import { llmMissionEnrichmentProvider } from "@/services/mission-enrichment/providers/llm";
+import { mockMissionEnrichmentProvider } from "@/services/mission-enrichment/providers/mock";
+import type { MissionEnrichmentProvider } from "@/services/mission-enrichment/providers/types";
+
+export const getMissionEnrichmentProvider = (): MissionEnrichmentProvider => {
+  if (MISSION_ENRICHMENT_PROVIDER === "mock") {
+    return mockMissionEnrichmentProvider;
+  }
+
+  return llmMissionEnrichmentProvider;
+};

--- a/api/src/services/mission-enrichment/providers/llm.ts
+++ b/api/src/services/mission-enrichment/providers/llm.ts
@@ -1,0 +1,33 @@
+import { LLM_MAX_RETRIES, LLM_NO_OBJECT_MAX_RETRIES } from "@/services/mission-enrichment/config";
+import type { MissionEnrichmentProvider, MissionEnrichmentProviderInput, MissionEnrichmentProviderResult } from "@/services/mission-enrichment/providers/types";
+import { generateObject } from "ai";
+
+const LOG_PREFIX = "[mission-enrichment]";
+
+export const llmMissionEnrichmentProvider: MissionEnrichmentProvider = {
+  async generate({ systemPrompt, userMessage, promptVersion }: MissionEnrichmentProviderInput): Promise<MissionEnrichmentProviderResult> {
+    for (let attempt = 1; attempt <= LLM_NO_OBJECT_MAX_RETRIES; attempt++) {
+      try {
+        const result = await generateObject({
+          model: promptVersion.MODEL,
+          schema: promptVersion.ENRICHMENT_SCHEMA,
+          system: systemPrompt,
+          prompt: userMessage,
+          maxRetries: LLM_MAX_RETRIES,
+          temperature: promptVersion.TEMPERATURE,
+        });
+
+        return result as MissionEnrichmentProviderResult;
+      } catch (error) {
+        const isNoObject = (error as { name?: string })?.name === "AI_NoObjectGeneratedError";
+        if (isNoObject && attempt < LLM_NO_OBJECT_MAX_RETRIES) {
+          console.warn(`${LOG_PREFIX} AI_NoObjectGeneratedError — retry ${attempt}/${LLM_NO_OBJECT_MAX_RETRIES}`);
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    throw new Error(`${LOG_PREFIX} no LLM result after retries`);
+  },
+};

--- a/api/src/services/mission-enrichment/providers/mock.ts
+++ b/api/src/services/mission-enrichment/providers/mock.ts
@@ -1,0 +1,10 @@
+import type { MissionEnrichmentProvider, MissionEnrichmentProviderResult } from "@/services/mission-enrichment/providers/types";
+
+export const mockMissionEnrichmentProvider: MissionEnrichmentProvider = {
+  async generate(): Promise<MissionEnrichmentProviderResult> {
+    return {
+      object: { classifications: [] },
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    };
+  },
+};

--- a/api/src/services/mission-enrichment/providers/types.ts
+++ b/api/src/services/mission-enrichment/providers/types.ts
@@ -1,0 +1,25 @@
+import type { ClassificationInput } from "@/services/mission-enrichment/parser";
+import type { FlexibleSchema, LanguageModel } from "ai";
+
+export type MissionEnrichmentProviderResult = {
+  object: { classifications: ClassificationInput[] };
+  usage: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
+};
+
+export type MissionEnrichmentProviderInput = {
+  systemPrompt: string;
+  userMessage: string;
+  promptVersion: {
+    MODEL: LanguageModel;
+    ENRICHMENT_SCHEMA: FlexibleSchema<unknown>;
+    TEMPERATURE: number;
+  };
+};
+
+export interface MissionEnrichmentProvider {
+  generate(input: MissionEnrichmentProviderInput): Promise<MissionEnrichmentProviderResult>;
+}


### PR DESCRIPTION
## Description

Permettre d’exécuter le flow `mission_enrichment` en local sans dépendre d’un provider LLM externe, tout en conservant le comportement actuel par défaut.

- Extraction de la génération d’enrichment derrière un provider dédié.
- Ajout d’un provider LLM qui reprend le comportement existant.
- Ajout d’un provider alternatif activable via variable d’environnement.
- Ajout de `MISSION_ENRICHMENT_PROVIDER`, avec `llm` comme valeur par défaut.
- Mise à jour de `missionEnrichmentService.enrich` pour utiliser le provider configuré, sans modifier le reste du flow :
  - création du `mission_enrichment`
  - validation des classifications
  - persistance des valeurs
  - déclenchement du scoring

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
