### PR TITLE
feat(plateform): url params in missions route

### DIFF
--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -48,7 +48,8 @@ export function meta(): Route.MetaDescriptors {
 export default function MissionsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
+  const rawPage = parseInt(searchParams.get("page") ?? "1", 10);
+  const page = Number.isNaN(rawPage) ? 1 : Math.max(1, rawPage);
   const filterValues: Record<FilterKey, string[]> = {
     departmentCode: searchParams.getAll("departmentCode"),
     tranche_age: searchParams.getAll("tranche_age"),

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -2,6 +2,7 @@ import type { MissionBrowse, MissionBrowseFacetCount, MissionBrowseFilters } fro
 import { TAXONOMY } from "@engagement/taxonomy";
 
 import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router";
 import Newsletter from "~/components/layout/newsletter";
 import Partners from "~/components/layout/partners";
 import MissionFiltersBar, { MissionFiltersTrigger, type FilterDef } from "~/components/missions/filters";
@@ -45,14 +46,17 @@ export function meta(): Route.MetaDescriptors {
 }
 
 export default function MissionsPage() {
-  const [filterValues, setFilterValues] = useState<Record<FilterKey, string[]>>({
-    departmentCode: [],
-    tranche_age: [],
-    type_mission: [],
-    secteur_activite: [],
-    domaine: [],
-  });
-  const [page, setPage] = useState(1);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
+  const filterValues: Record<FilterKey, string[]> = {
+    departmentCode: searchParams.getAll("departmentCode"),
+    tranche_age: searchParams.getAll("tranche_age"),
+    type_mission: searchParams.getAll("type_mission"),
+    secteur_activite: searchParams.getAll("secteur_activite"),
+    domaine: searchParams.getAll("domaine"),
+  };
+
   const [items, setItems] = useState<MissionBrowse[]>([]);
   const [total, setTotal] = useState(0);
   const [facets, setFacets] = useState<Record<string, MissionBrowseFacetCount[]>>({});
@@ -87,7 +91,7 @@ export default function MissionsPage() {
       });
 
     return () => controller.abort();
-  }, [filterValues, page]);
+  }, [searchParams]);
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
@@ -152,12 +156,22 @@ export default function MissionsPage() {
 
   const handleFilterChange = (key: string, next: string[]) => {
     if (!FILTER_KEYS.includes(key as FilterKey)) return;
-    setPage(1);
-    setFilterValues((prev) => ({ ...prev, [key as FilterKey]: next }));
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      params.delete(key);
+      params.delete("page");
+      for (const val of next) params.append(key, val);
+      return params;
+    });
   };
 
   const handlePageChange = (newPage: number) => {
-    setPage(newPage);
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      if (newPage === 1) params.delete("page");
+      else params.set("page", String(newPage));
+      return params;
+    });
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 


### PR DESCRIPTION
## Description

Les filtres et la pagination de la page `/missions` étaient gérés en state React local, ce qui rendait impossible le partage d'une URL pré-filtrée.

Ce changement synchronise l'état des filtres et de la page courante avec les search params de l'URL via le hook `useSearchParams` de React Router.

**Exemple d'URL partageable :**
`/missions?departmentCode=FR-75&domaine=education&page=2`

### Comportement

- Chaque filtre actif est reflété dans l'URL (params répétés pour les valeurs multiples : `?departmentCode=FR-75&departmentCode=FR-69`)
- La page 1 n'est pas écrite dans l'URL (URL propre par défaut)
- Changer un filtre remet la pagination à 1 et met à jour l'URL
- Le bouton retour du navigateur restaure l'état de filtres précédent
- Une URL filtrée copiée/partagée recharge directement les résultats correspondants

## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/URLs-pages-de-liste-des-missions-filtr-es-36c72a322d5080ecb5c8da06222fa20e?source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire (pas de test — composant client pur, pas de logique métier)
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire