### PR TITLE
refactor(api): setup search collection on image startup

### DIFF
--- a/api/docker-entrypoint.sh
+++ b/api/docker-entrypoint.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
+echo "Setting up search collections..."
+node /workspace/api/dist/jobs/run-job.js setup-search-collections
+
 exec node /workspace/api/dist/index.js

--- a/api/src/jobs/setup-search-collections/handler.ts
+++ b/api/src/jobs/setup-search-collections/handler.ts
@@ -1,7 +1,7 @@
 import { BaseHandler } from "@/jobs/base/handler";
 import { JobResult } from "@/jobs/types";
-import { searchProvider } from "@/services/search";
 import missionSchemaV1 from "@/services/search/collections/missions/schemas/v1";
+import { ensureCollection } from "@/services/search/providers/typesense/utils";
 
 const LOG_PREFIX = "[setup-search-collections-job]";
 
@@ -21,7 +21,7 @@ export class SetupSearchCollectionsHandler implements BaseHandler<Record<string,
 
     for (const schema of SCHEMAS) {
       console.log(`${LOG_PREFIX} ensuring collection: ${schema.name}`);
-      await searchProvider.ensure(schema);
+      await ensureCollection(schema);
       ensured.push(schema.name);
       console.log(`${LOG_PREFIX} done: ${schema.name}`);
     }

--- a/api/src/services/search/providers/typesense/index.ts
+++ b/api/src/services/search/providers/typesense/index.ts
@@ -1,28 +1,11 @@
-import type { CollectionCreateSchema } from "typesense/lib/Typesense/Collections";
 import type { SearchResponse } from "typesense/lib/Typesense/Documents";
 import type { SearchParams } from "typesense/lib/Typesense/Types";
 
 import type { SearchProvider } from "@/services/search/types";
 
 import { typesenseClient } from "./client";
-import { ensureCollection } from "./utils";
 
 export class TypesenseSearchProvider implements SearchProvider {
-  private ensurePromises = new Map<string, Promise<void>>();
-
-  ensure(schema: CollectionCreateSchema): Promise<void> {
-    if (!this.ensurePromises.has(schema.name)) {
-      this.ensurePromises.set(
-        schema.name,
-        ensureCollection(schema).catch((err) => {
-          this.ensurePromises.delete(schema.name);
-          throw err;
-        })
-      );
-    }
-    return this.ensurePromises.get(schema.name)!;
-  }
-
   async search<TDoc extends object>(collection: string, params: SearchParams<TDoc>): Promise<SearchResponse<TDoc>> {
     return typesenseClient.collections<TDoc>(collection).documents().search(params);
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,30 +99,6 @@ services:
       - "3000:3000"
     command: ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
 
-  widget:
-    build:
-      context: .
-      dockerfile: widget/Dockerfile
-    depends_on:
-      - api
-    environment:
-      API_URL: http://localhost:3002
-      ENV: development
-    volumes:
-      - ./widget:/workspace/widget
-      - /workspace/widget/node_modules
-    ports:
-      - "3003:3003"
-
-  typesense:
-    image: typesense/typesense:30.2
-    restart: always
-    command: --data-dir /data --api-key=xyz --enable-cors
-    ports:
-      - "8108:8108"
-    volumes:
-      - typesense-data:/data
-
   typesense-setup:
     build:
       context: .
@@ -150,6 +126,30 @@ services:
         "sleep 20 && npx ts-node src/jobs/run-job.ts setup-search-collections",
       ]
     restart: "no"
+
+  widget:
+    build:
+      context: .
+      dockerfile: widget/Dockerfile
+    depends_on:
+      - api
+    environment:
+      API_URL: http://localhost:3002
+      ENV: development
+    volumes:
+      - ./widget:/workspace/widget
+      - /workspace/widget/node_modules
+    ports:
+      - "3003:3003"
+
+  typesense:
+    image: typesense/typesense:30.2
+    restart: always
+    command: --data-dir /data --api-key=xyz --enable-cors
+    ports:
+      - "8108:8108"
+    volumes:
+      - typesense-data:/data
 
 volumes:
   api-node-modules:


### PR DESCRIPTION
## Description

Automatise l'exécution du job \`setup-search-collections\` au démarrage du container API de production, sans intervention manuelle. Le job initialise les collections Typesense (création si absentes, synchronisation des champs manquants) et est idempotent.

Couvre les 3 cas d'usage :
- Nouvel environnement (bootstrap initial)
- Nouveau champ indexé dans le schéma
- Nouvelle collection

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/jeveuxaider/Clarifier-l-initialisation-de-Typesense-36772a322d50805c8350f17e8ea4be32?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Approches explorées

### Option A — Entrypoint du container API ✅ (retenue)

Ajout de l'appel au job dans `api/docker-entrypoint.sh` avant le démarrage d'Express, sur le modèle d'`analytics/docker-entrypoint.sh` (qui exécute les migrations dbmate au démarrage).

Le container API est dans le VPC Scaleway (`private_network_id`), il atteint donc Typesense sur son IP privée. Zéro nouvelle infrastructure.

En cas d'échec (Typesense KO), le job est non-bloquant : `run-job.ts` retourne toujours exit 0 via son `finally`, Sentry capture l'exception, et Express démarre quand même.

Aucun downtime : le health check Scaleway (`GET /` toutes les 30s, `failure_threshold = 3`) garantit que l'ancienne instance continue de servir le trafic jusqu'à ce que la nouvelle soit prête.

### Option B — Scaleway Serverless Job déclenché depuis la CI ❌ (écartée)

Aurait été plus propre : job déclenché une seule fois par déploiement (pas à chaque restart), visible dans les logs CI, synchrone avec `terraform apply`.

Bloquée par une limitation du provider Terraform Scaleway : `scaleway_job_definition` ne supporte pas l'attachement à un VPC (confirmé sur les versions 2.74 et 2.75). Les Serverless Jobs tournent en réseau public et ne peuvent pas atteindre Typesense sur son IP privée `10.41.2.10:8108`.

À surveiller dans les futures versions du provider.

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Le refactoring supprime la méthode `ensure()` de `TypesenseSearchProvider` et la map de memoization associée (`ensurePromises`). Cette abstraction était utile quand `ensure()` pouvait être appelé depuis plusieurs endroits (lazy init avant chaque requête) ; maintenant que le setup est centralisé au démarrage, le handler appelle `ensureCollection()` directement depuis `utils.ts`.