### PR TITLE
refactor(plateform): display department name

### DIFF
--- a/packages/taxonomy/src/taxonomy.ts
+++ b/packages/taxonomy/src/taxonomy.ts
@@ -14,6 +14,7 @@
 //   icon       — emoji optionnel
 //   enrichable — false pour les valeurs exclues de l'enrichissement (ex : je_ne_sais_pas)
 
+import { DEPARTMENT_CODE_VALUES, resolveDepartmentCodeValues } from "./transformers/department-code";
 import { resolveLocationValues } from "./transformers/location";
 import { resolveTrancheAgeValues } from "./transformers/tranche-age";
 
@@ -404,6 +405,15 @@ export const TAXONOMY = {
     gate: false,
     transformer: resolveLocationValues,
     values: {},
+  },
+
+  departmentCode: {
+    label: "Département",
+    type: "multi_value",
+    enrichable: false,
+    gate: false,
+    transformer: resolveDepartmentCodeValues,
+    values: DEPARTMENT_CODE_VALUES,
   },
 
   // ─── taxonomy gate (filtre dur dans le matching) ────────────────────────

--- a/packages/taxonomy/src/transformers/department-code.ts
+++ b/packages/taxonomy/src/transformers/department-code.ts
@@ -1,0 +1,152 @@
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
+
+const DEPARTMENTS = {
+  "01": "Ain",
+  "02": "Aisne",
+  "03": "Allier",
+  "04": "Alpes-de-Haute-Provence",
+  "05": "Hautes-Alpes",
+  "06": "Alpes-Maritimes",
+  "07": "Ardèche",
+  "08": "Ardennes",
+  "09": "Ariège",
+  "10": "Aube",
+  "11": "Aude",
+  "12": "Aveyron",
+  "13": "Bouches-du-Rhône",
+  "14": "Calvados",
+  "15": "Cantal",
+  "16": "Charente",
+  "17": "Charente-Maritime",
+  "18": "Cher",
+  "19": "Corrèze",
+  "2A": "Corse-du-Sud",
+  "2B": "Haute-Corse",
+  "21": "Côte-d'Or",
+  "22": "Côtes d'Armor",
+  "23": "Creuse",
+  "24": "Dordogne",
+  "25": "Doubs",
+  "26": "Drôme",
+  "27": "Eure",
+  "28": "Eure-et-Loir",
+  "29": "Finistère",
+  "30": "Gard",
+  "31": "Haute-Garonne",
+  "32": "Gers",
+  "33": "Gironde",
+  "34": "Hérault",
+  "35": "Ille-et-Vilaine",
+  "36": "Indre",
+  "37": "Indre-et-Loire",
+  "38": "Isère",
+  "39": "Jura",
+  "40": "Landes",
+  "41": "Loir-et-Cher",
+  "42": "Loire",
+  "43": "Haute-Loire",
+  "44": "Loire-Atlantique",
+  "45": "Loiret",
+  "46": "Lot",
+  "47": "Lot-et-Garonne",
+  "48": "Lozère",
+  "49": "Maine-et-Loire",
+  "50": "Manche",
+  "51": "Marne",
+  "52": "Haute-Marne",
+  "53": "Mayenne",
+  "54": "Meurthe-et-Moselle",
+  "55": "Meuse",
+  "56": "Morbihan",
+  "57": "Moselle",
+  "58": "Nièvre",
+  "59": "Nord",
+  "60": "Oise",
+  "61": "Orne",
+  "62": "Pas-de-Calais",
+  "63": "Puy-de-Dôme",
+  "64": "Pyrénées-Atlantiques",
+  "65": "Hautes-Pyrénées",
+  "66": "Pyrénées-Orientales",
+  "67": "Bas-Rhin",
+  "68": "Haut-Rhin",
+  "69": "Rhône",
+  "70": "Haute-Saône",
+  "71": "Saône-et-Loire",
+  "72": "Sarthe",
+  "73": "Savoie",
+  "74": "Haute-Savoie",
+  "75": "Paris",
+  "76": "Seine-Maritime",
+  "77": "Seine-et-Marne",
+  "78": "Yvelines",
+  "79": "Deux-Sèvres",
+  "80": "Somme",
+  "81": "Tarn",
+  "82": "Tarn-et-Garonne",
+  "83": "Var",
+  "84": "Vaucluse",
+  "85": "Vendée",
+  "86": "Vienne",
+  "87": "Haute-Vienne",
+  "88": "Vosges",
+  "89": "Yonne",
+  "90": "Territoire de Belfort",
+  "91": "Essonne",
+  "92": "Hauts-de-Seine",
+  "93": "Seine-St-Denis",
+  "94": "Val-de-Marne",
+  "95": "Val-D'Oise",
+  "971": "Guadeloupe",
+  "972": "Martinique",
+  "973": "Guyane",
+  "974": "La Réunion",
+  "975": "Saint-Pierre-et-Miquelon",
+  "976": "Mayotte",
+  "977": "Saint-Barthélemy",
+  "978": "Saint-Martin",
+  "984": "Terres australes et antarctiques françaises",
+  "986": "Wallis-et-Futuna",
+  "987": "Polynésie française",
+  "988": "Nouvelle-Calédonie",
+  "989": "Clipperton",
+} as const;
+
+type DepartmentCode = keyof typeof DEPARTMENTS;
+type DepartmentCodeValue = { label: string; icon: null; enrichable: false };
+
+export const DEPARTMENT_CODE_VALUES = Object.fromEntries(
+  Object.entries(DEPARTMENTS).map(([code, name]) => [
+    code,
+    {
+      label: `${name} (${code})`,
+      icon: null,
+      enrichable: false,
+    },
+  ]),
+) as Record<DepartmentCode, DepartmentCodeValue>;
+
+const normalizeDepartmentCode = (code: string): string => code.trim().replace(/^FR-/i, "").toUpperCase();
+
+const isDepartmentCode = (code: string): code is DepartmentCode => Object.prototype.hasOwnProperty.call(DEPARTMENTS, code);
+
+export const resolveDepartmentCodeValues = (params: unknown): string[] => {
+  if (!isRecord(params)) {
+    throw new Error("departmentCode params must be an object");
+  }
+
+  const rawCodes = params.codes ?? params.code ?? params.departmentCode;
+  const codes = Array.isArray(rawCodes) ? rawCodes : [rawCodes];
+
+  if (!codes.length || codes.some((code) => typeof code !== "string")) {
+    throw new Error("departmentCode must be a string or an array of strings");
+  }
+
+  return codes.map((code) => normalizeDepartmentCode(code as string)).map((code) => {
+    if (!isDepartmentCode(code)) {
+      throw new Error(`Unknown departmentCode: ${code}`);
+    }
+
+    return code;
+  });
+};

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -18,22 +18,30 @@ const FILTER_KEYS = ["departmentCode", "tranche_age", "type_mission", "secteur_a
 
 type FilterKey = (typeof FILTER_KEYS)[number];
 type BrowseParams = MissionBrowseFilters;
-
-const filterTaxonomyLabel = (key: FilterKey, value: string): string => {
-  const taxonomyValues = TAXONOMY[key].values as Record<string, { label: string }>;
-  return taxonomyValues[value]?.label ?? value;
-};
-
-const isTaxonomyValueHidden = (key: FilterKey, value: string): boolean => {
-  const taxonomyValues = TAXONOMY[key].values as Record<string, { hidden?: boolean }>;
-  return taxonomyValues[value]?.hidden === true;
-};
+type TaxonomyFilterValue = { label: string; hidden?: boolean };
 
 const sortFacets = (facets: MissionBrowseFacetCount[] | undefined) =>
   (facets ?? [])
     .filter((f) => f.count > 0)
     .slice()
     .sort((a, b) => b.count - a.count);
+
+const buildTaxonomyFilterOptions = (key: FilterKey, facets: MissionBrowseFacetCount[] | undefined) => {
+  const taxonomyValues = TAXONOMY[key].values as Record<string, TaxonomyFilterValue>;
+
+  return sortFacets(facets).flatMap((facet) => {
+    const taxonomyValue = taxonomyValues[facet.key];
+    if (taxonomyValue?.hidden === true) return [];
+
+    return [
+      {
+        value: facet.key,
+        label: taxonomyValue?.label ?? facet.key,
+        count: facet.count,
+      },
+    ];
+  });
+};
 
 export async function clientLoader() {
   return {};
@@ -104,11 +112,7 @@ export default function MissionsPage() {
       label: "Département",
       placeholder: "Sélectionner un département",
       selected: filterValues.departmentCode,
-      options: sortFacets(facets.departmentCodes).map((facet) => ({
-        value: facet.key,
-        label: filterTaxonomyLabel("departmentCode", facet.key),
-        count: facet.count,
-      })),
+      options: buildTaxonomyFilterOptions("departmentCode", facets.departmentCodes),
     },
     {
       key: "tranche_age",
@@ -116,46 +120,28 @@ export default function MissionsPage() {
       placeholder: "Toutes",
       selected: filterValues.tranche_age,
       single: true,
-      options: sortFacets(facets.tranche_age)
-        .filter((facet) => !isTaxonomyValueHidden("tranche_age", facet.key))
-        .map((facet) => ({
-          value: facet.key,
-          label: filterTaxonomyLabel("tranche_age", facet.key),
-          count: facet.count,
-        })),
+      options: buildTaxonomyFilterOptions("tranche_age", facets.tranche_age),
     },
     {
       key: "type_mission",
       label: "Disponibilités",
       placeholder: "Toutes",
       selected: filterValues.type_mission,
-      options: sortFacets(facets.type_mission).map((facet) => ({
-        value: facet.key,
-        label: filterTaxonomyLabel("type_mission", facet.key),
-        count: facet.count,
-      })),
+      options: buildTaxonomyFilterOptions("type_mission", facets.type_mission),
     },
     {
       key: "secteur_activite",
       label: "Activités",
       placeholder: "Toutes",
       selected: filterValues.secteur_activite,
-      options: sortFacets(facets.secteur_activite).map((facet) => ({
-        value: facet.key,
-        label: filterTaxonomyLabel("secteur_activite", facet.key),
-        count: facet.count,
-      })),
+      options: buildTaxonomyFilterOptions("secteur_activite", facets.secteur_activite),
     },
     {
       key: "domaine",
       label: "Domaine",
       placeholder: "Tous",
       selected: filterValues.domaine,
-      options: sortFacets(facets.domaine).map((facet) => ({
-        value: facet.key,
-        label: filterTaxonomyLabel("domaine", facet.key),
-        count: facet.count,
-      })),
+      options: buildTaxonomyFilterOptions("domaine", facets.domaine),
     },
   ];
 

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -17,20 +17,17 @@ const PAGE_SIZE = 9;
 const FILTER_KEYS = ["departmentCode", "tranche_age", "type_mission", "secteur_activite", "domaine"] as const satisfies readonly (keyof MissionBrowseFilters)[];
 
 type FilterKey = (typeof FILTER_KEYS)[number];
-type TaxonomyFilterKey = Exclude<FilterKey, "departmentCode">;
 type BrowseParams = MissionBrowseFilters;
 
-const filterTaxonomyLabel = (key: TaxonomyFilterKey, value: string): string => {
+const filterTaxonomyLabel = (key: FilterKey, value: string): string => {
   const taxonomyValues = TAXONOMY[key].values as Record<string, { label: string }>;
   return taxonomyValues[value]?.label ?? value;
 };
 
-const isTaxonomyValueHidden = (key: TaxonomyFilterKey, value: string): boolean => {
+const isTaxonomyValueHidden = (key: FilterKey, value: string): boolean => {
   const taxonomyValues = TAXONOMY[key].values as Record<string, { hidden?: boolean }>;
   return taxonomyValues[value]?.hidden === true;
 };
-
-const formatDepartmentLabel = (code: string): string => code.replace(/^FR-/, "");
 
 const sortFacets = (facets: MissionBrowseFacetCount[] | undefined) =>
   (facets ?? [])
@@ -109,7 +106,7 @@ export default function MissionsPage() {
       selected: filterValues.departmentCode,
       options: sortFacets(facets.departmentCodes).map((facet) => ({
         value: facet.key,
-        label: formatDepartmentLabel(facet.key),
+        label: filterTaxonomyLabel("departmentCode", facet.key),
         count: facet.count,
       })),
     },


### PR DESCRIPTION
## Description

Cette Pull Request centralise l'affichage des départements dans `@engagement/taxonomy` et met à jour le filtre des missions côté `plateform`.

Le filtre département continue d'utiliser le code comme valeur technique (`75`, `69`, etc.) afin de préserver le contrat existant avec l'API browse et l'index Typesense, mais affiche désormais un libellé lisible au format `Nom (code)`, par exemple `Paris (75)`. Ce format permet aussi de rechercher une option dans l'autocomplete par nom ou par code.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

<img width="697" height="833" alt="image" src="https://github.com/user-attachments/assets/a0e4e295-1802-4ace-bed9-911971988359" />

