### PR TITLE
refactor(api): model publisher diffusion rule

### DIFF
--- a/api/prisma/migrations/20260521132812_add_publisher_diffusion_rule/migration.sql
+++ b/api/prisma/migrations/20260521132812_add_publisher_diffusion_rule/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "publisher_diffusion_rule" (
+    "id" TEXT NOT NULL,
+    "publisher_id" TEXT NOT NULL,
+    "field" TEXT NOT NULL,
+    "field_type" TEXT,
+    "operator" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "combinator" TEXT NOT NULL,
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "publisher_diffusion_rule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "publisher_diffusion_rule_publisher_id_idx" ON "publisher_diffusion_rule"("publisher_id");
+
+-- AddForeignKey
+ALTER TABLE "publisher_diffusion_rule" ADD CONSTRAINT "publisher_diffusion_rule_publisher_id_fkey" FOREIGN KEY ("publisher_id") REFERENCES "publisher"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -369,6 +369,7 @@ model Publisher {
 
   diffuseurs             PublisherDiffusion[]          @relation("PublisherAnnonceurRelation")
   diffusionsAsDiffuseur  PublisherDiffusion[]          @relation("PublisherDiffuseurRelation")
+  diffusionRules         PublisherDiffusionRule[]      @relation("PublisherDiffuseurRuleRelation")
   warnings               Warning[]                     @relation("WarningPublisherRelation")
   warningBots            WarningBot[]                  @relation("WarningBotPublisherRelation")
   imports                Import[]                      @relation("ImportPublisherRelation")
@@ -428,6 +429,24 @@ model PublisherDiffusion {
   @@index([diffuseurPublisherId], map: "publisher_diffusion_diffuseur_id_idx")
   @@index([annonceurPublisherId], map: "publisher_diffusion_annonceur_id_idx")
   @@map("publisher_diffusion")
+}
+
+model PublisherDiffusionRule {
+  id          String   @id @default(uuid())
+  publisherId String   @map("publisher_id")
+  field       String
+  fieldType   String?  @map("field_type")
+  operator    String
+  value       String
+  combinator  String
+  position    Int      @default(0)
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  publisher Publisher @relation("PublisherDiffuseurRuleRelation", fields: [publisherId], references: [id], onDelete: Cascade)
+
+  @@index([publisherId], map: "publisher_diffusion_rule_publisher_id_idx")
+  @@map("publisher_diffusion_rule")
 }
 
 model Warning {

--- a/api/scripts/README.md
+++ b/api/scripts/README.md
@@ -23,6 +23,12 @@ Ce répertoire contient des scripts de maintenance/migration pour l’API. Les s
   - Usage: Crée/met à jour les `PublisherOrganization` à partir des champs `organization*` encore présents sur `Mission`.
   - Notes: À exécuter avant la suppression des colonnes `organization*` côté `mission`.
 
+- **backfill-publisher-diffusion-rules.ts**
+
+  - Exécution: `npx ts-node scripts/backfill-publisher-diffusion-rules.ts [--dry-run]`
+  - Usage: Copie les anciennes lignes `publisher_diffusion` vers `publisher_diffusion_rule` sous forme de règles compatibles
+  - Notes: Idempotent, le script peut être rejoué. À exécuter après la migration Prisma qui crée la table `publisher_diffusion_rule`.
+
 - **backfill-organization-search-text.ts**
 
   - Exécution: `npx ts-node scripts/backfill-organization-search-text.ts [--batch <taille>] [--last-id <id>] [--only-null]`

--- a/api/scripts/backfill-publisher-diffusion-rules.ts
+++ b/api/scripts/backfill-publisher-diffusion-rules.ts
@@ -1,0 +1,115 @@
+/**
+ * Backfill : copie les anciennes PublisherDiffusion vers PublisherDiffusionRule.
+ *
+ * Exécuter après la migration Prisma qui crée publisher_diffusion_rule :
+ *   npx ts-node scripts/backfill-publisher-diffusion-rules.ts --dry-run
+ *   npx ts-node scripts/backfill-publisher-diffusion-rules.ts
+ */
+import dotenv from "dotenv";
+
+dotenv.config();
+
+import { prisma } from "../src/db/postgres";
+
+const isDryRun = process.argv.includes("--dry-run");
+
+type CountRow = { count: bigint | number };
+
+const toCount = (value: bigint | number | undefined): number => Number(value ?? 0);
+
+const countRows = async (tableName: "publisher_diffusion" | "publisher_diffusion_rule"): Promise<number> => {
+  const result =
+    tableName === "publisher_diffusion"
+      ? await prisma.$queryRaw<CountRow[]>`
+          SELECT COUNT(*)::bigint AS "count"
+          FROM "public"."publisher_diffusion"
+        `
+      : await prisma.$queryRaw<CountRow[]>`
+          SELECT COUNT(*)::bigint AS "count"
+          FROM "public"."publisher_diffusion_rule"
+        `;
+
+  return toCount(result[0]?.count);
+};
+
+const backfillPublisherDiffusionRules = async (): Promise<number> =>
+  prisma.$executeRaw`
+    INSERT INTO "public"."publisher_diffusion_rule" (
+      "id",
+      "publisher_id",
+      "field",
+      "field_type",
+      "operator",
+      "value",
+      "combinator",
+      "position",
+      "created_at",
+      "updated_at"
+    )
+    SELECT
+      pd."id",
+      pd."annonceur_publisher_id",
+      'publisherId',
+      'string',
+      'is',
+      pd."diffuseur_publisher_id",
+      'or',
+      ROW_NUMBER() OVER (
+        PARTITION BY pd."annonceur_publisher_id"
+        ORDER BY pd."created_at", pd."id"
+      ) - 1,
+      pd."created_at",
+      pd."updated_at"
+    FROM "public"."publisher_diffusion" pd
+    ON CONFLICT ("id") DO UPDATE SET
+      "publisher_id" = EXCLUDED."publisher_id",
+      "field" = EXCLUDED."field",
+      "field_type" = EXCLUDED."field_type",
+      "operator" = EXCLUDED."operator",
+      "value" = EXCLUDED."value",
+      "combinator" = EXCLUDED."combinator",
+      "position" = EXCLUDED."position",
+      "created_at" = EXCLUDED."created_at",
+      "updated_at" = EXCLUDED."updated_at";
+  `;
+
+const run = async () => {
+  const startedAt = new Date();
+  console.log(`[PublisherDiffusionRuleBackfill] Démarré à ${startedAt.toISOString()}${isDryRun ? " (dry-run)" : ""}.`);
+
+  await prisma.$connect();
+
+  const sourceCount = await countRows("publisher_diffusion");
+  const existingRuleCount = await countRows("publisher_diffusion_rule");
+
+  console.log(`[PublisherDiffusionRuleBackfill] publisher_diffusion=${sourceCount}`);
+  console.log(`[PublisherDiffusionRuleBackfill] publisher_diffusion_rule=${existingRuleCount}`);
+
+  if (isDryRun) {
+    console.log(`[PublisherDiffusionRuleBackfill] ${sourceCount} règles seraient insérées ou mises à jour.`);
+    return;
+  }
+
+  const upserted = await backfillPublisherDiffusionRules();
+  const finalRuleCount = await countRows("publisher_diffusion_rule");
+
+  console.log(`[PublisherDiffusionRuleBackfill] Règles insérées ou mises à jour: ${upserted}`);
+  console.log(`[PublisherDiffusionRuleBackfill] publisher_diffusion_rule=${finalRuleCount}`);
+
+  const durationMs = Date.now() - startedAt.getTime();
+  console.log(`[PublisherDiffusionRuleBackfill] Terminé en ${(durationMs / 1000).toFixed(1)}s.`);
+};
+
+const shutdown = async (exitCode: number) => {
+  await prisma.$disconnect().catch(() => undefined);
+  process.exit(exitCode);
+};
+
+run()
+  .then(async () => {
+    await shutdown(0);
+  })
+  .catch(async (error) => {
+    console.error("[PublisherDiffusionRuleBackfill] Échec:", error);
+    await shutdown(1);
+  });

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { prisma } from "@/db/postgres";
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
+
+const prismaMock = prisma as unknown as {
+  publisherDiffusionRule: {
+    findMany: ReturnType<typeof vi.fn>;
+  };
+};
+
+const buildRule = (overrides: Record<string, unknown> = {}) => ({
+  id: "rule-1",
+  publisherId: "publisher-1",
+  field: "publisherId",
+  fieldType: "string",
+  operator: "is",
+  value: "annonceur-1",
+  combinator: "or",
+  position: 0,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  ...overrides,
+});
+
+describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere", () => {
+  beforeEach(() => {
+    prismaMock.publisherDiffusionRule.findMany.mockReset();
+  });
+
+  it("charge les règles du publisher triées par position", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([]);
+
+    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
+
+    expect(where).toEqual({});
+    expect(prismaMock.publisherDiffusionRule.findMany).toHaveBeenCalledWith({
+      where: { publisherId: "publisher-1" },
+      orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+    });
+  });
+
+  it("construit une condition OR pour les règles migrées depuis publisher_diffusion", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "rule-1", value: "annonceur-1", position: 0 }),
+      buildRule({ id: "rule-2", value: "annonceur-2", position: 1 }),
+    ]);
+
+    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
+
+    expect(where).toEqual({
+      OR: [{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }],
+    });
+  });
+
+  it("construit un where imbriqué pour un champ Prisma relationnel", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({
+        field: "publisherOrganization.parentOrganizations",
+        value: "Croix-Rouge",
+      }),
+    ]);
+
+    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
+
+    expect(where).toEqual({
+      OR: [
+        {
+          publisherOrganization: {
+            parentOrganizations: {
+              has: "Croix-Rouge",
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it("utilise un contains insensible à la casse pour les champs texte", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({
+        field: "title",
+        operator: "contains",
+        value: "secourisme",
+      }),
+    ]);
+
+    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
+
+    expect(where).toEqual({
+      OR: [
+        {
+          title: {
+            contains: "secourisme",
+            mode: "insensitive",
+          },
+        },
+      ],
+    });
+  });
+
+  it("combine les règles en AND quand le combinator est and", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ field: "publisherId", value: "annonceur-1", combinator: "or", position: 0 }),
+      buildRule({ field: "type", value: "volontariat_sapeurs_pompiers", combinator: "and", position: 1 }),
+    ]);
+
+    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
+
+    expect(where).toEqual({
+      AND: [{ publisherId: "annonceur-1" }, { type: "volontariat_sapeurs_pompiers" }],
+    });
+  });
+});

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -1,0 +1,136 @@
+import { Prisma, PublisherDiffusionRule } from "@/db/core";
+import { prisma } from "@/db/postgres";
+
+type PublisherDiffusionRuleCondition = Pick<PublisherDiffusionRule, "field" | "fieldType" | "operator" | "value" | "combinator">;
+
+const ARRAY_FIELD_PATHS = new Set(["publisherOrganization.parentOrganizations"]);
+
+const normalizeBooleanValue = (value: string) => {
+  const normalized = value.trim().toLowerCase();
+  if (["yes", "true", "1"].includes(normalized)) {
+    return true;
+  }
+  if (["no", "false", "0"].includes(normalized)) {
+    return false;
+  }
+  return value;
+};
+
+const normalizeRuleValue = (rule: PublisherDiffusionRuleCondition) => {
+  if (rule.fieldType === "boolean") {
+    return normalizeBooleanValue(rule.value);
+  }
+  if (rule.fieldType === "number" || rule.fieldType === "int" || rule.fieldType === "float") {
+    const parsed = Number(rule.value);
+    return Number.isNaN(parsed) ? rule.value : parsed;
+  }
+  return rule.value;
+};
+
+const buildNestedWhere = (fieldPath: string, condition: unknown): Prisma.MissionWhereInput =>
+  fieldPath
+    .split(".")
+    .reverse()
+    .reduce<Prisma.MissionWhereInput>((acc, key) => ({ [key]: acc }), condition as Prisma.MissionWhereInput);
+
+const buildRuleCondition = (rule: PublisherDiffusionRuleCondition): Prisma.MissionWhereInput | null => {
+  const fieldPath = rule.field;
+  const value = normalizeRuleValue(rule);
+  const isArrayField = rule.fieldType === "array" || ARRAY_FIELD_PATHS.has(fieldPath);
+
+  if (rule.operator !== "exists" && rule.operator !== "does_not_exist" && (value === "" || value === null || value === undefined)) {
+    return null;
+  }
+
+  let condition: unknown;
+
+  switch (rule.operator) {
+    case "is":
+      condition = isArrayField ? { has: `${value}` } : value;
+      break;
+    case "is_not":
+      condition = isArrayField ? { has: `${value}` } : { not: value };
+      break;
+    case "contains":
+      condition = isArrayField ? { has: `${value}` } : { contains: value, mode: "insensitive" };
+      break;
+    case "does_not_contain":
+      condition = isArrayField ? { has: `${value}` } : { contains: value, mode: "insensitive" };
+      break;
+    case "starts_with":
+      condition = { startsWith: value, mode: "insensitive" };
+      break;
+    case "is_greater_than":
+      condition = { gt: value };
+      break;
+    case "is_less_than":
+      condition = { lt: value };
+      break;
+    case "exists":
+      condition = isArrayField ? { isEmpty: false } : { not: null };
+      break;
+    case "does_not_exist":
+      condition = isArrayField ? { isEmpty: true } : null;
+      break;
+    default:
+      return null;
+  }
+
+  const where = buildNestedWhere(fieldPath, condition);
+
+  if (rule.operator === "does_not_contain" || (rule.operator === "is_not" && isArrayField)) {
+    return { NOT: where };
+  }
+
+  return where;
+};
+
+const applyPublisherDiffusionRules = (rules: PublisherDiffusionRuleCondition[]): Prisma.MissionWhereInput => {
+  const andConditions: Prisma.MissionWhereInput[] = [];
+  const orConditions: Prisma.MissionWhereInput[] = [];
+
+  rules.forEach((rule, index) => {
+    const condition = buildRuleCondition(rule);
+    if (!condition) {
+      return;
+    }
+
+    let combinator = rule.combinator;
+    if (index === 0 && rules.length > 1) {
+      combinator = rules[1].combinator;
+    }
+
+    if (combinator === "and") {
+      andConditions.push(condition);
+      return;
+    }
+    if (combinator === "or") {
+      orConditions.push(condition);
+    }
+  });
+
+  const where: Prisma.MissionWhereInput = {};
+
+  if (andConditions.length > 0) {
+    where.AND = andConditions;
+  }
+
+  if (orConditions.length > 0) {
+    where.OR = orConditions;
+  }
+
+  return where;
+};
+
+export const publisherDiffusionRuleService = {
+  async buildMissionPublisherDiffusionRuleWhere(publisherId: string): Promise<Prisma.MissionWhereInput> {
+    const rules = await prisma.publisherDiffusionRule.findMany({
+      where: { publisherId },
+      orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
+    });
+
+    return applyPublisherDiffusionRules(rules);
+  },
+};
+
+export default publisherDiffusionRuleService;


### PR DESCRIPTION
## Description

La table `publisher_diffusion` manque de flexibilité et son naming ne reflète pas clairement le modèle métier attendu.  
L’objectif est de préparer une évolution vers un système de règles proche de `WidgetRule`, sans modifier les usages applicatifs existants dans cette première étape.

### Changements

- Ajout du modèle Prisma `PublisherDiffusionRule`.
- Ajout de la table `publisher_diffusion_rule` via migration Prisma.
- Conservation de la table existante `publisher_diffusion` et des usages actuels.
- Ajout du script de backfill `backfill-publisher-diffusion-rules.ts`.
- Documentation du nouveau script dans `api/scripts/README.md`.

Le script de backfill transforme les relations existantes ainsi :

- `publisher_diffusion.annonceur_publisher_id` devient `publisher_diffusion_rule.publisher_id`.
- `publisher_diffusion.diffuseur_publisher_id` devient une règle :
  - `field = "publisherId"`
  - `field_type = "string"`
  - `operator = "is"`
  - `value = diffuseur_publisher_id`
  - `combinator = "or"`

Le script est idempotent grâce à un `ON CONFLICT ("id") DO UPDATE`, il peut donc être rejoué sans créer de doublons.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire
