### PR TITLE
refactor(plateform): accessible disclosure pattern for filter combobox

### DIFF
--- a/plateform/app/components/ui/combobox.tsx
+++ b/plateform/app/components/ui/combobox.tsx
@@ -12,7 +12,9 @@ interface ComboboxProps {
 
 export default function Combobox({ label, placeholder, options, selected, onChange }: ComboboxProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const reactId = useId();
+  const panelId = `${reactId}-panel`;
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
 
@@ -25,7 +27,10 @@ export default function Combobox({ label, placeholder, options, selected, onChan
       if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) setOpen(false);
     };
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
+      if (event.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
     };
     document.addEventListener("mousedown", handleClickOutside);
     document.addEventListener("keydown", handleEscape);
@@ -49,9 +54,11 @@ export default function Combobox({ label, placeholder, options, selected, onChan
   return (
     <div className="relative" ref={wrapperRef}>
       <button
+        ref={triggerRef}
         type="button"
         className="w-full px-4 text-left transition-colors hover:bg-background-default-grey-hover"
         aria-expanded={open}
+        aria-controls={panelId}
         onClick={() => setOpen((value) => !value)}
       >
         <span className="fr-text text-title-grey">{label}</span>
@@ -63,7 +70,7 @@ export default function Combobox({ label, placeholder, options, selected, onChan
       </button>
 
       {open && (
-        <div className="absolute right-0 left-0 z-50 min-w-80 mt-1 border border-border-default-grey bg-white shadow-lg">
+        <div id={panelId} className="absolute right-0 left-0 z-50 min-w-80 mt-1 border border-border-default-grey bg-white shadow-lg">
           <div className="relative m-4">
             <input
               type="text"
@@ -77,7 +84,7 @@ export default function Combobox({ label, placeholder, options, selected, onChan
             <i className="fr-icon-search-line fr-icon--sm pointer-events-none absolute top-1/2 right-3 -translate-y-1/2" aria-hidden="true" />
           </div>
 
-          <fieldset className="fr-fieldset mx-2! max-h-60 overflow-y-auto" tabIndex={-1}>
+          <fieldset className="fr-fieldset mx-2! py-2! max-h-60 overflow-y-auto" tabIndex={-1}>
             <legend className="fr-fieldset__legend sr-only">Sélectionner {label.toLowerCase()}</legend>
 
             <div className="fr-fieldset__content">
@@ -88,14 +95,12 @@ export default function Combobox({ label, placeholder, options, selected, onChan
                   const inputId = `${reactId}-${option.value}`;
                   const isSelected = selected.includes(option.value);
                   return (
-                    <div key={option.value} className="flex items-center justify-between gap-3">
-                      <div className="fr-checkbox-group fr-checkbox-group min-w-0 flex-1">
-                        <input type="checkbox" id={inputId} checked={isSelected} onChange={() => toggleOption(option)} />
-                        <label className="fr-label" htmlFor={inputId}>
-                          {option.label}
-                        </label>
-                      </div>
-                      {option.count !== undefined && <span className="shrink-0 text-xs text-title-grey">{option.count}</span>}
+                    <div key={option.value} className="fr-checkbox-group">
+                      <input type="checkbox" id={inputId} checked={isSelected} onChange={() => toggleOption(option)} className="mr-2!" />
+                      <label className="fr-label flex flex-1 items-center justify-between gap-3 px-2! py-2! before:top-2!" htmlFor={inputId}>
+                        <span className="min-w-0 truncate flex-1">{option.label}</span>
+                        {option.count !== undefined && <span className="shrink-0 text-xs text-title-grey">{option.count}</span>}
+                      </label>
                     </div>
                   );
                 })


### PR DESCRIPTION
## Description

Rend le composant `Combobox` (filtres desktop de la plateforme) pleinement accessible en s'appuyant sur un pattern de disclosure simple plutôt que sur un faux pattern ARIA combobox.

**Changements** :
- Le bouton déclencheur expose désormais `aria-controls` pointant vers le panneau (id généré via `useId`), en complément de `aria-expanded`.
- À la fermeture par `Échap`, le focus revient sur le bouton déclencheur (évite la perte de focus sur `document.body`).
- Le compteur d'options est intégré dans le `<label>` du checkbox (via un layout flex) afin d'être inclus dans le nom accessible de la case à cocher, au lieu d'être un `<span>` orphelin.
- Nettoyage : suppression de la classe `fr-checkbox-group` dupliquée.

## Liens utiles

- 📝 Ticket Notion : [lient](https://www.notion.so/jeveuxaider/Etat-des-lieux-accessibilit-36472a322d508013ad1afec971649088?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Le composant reste un disclosure (bouton + panneau identifié + fieldset/legend pour les checkboxes), conformément à la note d'audit a11y : on évite délibérément le pattern ARIA `combobox` qui ne correspond pas à l'interaction réelle.
- Aucune modification fonctionnelle : sélection, recherche, et action `Effacer` restent identiques.