### PR TITLE
refactor(plateform): accessible progressbar pattern for quiz header

### DIFF
--- a/plateform/app/components/quiz/header.tsx
+++ b/plateform/app/components/quiz/header.tsx
@@ -41,7 +41,15 @@ export default function QuizHeader({ step = 0, stepCount }: QuizHeaderProps) {
         <p className="fr-h6 absolute left-1/2 -translate-x-1/2 mb-0">Trouve ta mission</p>
       </div>
 
-      <div className="h-2 bg-beige-gris-galet">
+      <div
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={stepCount}
+        aria-valuenow={step}
+        aria-valuetext={`Étape ${step} sur ${stepCount}`}
+        className="h-2 bg-beige-gris-galet"
+      >
+        <span className="sr-only">{`Étape ${step} sur ${stepCount}`}</span>
         <div className="h-full bg-blue-france-sun transition-[width] ease-out duration-500" style={{ width: `${progress}%` }} />
       </div>
     </header>


### PR DESCRIPTION
## Description

Rend la barre de progression du quiz accessible aux technologies d'assistance.

**Changements** :
- Ajout du `role="progressbar"` sur le conteneur de la barre
- Ajout des attributs `aria-valuemin`, `aria-valuemax`, `aria-valuenow`
- Ajout de `aria-valuetext` avec « Étape X sur Y » pour une annonce lisible
- Ajout d'un `<span class="sr-only">` redondant pour les lecteurs d'écran qui ignoreraient `aria-valuetext`


## Liens

- [notion](https://www.notion.so/jeveuxaider/Etat-des-lieux-accessibilit-36472a322d508013ad1afec971649088?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Aucun changement visuel : seuls les attributs ARIA sont ajoutés.
- S'inscrit dans la série des refactos d'accessibilité de la plateforme (cf. #1053, #1054, #1055, #1057).