### PR TITLE
feat(api): monitoring Typesense node

### DIFF
--- a/terraform/containers.tf
+++ b/terraform/containers.tf
@@ -1,19 +1,19 @@
 resource "scaleway_container" "api" {
-  name                = "${var.workspace}-api"
-  description         = "API ${var.workspace} container"
-  namespace_id        = scaleway_container_namespace.main.id
-  registry_image      = "ghcr.io/${var.github_repository}/api:${var.env}${var.image_tag == "latest" ? "" : "-${var.image_tag}"}"
-  port                = 8080
-  cpu_limit           = var.api_cpu_limit
-  memory_limit        = var.api_memory_limit
-  min_scale           = var.api_min_scale
-  max_scale           = var.api_max_scale
-  timeout             = 60
-  privacy             = "public"
-  protocol            = "http1"
-  http_option         = "redirected" # https only
-  deploy              = true
-  private_network_id  = scaleway_vpc_private_network.main.id
+  name               = "${var.workspace}-api"
+  description        = "API ${var.workspace} container"
+  namespace_id       = scaleway_container_namespace.main.id
+  registry_image     = "ghcr.io/${var.github_repository}/api:${var.env}${var.image_tag == "latest" ? "" : "-${var.image_tag}"}"
+  port               = 8080
+  cpu_limit          = var.api_cpu_limit
+  memory_limit       = var.api_memory_limit
+  min_scale          = var.api_min_scale
+  max_scale          = var.api_max_scale
+  timeout            = 60
+  privacy            = "public"
+  protocol           = "http1"
+  http_option        = "redirected" # https only
+  deploy             = true
+  private_network_id = scaleway_vpc_private_network.main.id
 
   health_check {
     http {
@@ -40,7 +40,6 @@ resource "scaleway_container" "api" {
     "PRISMA_POOL_SIZE_CORE"      = "20"
     "PRISMA_POOL_TIMEOUT"        = "20"
     "PRISMA_CONNECT_TIMEOUT"     = "10"
-    "COCKPIT_METRICS_OTLP_URL"   = var.cockpit_metrics_otlp_url
     "TYPESENSE_HOST"             = var.typesense_load_balancer_private_ip
     "TYPESENSE_PORT"             = "8108"
 
@@ -55,36 +54,37 @@ resource "scaleway_container" "api" {
   }
 
   secret_environment_variables = {
-    "SECRET"                 = local.secrets.SECRET
-    "DATABASE_URL_CORE"      = local.secrets.DATABASE_URL_CORE
-    "SENTRY_DSN_API"         = local.secrets.SENTRY_DSN_API
-    "SENDINBLUE_APIKEY"      = local.secrets.SENDINBLUE_APIKEY
-    "BREVO_WEBHOOK_TOKEN"    = local.secrets.BREVO_WEBHOOK_TOKEN
-    "SLACK_TOKEN"            = local.secrets.SLACK_TOKEN
-    "SCW_ACCESS_KEY"         = local.secrets.SCW_ACCESS_KEY
-    "SCW_SECRET_KEY"         = local.secrets.SCW_SECRET_KEY
-    "SCW_QUEUE_ACCESS_KEY"   = var.enable_async_tasks ? scaleway_mnq_sqs_credentials.async_task_publisher[0].access_key : ""
-    "SCW_QUEUE_SECRET_KEY"   = var.enable_async_tasks ? scaleway_mnq_sqs_credentials.async_task_publisher[0].secret_key : ""
-    "LETUDIANT_PILOTY_TOKEN" = lookup(local.secrets, "LETUDIANT_PILOTY_TOKEN", "")
-    "METABASE_API_KEY"       = lookup(local.secrets, "METABASE_API_KEY", "")
-    "METABASE_URL"           = lookup(local.secrets, "METABASE_URL", "")
-    "COCKPIT_METRICS_TOKEN"  = lookup(local.secrets, "COCKPIT_METRICS_TOKEN", "")
-    "TYPESENSE_API_KEY"      = lookup(local.secrets, "TYPESENSE_API_KEY", "")
+    "SECRET"                   = local.secrets.SECRET
+    "DATABASE_URL_CORE"        = local.secrets.DATABASE_URL_CORE
+    "SENTRY_DSN_API"           = local.secrets.SENTRY_DSN_API
+    "SENDINBLUE_APIKEY"        = local.secrets.SENDINBLUE_APIKEY
+    "BREVO_WEBHOOK_TOKEN"      = local.secrets.BREVO_WEBHOOK_TOKEN
+    "SLACK_TOKEN"              = local.secrets.SLACK_TOKEN
+    "SCW_ACCESS_KEY"           = local.secrets.SCW_ACCESS_KEY
+    "SCW_SECRET_KEY"           = local.secrets.SCW_SECRET_KEY
+    "SCW_QUEUE_ACCESS_KEY"     = var.enable_async_tasks ? scaleway_mnq_sqs_credentials.async_task_publisher[0].access_key : ""
+    "SCW_QUEUE_SECRET_KEY"     = var.enable_async_tasks ? scaleway_mnq_sqs_credentials.async_task_publisher[0].secret_key : ""
+    "LETUDIANT_PILOTY_TOKEN"   = lookup(local.secrets, "LETUDIANT_PILOTY_TOKEN", "")
+    "METABASE_API_KEY"         = lookup(local.secrets, "METABASE_API_KEY", "")
+    "METABASE_URL"             = lookup(local.secrets, "METABASE_URL", "")
+    "COCKPIT_METRICS_OTLP_URL" = lookup(local.secrets, "COCKPIT_METRICS_OTLP_URL", "")
+    "COCKPIT_METRICS_TOKEN"    = lookup(local.secrets, "COCKPIT_METRICS_TOKEN", "")
+    "TYPESENSE_API_KEY"        = lookup(local.secrets, "TYPESENSE_API_KEY", "")
   }
 }
 
 resource "scaleway_container" "api_worker" {
-  count          = var.enable_async_tasks ? 1 : 0
-  name           = "${var.workspace}-api-worker"
-  description    = "API worker ${var.workspace} container"
-  namespace_id   = scaleway_container_namespace.main.id
-  registry_image = "ghcr.io/${var.github_repository}/api-worker:${var.env}${var.image_tag == "latest" ? "" : "-${var.image_tag}"}"
-  port           = 8080
-  cpu_limit      = var.worker_cpu_limit
-  memory_limit   = var.worker_memory_limit
-  min_scale      = var.worker_min_scale
-  max_scale      = var.worker_max_scale
-  timeout        = 300
+  count              = var.enable_async_tasks ? 1 : 0
+  name               = "${var.workspace}-api-worker"
+  description        = "API worker ${var.workspace} container"
+  namespace_id       = scaleway_container_namespace.main.id
+  registry_image     = "ghcr.io/${var.github_repository}/api-worker:${var.env}${var.image_tag == "latest" ? "" : "-${var.image_tag}"}"
+  port               = 8080
+  cpu_limit          = var.worker_cpu_limit
+  memory_limit       = var.worker_memory_limit
+  min_scale          = var.worker_min_scale
+  max_scale          = var.worker_max_scale
+  timeout            = 300
   privacy            = "private"
   protocol           = "http1"
   deploy             = true
@@ -99,19 +99,19 @@ resource "scaleway_container" "api_worker" {
   }
 
   environment_variables = {
-    "ENV"                               = var.env
-    "IMAGE_VERSION"                     = var.image_tag
-    "PORT_WORKER"                       = "8080"
-    "PRISMA_POOL_SIZE_CORE"             = "20"
-    "PRISMA_POOL_TIMEOUT"               = "20"
-    "PRISMA_CONNECT_TIMEOUT"            = "10"
-    "SCW_QUEUE_ENDPOINT"                = "https://sqs.mnq.fr-par.scaleway.com"
-    "SCW_QUEUE_URL_MISSION_ENRICHMENT"  = module.async_task_queues["mission_enrichment"].url
-    "SCW_QUEUE_URL_MISSION_SCORING"     = module.async_task_queues["mission_scoring"].url
-    "SCW_QUEUE_URL_MISSION_INDEX"       = module.async_task_queues["mission_index"].url
-    "ALBERT_BASE_URL"                   = lookup(local.secrets, "ALBERT_BASE_URL", "https://albert.api.etalab.gouv.fr")
-    "TYPESENSE_HOST"                    = var.typesense_load_balancer_private_ip
-    "TYPESENSE_PORT"                    = "8108"
+    "ENV"                              = var.env
+    "IMAGE_VERSION"                    = var.image_tag
+    "PORT_WORKER"                      = "8080"
+    "PRISMA_POOL_SIZE_CORE"            = "20"
+    "PRISMA_POOL_TIMEOUT"              = "20"
+    "PRISMA_CONNECT_TIMEOUT"           = "10"
+    "SCW_QUEUE_ENDPOINT"               = "https://sqs.mnq.fr-par.scaleway.com"
+    "SCW_QUEUE_URL_MISSION_ENRICHMENT" = module.async_task_queues["mission_enrichment"].url
+    "SCW_QUEUE_URL_MISSION_SCORING"    = module.async_task_queues["mission_scoring"].url
+    "SCW_QUEUE_URL_MISSION_INDEX"      = module.async_task_queues["mission_index"].url
+    "ALBERT_BASE_URL"                  = lookup(local.secrets, "ALBERT_BASE_URL", "https://albert.api.etalab.gouv.fr")
+    "TYPESENSE_HOST"                   = var.typesense_load_balancer_private_ip
+    "TYPESENSE_PORT"                   = "8108"
   }
 
   secret_environment_variables = {

--- a/terraform/envs/production.tfvars
+++ b/terraform/envs/production.tfvars
@@ -1,5 +1,5 @@
-workspace                  = "production"
-env                        = "production"
+workspace = "production"
+env       = "production"
 
 api_hostname               = "api.api-engagement.beta.gouv.fr"
 app_hostname               = "app.api-engagement.beta.gouv.fr"
@@ -8,28 +8,27 @@ volontariat_hostname       = "sc.api-engagement.beta.gouv.fr"
 piloty_hostname            = "api.piloty.fr"
 bucket_name                = "api-engagement-bucket"
 slack_jobteaser_channel_id = "C080H9MH56W"
-cockpit_metrics_otlp_url   = "https://4cf96773-b69e-4c42-81ed-940b78886deb.metrics.cockpit.fr-par.scw.cloud/otlp/v1/metrics"
 core_database_id           = "9a0421d5-c618-4d88-956b-3f758ab9aa0e"
 
-api_cpu_limit              = 1500
-api_memory_limit           = 2048
-api_min_scale              = 1
-api_max_scale              = 4
+api_cpu_limit    = 1500
+api_memory_limit = 2048
+api_min_scale    = 1
+api_max_scale    = 4
 
-app_cpu_limit              = 500
-app_memory_limit           = 1024
-app_min_scale              = 1
-app_max_scale              = 1
+app_cpu_limit    = 500
+app_memory_limit = 1024
+app_min_scale    = 1
+app_max_scale    = 1
 
-widget_cpu_limit           = 500
-widget_memory_limit        = 1024
-widget_min_scale           = 1
-widget_max_scale           = 2
+widget_cpu_limit    = 500
+widget_memory_limit = 1024
+widget_min_scale    = 1
+widget_max_scale    = 2
 
-enable_widget              = true
-enable_intern_jobs         = true
-enable_analytics_jobs      = true
-enable_rdb_backup_job      = true
+enable_widget         = true
+enable_intern_jobs    = true
+enable_analytics_jobs = true
+enable_rdb_backup_job = true
 
-enable_plateform           = true
-plateform_hostname         = "plateform.api-engagement.beta.gouv.fr"
+enable_plateform   = true
+plateform_hostname = "plateform.api-engagement.beta.gouv.fr"

--- a/terraform/modules/typesense/main.tf
+++ b/terraform/modules/typesense/main.tf
@@ -67,6 +67,15 @@ resource "scaleway_instance_server" "node" {
       typesense_version      = each.value.typesense_version
       typesense_docker_image = "typesense/typesense"
       typesense_container    = "typesense"
+      monitoring_enabled     = var.monitoring_enabled
+      alloy_config = indent(6, templatefile("${path.module}/templates/alloy-config.alloy.tftpl", {
+        api_port  = local.api_port
+        node      = each.key
+        cluster   = var.name_prefix
+        workspace = var.workspace
+      }))
+      monitoring_metrics_remote_write_url = var.monitoring_metrics_remote_write_url
+      monitoring_cockpit_token_b64        = base64encode(var.monitoring_cockpit_token)
     })
   }
 }

--- a/terraform/modules/typesense/templates/alloy-config.alloy.tftpl
+++ b/terraform/modules/typesense/templates/alloy-config.alloy.tftpl
@@ -23,7 +23,7 @@ prometheus.remote_write "cockpit" {
 }
 
 prometheus.exporter.unix "node" {
-  disable_collectors = ["ipvs", "btrfs", "infiniband", "xfs", "zfs"]
+  disable_collectors = ["ipvs", "btrfs", "infiniband", "thermal_zone", "xfs", "zfs"]
   enable_collectors  = ["meminfo"]
 
   filesystem {
@@ -38,6 +38,16 @@ prometheus.exporter.unix "node" {
 
   netdev {
     device_exclude = "^(veth.*|docker.*|br-.*|lo)$"
+  }
+}
+
+prometheus.relabel "node_metrics_filter" {
+  forward_to = [prometheus.remote_write.cockpit.receiver]
+
+  rule {
+    action        = "keep"
+    source_labels = ["__name__"]
+    regex         = "node_boot_time_seconds|node_cpu_seconds_total|node_disk_io_time_seconds_total|node_disk_read_bytes_total|node_disk_reads_completed_total|node_disk_written_bytes_total|node_disk_writes_completed_total|node_filesystem_avail_bytes|node_filesystem_readonly|node_filesystem_size_bytes|node_load1|node_load5|node_load15|node_memory_MemAvailable_bytes|node_memory_MemTotal_bytes|node_network_receive_bytes_total|node_network_transmit_bytes_total|node_network_up|node_time_seconds"
   }
 }
 
@@ -58,7 +68,7 @@ discovery.relabel "node" {
 prometheus.scrape "node" {
   scrape_interval = "30s"
   targets         = discovery.relabel.node.output
-  forward_to      = [prometheus.remote_write.cockpit.receiver]
+  forward_to      = [prometheus.relabel.node_metrics_filter.receiver]
 }
 
 prometheus.exporter.blackbox "typesense_health" {

--- a/terraform/modules/typesense/templates/alloy-config.alloy.tftpl
+++ b/terraform/modules/typesense/templates/alloy-config.alloy.tftpl
@@ -1,0 +1,95 @@
+logging {
+  level  = "info"
+  format = "logfmt"
+}
+
+prometheus.remote_write "cockpit" {
+  external_labels = {
+    cluster   = "${cluster}",
+    env       = "${workspace}",
+    node      = "${node}",
+    service   = "typesense",
+    workspace = "${workspace}",
+  }
+
+  endpoint {
+    url = sys.env("COCKPIT_METRICS_REMOTE_WRITE_URL")
+
+    authorization {
+      type        = "Bearer"
+      credentials = sys.env("COCKPIT_METRICS_TOKEN")
+    }
+  }
+}
+
+prometheus.exporter.unix "node" {
+  disable_collectors = ["ipvs", "btrfs", "infiniband", "xfs", "zfs"]
+  enable_collectors  = ["meminfo"]
+
+  filesystem {
+    fs_types_exclude     = "^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|tmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$"
+    mount_points_exclude = "^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+)($|/)"
+    mount_timeout        = "5s"
+  }
+
+  netclass {
+    ignored_devices = "^(veth.*|docker.*|br-.*|lo)$"
+  }
+
+  netdev {
+    device_exclude = "^(veth.*|docker.*|br-.*|lo)$"
+  }
+}
+
+discovery.relabel "node" {
+  targets = prometheus.exporter.unix.node.targets
+
+  rule {
+    target_label = "job"
+    replacement  = "typesense/node"
+  }
+
+  rule {
+    target_label = "instance"
+    replacement  = "${node}"
+  }
+}
+
+prometheus.scrape "node" {
+  scrape_interval = "30s"
+  targets         = discovery.relabel.node.output
+  forward_to      = [prometheus.remote_write.cockpit.receiver]
+}
+
+prometheus.exporter.blackbox "typesense_health" {
+  config = "{ modules: { http_2xx: { prober: http, timeout: 5s } } }"
+
+  target {
+    name    = "typesense-health"
+    address = "http://127.0.0.1:${api_port}/health"
+    module  = "http_2xx"
+    labels = {
+      component = "typesense",
+    }
+  }
+}
+
+discovery.relabel "typesense_health" {
+  targets = prometheus.exporter.blackbox.typesense_health.targets
+
+  rule {
+    target_label = "job"
+    replacement  = "typesense/health"
+  }
+
+  rule {
+    target_label = "instance"
+    replacement  = "${node}"
+  }
+}
+
+prometheus.scrape "typesense_health" {
+  scrape_interval = "30s"
+  targets         = discovery.relabel.typesense_health.output
+  forward_to      = [prometheus.remote_write.cockpit.receiver]
+}

--- a/terraform/modules/typesense/templates/cloud-init.yaml.tftpl
+++ b/terraform/modules/typesense/templates/cloud-init.yaml.tftpl
@@ -83,7 +83,31 @@ write_files:
       [Install]
       WantedBy=multi-user.target
 
+  #%{ if monitoring_enabled }
+  - path: /etc/alloy/config.alloy
+    permissions: "0644"
+    owner: root:root
+    content: |
+      ${alloy_config}
+  #%{ endif }
+
 runcmd:
   - systemctl enable --now docker
   - systemctl daemon-reload
   - systemctl enable --now typesense
+  #%{ if monitoring_enabled }
+  - install -d -m 0755 /etc/apt/keyrings
+  - curl -fsSL https://apt.grafana.com/gpg-full.key -o /etc/apt/keyrings/grafana.asc
+  - chmod 0644 /etc/apt/keyrings/grafana.asc
+  - sh -c 'echo "deb [signed-by=/etc/apt/keyrings/grafana.asc] https://apt.grafana.com stable main" > /etc/apt/sources.list.d/grafana.list'
+  - apt-get update
+  - apt-get install -y alloy
+  - install -d -m 0750 /etc/alloy
+  - sh -c 'printf "COCKPIT_METRICS_REMOTE_WRITE_URL=%s\n" "${monitoring_metrics_remote_write_url}" > /etc/alloy/cockpit.env'
+  - sh -c 'printf "COCKPIT_METRICS_TOKEN=%s\n" "$(printf "%s" "${monitoring_cockpit_token_b64}" | base64 -d)" >> /etc/alloy/cockpit.env'
+  - chmod 0600 /etc/alloy/cockpit.env
+  - install -d -m 0755 /etc/systemd/system/alloy.service.d
+  - sh -c 'printf "[Service]\nEnvironmentFile=/etc/alloy/cockpit.env\n" > /etc/systemd/system/alloy.service.d/cockpit.conf'
+  - systemctl daemon-reload
+  - systemctl enable --now alloy
+#%{ endif }

--- a/terraform/modules/typesense/variables.tf
+++ b/terraform/modules/typesense/variables.tf
@@ -77,3 +77,22 @@ variable "typesense_api_key" {
     error_message = "typesense_api_key must not be empty when the Typesense module is enabled."
   }
 }
+
+variable "monitoring_enabled" {
+  type        = bool
+  default     = false
+  description = "Install and configure Grafana Alloy to push Typesense node metrics to Cockpit."
+}
+
+variable "monitoring_metrics_remote_write_url" {
+  type        = string
+  default     = ""
+  description = "Cockpit metrics Prometheus Remote Write URL."
+}
+
+variable "monitoring_cockpit_token" {
+  type        = string
+  default     = ""
+  sensitive   = true
+  description = "Cockpit token used by Alloy to push metrics."
+}

--- a/terraform/typesense.tf
+++ b/terraform/typesense.tf
@@ -13,4 +13,8 @@ module "typesense" {
   load_balancer_type       = var.typesense_load_balancer_type
   load_balancer_zone       = var.public_gateway_zone
   typesense_api_key        = lookup(local.secrets, "TYPESENSE_API_KEY", "")
+
+  monitoring_enabled                  = lookup(local.secrets, "COCKPIT_METRICS_OTLP_URL", "") != "" && lookup(local.secrets, "COCKPIT_METRICS_TOKEN", "") != ""
+  monitoring_metrics_remote_write_url = replace(lookup(local.secrets, "COCKPIT_METRICS_OTLP_URL", ""), "/otlp/v1/metrics", "/api/v1/push")
+  monitoring_cockpit_token            = lookup(local.secrets, "COCKPIT_METRICS_TOKEN", "")
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -182,11 +182,6 @@ variable "core_database_id" {
   description = "ID of the managed PostgreSQL instance to back up"
 }
 
-variable "cockpit_metrics_otlp_url" {
-  type    = string
-  default = ""
-}
-
 variable "enable_app" {
   type        = bool
   default     = true


### PR DESCRIPTION
## Description

Cette PR ajoute le monitoring des nodes Typesense via Grafana Alloy et Cockpit.

Elle configure Alloy sur les instances Typesense pour :
- collecter des métriques système du node avec `prometheus.exporter.unix` ;
- vérifier la santé locale de Typesense via `/health` avec `prometheus.exporter.blackbox` ;
- pousser les métriques vers Cockpit via `prometheus.remote_write` ;
- filtrer les métriques envoyées pour limiter le volume aux métriques utiles : CPU, mémoire, disque, réseau, load average et healthcheck.

La configuration Cockpit utilise les secrets existants :
- `COCKPIT_METRICS_OTLP_URL`
- `COCKPIT_METRICS_TOKEN`

## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Monitoring-Typesense-35e72a322d50808bb464ec5e9fe139ec?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Le monitoring est installé via `cloud-init`, donc il s’applique automatiquement aux nouveaux nodes Typesense. Pour un node existant, il faut appliquer la configuration Alloy manuellement ou recréer le node.
