### PR TITLE
fix(ci): alloy installation

### DIFF
--- a/terraform/modules/typesense/main.tf
+++ b/terraform/modules/typesense/main.tf
@@ -68,7 +68,7 @@ resource "scaleway_instance_server" "node" {
       typesense_docker_image = "typesense/typesense"
       typesense_container    = "typesense"
       monitoring_enabled     = var.monitoring_enabled
-      alloy_config = indent(6, templatefile("${path.module}/templates/alloy-config.alloy.tftpl", {
+      alloy_config_b64 = base64encode(templatefile("${path.module}/templates/alloy-config.alloy.tftpl", {
         api_port  = local.api_port
         node      = each.key
         cluster   = var.name_prefix

--- a/terraform/modules/typesense/templates/cloud-init.yaml.tftpl
+++ b/terraform/modules/typesense/templates/cloud-init.yaml.tftpl
@@ -83,14 +83,6 @@ write_files:
       [Install]
       WantedBy=multi-user.target
 
-  #%{ if monitoring_enabled }
-  - path: /etc/alloy/config.alloy
-    permissions: "0644"
-    owner: root:root
-    content: |
-      ${alloy_config}
-  #%{ endif }
-
 runcmd:
   - systemctl enable --now docker
   - systemctl daemon-reload
@@ -103,6 +95,8 @@ runcmd:
   - apt-get update
   - apt-get install -y alloy
   - install -d -m 0750 /etc/alloy
+  - sh -c 'printf "%s" "${alloy_config_b64}" | base64 -d > /etc/alloy/config.alloy'
+  - chmod 0644 /etc/alloy/config.alloy
   - sh -c 'printf "COCKPIT_METRICS_REMOTE_WRITE_URL=%s\n" "${monitoring_metrics_remote_write_url}" > /etc/alloy/cockpit.env'
   - sh -c 'printf "COCKPIT_METRICS_TOKEN=%s\n" "$(printf "%s" "${monitoring_cockpit_token_b64}" | base64 -d)" >> /etc/alloy/cockpit.env'
   - chmod 0600 /etc/alloy/cockpit.env


### PR DESCRIPTION
## Description

On écrivait des fichiers `alloy` avant son installation ce qui causait une installation partiel, en déplaçant l'écriture du `/etc/alloy/config.alloy` après l'installation `apt-get install -y alloy` cela corrige le problème

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
