### PR TITLE
refactor(api): mission email shared dto

### DIFF
--- a/api/src/controllers/email.ts
+++ b/api/src/controllers/email.ts
@@ -4,6 +4,7 @@ import zod from "zod";
 
 import { EMAIL_SEND_FAILED, FORBIDDEN, INVALID_BODY, NOT_FOUND } from "@/error";
 import { sendMissionEmail } from "@/services/mission-email";
+import type { SendMissionEmailResponse } from "@engagement/dto";
 
 const router = Router();
 router.use(passport.authenticate(["apikey", "api"], { session: false }));
@@ -36,7 +37,7 @@ router.post("/mission", async (req: Request, res: Response, next: NextFunction) 
     }
 
     const result = await sendMissionEmail(body.data);
-    const data = {
+    const data: Pick<SendMissionEmailResponse, "user_scoring_id"> = {
       ...(body.data.userScoringId ? { user_scoring_id: body.data.userScoringId } : {}),
     };
 
@@ -49,7 +50,7 @@ router.post("/mission", async (req: Request, res: Response, next: NextFunction) 
     }
 
     if (result.status === "failed") {
-      return res.status(502).send({ ok: false, code: EMAIL_SEND_FAILED, message: "Email send failed", data: { ...data, email_sent: false } });
+      return res.status(502).send({ ok: false, code: EMAIL_SEND_FAILED, message: "Email send failed", data: { ...data, email_sent: false } satisfies SendMissionEmailResponse });
     }
 
     if (result.status === "skipped") {
@@ -63,7 +64,7 @@ router.post("/mission", async (req: Request, res: Response, next: NextFunction) 
       });
     }
 
-    return res.status(200).send({ ok: true, data: { ...data, email_sent: true } });
+    return res.status(200).send({ ok: true, data: { ...data, email_sent: true } satisfies SendMissionEmailResponse });
   } catch (error) {
     next(error);
   }

--- a/api/src/services/mission-email/index.ts
+++ b/api/src/services/mission-email/index.ts
@@ -4,6 +4,7 @@ import { userScoringRepository } from "@/repositories/user-scoring";
 import { createOrUpdateContact, sendTemplate, TEMPLATE_IDS } from "@/services/brevo";
 import type { MissionMatchingResultItem } from "@/services/matching-engine/types";
 import { missionService } from "@/services/mission";
+import type { MissionEmailSkipReason, SendMissionEmailRequest } from "@engagement/dto";
 
 const BREVO_CONTACT_LIST_ID = 22;
 const USER_SCORING_EMAIL_MISSION_LIMIT = 5;
@@ -11,9 +12,7 @@ const USER_SCORING_EMAIL_MISSION_LIMIT = 5;
 export const MISSION_EMAIL_SKIP_REASONS = {
   NO_MATCHING_RESULT: "NO_MATCHING_RESULT",
   MISSION_NOT_FOUND: "MISSION_NOT_FOUND",
-} as const;
-
-export type MissionEmailSkipReason = (typeof MISSION_EMAIL_SKIP_REASONS)[keyof typeof MISSION_EMAIL_SKIP_REASONS];
+} as const satisfies Record<MissionEmailSkipReason, MissionEmailSkipReason>;
 
 type EmailMission = {
   id: string;
@@ -46,14 +45,6 @@ type MissionEmailItem = {
 
 type MissionEmailParams = {
   missions: MissionEmailItem[];
-};
-
-type SendMissionEmailInput = {
-  email: string;
-  publisherId: string;
-  distinctId?: string;
-  userScoringId?: string;
-  missionIds?: string[];
 };
 
 type SendMissionEmailResult = { status: "sent" } | { status: "skipped"; reason: MissionEmailSkipReason } | { status: "failed" } | { status: "forbidden" } | { status: "not_found" };
@@ -203,7 +194,7 @@ export const getMissionEmailSkipReason = (missionIds?: string[]): MissionEmailSk
   return missionIds?.length ? MISSION_EMAIL_SKIP_REASONS.MISSION_NOT_FOUND : MISSION_EMAIL_SKIP_REASONS.NO_MATCHING_RESULT;
 };
 
-export const sendMissionEmail = async (input: SendMissionEmailInput): Promise<SendMissionEmailResult> => {
+export const sendMissionEmail = async (input: SendMissionEmailRequest): Promise<SendMissionEmailResult> => {
   if (input.userScoringId) {
     const userScoring = await userScoringRepository.findById(input.userScoringId);
     if (!userScoring) {

--- a/packages/dto/src/resources/index.ts
+++ b/packages/dto/src/resources/index.ts
@@ -1,3 +1,4 @@
 export * from "./mission-browse";
+export * from "./mission-email";
 export * from "./mission-match";
 export * from "./user-scoring";

--- a/packages/dto/src/resources/mission-email.ts
+++ b/packages/dto/src/resources/mission-email.ts
@@ -1,0 +1,15 @@
+export type MissionEmailSkipReason = "NO_MATCHING_RESULT" | "MISSION_NOT_FOUND";
+
+export type SendMissionEmailRequest = {
+  email: string;
+  publisherId: string;
+  distinctId?: string;
+  userScoringId?: string;
+  missionIds?: string[];
+};
+
+export type SendMissionEmailResponse = {
+  user_scoring_id?: string;
+  email_sent: boolean;
+  email_skip_reason?: MissionEmailSkipReason;
+};

--- a/plateform/app/routes/api.email.mission.ts
+++ b/plateform/app/routes/api.email.mission.ts
@@ -1,10 +1,11 @@
+import type { SendMissionEmailRequest, SendMissionEmailResponse } from "@engagement/dto";
 import type { ActionFunctionArgs } from "react-router";
+
 import { api, upstreamErrorResponse } from "~/services/api";
-import type { SendMissionEmailPayload, SendMissionEmailResponse } from "~/services/email";
 
 export async function action({ request }: ActionFunctionArgs) {
   try {
-    const body = (await request.json()) as SendMissionEmailPayload;
+    const body = (await request.json()) as SendMissionEmailRequest;
     const data = await api.post<SendMissionEmailResponse>("/email/mission", body, request.signal);
     return Response.json({ ok: true, data });
   } catch (error) {

--- a/plateform/app/services/email.ts
+++ b/plateform/app/services/email.ts
@@ -1,18 +1,7 @@
+import type { SendMissionEmailRequest, SendMissionEmailResponse } from "@engagement/dto";
+
 import { client } from "~/services/client";
 
-export type SendMissionEmailPayload = {
-  email: string;
-  publisherId: string;
-  userScoringId?: string;
-  distinctId?: string;
-  missionIds?: string[];
-};
-
-export type SendMissionEmailResponse = {
-  email_sent: boolean;
-  email_skip_reason?: string;
-};
-
-export async function sendMissionEmail(payload: SendMissionEmailPayload): Promise<SendMissionEmailResponse> {
+export async function sendMissionEmail(payload: SendMissionEmailRequest): Promise<SendMissionEmailResponse> {
   return client.post<SendMissionEmailResponse>("/api/email/mission", payload);
 }


### PR DESCRIPTION
## Description

Les types de l’endpoint `/email/mission` étaient définis localement dans l’API et dans `plateform`, ce qui pouvait créer une divergence entre le contrat exposé par l’API et celui consommé par le front.

### Changements

- Ajout des DTO partagés `SendMissionEmailRequest`, `SendMissionEmailResponse` et `MissionEmailSkipReason` dans `@engagement/dto`.
- Export des nouveaux types depuis `packages/dto`.
- Utilisation du DTO de requête dans le service `mission-email` côté API.
- Typage de la réponse envoyée par le contrôleur email avec le DTO partagé.
- Remplacement des types locaux dans `plateform/app/services/email.ts` par les types `@engagement/dto`.


## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Utiliser-le-type-DTO-partag-dans-l-endpoint-email-36872a322d5080d58c58d38b09692949?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
