### PR TITLE
fix(ci): scaleway mnq sqs declaration

### DIFF
--- a/terraform/queues.tf
+++ b/terraform/queues.tf
@@ -1,11 +1,10 @@
-resource "scaleway_mnq_sqs" "main" {
-  count      = var.enable_async_tasks ? 1 : 0
+data "scaleway_mnq_sqs" "main" {
   project_id = var.project_id
 }
 
 resource "scaleway_mnq_sqs_credentials" "async_task_manager" {
   count      = var.enable_async_tasks ? 1 : 0
-  project_id = scaleway_mnq_sqs.main[0].project_id
+  project_id = data.scaleway_mnq_sqs.main.project_id
   name       = "${var.workspace}-async-task-manager"
 
   permissions {
@@ -17,7 +16,7 @@ resource "scaleway_mnq_sqs_credentials" "async_task_manager" {
 
 resource "scaleway_mnq_sqs_credentials" "async_task_publisher" {
   count      = var.enable_async_tasks ? 1 : 0
-  project_id = scaleway_mnq_sqs.main[0].project_id
+  project_id = data.scaleway_mnq_sqs.main.project_id
   name       = "${var.workspace}-async-task-publisher"
 
   permissions {
@@ -29,7 +28,7 @@ resource "scaleway_mnq_sqs_credentials" "async_task_publisher" {
 
 resource "scaleway_mnq_sqs_credentials" "async_task_trigger" {
   count      = var.enable_async_tasks ? 1 : 0
-  project_id = scaleway_mnq_sqs.main[0].project_id
+  project_id = data.scaleway_mnq_sqs.main.project_id
   name       = "${var.workspace}-async-task-trigger"
 
   permissions {

--- a/terraform/triggers.tf
+++ b/terraform/triggers.tf
@@ -6,7 +6,7 @@ resource "scaleway_container_trigger" "api_worker_async_tasks" {
   description  = "Trigger ${each.value.task_type} for API worker"
 
   sqs {
-    project_id = scaleway_mnq_sqs.main[0].project_id
+    project_id = data.scaleway_mnq_sqs.main.project_id
     queue      = module.async_task_queues[each.key].name
     region     = "fr-par"
   }


### PR DESCRIPTION
## Description

Corrige cette erreur suite à l'utilisation de workspace alors que la déclaration de `scaleway_mnq_sqs` est un singleton

```
module.typesense[0].scaleway_lb_frontend.typesense: Creation complete after 1s [id=fr-par-1/b12a7c50-993a-4917-9bec-3dbb0e6ba38b]
╷
│ Error: scaleway-sdk-go: http error 409 Conflict: resource MnqSQSNamespace: resource already exists
│
│   with scaleway_mnq_sqs.main[0],
│   on queues.tf line 1, in resource "scaleway_mnq_sqs" "main":
│    1: resource "scaleway_mnq_sqs" "main" {
│
╵
Error: Terraform exited with code 1.
```

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
