### PR TITLE
feat(api): publisher diffusion rule for matching

### DIFF
--- a/api/src/controllers/mission-match.ts
+++ b/api/src/controllers/mission-match.ts
@@ -10,6 +10,7 @@ router.use(passport.authenticate(["apikey", "api"], { session: false }));
 
 const matchQuerySchema = zod.object({
   userScoringId: zod.string().uuid(),
+  publisherId: zod.string().optional(),
   limit: zod.coerce.number().int().min(1).max(100).default(20),
   offset: zod.coerce.number().int().min(0).default(0),
 });

--- a/api/src/controllers/mission-match.ts
+++ b/api/src/controllers/mission-match.ts
@@ -4,24 +4,27 @@ import zod from "zod";
 
 import { INVALID_QUERY } from "@/error";
 import { missionMatchService } from "@/services/mission-match";
+import type { PublisherRequest } from "@/types/passport";
 
 const router = Router();
 router.use(passport.authenticate(["apikey", "api"], { session: false }));
 
 const matchQuerySchema = zod.object({
   userScoringId: zod.string().uuid(),
-  publisherId: zod.string().optional(),
   limit: zod.coerce.number().int().min(1).max(100).default(20),
   offset: zod.coerce.number().int().min(0).default(0),
 });
 
-router.get("/match", async (req, res, next) => {
+router.get("/match", async (req: PublisherRequest, res, next) => {
   try {
     const query = matchQuerySchema.safeParse(req.query);
     if (!query.success) {
       return res.status(400).send({ ok: false, code: INVALID_QUERY, error: query.error });
     }
-    const data = await missionMatchService.getMatchedMissions(query.data);
+    const data = await missionMatchService.getMatchedMissions({
+      ...query.data,
+      publisherId: req.user.id,
+    });
     return res.status(200).send({ ok: true, data });
   } catch (error) {
     next(error);

--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -6,10 +6,18 @@ vi.mock("@/repositories/mission-matching-result", () => ({
   },
 }));
 
+vi.mock("@/services/publisher-diffusion-rule", () => ({
+  default: {
+    buildMissionPublisherDiffusionRuleSql: vi.fn(),
+  },
+}));
+
+import { Prisma } from "@/db/core";
 import { prisma } from "@/db/postgres";
 import { missionMatchingResultRepository } from "@/repositories/mission-matching-result";
 import { matchingEngineService } from "@/services/matching-engine";
 import { CURRENT_MATCHING_ENGINE_VERSION } from "@/services/matching-engine/config";
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 
 const prismaMock = prisma as unknown as {
   $queryRaw: ReturnType<typeof vi.fn>;
@@ -17,6 +25,10 @@ const prismaMock = prisma as unknown as {
 
 const missionMatchingResultRepositoryMock = missionMatchingResultRepository as unknown as {
   createForUserScoringVersion: ReturnType<typeof vi.fn>;
+};
+
+const publisherDiffusionRuleServiceMock = publisherDiffusionRuleService as unknown as {
+  buildMissionPublisherDiffusionRuleSql: ReturnType<typeof vi.fn>;
 };
 
 const getSqlText = (query: unknown): string => {
@@ -39,6 +51,7 @@ describe("matchingEngineService", () => {
   beforeEach(() => {
     prismaMock.$queryRaw.mockReset();
     missionMatchingResultRepositoryMock.createForUserScoringVersion.mockReset();
+    publisherDiffusionRuleServiceMock.buildMissionPublisherDiffusionRuleSql.mockReset();
   });
 
   describe("rankMissionsByUserScoring", () => {
@@ -166,6 +179,31 @@ describe("matchingEngineService", () => {
         ],
       });
       expect(result.tookMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("injecte le filtre SQL des règles publisher dans les missions candidates", async () => {
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            id: "user-scoring-publisher-filter",
+            expires_at: null,
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      publisherDiffusionRuleServiceMock.buildMissionPublisherDiffusionRuleSql.mockResolvedValue(Prisma.sql`AND m."publisher_id" = ${"annonceur-1"}`);
+      missionMatchingResultRepositoryMock.createForUserScoringVersion.mockResolvedValue({
+        id: "mission-matching-result-publisher-filter",
+      });
+
+      await matchingEngineService.rankMissionsByUserScoring({
+        userScoringId: "user-scoring-publisher-filter",
+        publisherId: "publisher-diffuseur-1",
+      });
+
+      expect(publisherDiffusionRuleServiceMock.buildMissionPublisherDiffusionRuleSql).toHaveBeenCalledWith("publisher-diffuseur-1", { missionAlias: "m" });
+
+      const rankingSql = getSqlText(prismaMock.$queryRaw.mock.calls[1][0]);
+      expect(rankingSql).toContain('AND m."publisher_id" =');
     });
 
     it("does not query taxonomy scores when no mission is ranked", async () => {

--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -181,7 +181,7 @@ describe("matchingEngineService", () => {
       expect(result.tookMs).toBeGreaterThanOrEqual(0);
     });
 
-    it("injecte le filtre SQL des règles publisher dans les missions candidates", async () => {
+    it("injects the SQL filter from the publisher rules into the candidate jobs", async () => {
       prismaMock.$queryRaw
         .mockResolvedValueOnce([
           {

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -1,6 +1,7 @@
 import { Prisma } from "@/db/core";
 import { prisma } from "@/db/postgres";
 import { missionMatchingResultRepository } from "@/repositories/mission-matching-result";
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import { GATE_TAXONOMIES } from "@engagement/taxonomy";
 import { CURRENT_MATCHING_ENGINE_VERSION, MATCHING_ENGINE_TAXONOMIES, MATCHING_ENGINE_TOP_RESULTS_LIMIT, MATCHING_ENGINE_VERSIONS } from "./config";
 import type { MatchMissionItem, MatchingEngineTaxonomy, MissionMatchingResultItem, RankMissionsByUserScoringInput, RankMissionsByUserScoringResult } from "./types";
@@ -78,6 +79,7 @@ const assertUserScoringIsQueryable = async (userScoringId: string): Promise<void
 
 const buildRanking = (params: {
   userScoringId: string;
+  publisherRuleSql?: Prisma.Sql;
   taxonomyWeights: Record<MatchingEngineTaxonomy, number>;
   taxonomyWeight: number;
   geoWeight: number;
@@ -125,6 +127,7 @@ const buildRanking = (params: {
       ON m."id" = ms."mission_id"
     WHERE m."deleted_at" IS NULL
       AND m."status_code" = 'ACCEPTED'
+      ${params.publisherRuleSql ?? Prisma.empty}
     ORDER BY
       ms."mission_id" ASC,
       me."completed_at" DESC NULLS LAST,
@@ -448,6 +451,14 @@ const buildRanking = (params: {
   OFFSET ${params.offset}
 `;
 
+const buildPublisherRuleSql = async (publisherId?: string): Promise<Prisma.Sql> => {
+  if (!publisherId) {
+    return Prisma.empty;
+  }
+
+  return publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleSql(publisherId, { missionAlias: "m" });
+};
+
 const buildTaxonomyScoresSql = (params: { userScoringId: string; missionScoringIds: string[] }) => Prisma.sql`
   WITH user_values AS (
     SELECT
@@ -540,10 +551,12 @@ export const matchingEngineService = {
     const geoCandidateLimit = getGeoCandidateLimit({ limit: rankingLimit, offset });
 
     await assertUserScoringIsQueryable(input.userScoringId);
+    const publisherRuleSql = await buildPublisherRuleSql(input.publisherId);
 
     const rows = await prisma.$queryRaw<DbRankRow[]>(
       buildRanking({
         userScoringId: input.userScoringId,
+        publisherRuleSql,
         taxonomyWeights,
         taxonomyWeight,
         geoWeight,

--- a/api/src/services/matching-engine/types.ts
+++ b/api/src/services/matching-engine/types.ts
@@ -12,6 +12,7 @@ export type MatchingEngineVersionConfig = {
 
 export type RankMissionsByUserScoringInput = {
   userScoringId: string;
+  publisherId?: string;
   version?: MatchingEngineVersion;
   limit?: number;
   offset?: number;

--- a/api/src/services/mission-match/index.ts
+++ b/api/src/services/mission-match/index.ts
@@ -6,6 +6,7 @@ import { buildMissionIndex, buildValuesIndex, missionMatchMissionSelect, mission
 
 export type MissionMatchInput = {
   userScoringId: string;
+  publisherId?: string;
   limit: number;
   offset: number;
 };

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -44,7 +44,7 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     prismaMock.publisherDiffusionRule.findMany.mockReset();
   });
 
-  it("charge les règles du publisher triées par position", async () => {
+  it("loads the publisher's rules sorted by position", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([]);
 
     const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
@@ -56,7 +56,7 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     });
   });
 
-  it("construit une condition OR pour les règles migrées depuis publisher_diffusion", async () => {
+  it("creates an OR condition for rules migrated from publisher_diffusion", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
       buildRule({ id: "rule-1", value: "annonceur-1", position: 0 }),
       buildRule({ id: "rule-2", value: "annonceur-2", position: 1 }),
@@ -69,7 +69,7 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     });
   });
 
-  it("construit un where imbriqué pour un champ Prisma relationnel", async () => {
+  it("constructs a nested WHERE clause for a relational Prisma field", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
       buildRule({
         field: "publisherOrganization.parentOrganizations",
@@ -92,7 +92,7 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     });
   });
 
-  it("utilise un contains insensible à la casse pour les champs texte", async () => {
+  it("uses a case-insensitive contains operator for text fields", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
       buildRule({
         field: "title",
@@ -115,7 +115,7 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     });
   });
 
-  it("combine les règles en AND quand le combinator est and", async () => {
+  it("combines the rules using AND when the combinator is and", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
       buildRule({ field: "publisherId", value: "annonceur-1", combinator: "or", position: 0 }),
       buildRule({ field: "type", value: "volontariat_sapeurs_pompiers", combinator: "and", position: 1 }),
@@ -128,7 +128,7 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     });
   });
 
-  it("construit un fragment SQL sur les colonnes mission", async () => {
+  it("constructs an SQL query on the mission columns", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
       buildRule({ id: "rule-1", value: "annonceur-1", position: 0 }),
       buildRule({ id: "rule-2", field: "type", value: "volontariat_sapeurs_pompiers", position: 1 }),
@@ -141,7 +141,7 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     expect(sqlText).toContain('OR m."type"::text =');
   });
 
-  it("construit un fragment SQL avec EXISTS pour publisherOrganization.parentOrganizations", async () => {
+  it("constructs an SQL fragment using EXISTS for publisherOrganization.parentOrganizations", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
       buildRule({
         field: "publisherOrganization.parentOrganizations",
@@ -158,7 +158,7 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     expect(sqlText).toContain('= ANY(po."parent_organizations")');
   });
 
-  it("construit un fragment SQL avec EXISTS pour publisherOrganization.clientId", async () => {
+  it("constructs an SQL fragment using EXISTS for publisherOrganization.clientId", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
       buildRule({
         field: "publisherOrganization.clientId",
@@ -175,7 +175,7 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     expect(sqlText).toContain('po."client_id" =');
   });
 
-  it("ne filtre pas quand le publisher n'a aucune règle", async () => {
+  it("does not filter when the publisher has no rules", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([]);
 
     const sql = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleSql("publisher-1", { missionAlias: "m" });
@@ -183,7 +183,7 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     expect(getSqlText(sql)).toBe("");
   });
 
-  it("retourne un filtre SQL bloquant quand des règles existent mais aucune n'est exploitable", async () => {
+  it("returns a blocking SQL filter when rules exist but none of them can be applied", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ field: "unknownField" })]);
 
     const sql = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleSql("publisher-1", { missionAlias: "m" });

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -9,6 +9,22 @@ const prismaMock = prisma as unknown as {
   };
 };
 
+const getSqlText = (query: unknown): string => {
+  if (typeof query === "object" && query !== null && "sql" in query && typeof query.sql === "string") {
+    return query.sql;
+  }
+
+  if (typeof query === "object" && query !== null && "text" in query && typeof query.text === "string") {
+    return query.text;
+  }
+
+  if (typeof query === "object" && query !== null && "strings" in query && Array.isArray(query.strings)) {
+    return query.strings.join("");
+  }
+
+  return String(query);
+};
+
 const buildRule = (overrides: Record<string, unknown> = {}) => ({
   id: "rule-1",
   publisherId: "publisher-1",
@@ -110,5 +126,68 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     expect(where).toEqual({
       AND: [{ publisherId: "annonceur-1" }, { type: "volontariat_sapeurs_pompiers" }],
     });
+  });
+
+  it("construit un fragment SQL sur les colonnes mission", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "rule-1", value: "annonceur-1", position: 0 }),
+      buildRule({ id: "rule-2", field: "type", value: "volontariat_sapeurs_pompiers", position: 1 }),
+    ]);
+
+    const sql = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleSql("publisher-1", { missionAlias: "m" });
+    const sqlText = getSqlText(sql);
+
+    expect(sqlText).toContain('AND ((m."publisher_id" =');
+    expect(sqlText).toContain('OR m."type"::text =');
+  });
+
+  it("construit un fragment SQL avec EXISTS pour publisherOrganization.parentOrganizations", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({
+        field: "publisherOrganization.parentOrganizations",
+        value: "Croix-Rouge",
+      }),
+    ]);
+
+    const sql = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleSql("publisher-1", { missionAlias: "m" });
+    const sqlText = getSqlText(sql);
+
+    expect(sqlText).toContain("AND ((EXISTS");
+    expect(sqlText).toContain('FROM "publisher_organization" po');
+    expect(sqlText).toContain('po."id" = m."publisher_organization_id"');
+    expect(sqlText).toContain('= ANY(po."parent_organizations")');
+  });
+
+  it("construit un fragment SQL avec EXISTS pour publisherOrganization.clientId", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({
+        field: "publisherOrganization.clientId",
+        value: "organization-client-1",
+      }),
+    ]);
+
+    const sql = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleSql("publisher-1", { missionAlias: "m" });
+    const sqlText = getSqlText(sql);
+
+    expect(sqlText).toContain("AND ((EXISTS");
+    expect(sqlText).toContain('FROM "publisher_organization" po');
+    expect(sqlText).toContain('po."id" = m."publisher_organization_id"');
+    expect(sqlText).toContain('po."client_id" =');
+  });
+
+  it("ne filtre pas quand le publisher n'a aucune règle", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([]);
+
+    const sql = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleSql("publisher-1", { missionAlias: "m" });
+
+    expect(getSqlText(sql)).toBe("");
+  });
+
+  it("retourne un filtre SQL bloquant quand des règles existent mais aucune n'est exploitable", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ field: "unknownField" })]);
+
+    const sql = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleSql("publisher-1", { missionAlias: "m" });
+
+    expect(getSqlText(sql)).toBe("AND FALSE");
   });
 });

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -1,135 +1,24 @@
 import { Prisma, PublisherDiffusionRule } from "@/db/core";
 import { prisma } from "@/db/postgres";
+import { buildMissionPublisherDiffusionRuleSqlFromRules, buildMissionPublisherDiffusionRuleWhereFromRules } from "@/utils/publisher-diffusion-rule-query";
 
-type PublisherDiffusionRuleCondition = Pick<PublisherDiffusionRule, "field" | "fieldType" | "operator" | "value" | "combinator">;
-
-const ARRAY_FIELD_PATHS = new Set(["publisherOrganization.parentOrganizations"]);
-
-const normalizeBooleanValue = (value: string) => {
-  const normalized = value.trim().toLowerCase();
-  if (["yes", "true", "1"].includes(normalized)) {
-    return true;
-  }
-  if (["no", "false", "0"].includes(normalized)) {
-    return false;
-  }
-  return value;
-};
-
-const normalizeRuleValue = (rule: PublisherDiffusionRuleCondition) => {
-  if (rule.fieldType === "boolean") {
-    return normalizeBooleanValue(rule.value);
-  }
-  if (rule.fieldType === "number" || rule.fieldType === "int" || rule.fieldType === "float") {
-    const parsed = Number(rule.value);
-    return Number.isNaN(parsed) ? rule.value : parsed;
-  }
-  return rule.value;
-};
-
-const buildNestedWhere = (fieldPath: string, condition: unknown): Prisma.MissionWhereInput =>
-  fieldPath
-    .split(".")
-    .reverse()
-    .reduce<Prisma.MissionWhereInput>((acc, key) => ({ [key]: acc }), condition as Prisma.MissionWhereInput);
-
-const buildRuleCondition = (rule: PublisherDiffusionRuleCondition): Prisma.MissionWhereInput | null => {
-  const fieldPath = rule.field;
-  const value = normalizeRuleValue(rule);
-  const isArrayField = rule.fieldType === "array" || ARRAY_FIELD_PATHS.has(fieldPath);
-
-  if (rule.operator !== "exists" && rule.operator !== "does_not_exist" && (value === "" || value === null || value === undefined)) {
-    return null;
-  }
-
-  let condition: unknown;
-
-  switch (rule.operator) {
-    case "is":
-      condition = isArrayField ? { has: `${value}` } : value;
-      break;
-    case "is_not":
-      condition = isArrayField ? { has: `${value}` } : { not: value };
-      break;
-    case "contains":
-      condition = isArrayField ? { has: `${value}` } : { contains: value, mode: "insensitive" };
-      break;
-    case "does_not_contain":
-      condition = isArrayField ? { has: `${value}` } : { contains: value, mode: "insensitive" };
-      break;
-    case "starts_with":
-      condition = { startsWith: value, mode: "insensitive" };
-      break;
-    case "is_greater_than":
-      condition = { gt: value };
-      break;
-    case "is_less_than":
-      condition = { lt: value };
-      break;
-    case "exists":
-      condition = isArrayField ? { isEmpty: false } : { not: null };
-      break;
-    case "does_not_exist":
-      condition = isArrayField ? { isEmpty: true } : null;
-      break;
-    default:
-      return null;
-  }
-
-  const where = buildNestedWhere(fieldPath, condition);
-
-  if (rule.operator === "does_not_contain" || (rule.operator === "is_not" && isArrayField)) {
-    return { NOT: where };
-  }
-
-  return where;
-};
-
-const applyPublisherDiffusionRules = (rules: PublisherDiffusionRuleCondition[]): Prisma.MissionWhereInput => {
-  const andConditions: Prisma.MissionWhereInput[] = [];
-  const orConditions: Prisma.MissionWhereInput[] = [];
-
-  rules.forEach((rule, index) => {
-    const condition = buildRuleCondition(rule);
-    if (!condition) {
-      return;
-    }
-
-    let combinator = rule.combinator;
-    if (index === 0 && rules.length > 1) {
-      combinator = rules[1].combinator;
-    }
-
-    if (combinator === "and") {
-      andConditions.push(condition);
-      return;
-    }
-    if (combinator === "or") {
-      orConditions.push(condition);
-    }
+const findRulesByPublisherId = async (publisherId: string): Promise<PublisherDiffusionRule[]> =>
+  prisma.publisherDiffusionRule.findMany({
+    where: { publisherId },
+    orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
   });
-
-  const where: Prisma.MissionWhereInput = {};
-
-  if (andConditions.length > 0) {
-    where.AND = andConditions;
-  }
-
-  if (orConditions.length > 0) {
-    where.OR = orConditions;
-  }
-
-  return where;
-};
 
 export const publisherDiffusionRuleService = {
   async buildMissionPublisherDiffusionRuleWhere(publisherId: string): Promise<Prisma.MissionWhereInput> {
-    const rules = await prisma.publisherDiffusionRule.findMany({
-      where: { publisherId },
-      orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
-    });
+    const rules = await findRulesByPublisherId(publisherId);
 
-    return applyPublisherDiffusionRules(rules);
+    return buildMissionPublisherDiffusionRuleWhereFromRules(rules);
+  },
+
+  async buildMissionPublisherDiffusionRuleSql(publisherId: string, options: { missionAlias?: string } = {}): Promise<Prisma.Sql> {
+    const rules = await findRulesByPublisherId(publisherId);
+
+    return buildMissionPublisherDiffusionRuleSqlFromRules(rules, options);
   },
 };
 

--- a/api/src/utils/__tests__/mission-rule.test.ts
+++ b/api/src/utils/__tests__/mission-rule.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { applyMissionRules, buildNestedMissionWhere, collectMissionRuleConditions, type MissionRule } from "@/utils/mission-rule";
+
+describe("mission-rule utils", () => {
+  describe("buildNestedMissionWhere", () => {
+    it("builds nested Prisma where input from a dotted field path", () => {
+      expect(buildNestedMissionWhere("publisherOrganization.parentOrganizations", { has: "AFEV" })).toEqual({
+        publisherOrganization: {
+          parentOrganizations: {
+            has: "AFEV",
+          },
+        },
+      });
+    });
+  });
+
+  describe("collectMissionRuleConditions", () => {
+    it("uses the second rule combinator for the first condition", () => {
+      const rules = [rule({ field: "publisherId", value: "publisher-1", combinator: "or" }), rule({ field: "type", value: "volontariat", combinator: "and" })];
+
+      expect(collectMissionRuleConditions(rules, (currentRule) => currentRule.field)).toEqual({
+        andConditions: ["publisherId", "type"],
+        orConditions: [],
+      });
+    });
+
+    it("ignores null conditions", () => {
+      const rules = [rule({ field: "publisherId", value: "publisher-1", combinator: "or" }), rule({ field: "type", value: "volontariat", combinator: "or" })];
+
+      expect(collectMissionRuleConditions(rules, (currentRule) => (currentRule.field === "type" ? null : currentRule.field))).toEqual({
+        andConditions: [],
+        orConditions: ["publisherId"],
+      });
+    });
+  });
+
+  describe("applyMissionRules", () => {
+    it("builds basic scalar operators", () => {
+      expect(
+        applyMissionRules([
+          rule({ field: "publisherId", operator: "is", value: "publisher-1", combinator: "or" }),
+          rule({ field: "type", operator: "is_not", value: "benevolat", combinator: "and" }),
+        ])
+      ).toEqual({
+        AND: [{ publisherId: "publisher-1" }, { type: { not: "benevolat" } }],
+      });
+    });
+
+    it("builds array operators and wraps negative array checks in NOT", () => {
+      expect(
+        applyMissionRules(
+          [rule({ field: "tags", operator: "contains", value: "health", combinator: "or" }), rule({ field: "tags", operator: "is_not", value: "private", combinator: "and" })],
+          { arrayFields: new Set(["tags"]) }
+        )
+      ).toEqual({
+        AND: [{ tags: { has: "health" } }, { NOT: { tags: { has: "private" } } }],
+      });
+    });
+
+    it("builds contains and existence operators", () => {
+      expect(
+        applyMissionRules([
+          rule({ field: "title", operator: "contains", value: "mentor", combinator: "or" }),
+          rule({ field: "description", operator: "exists", value: null, combinator: "and" }),
+        ])
+      ).toEqual({
+        AND: [{ title: { contains: "mentor", mode: "insensitive" } }, { description: { not: null } }],
+      });
+    });
+
+    it("supports custom nested field builders", () => {
+      expect(
+        applyMissionRules([rule({ field: "publisherOrganization.parentOrganizations", operator: "is", value: "AFEV", combinator: "or" })], {
+          arrayFields: new Set(["publisherOrganization.parentOrganizations"]),
+          buildFieldWhere: buildNestedMissionWhere,
+        })
+      ).toEqual({
+        OR: [
+          {
+            publisherOrganization: {
+              parentOrganizations: {
+                has: "AFEV",
+              },
+            },
+          },
+        ],
+      });
+    });
+
+    it("ignores unsupported operators and empty values", () => {
+      expect(
+        applyMissionRules([
+          rule({ field: "publisherId", operator: "is", value: "", combinator: "or" }),
+          rule({ field: "type", operator: "unsupported", value: "benevolat", combinator: "or" }),
+        ])
+      ).toEqual({});
+    });
+  });
+});
+
+const rule = (override: Partial<MissionRule> = {}): MissionRule => ({
+  field: "publisherId",
+  fieldType: "string",
+  operator: "is",
+  value: "publisher-1",
+  combinator: "or",
+  ...override,
+});

--- a/api/src/utils/mission-rule.ts
+++ b/api/src/utils/mission-rule.ts
@@ -1,0 +1,150 @@
+import { Prisma } from "@/db/core";
+
+export type MissionRule = {
+  field: string;
+  fieldType?: string | null;
+  operator: string;
+  value?: string | null;
+  combinator: string;
+};
+
+type MissionRuleOptions = {
+  arrayFields?: ReadonlySet<string>;
+  fieldMappers?: Record<string, (condition: unknown) => Prisma.MissionWhereInput>;
+  normalizeOperator?: (rule: MissionRule, isArrayField: boolean) => string;
+  normalizeValue?: (rule: MissionRule) => unknown;
+  buildFieldWhere?: (field: string, condition: unknown) => Prisma.MissionWhereInput;
+  skipEmptyValue?: (value: unknown) => boolean;
+};
+
+export const shouldSkipMissionRuleValue = (value: unknown): boolean => value === "" || value === null || value === undefined;
+
+export const normalizeBooleanRuleValue = (value?: string | null) => {
+  if (!value) {
+    return value;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (["yes", "true", "1"].includes(normalized)) {
+    return true;
+  }
+  if (["no", "false", "0"].includes(normalized)) {
+    return false;
+  }
+  return value;
+};
+
+export const normalizeTypedRuleValue = (rule: MissionRule) => {
+  if (rule.fieldType === "boolean") {
+    return normalizeBooleanRuleValue(rule.value);
+  }
+  if (rule.fieldType === "number" || rule.fieldType === "int" || rule.fieldType === "float") {
+    const parsed = Number(rule.value);
+    return Number.isNaN(parsed) ? rule.value : parsed;
+  }
+  return rule.value;
+};
+
+export const buildNestedMissionWhere = (fieldPath: string, condition: unknown): Prisma.MissionWhereInput =>
+  fieldPath
+    .split(".")
+    .reverse()
+    .reduce<Prisma.MissionWhereInput>((acc, key) => ({ [key]: acc }), condition as Prisma.MissionWhereInput);
+
+const buildDefaultFieldWhere = (field: string, condition: unknown): Prisma.MissionWhereInput => ({ [field]: condition });
+
+const buildRuleCondition = (rule: MissionRule, options: MissionRuleOptions): Prisma.MissionWhereInput | null => {
+  const isArrayField = rule.fieldType === "array" || Boolean(options.arrayFields?.has(rule.field));
+  const operator = options.normalizeOperator?.(rule, isArrayField) ?? rule.operator;
+  const value = options.normalizeValue?.(rule) ?? normalizeTypedRuleValue(rule);
+  const skipEmpty = options.skipEmptyValue ?? shouldSkipMissionRuleValue;
+
+  if (operator !== "exists" && operator !== "does_not_exist" && skipEmpty(value)) {
+    return null;
+  }
+
+  let condition: unknown;
+
+  switch (operator) {
+    case "is":
+      condition = isArrayField ? { has: `${value}` } : value;
+      break;
+    case "is_not":
+      condition = isArrayField ? { has: `${value}` } : { not: value };
+      break;
+    case "contains":
+      condition = isArrayField ? { has: `${value}` } : { contains: value, mode: "insensitive" };
+      break;
+    case "does_not_contain":
+      condition = isArrayField ? { has: `${value}` } : { contains: value, mode: "insensitive" };
+      break;
+    case "starts_with":
+      condition = { startsWith: value, mode: "insensitive" };
+      break;
+    case "is_greater_than":
+      condition = { gt: value };
+      break;
+    case "is_less_than":
+      condition = { lt: value };
+      break;
+    case "exists":
+      condition = isArrayField ? { isEmpty: false } : { not: null };
+      break;
+    case "does_not_exist":
+      condition = isArrayField ? { isEmpty: true } : null;
+      break;
+    default:
+      return null;
+  }
+
+  const mapper = options.fieldMappers?.[rule.field];
+  const where = mapper ? mapper(condition) : (options.buildFieldWhere ?? buildDefaultFieldWhere)(rule.field, condition);
+
+  if (operator === "does_not_contain" || (operator === "is_not" && isArrayField)) {
+    return { NOT: where };
+  }
+
+  return where;
+};
+
+export const collectMissionRuleConditions = <Rule extends MissionRule, T>(rules: Rule[], buildCondition: (rule: Rule) => T | null): { andConditions: T[]; orConditions: T[] } => {
+  const andConditions: T[] = [];
+  const orConditions: T[] = [];
+
+  rules.forEach((rule, index) => {
+    const condition = buildCondition(rule);
+    if (!condition) {
+      return;
+    }
+
+    let combinator = rule.combinator;
+    if (index === 0 && rules.length > 1) {
+      combinator = rules[1].combinator;
+    }
+
+    if (combinator === "and") {
+      andConditions.push(condition);
+      return;
+    }
+    if (combinator === "or") {
+      orConditions.push(condition);
+    }
+  });
+
+  return { andConditions, orConditions };
+};
+
+export const applyMissionRules = (rules: MissionRule[], options: MissionRuleOptions = {}): Prisma.MissionWhereInput => {
+  const { andConditions, orConditions } = collectMissionRuleConditions(rules, (rule) => buildRuleCondition(rule, options));
+
+  const where: Prisma.MissionWhereInput = {};
+
+  if (andConditions.length > 0) {
+    where.AND = andConditions;
+  }
+
+  if (orConditions.length > 0) {
+    where.OR = orConditions;
+  }
+
+  return where;
+};

--- a/api/src/utils/publisher-diffusion-rule-query.ts
+++ b/api/src/utils/publisher-diffusion-rule-query.ts
@@ -1,0 +1,154 @@
+import { Prisma, PublisherDiffusionRule } from "@/db/core";
+import { applyMissionRules, buildNestedMissionWhere, collectMissionRuleConditions, normalizeTypedRuleValue, shouldSkipMissionRuleValue } from "@/utils/mission-rule";
+
+export type PublisherDiffusionRuleCondition = Pick<PublisherDiffusionRule, "field" | "fieldType" | "operator" | "value" | "combinator">;
+
+const ARRAY_FIELD_PATHS = new Set(["publisherOrganization.parentOrganizations"]);
+
+type SqlFieldConfig = {
+  column: string;
+  source: "mission" | "publisherOrganization";
+  kind: "scalar" | "array";
+  castText?: boolean;
+};
+
+const FIELD_TO_SQL_CONFIG: Record<string, SqlFieldConfig> = {
+  publisherId: { source: "mission", column: "publisher_id", kind: "scalar" },
+  publisherOrganizationId: { source: "mission", column: "publisher_organization_id", kind: "scalar" },
+  type: { source: "mission", column: "type", kind: "scalar", castText: true },
+  "publisherOrganization.clientId": { source: "publisherOrganization", column: "client_id", kind: "scalar" },
+  "publisherOrganization.parentOrganizations": { source: "publisherOrganization", column: "parent_organizations", kind: "array" },
+};
+
+const sqlIdentifier = (value: string) => Prisma.raw(`"${value.replaceAll('"', '""')}"`);
+
+const missionColumnSql = (missionAlias: string, column: string, options: { castText?: boolean } = {}) =>
+  Prisma.sql`${Prisma.raw(missionAlias)}.${sqlIdentifier(column)}${options.castText ? Prisma.raw("::text") : Prisma.empty}`;
+
+const sqlContainsValue = (value: unknown) => `%${String(value)}%`;
+const sqlStartsWithValue = (value: unknown) => `${String(value)}%`;
+
+const shouldSkipValue = (rule: PublisherDiffusionRuleCondition, value: unknown) =>
+  rule.operator !== "exists" && rule.operator !== "does_not_exist" && shouldSkipMissionRuleValue(value);
+
+const buildScalarSqlCondition = (target: Prisma.Sql, rule: PublisherDiffusionRuleCondition): Prisma.Sql | null => {
+  const value = normalizeTypedRuleValue(rule);
+
+  if (shouldSkipValue(rule, value)) {
+    return null;
+  }
+
+  switch (rule.operator) {
+    case "is":
+      return Prisma.sql`${target} = ${value}`;
+    case "is_not":
+      return Prisma.sql`${target} IS DISTINCT FROM ${value}`;
+    case "contains":
+      return Prisma.sql`${target} ILIKE ${sqlContainsValue(value)}`;
+    case "does_not_contain":
+      return Prisma.sql`${target} NOT ILIKE ${sqlContainsValue(value)}`;
+    case "starts_with":
+      return Prisma.sql`${target} ILIKE ${sqlStartsWithValue(value)}`;
+    case "is_greater_than":
+      return Prisma.sql`${target} > ${value}`;
+    case "is_less_than":
+      return Prisma.sql`${target} < ${value}`;
+    case "exists":
+      return Prisma.sql`${target} IS NOT NULL`;
+    case "does_not_exist":
+      return Prisma.sql`${target} IS NULL`;
+    default:
+      return null;
+  }
+};
+
+const buildArraySqlCondition = (target: Prisma.Sql, rule: PublisherDiffusionRuleCondition): Prisma.Sql | null => {
+  const value = normalizeTypedRuleValue(rule);
+
+  if (shouldSkipValue(rule, value)) {
+    return null;
+  }
+
+  switch (rule.operator) {
+    case "is":
+    case "contains":
+      return Prisma.sql`${value} = ANY(${target})`;
+    case "is_not":
+    case "does_not_contain":
+      return Prisma.sql`NOT (${value} = ANY(${target}))`;
+    case "exists":
+      return Prisma.sql`COALESCE(cardinality(${target}), 0) > 0`;
+    case "does_not_exist":
+      return Prisma.sql`COALESCE(cardinality(${target}), 0) = 0`;
+    default:
+      return null;
+  }
+};
+
+const buildPublisherOrganizationExistsSql = (missionAlias: string, condition: Prisma.Sql) => Prisma.sql`EXISTS (
+  SELECT 1
+  FROM "publisher_organization" po
+  WHERE po."id" = ${Prisma.raw(missionAlias)}."publisher_organization_id"
+    AND ${condition}
+)`;
+
+const buildRuleSqlCondition = (rule: PublisherDiffusionRuleCondition, missionAlias: string): Prisma.Sql | null => {
+  const fieldConfig = FIELD_TO_SQL_CONFIG[rule.field];
+  if (!fieldConfig) {
+    return null;
+  }
+
+  const column =
+    fieldConfig.source === "mission" ? missionColumnSql(missionAlias, fieldConfig.column, { castText: fieldConfig.castText }) : Prisma.sql`po.${sqlIdentifier(fieldConfig.column)}`;
+
+  const condition = fieldConfig.kind === "array" ? buildArraySqlCondition(column, rule) : buildScalarSqlCondition(column, rule);
+  if (!condition) {
+    return null;
+  }
+
+  if (fieldConfig.source === "publisherOrganization") {
+    return buildPublisherOrganizationExistsSql(missionAlias, condition);
+  }
+
+  return condition;
+};
+
+const combineRuleSqlConditions = (rules: PublisherDiffusionRuleCondition[], missionAlias: string): Prisma.Sql | null => {
+  const { andConditions, orConditions } = collectMissionRuleConditions(rules, (rule) => buildRuleSqlCondition(rule, missionAlias));
+
+  const parts: Prisma.Sql[] = [];
+
+  if (andConditions.length > 0) {
+    parts.push(Prisma.sql`(${Prisma.join(andConditions, " AND ")})`);
+  }
+
+  if (orConditions.length > 0) {
+    parts.push(Prisma.sql`(${Prisma.join(orConditions, " OR ")})`);
+  }
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  return Prisma.sql`(${Prisma.join(parts, " AND ")})`;
+};
+
+export const buildMissionPublisherDiffusionRuleWhereFromRules = (rules: PublisherDiffusionRuleCondition[]): Prisma.MissionWhereInput =>
+  applyMissionRules(rules, {
+    arrayFields: ARRAY_FIELD_PATHS,
+    buildFieldWhere: buildNestedMissionWhere,
+  });
+
+export const buildMissionPublisherDiffusionRuleSqlFromRules = (rules: PublisherDiffusionRuleCondition[], options: { missionAlias?: string } = {}): Prisma.Sql => {
+  if (rules.length === 0) {
+    return Prisma.empty;
+  }
+
+  const condition = combineRuleSqlConditions(rules, options.missionAlias ?? "m");
+
+  if (!condition) {
+    return Prisma.sql`AND FALSE`;
+  }
+
+  return Prisma.sql`AND ${condition}`;
+};


### PR DESCRIPTION
## Description

Le matching engine retournait jusqu’ici des missions sans tenir compte des règles de diffusion associées au publisher diffuseur.

Cette PR branche les `publisher_diffusion_rule` dans le matching engine afin de restreindre les missions candidates aux missions autorisées pour le publisher demandé.

### Changements

- Ajout du paramètre `publisherId` dans l’input du matching engine.
- Propagation de `publisherId` depuis l’endpoint `/mission-match/match`.
- Ajout d’un builder SQL pour traduire les `PublisherDiffusionRule` en filtre SQL utilisable dans le ranking.
- Injection du filtre directement dans la CTE `active_mission_scorings`.
- Factorisation d’une partie de la logique de règles dans `mission-rule`.

### Comportement

- Si aucun `publisherId` n’est fourni, le matching reste inchangé.
- Si un `publisherId` est fourni sans règle associée, toutes les missions restent candidates.
- Si des règles existent, seules les missions qui matchent ces règles sont candidates.
- Si des règles existent mais qu’aucune n’est exploitable, aucune mission ne matche.

### Performance

Le filtre est injecté directement dans la requête SQL du matching engine.

On évite donc :
- une requête intermédiaire pour récupérer les `missionId`;
- un gros `IN (...)` avec potentiellement plusieurs milliers d’ids;
- un transfert inutile de données entre Postgres et Node.


## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Restreindre-les-publishers-35d72a322d50805b9acbf884c0b3d91e?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

