### PR TITLE
refactor(plateform): tranche-age taxonomy

### DIFF
--- a/api/src/services/mission-scoring/__tests__/index.test.ts
+++ b/api/src/services/mission-scoring/__tests__/index.test.ts
@@ -205,7 +205,7 @@ describe("missionScoringService.score", () => {
         {
           missionEnrichmentValueId: null,
           taxonomyKey: "tranche_age",
-          valueKey: "moins_18_ans",
+          valueKey: "entre_16_17_ans",
           score: 1,
         },
         {
@@ -229,7 +229,7 @@ describe("missionScoringService.score", () => {
         {
           missionEnrichmentValueId: null,
           taxonomyKey: "tranche_age",
-          valueKey: "entre_46_67_ans",
+          valueKey: "entre_46_66_ans",
           score: 1,
         },
       ],

--- a/api/src/services/mission-scoring/__tests__/index.test.ts
+++ b/api/src/services/mission-scoring/__tests__/index.test.ts
@@ -165,7 +165,13 @@ describe("missionScoringService.score", () => {
         {
           missionEnrichmentValueId: null,
           taxonomyKey: "tranche_age",
-          valueKey: "moins_26_ans",
+          valueKey: "moins_18_ans",
+          score: 1,
+        },
+        {
+          missionEnrichmentValueId: null,
+          taxonomyKey: "tranche_age",
+          valueKey: "entre_18_25_ans",
           score: 1,
         },
         {
@@ -199,7 +205,31 @@ describe("missionScoringService.score", () => {
         {
           missionEnrichmentValueId: null,
           taxonomyKey: "tranche_age",
-          valueKey: "entre_16_67_ans",
+          valueKey: "moins_18_ans",
+          score: 1,
+        },
+        {
+          missionEnrichmentValueId: null,
+          taxonomyKey: "tranche_age",
+          valueKey: "entre_18_25_ans",
+          score: 1,
+        },
+        {
+          missionEnrichmentValueId: null,
+          taxonomyKey: "tranche_age",
+          valueKey: "entre_25_30_ans",
+          score: 1,
+        },
+        {
+          missionEnrichmentValueId: null,
+          taxonomyKey: "tranche_age",
+          valueKey: "entre_30_45_ans",
+          score: 1,
+        },
+        {
+          missionEnrichmentValueId: null,
+          taxonomyKey: "tranche_age",
+          valueKey: "entre_46_67_ans",
           score: 1,
         },
       ],

--- a/api/src/services/mission-scoring/scoring-rules.ts
+++ b/api/src/services/mission-scoring/scoring-rules.ts
@@ -23,7 +23,7 @@ export const SCORING_RULES = {
   publisherId: {
     [PUBLISHER_IDS.SERVICE_CIVIQUE]: ["tranche_age.moins_18_ans", "tranche_age.entre_18_25_ans", "tranche_age.moins_31_ans_handicap"],
     [PUBLISHER_IDS.ROC]: [
-      "tranche_age.moins_18_ans",
+      "tranche_age.entre_16_17_ans",
       "tranche_age.entre_18_25_ans",
       "tranche_age.entre_25_30_ans",
       "tranche_age.entre_30_45_ans",
@@ -33,11 +33,11 @@ export const SCORING_RULES = {
   },
   type: {
     volontariat_sapeurs_pompiers: [
-      "tranche_age.moins_18_ans",
+      "tranche_age.entre_16_17_ans",
       "tranche_age.entre_18_25_ans",
       "tranche_age.entre_25_30_ans",
       "tranche_age.entre_30_45_ans",
-      "tranche_age.entre_46_67_ans",
+      "tranche_age.entre_46_66_ans",
     ],
   },
 } satisfies MissionScoringRules;

--- a/api/src/services/mission-scoring/scoring-rules.ts
+++ b/api/src/services/mission-scoring/scoring-rules.ts
@@ -21,11 +21,24 @@ type MissionScoringRules = {
  */
 export const SCORING_RULES = {
   publisherId: {
-    [PUBLISHER_IDS.SERVICE_CIVIQUE]: ["tranche_age.moins_26_ans", "tranche_age.moins_31_ans_handicap"],
-    [PUBLISHER_IDS.ROC]: ["tranche_age.entre_17_72_ans"],
+    [PUBLISHER_IDS.SERVICE_CIVIQUE]: ["tranche_age.moins_18_ans", "tranche_age.entre_18_25_ans", "tranche_age.moins_31_ans_handicap"],
+    [PUBLISHER_IDS.ROC]: [
+      "tranche_age.moins_18_ans",
+      "tranche_age.entre_18_25_ans",
+      "tranche_age.entre_25_30_ans",
+      "tranche_age.entre_30_45_ans",
+      "tranche_age.entre_46_67_ans",
+      "tranche_age.entre_68_72_ans",
+    ],
   },
   type: {
-    volontariat_sapeurs_pompiers: ["tranche_age.entre_16_67_ans"],
+    volontariat_sapeurs_pompiers: [
+      "tranche_age.moins_18_ans",
+      "tranche_age.entre_18_25_ans",
+      "tranche_age.entre_25_30_ans",
+      "tranche_age.entre_30_45_ans",
+      "tranche_age.entre_46_67_ans",
+    ],
   },
 } satisfies MissionScoringRules;
 

--- a/api/tests/integration/api/user-scoring.test.ts
+++ b/api/tests/integration/api/user-scoring.test.ts
@@ -67,8 +67,7 @@ describe("POST /user-scoring", () => {
   // ─── Success cases ──────────────────────────────────────────────────────────
 
   it("should create a user scoring with one answer (no geo)", async () => {
-    const res = await postUserScoringRequest()
-      .send({ answers: [taxonomyAnswer] });
+    const res = await postUserScoringRequest().send({ answers: [taxonomyAnswer] });
 
     expect(res.status).toBe(201);
     expect(res.body.ok).toBe(true);
@@ -90,10 +89,9 @@ describe("POST /user-scoring", () => {
   });
 
   it("should create a user scoring with location params (lat/lon only)", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [taxonomyAnswer, { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } }],
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [taxonomyAnswer, { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } }],
+    });
 
     expect(res.status).toBe(201);
 
@@ -107,10 +105,9 @@ describe("POST /user-scoring", () => {
   });
 
   it("should create a user scoring with location params including radius_km and country_code", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [taxonomyAnswer, { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522, radius_km: 50, country_code: "fr" } }],
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [taxonomyAnswer, { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522, radius_km: 50, country_code: "fr" } }],
+    });
 
     expect(res.status).toBe(201);
 
@@ -122,10 +119,9 @@ describe("POST /user-scoring", () => {
   });
 
   it("should create a user scoring with only location params", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } }],
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } }],
+    });
 
     expect(res.status).toBe(201);
 
@@ -143,10 +139,9 @@ describe("POST /user-scoring", () => {
   });
 
   it("should create a user scoring with multiple answers", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [taxonomyAnswer, secondaryTaxonomyAnswer],
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [taxonomyAnswer, secondaryTaxonomyAnswer],
+    });
 
     expect(res.status).toBe(201);
 
@@ -159,12 +154,11 @@ describe("POST /user-scoring", () => {
   });
 
   it("should create a user scoring with distinctId and missionAlertEnabled", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [taxonomyAnswer],
-        distinctId: "distinct-user-1",
-        missionAlertEnabled: true,
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [taxonomyAnswer],
+      distinctId: "distinct-user-1",
+      missionAlertEnabled: true,
+    });
 
     expect(res.status).toBe(201);
 
@@ -176,10 +170,9 @@ describe("POST /user-scoring", () => {
   });
 
   it("should deduplicate repeated answers", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [taxonomyAnswer, taxonomyAnswer],
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [taxonomyAnswer, taxonomyAnswer],
+    });
 
     expect(res.status).toBe(201);
 
@@ -191,8 +184,7 @@ describe("POST /user-scoring", () => {
 
   it("should set expiresAt on the created user scoring", async () => {
     const before = Date.now();
-    const res = await postUserScoringRequest()
-      .send({ answers: [taxonomyAnswer] });
+    const res = await postUserScoringRequest().send({ answers: [taxonomyAnswer] });
 
     const userScoring = await prisma.userScoring.findUniqueOrThrow({
       where: { id: res.body.data.id },
@@ -220,10 +212,9 @@ describe("POST /user-scoring", () => {
   });
 
   it("should create a user scoring from tranche_age params", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [{ taxonomy: "tranche_age", params: { age: 18, handicap: false } }],
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [{ taxonomy: "tranche_age", params: { age: 18, handicap: false } }],
+    });
 
     expect(res.status).toBe(201);
 
@@ -231,14 +222,13 @@ describe("POST /user-scoring", () => {
       where: { userScoringId: res.body.data.id },
       orderBy: [{ valueKey: "asc" }],
     });
-    expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual(["tranche_age.entre_16_67_ans", "tranche_age.entre_17_72_ans", "tranche_age.moins_26_ans"]);
+    expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual(["tranche_age.entre_18_25_ans"]);
   });
 
   it("should create a user scoring with handicap tranche_age params", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [{ taxonomy: "tranche_age", params: { age: 30, handicap: true } }],
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [{ taxonomy: "tranche_age", params: { age: 30, handicap: true } }],
+    });
 
     expect(res.status).toBe(201);
 
@@ -246,57 +236,47 @@ describe("POST /user-scoring", () => {
       where: { userScoringId: res.body.data.id },
       orderBy: [{ valueKey: "asc" }],
     });
-    expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual([
-      "tranche_age.entre_16_67_ans",
-      "tranche_age.entre_17_72_ans",
-      "tranche_age.moins_31_ans_handicap",
-    ]);
+    expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual(["tranche_age.entre_25_30_ans", "tranche_age.moins_31_ans_handicap"]);
   });
 
   it("should deduplicate direct and resolved answers", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [
-          { taxonomy: "tranche_age", value: "moins_26_ans" },
-          { taxonomy: "tranche_age", params: { age: 18, handicap: false } },
-        ],
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [
+        { taxonomy: "tranche_age", value: "entre_18_25_ans" },
+        { taxonomy: "tranche_age", params: { age: 18, handicap: false } },
+      ],
+    });
 
     expect(res.status).toBe(201);
 
     const values = await prisma.userScoringValue.findMany({
       where: { userScoringId: res.body.data.id },
     });
-    expect(values).toHaveLength(3);
+    expect(values).toHaveLength(1);
   });
 
   it("should return 400 when taxonomy is unknown", async () => {
-    const res = await postUserScoringRequest()
-      .send({ answers: [{ taxonomy: "unknown", value: "sante_soins" }] });
+    const res = await postUserScoringRequest().send({ answers: [{ taxonomy: "unknown", value: "sante_soins" }] });
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
   });
 
   it("should return 400 when taxonomy value is unknown", async () => {
-    const res = await postUserScoringRequest()
-      .send({ answers: [{ taxonomy: "domaine", value: "does_not_exist" }] });
+    const res = await postUserScoringRequest().send({ answers: [{ taxonomy: "domaine", value: "does_not_exist" }] });
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
   });
 
   it("should return 400 when params target a taxonomy without transformer", async () => {
-    const res = await postUserScoringRequest()
-      .send({ answers: [{ taxonomy: "domaine", params: { age: 18 } }] });
+    const res = await postUserScoringRequest().send({ answers: [{ taxonomy: "domaine", params: { age: 18 } }] });
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
   });
 
   it("should return 400 when tranche_age params are invalid", async () => {
     const responses = await Promise.all([
-      postUserScoringRequest()
-        .send({ answers: [{ taxonomy: "tranche_age", params: { age: 121, handicap: false } }] }),
-      postUserScoringRequest()
-        .send({ answers: [{ taxonomy: "tranche_age", params: { age: 18, handicap: "false" } }] }),
+      postUserScoringRequest().send({ answers: [{ taxonomy: "tranche_age", params: { age: 121, handicap: false } }] }),
+      postUserScoringRequest().send({ answers: [{ taxonomy: "tranche_age", params: { age: 18, handicap: "false" } }] }),
     ]);
 
     expect(responses.map((res) => res.status)).toEqual([400, 400]);
@@ -305,10 +285,8 @@ describe("POST /user-scoring", () => {
 
   it("should return 400 when answer has both value and params or neither", async () => {
     const responses = await Promise.all([
-      postUserScoringRequest()
-        .send({ answers: [{ taxonomy: "domaine", value: "social_solidarite", params: { age: 18 } }] }),
-      postUserScoringRequest()
-        .send({ answers: [{ taxonomy: "domaine" }] }),
+      postUserScoringRequest().send({ answers: [{ taxonomy: "domaine", value: "social_solidarite", params: { age: 18 } }] }),
+      postUserScoringRequest().send({ answers: [{ taxonomy: "domaine" }] }),
     ]);
 
     expect(responses.map((res) => res.status)).toEqual([400, 400]);
@@ -316,10 +294,9 @@ describe("POST /user-scoring", () => {
   });
 
   it("should create a user scoring with direct values, tranche_age and location params", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [taxonomyAnswer, { taxonomy: "tranche_age", params: { age: 18, handicap: false } }, { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } }],
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [taxonomyAnswer, { taxonomy: "tranche_age", params: { age: 18, handicap: false } }, { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } }],
+    });
 
     expect(res.status).toBe(201);
 
@@ -335,52 +312,46 @@ describe("POST /user-scoring", () => {
   });
 
   it("should return 400 when location lat is out of range", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [{ taxonomy: "location", params: { lat: 999, lon: 2.3522 } }],
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [{ taxonomy: "location", params: { lat: 999, lon: 2.3522 } }],
+    });
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
   });
 
   it("should return 400 when location lon is out of range", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 999 } }],
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 999 } }],
+    });
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
   });
 
   it("should return 400 when location radius_km is invalid", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 2.3522, radius_km: 0 } }],
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 2.3522, radius_km: 0 } }],
+    });
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
   });
 
   it("should return 400 when location country_code is invalid", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 2.3522, country_code: "FRA" } }],
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 2.3522, country_code: "FRA" } }],
+    });
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
   });
 
   it("should return 400 when location uses a value or is duplicated", async () => {
     const responses = await Promise.all([
-      postUserScoringRequest()
-        .send({ answers: [{ taxonomy: "location", value: "paris" }] }),
-      postUserScoringRequest()
-        .send({
-          answers: [
-            { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } },
-            { taxonomy: "location", params: { lat: 45.764, lon: 4.8357 } },
-          ],
-        }),
+      postUserScoringRequest().send({ answers: [{ taxonomy: "location", value: "paris" }] }),
+      postUserScoringRequest().send({
+        answers: [
+          { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } },
+          { taxonomy: "location", params: { lat: 45.764, lon: 4.8357 } },
+        ],
+      }),
     ]);
 
     expect(responses.map((res) => res.status)).toEqual([400, 400]);
@@ -388,11 +359,10 @@ describe("POST /user-scoring", () => {
   });
 
   it("should return 400 when top-level geo is provided", async () => {
-    const res = await postUserScoringRequest()
-      .send({
-        answers: [taxonomyAnswer],
-        geo: { lat: 48.8566, lon: 2.3522 },
-      });
+    const res = await postUserScoringRequest().send({
+      answers: [taxonomyAnswer],
+      geo: { lat: 48.8566, lon: 2.3522 },
+    });
 
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
@@ -415,8 +385,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
       answers?: Array<{ taxonomy: string; value?: string; params?: Record<string, unknown> }>;
     } = { distinctId }
   ) => {
-    const res = await postUserScoringRequest()
-      .send({ answers: params.answers ?? [taxonomyAnswer], distinctId: params.distinctId });
+    const res = await postUserScoringRequest().send({ answers: params.answers ?? [taxonomyAnswer], distinctId: params.distinctId });
 
     expect(res.status).toBe(201);
     return res.body.data.id as string;
@@ -487,8 +456,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should replace existing answers on an existing user scoring", async () => {
     const userScoringId = await createUserScoring();
 
-    const res = await putUserScoringRequest(userScoringId)
-      .send({ distinctId, answers: [secondaryTaxonomyAnswer] });
+    const res = await putUserScoringRequest(userScoringId).send({ distinctId, answers: [secondaryTaxonomyAnswer] });
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
@@ -531,12 +499,11 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should replace answers and update missionAlertEnabled in the same request", async () => {
     const userScoringId = await createUserScoring();
 
-    const res = await putUserScoringRequest(userScoringId)
-      .send({
-        distinctId,
-        missionAlertEnabled: true,
-        answers: [secondaryTaxonomyAnswer],
-      });
+    const res = await putUserScoringRequest(userScoringId).send({
+      distinctId,
+      missionAlertEnabled: true,
+      answers: [secondaryTaxonomyAnswer],
+    });
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
@@ -558,11 +525,10 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should replace all existing values with payload values and deduplicate answers", async () => {
     const userScoringId = await createUserScoring();
 
-    const res = await putUserScoringRequest(userScoringId)
-      .send({
-        distinctId,
-        answers: [taxonomyAnswer, secondaryTaxonomyAnswer, secondaryTaxonomyAnswer],
-      });
+    const res = await putUserScoringRequest(userScoringId).send({
+      distinctId,
+      answers: [taxonomyAnswer, secondaryTaxonomyAnswer, secondaryTaxonomyAnswer],
+    });
 
     expect(res.status).toBe(200);
     expect(res.body.data.created_count).toBe(2);
@@ -728,12 +694,11 @@ describe("PUT /user-scoring/:userScoringId", () => {
       city: "Paris",
     });
 
-    const res = await postMissionEmailRequest()
-      .send({
-        email: "user@example.com",
-        publisherId: emailPublisher.id,
-        missionIds: [mission.id],
-      });
+    const res = await postMissionEmailRequest().send({
+      email: "user@example.com",
+      publisherId: emailPublisher.id,
+      missionIds: [mission.id],
+    });
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
@@ -770,12 +735,11 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should skip mission email when missionIds are not found", async () => {
     const emailPublisher = await createEmailPublisher();
 
-    const res = await postMissionEmailRequest()
-      .send({
-        email: "user@example.com",
-        publisherId: emailPublisher.id,
-        missionIds: ["00000000-0000-0000-0000-000000000000"],
-      });
+    const res = await postMissionEmailRequest().send({
+      email: "user@example.com",
+      publisherId: emailPublisher.id,
+      missionIds: ["00000000-0000-0000-0000-000000000000"],
+    });
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
@@ -888,11 +852,10 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should replace existing values for a direct taxonomy", async () => {
     const userScoringId = await createUserScoring();
 
-    const res = await putUserScoringRequest(userScoringId)
-      .send({
-        distinctId,
-        answers: [{ taxonomy: "domaine", value: "sante_soins" }],
-      });
+    const res = await putUserScoringRequest(userScoringId).send({
+      distinctId,
+      answers: [{ taxonomy: "domaine", value: "sante_soins" }],
+    });
 
     expect(res.status).toBe(200);
     expect(res.body.data.created_count).toBe(1);
@@ -908,11 +871,10 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should replace existing values with resolved tranche_age answers", async () => {
     const userScoringId = await createUserScoring();
 
-    const res = await putUserScoringRequest(userScoringId)
-      .send({
-        distinctId,
-        answers: [{ taxonomy: "tranche_age", params: { age: 18, handicap: false } }],
-      });
+    const res = await putUserScoringRequest(userScoringId).send({
+      distinctId,
+      answers: [{ taxonomy: "tranche_age", params: { age: 18, handicap: false } }],
+    });
 
     expect(res.status).toBe(200);
     expect(res.body.data.created_count).toBe(3);
@@ -926,19 +888,17 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should replace existing tranche_age values when age changes", async () => {
     const userScoringId = await createUserScoring();
 
-    const firstRes = await putUserScoringRequest(userScoringId)
-      .send({
-        distinctId,
-        answers: [{ taxonomy: "tranche_age", params: { age: 18, handicap: false } }],
-      });
+    const firstRes = await putUserScoringRequest(userScoringId).send({
+      distinctId,
+      answers: [{ taxonomy: "tranche_age", params: { age: 18, handicap: false } }],
+    });
     expect(firstRes.status).toBe(200);
     expect(firstRes.body.data.created_count).toBe(3);
 
-    const secondRes = await putUserScoringRequest(userScoringId)
-      .send({
-        distinctId,
-        answers: [{ taxonomy: "tranche_age", params: { age: 70, handicap: false } }],
-      });
+    const secondRes = await putUserScoringRequest(userScoringId).send({
+      distinctId,
+      answers: [{ taxonomy: "tranche_age", params: { age: 70, handicap: false } }],
+    });
 
     expect(secondRes.status).toBe(200);
     expect(secondRes.body.data.created_count).toBe(1);
@@ -956,11 +916,10 @@ describe("PUT /user-scoring/:userScoringId", () => {
       answers: [taxonomyAnswer, { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } }],
     });
 
-    const res = await putUserScoringRequest(userScoringId)
-      .send({
-        distinctId,
-        answers: [secondaryTaxonomyAnswer],
-      });
+    const res = await putUserScoringRequest(userScoringId).send({
+      distinctId,
+      answers: [secondaryTaxonomyAnswer],
+    });
 
     expect(res.status).toBe(200);
     expect(res.body.data.created_count).toBe(1);
@@ -992,11 +951,10 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should update geo from location params", async () => {
     const userScoringId = await createUserScoring();
 
-    const res = await putUserScoringRequest(userScoringId)
-      .send({
-        distinctId,
-        answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 2.3522, radius_km: 25, country_code: "FR" } }],
-      });
+    const res = await putUserScoringRequest(userScoringId).send({
+      distinctId,
+      answers: [{ taxonomy: "location", params: { lat: 48.8566, lon: 2.3522, radius_km: 25, country_code: "FR" } }],
+    });
 
     expect(res.status).toBe(200);
     expect(res.body.data.created_count).toBe(0);
@@ -1019,11 +977,10 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should accept an update with only location params", async () => {
     const userScoringId = await createUserScoring();
 
-    const res = await putUserScoringRequest(userScoringId)
-      .send({
-        distinctId,
-        answers: [{ taxonomy: "location", params: { lat: 45.764, lon: 4.8357 } }],
-      });
+    const res = await putUserScoringRequest(userScoringId).send({
+      distinctId,
+      answers: [{ taxonomy: "location", params: { lat: 45.764, lon: 4.8357 } }],
+    });
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
@@ -1035,8 +992,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should return 400 when added answers are invalid", async () => {
     const userScoringId = await createUserScoring();
 
-    const res = await putUserScoringRequest(userScoringId)
-      .send({ distinctId, answers: [{ taxonomy: "domaine", value: "does_not_exist" }] });
+    const res = await putUserScoringRequest(userScoringId).send({ distinctId, answers: [{ taxonomy: "domaine", value: "does_not_exist" }] });
 
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
@@ -1054,8 +1010,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should return 400 when email is invalid", async () => {
     const emailPublisher = await createEmailPublisher();
 
-    const res = await postMissionEmailRequest()
-      .send({ email: "not-an-email", publisherId: emailPublisher.id, missionIds: ["00000000-0000-0000-0000-000000000000"] });
+    const res = await postMissionEmailRequest().send({ email: "not-an-email", publisherId: emailPublisher.id, missionIds: ["00000000-0000-0000-0000-000000000000"] });
 
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
@@ -1066,8 +1021,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should return 400 when top-level geo is provided on update", async () => {
     const userScoringId = await createUserScoring();
 
-    const res = await putUserScoringRequest(userScoringId)
-      .send({ distinctId, geo: { lat: 48.8566, lon: 2.3522 } });
+    const res = await putUserScoringRequest(userScoringId).send({ distinctId, geo: { lat: 48.8566, lon: 2.3522 } });
 
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
@@ -1076,8 +1030,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should return 400 when distinctId is missing", async () => {
     const userScoringId = await createUserScoring();
 
-    const res = await putUserScoringRequest(userScoringId)
-      .send({ answers: [secondaryTaxonomyAnswer] });
+    const res = await putUserScoringRequest(userScoringId).send({ answers: [secondaryTaxonomyAnswer] });
 
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
@@ -1086,8 +1039,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should return 403 when distinctId does not match the user scoring", async () => {
     const userScoringId = await createUserScoring();
 
-    const res = await putUserScoringRequest(userScoringId)
-      .send({ distinctId: "another-distinct-user", answers: [secondaryTaxonomyAnswer] });
+    const res = await putUserScoringRequest(userScoringId).send({ distinctId: "another-distinct-user", answers: [secondaryTaxonomyAnswer] });
 
     expect(res.status).toBe(403);
     expect(res.body.ok).toBe(false);
@@ -1103,24 +1055,21 @@ describe("PUT /user-scoring/:userScoringId", () => {
   it("should return 403 when user scoring has no distinctId", async () => {
     const userScoringId = await createUserScoring({ distinctId: undefined });
 
-    const res = await putUserScoringRequest(userScoringId)
-      .send({ distinctId, answers: [secondaryTaxonomyAnswer] });
+    const res = await putUserScoringRequest(userScoringId).send({ distinctId, answers: [secondaryTaxonomyAnswer] });
 
     expect(res.status).toBe(403);
     expect(res.body.ok).toBe(false);
   });
 
   it("should return 400 when userScoringId is not a uuid", async () => {
-    const res = await putUserScoringRequest("not-a-uuid")
-      .send({ distinctId, answers: [taxonomyAnswer] });
+    const res = await putUserScoringRequest("not-a-uuid").send({ distinctId, answers: [taxonomyAnswer] });
 
     expect(res.status).toBe(400);
     expect(res.body.ok).toBe(false);
   });
 
   it("should return 404 when user scoring does not exist", async () => {
-    const res = await putUserScoringRequest("00000000-0000-4000-8000-000000000000")
-      .send({ distinctId, answers: [taxonomyAnswer] });
+    const res = await putUserScoringRequest("00000000-0000-4000-8000-000000000000").send({ distinctId, answers: [taxonomyAnswer] });
 
     expect(res.status).toBe(404);
     expect(res.body.ok).toBe(false);

--- a/api/tests/integration/api/user-scoring.test.ts
+++ b/api/tests/integration/api/user-scoring.test.ts
@@ -303,7 +303,7 @@ describe("POST /user-scoring", () => {
     const values = await prisma.userScoringValue.findMany({
       where: { userScoringId: res.body.data.id },
     });
-    expect(values).toHaveLength(4);
+    expect(values).toHaveLength(2);
 
     const geo = await prisma.userScoringGeo.findUnique({
       where: { userScoringId: res.body.data.id },
@@ -877,12 +877,12 @@ describe("PUT /user-scoring/:userScoringId", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(res.body.data.created_count).toBe(3);
+    expect(res.body.data.created_count).toBe(1);
 
     const values = await prisma.userScoringValue.findMany({
       where: { userScoringId },
     });
-    expect(values).toHaveLength(3);
+    expect(values).toHaveLength(1);
   });
 
   it("should replace existing tranche_age values when age changes", async () => {
@@ -893,7 +893,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
       answers: [{ taxonomy: "tranche_age", params: { age: 18, handicap: false } }],
     });
     expect(firstRes.status).toBe(200);
-    expect(firstRes.body.data.created_count).toBe(3);
+    expect(firstRes.body.data.created_count).toBe(1);
 
     const secondRes = await putUserScoringRequest(userScoringId).send({
       distinctId,
@@ -907,7 +907,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
       where: { userScoringId },
       orderBy: [{ taxonomyKey: "asc" }, { valueKey: "asc" }],
     });
-    expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual(["tranche_age.entre_17_72_ans"]);
+    expect(values.map((value) => `${value.taxonomyKey}.${value.valueKey}`)).toEqual(["tranche_age.entre_68_72_ans"]);
   });
 
   it("should delete existing geo when answers do not include location", async () => {

--- a/packages/taxonomy/src/taxonomy.ts
+++ b/packages/taxonomy/src/taxonomy.ts
@@ -301,10 +301,14 @@ export const TAXONOMY = {
     gate: true,
     transformer: resolveTrancheAgeValues,
     values: {
-      moins_26_ans: { label: "Moins de 26 ans", icon: null, enrichable: false },
-      moins_31_ans_handicap: { label: "Moins de 31 ans — situation de handicap", icon: null, enrichable: false },
-      entre_17_72_ans: { label: "Être âgé de 17 à 72 ans", icon: null, enrichable: false },
-      entre_16_67_ans: { label: "Avoir au minimum 16 ans (avec autorisation parentale pour les mineurs) et moins de 67 ans", icon: null, enrichable: false },
+      moins_18_ans: { label: "Moins de 18 ans", icon: null, enrichable: false },
+      entre_18_25_ans: { label: "18-25 ans", icon: null, enrichable: false },
+      entre_25_30_ans: { label: "25-30 ans", icon: null, enrichable: false },
+      entre_30_45_ans: { label: "30-45 ans", icon: null, enrichable: false },
+      entre_46_67_ans: { label: "46-67 ans", icon: null, enrichable: false },
+      entre_68_72_ans: { label: "68-72 ans", icon: null, enrichable: false },
+      plus_72_ans: { label: "72 ans et plus", icon: null, enrichable: false },
+      moins_31_ans_handicap: { label: "Moins de 31 ans — situation de handicap", icon: null, enrichable: false, hidden: true },
     },
   },
 } as const;

--- a/packages/taxonomy/src/taxonomy.ts
+++ b/packages/taxonomy/src/taxonomy.ts
@@ -308,6 +308,8 @@ export const TAXONOMY = {
       entre_46_67_ans: { label: "46-67 ans", icon: null, enrichable: false },
       entre_68_72_ans: { label: "68-72 ans", icon: null, enrichable: false },
       plus_72_ans: { label: "72 ans et plus", icon: null, enrichable: false },
+      entre_16_17_ans: { label: "16-17 ans", icon: null, enrichable: false, hidden: true },
+      entre_46_66_ans: { label: "46-66 ans", icon: null, enrichable: false, hidden: true },
       moins_31_ans_handicap: { label: "Moins de 31 ans — situation de handicap", icon: null, enrichable: false, hidden: true },
     },
   },

--- a/packages/taxonomy/src/transformers/tranche-age.ts
+++ b/packages/taxonomy/src/transformers/tranche-age.ts
@@ -2,10 +2,12 @@ const isRecord = (value: unknown): value is Record<string, unknown> => typeof va
 
 type TrancheAgeValueKey =
   | "moins_18_ans"
+  | "entre_16_17_ans"
   | "entre_18_25_ans"
   | "entre_25_30_ans"
   | "entre_30_45_ans"
   | "entre_46_67_ans"
+  | "entre_46_66_ans"
   | "entre_68_72_ans"
   | "plus_72_ans"
   | "moins_31_ans_handicap";
@@ -30,6 +32,11 @@ export const resolveTrancheAgeValues = (params: unknown): TrancheAgeValueKey[] =
 
   if (age < 18) {
     values.push("moins_18_ans");
+    if (age >= 16) {
+      // bucket caché : permet aux règles de scoring d'inclure les 16-17 ans
+      // sans englober les âges < 16 via moins_18_ans
+      values.push("entre_16_17_ans");
+    }
   } else if (age <= 25) {
     values.push("entre_18_25_ans");
   } else if (age <= 30) {
@@ -38,6 +45,11 @@ export const resolveTrancheAgeValues = (params: unknown): TrancheAgeValueKey[] =
     values.push("entre_30_45_ans");
   } else if (age <= 67) {
     values.push("entre_46_67_ans");
+    if (age < 67) {
+      // bucket caché : permet aux règles de scoring d'exclure précisément les 67 ans
+      // (ex : volontariat_sapeurs_pompiers impose age < 67)
+      values.push("entre_46_66_ans");
+    }
   } else if (age <= 72) {
     values.push("entre_68_72_ans");
   } else {

--- a/packages/taxonomy/src/transformers/tranche-age.ts
+++ b/packages/taxonomy/src/transformers/tranche-age.ts
@@ -1,6 +1,14 @@
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
 
-type TrancheAgeValueKey = "moins_26_ans" | "moins_31_ans_handicap" | "entre_17_72_ans" | "entre_16_67_ans";
+type TrancheAgeValueKey =
+  | "moins_18_ans"
+  | "entre_18_25_ans"
+  | "entre_25_30_ans"
+  | "entre_30_45_ans"
+  | "entre_46_67_ans"
+  | "entre_68_72_ans"
+  | "plus_72_ans"
+  | "moins_31_ans_handicap";
 
 export const resolveTrancheAgeValues = (params: unknown): TrancheAgeValueKey[] => {
   if (!isRecord(params)) {
@@ -20,20 +28,24 @@ export const resolveTrancheAgeValues = (params: unknown): TrancheAgeValueKey[] =
 
   const values: TrancheAgeValueKey[] = [];
 
-  if (age < 26) {
-    values.push("moins_26_ans");
+  if (age < 18) {
+    values.push("moins_18_ans");
+  } else if (age <= 25) {
+    values.push("entre_18_25_ans");
+  } else if (age <= 30) {
+    values.push("entre_25_30_ans");
+  } else if (age <= 45) {
+    values.push("entre_30_45_ans");
+  } else if (age <= 67) {
+    values.push("entre_46_67_ans");
+  } else if (age <= 72) {
+    values.push("entre_68_72_ans");
+  } else {
+    values.push("plus_72_ans");
   }
 
   if (age < 31 && handicap) {
     values.push("moins_31_ans_handicap");
-  }
-
-  if (age >= 17 && age <= 72) {
-    values.push("entre_17_72_ans");
-  }
-
-  if (age >= 16 && age < 67) {
-    values.push("entre_16_67_ans");
   }
 
   return values;

--- a/packages/taxonomy/src/types.ts
+++ b/packages/taxonomy/src/types.ts
@@ -30,6 +30,7 @@ export type TaxonomyValueItem = {
   icon: string | null;
   order: number;
   enrichable: boolean;
+  hidden?: boolean;
 };
 
 export type TaxonomyListItem = {

--- a/packages/taxonomy/src/utils.ts
+++ b/packages/taxonomy/src/utils.ts
@@ -46,13 +46,14 @@ export function getTaxonomyList(): TaxonomyListItem[] {
     type: dim.type,
     enrichable: dim.enrichable,
     gate: dim.gate,
-    values: (Object.entries(dim.values) as [string, { label: string; sublabel?: string; icon: string | null; enrichable: boolean }][]).map(([vKey, val], i) => ({
+    values: (Object.entries(dim.values) as [string, { label: string; sublabel?: string; icon: string | null; enrichable: boolean; hidden?: boolean }][]).map(([vKey, val], i) => ({
       key: vKey,
       label: val.label,
       sublabel: val.sublabel,
       icon: val.icon,
       order: i,
       enrichable: val.enrichable,
+      hidden: val.hidden,
     })),
   }));
 }

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -24,6 +24,11 @@ const filterTaxonomyLabel = (key: TaxonomyFilterKey, value: string): string => {
   return taxonomyValues[value]?.label ?? value;
 };
 
+const isTaxonomyValueHidden = (key: TaxonomyFilterKey, value: string): boolean => {
+  const taxonomyValues = TAXONOMY[key].values as Record<string, { hidden?: boolean }>;
+  return taxonomyValues[value]?.hidden === true;
+};
+
 const formatDepartmentLabel = (code: string): string => code.replace(/^FR-/, "");
 
 const sortFacets = (facets: MissionBrowseFacetCount[] | undefined) =>
@@ -109,11 +114,13 @@ export default function MissionsPage() {
       placeholder: "Toutes",
       selected: filterValues.tranche_age,
       single: true,
-      options: sortFacets(facets.tranche_age).map((facet) => ({
-        value: facet.key,
-        label: filterTaxonomyLabel("tranche_age", facet.key),
-        count: facet.count,
-      })),
+      options: sortFacets(facets.tranche_age)
+        .filter((facet) => !isTaxonomyValueHidden("tranche_age", facet.key))
+        .map((facet) => ({
+          value: facet.key,
+          label: filterTaxonomyLabel("tranche_age", facet.key),
+          count: facet.count,
+        })),
     },
     {
       key: "type_mission",


### PR DESCRIPTION
## Description

Refonte des tranches d'âge dans la taxonomy `tranche_age`.

Les 4 anciennes valeurs décrivaient l'éligibilité d'une mission de son propre point de vue (`moins_26_ans`, `entre_17_72_ans`, `entre_16_67_ans`, `moins_31_ans_handicap`). Elles sont remplacées par 7 tranches du point de vue utilisateur, directement affichables dans les filtres de la plateform :

| Clé | Label affiché |
|---|---|
| `moins_18_ans` | Moins de 18 ans |
| `entre_18_25_ans` | 18-25 ans |
| `entre_25_30_ans` | 25-30 ans |
| `entre_30_45_ans` | 30-45 ans |
| `entre_46_67_ans` | 46-67 ans |
| `entre_68_72_ans` | 68-72 ans |
| `plus_72_ans` | 72 ans et plus |

La valeur `moins_31_ans_handicap` est conservée mais marquée `hidden: true` : elle reste utilisée dans le scoring (Service Civique) mais n'apparaît pas dans les filtres UI.

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Changements

**`packages/taxonomy`**
- Remplacement des 4 anciennes valeurs `tranche_age` par les 7 nouvelles + ajout de `hidden: true` sur `moins_31_ans_handicap`
- Mise à jour du transformer `resolveTrancheAgeValues` : chaque âge retourne désormais exactement un bucket (+ `moins_31_ans_handicap` si age < 31 et handicap)
- Ajout de `hidden?: boolean` sur le type `TaxonomyValueItem` et propagation dans `getTaxonomyList()`

**`api/src/services/mission-scoring/scoring-rules.ts`**
- Mise à jour des `SCORING_RULES` pour utiliser les nouvelles clés :
  - Service Civique → `moins_18_ans` + `entre_18_25_ans` + `moins_31_ans_handicap`
  - ROC → les 6 tranches de `moins_18_ans` à `entre_68_72_ans`
  - Volontaires sapeurs-pompiers → les 5 tranches de `moins_18_ans` à `entre_46_67_ans`

**`plateform/app/routes/missions.tsx`**
- Ajout d'un helper `isTaxonomyValueHidden` pour filtrer les valeurs `hidden` des facettes avant affichage dans le filtre

**Tests**
- Mise à jour des assertions dans `user-scoring.test.ts` et `mission-scoring/__tests__/index.test.ts`

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

⚠️ **Données existantes** : les missions déjà indexées en base conservent les anciennes clés (`moins_26_ans`, `entre_17_72_ans`, `entre_16_67_ans`). Un rescoring + réindexation de toutes les missions sera nécessaire après déploiement pour que les filtres de la plateform fonctionnent correctement avec les nouvelles tranches.

<img width="685" height="518" alt="image" src="https://github.com/user-attachments/assets/cd147e7c-fc81-4f24-8732-82ecde2f1b1f" />
