### PR TITLE
feat(api): ip rate limit on plateform api routes

### DIFF
--- a/api/src/controllers/email.ts
+++ b/api/src/controllers/email.ts
@@ -3,13 +3,13 @@ import passport from "passport";
 import zod from "zod";
 
 import { EMAIL_SEND_FAILED, FORBIDDEN, INVALID_BODY, NOT_FOUND } from "@/error";
-import { ipRateLimiter } from "@/middlewares/rate-limit";
+import { plateformRateLimiter } from "@/middlewares/rate-limit";
 import { sendMissionEmail } from "@/services/mission-email";
 import type { SendMissionEmailResponse } from "@engagement/dto";
 
 const router = Router();
 router.use(passport.authenticate(["apikey", "api"], { session: false }));
-router.use(ipRateLimiter);
+router.use(plateformRateLimiter);
 
 const distinctIdSchema = zod.string().trim().min(1);
 const emailSchema = zod.preprocess((value) => (typeof value === "string" ? value.trim().toLowerCase() : value), zod.email());

--- a/api/src/controllers/email.ts
+++ b/api/src/controllers/email.ts
@@ -3,11 +3,13 @@ import passport from "passport";
 import zod from "zod";
 
 import { EMAIL_SEND_FAILED, FORBIDDEN, INVALID_BODY, NOT_FOUND } from "@/error";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { sendMissionEmail } from "@/services/mission-email";
 import type { SendMissionEmailResponse } from "@engagement/dto";
 
 const router = Router();
 router.use(passport.authenticate(["apikey", "api"], { session: false }));
+router.use(ipRateLimiter);
 
 const distinctIdSchema = zod.string().trim().min(1);
 const emailSchema = zod.preprocess((value) => (typeof value === "string" ? value.trim().toLowerCase() : value), zod.email());

--- a/api/src/controllers/mission-browse.ts
+++ b/api/src/controllers/mission-browse.ts
@@ -3,13 +3,13 @@ import passport from "passport";
 import zod from "zod";
 
 import { INVALID_QUERY, NOT_FOUND, SERVICE_UNAVAILABLE, captureException } from "@/error";
-import { ipRateLimiter } from "@/middlewares/rate-limit";
+import { plateformRateLimiter } from "@/middlewares/rate-limit";
 import { MissionBrowseIndexUnavailableError, missionBrowseService } from "@/services/mission-browse";
 import { INDEXED_TAXONOMY_KEYS } from "@/services/search/collections/missions/fields";
 
 const router = Router();
 router.use(passport.authenticate(["apikey", "api"], { session: false }));
-router.use(ipRateLimiter);
+router.use(plateformRateLimiter);
 
 const stringOrStringArraySchema = zod.union([zod.string(), zod.array(zod.string())]);
 

--- a/api/src/controllers/mission-browse.ts
+++ b/api/src/controllers/mission-browse.ts
@@ -3,11 +3,13 @@ import passport from "passport";
 import zod from "zod";
 
 import { INVALID_QUERY, NOT_FOUND, SERVICE_UNAVAILABLE, captureException } from "@/error";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { MissionBrowseIndexUnavailableError, missionBrowseService } from "@/services/mission-browse";
 import { INDEXED_TAXONOMY_KEYS } from "@/services/search/collections/missions/fields";
 
 const router = Router();
 router.use(passport.authenticate(["apikey", "api"], { session: false }));
+router.use(ipRateLimiter);
 
 const stringOrStringArraySchema = zod.union([zod.string(), zod.array(zod.string())]);
 

--- a/api/src/controllers/mission-match.ts
+++ b/api/src/controllers/mission-match.ts
@@ -3,11 +3,13 @@ import passport from "passport";
 import zod from "zod";
 
 import { INVALID_QUERY } from "@/error";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { missionMatchService } from "@/services/mission-match";
 import type { PublisherRequest } from "@/types/passport";
 
 const router = Router();
 router.use(passport.authenticate(["apikey", "api"], { session: false }));
+router.use(ipRateLimiter);
 
 const matchQuerySchema = zod.object({
   userScoringId: zod.string().uuid(),

--- a/api/src/controllers/mission-match.ts
+++ b/api/src/controllers/mission-match.ts
@@ -3,13 +3,13 @@ import passport from "passport";
 import zod from "zod";
 
 import { INVALID_QUERY } from "@/error";
-import { ipRateLimiter } from "@/middlewares/rate-limit";
+import { plateformRateLimiter } from "@/middlewares/rate-limit";
 import { missionMatchService } from "@/services/mission-match";
 import type { PublisherRequest } from "@/types/passport";
 
 const router = Router();
 router.use(passport.authenticate(["apikey", "api"], { session: false }));
-router.use(ipRateLimiter);
+router.use(plateformRateLimiter);
 
 const matchQuerySchema = zod.object({
   userScoringId: zod.string().uuid(),

--- a/api/src/controllers/user-scoring.ts
+++ b/api/src/controllers/user-scoring.ts
@@ -3,12 +3,12 @@ import passport from "passport";
 import zod from "zod";
 
 import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, NOT_FOUND } from "@/error";
-import { ipRateLimiter } from "@/middlewares/rate-limit";
+import { plateformRateLimiter } from "@/middlewares/rate-limit";
 import { UserScoringAnswerValidationError, userScoringService } from "@/services/user-scoring";
 
 const router = Router();
 router.use(passport.authenticate(["apikey", "api"], { session: false }));
-router.use(ipRateLimiter);
+router.use(plateformRateLimiter);
 
 const answerSchema = zod
   .object({

--- a/api/src/controllers/user-scoring.ts
+++ b/api/src/controllers/user-scoring.ts
@@ -3,10 +3,12 @@ import passport from "passport";
 import zod from "zod";
 
 import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, NOT_FOUND } from "@/error";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { UserScoringAnswerValidationError, userScoringService } from "@/services/user-scoring";
 
 const router = Router();
 router.use(passport.authenticate(["apikey", "api"], { session: false }));
+router.use(ipRateLimiter);
 
 const answerSchema = zod
   .object({

--- a/api/src/middlewares/rate-limit.ts
+++ b/api/src/middlewares/rate-limit.ts
@@ -37,5 +37,28 @@ export const createIpRateLimiter = (limit = RATE_LIMIT_IP_MAX): RateLimitRequest
     skip: isDisabled,
   });
 
+// 120 req/min par IP utilisateur final — routes plateform (appels S2S authentifiés).
+// La clé est lue depuis x-platform-client-ip, header injecté par le serveur Express
+// de la plateform (depuis req.ip après trust proxy : non-spoofable par le user).
+// Seules les routes déjà protégées par passport.authenticate font confiance à ce header.
+// Fallback sur req.ip si le header est absent (appel direct, hors plateform).
+export const createPlateformRateLimiter = (limit = RATE_LIMIT_IP_MAX): RateLimitRequestHandler =>
+  rateLimit({
+    windowMs: 60_000,
+    limit,
+    keyGenerator: (req) => {
+      const clientIp = req.headers["x-platform-client-ip"];
+
+      if (clientIp && typeof clientIp === "string") {
+        return clientIp;
+      }
+
+      return ipKeyGenerator(req.ip ?? "");
+    },
+    handler,
+    skip: isDisabled,
+  });
+
 export const publisherRateLimiter = createPublisherRateLimiter();
 export const ipRateLimiter = createIpRateLimiter();
+export const plateformRateLimiter = createPlateformRateLimiter();

--- a/api/src/services/observability/metrics.ts
+++ b/api/src/services/observability/metrics.ts
@@ -7,6 +7,8 @@ const HISTOGRAM_BUCKETS = [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30,
 const METRICS_EXPORT_INTERVAL_MS = 30000;
 const SERVICE_NAME = "api-engagement-api";
 const TRACKED_PREFIXES = ["/v0/", "/v2/"];
+// API Endpoints call by the plateform in S2S
+const PLATEFORM_PREFIXES = ["/missions/browse", "/missions/match", "/user-scoring", "/email/mission"];
 
 export interface RecordedHttpRequestMetric {
   durationSeconds: number;
@@ -81,7 +83,7 @@ const getPublisherId = (req: Request) => {
   return String(user.id);
 };
 
-const shouldTrackPath = (pathname: string) => TRACKED_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+const shouldTrackPath = (pathname: string) => TRACKED_PREFIXES.some((prefix) => pathname.startsWith(prefix)) || PLATEFORM_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 
 const createActiveRecorder = (config: Required<Pick<HttpMetricsConfig, "environment" | "otlpUrl" | "token">>): HttpMetricsRecorder => {
   const exporter = new OTLPMetricExporter({

--- a/api/src/services/observability/metrics.ts
+++ b/api/src/services/observability/metrics.ts
@@ -6,9 +6,7 @@ import { Request, RequestHandler } from "express";
 const HISTOGRAM_BUCKETS = [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60];
 const METRICS_EXPORT_INTERVAL_MS = 30000;
 const SERVICE_NAME = "api-engagement-api";
-const TRACKED_PREFIXES = ["/v0/", "/v2/"];
-// API Endpoints call by the plateform in S2S
-const PLATEFORM_PREFIXES = ["/missions/browse", "/missions/match", "/user-scoring", "/email/mission"];
+const TRACKED_PREFIXES = ["/v0/", "/v2/", "/missions/browse", "/missions/match", "/user-scoring", "/email/mission"];
 
 export interface RecordedHttpRequestMetric {
   durationSeconds: number;
@@ -83,7 +81,7 @@ const getPublisherId = (req: Request) => {
   return String(user.id);
 };
 
-const shouldTrackPath = (pathname: string) => TRACKED_PREFIXES.some((prefix) => pathname.startsWith(prefix)) || PLATEFORM_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+const shouldTrackPath = (pathname: string) => TRACKED_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 
 const createActiveRecorder = (config: Required<Pick<HttpMetricsConfig, "environment" | "otlpUrl" | "token">>): HttpMetricsRecorder => {
   const exporter = new OTLPMetricExporter({

--- a/plateform/app/routes/_index.tsx
+++ b/plateform/app/routes/_index.tsx
@@ -28,9 +28,9 @@ export function meta(): Route.MetaDescriptors {
   ];
 }
 
-export async function loader(): Promise<{ examples: BrowseMission[]; testimonials: BrowseMission[] }> {
+export async function loader({ request }: Route.LoaderArgs): Promise<{ examples: BrowseMission[]; testimonials: BrowseMission[] }> {
   try {
-    const res = await browseMissions({ pageSize: EXAMPLES_COUNT + TESTIMONIALS_COUNT });
+    const res = await browseMissions({ pageSize: EXAMPLES_COUNT + TESTIMONIALS_COUNT }, request);
     return {
       examples: res.data.slice(0, EXAMPLES_COUNT),
       testimonials: res.data.slice(EXAMPLES_COUNT, EXAMPLES_COUNT + TESTIMONIALS_COUNT),

--- a/plateform/app/routes/api.email.mission.ts
+++ b/plateform/app/routes/api.email.mission.ts
@@ -1,12 +1,13 @@
 import type { SendMissionEmailRequest, SendMissionEmailResponse } from "@engagement/dto";
 import type { ActionFunctionArgs } from "react-router";
 
-import { api, upstreamErrorResponse } from "~/services/api";
+import { createApi, upstreamErrorResponse } from "~/services/api";
 
 export async function action({ request }: ActionFunctionArgs) {
+  const api = createApi(request);
   try {
     const body = (await request.json()) as SendMissionEmailRequest;
-    const data = await api.post<SendMissionEmailResponse>("/email/mission", body, request.signal);
+    const data = await api.post<SendMissionEmailResponse>("/email/mission", body);
     return Response.json({ ok: true, data });
   } catch (error) {
     return upstreamErrorResponse(error);

--- a/plateform/app/routes/api.missions.browse.$id.ts
+++ b/plateform/app/routes/api.missions.browse.$id.ts
@@ -1,13 +1,14 @@
 import type { MissionDetailResponse } from "@engagement/dto";
 import type { LoaderFunctionArgs } from "react-router";
 
-import { api, upstreamErrorResponse } from "~/services/api";
+import { createApi, upstreamErrorResponse } from "~/services/api";
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const { id } = params;
   if (!id) return Response.json({ ok: false, code: "MISSING_ID" }, { status: 400 });
+  const api = createApi(request);
   try {
-    const data = await api.get<MissionDetailResponse>(`/missions/browse/${id}`, request.signal);
+    const data = await api.get<MissionDetailResponse>(`/missions/browse/${id}`);
     return Response.json({ ok: true, data });
   } catch (error) {
     return upstreamErrorResponse(error);

--- a/plateform/app/routes/api.missions.browse.ts
+++ b/plateform/app/routes/api.missions.browse.ts
@@ -1,12 +1,13 @@
 import type { MissionBrowseResponse } from "@engagement/dto";
 import type { LoaderFunctionArgs } from "react-router";
 
-import { api, upstreamErrorResponse } from "~/services/api";
+import { createApi, upstreamErrorResponse } from "~/services/api";
 
 export async function loader({ request }: LoaderFunctionArgs) {
+  const api = createApi(request);
   const url = new URL(request.url);
   try {
-    const data = await api.get<MissionBrowseResponse>(`/missions/browse?${url.searchParams}`, request.signal);
+    const data = await api.get<MissionBrowseResponse>(`/missions/browse?${url.searchParams}`);
     return Response.json({ ok: true, data });
   } catch (error) {
     return upstreamErrorResponse(error);

--- a/plateform/app/routes/api.missions.match.ts
+++ b/plateform/app/routes/api.missions.match.ts
@@ -1,12 +1,13 @@
 import type { MissionMatchResponse } from "@engagement/dto";
 import type { LoaderFunctionArgs } from "react-router";
 
-import { api, upstreamErrorResponse } from "~/services/api";
+import { createApi, upstreamErrorResponse } from "~/services/api";
 
 export async function loader({ request }: LoaderFunctionArgs) {
+  const api = createApi(request);
   const url = new URL(request.url);
   try {
-    const data = await api.get<MissionMatchResponse>(`/missions/match?${url.searchParams}`, request.signal);
+    const data = await api.get<MissionMatchResponse>(`/missions/match?${url.searchParams}`);
     return Response.json({ ok: true, data });
   } catch (error) {
     return upstreamErrorResponse(error);

--- a/plateform/app/routes/api.user-scoring.$id.ts
+++ b/plateform/app/routes/api.user-scoring.$id.ts
@@ -1,13 +1,14 @@
 import type { ActionFunctionArgs } from "react-router";
 
-import { api, upstreamErrorResponse } from "~/services/api";
+import { createApi, upstreamErrorResponse } from "~/services/api";
 
 export async function action({ params, request }: ActionFunctionArgs) {
   const { id } = params;
   if (!id) return Response.json({ ok: false, code: "MISSING_ID" }, { status: 400 });
+  const api = createApi(request);
   try {
     const body = await request.json();
-    await api.put(`/user-scoring/${id}`, body, request.signal);
+    await api.put(`/user-scoring/${id}`, body);
     return Response.json({ ok: true, data: null });
   } catch (error) {
     return upstreamErrorResponse(error);

--- a/plateform/app/routes/api.user-scoring.ts
+++ b/plateform/app/routes/api.user-scoring.ts
@@ -1,12 +1,13 @@
 import type { UserScoringCreateRequest, UserScoringCreateResponse } from "@engagement/dto";
 import type { ActionFunctionArgs } from "react-router";
 
-import { api, upstreamErrorResponse } from "~/services/api";
+import { createApi, upstreamErrorResponse } from "~/services/api";
 
 export async function action({ request }: ActionFunctionArgs) {
+  const api = createApi(request);
   try {
     const body = (await request.json()) as UserScoringCreateRequest;
-    const data = await api.post<UserScoringCreateResponse>("/user-scoring", body, request.signal);
+    const data = await api.post<UserScoringCreateResponse>("/user-scoring", body);
     return Response.json({ ok: true, data });
   } catch (error) {
     return upstreamErrorResponse(error);

--- a/plateform/app/services/api/__tests__/index.test.ts
+++ b/plateform/app/services/api/__tests__/index.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { UpstreamApiError, api, upstreamErrorResponse } from "../index";
+import { UpstreamApiError, createApi, upstreamErrorResponse } from "../index";
+
+const fakeRequest = (ip?: string) =>
+  new Request("http://localhost", {
+    headers: ip ? { "x-envoy-external-address": ip } : {},
+  });
 
 const mockFetch = (status: number, body: unknown, ok = status >= 200 && status < 300) => {
   return vi.fn().mockResolvedValue({
@@ -24,19 +29,16 @@ describe("api.get", () => {
     const fetchMock = mockFetch(200, { ok: true, data: { id: 1 } });
     vi.stubGlobal("fetch", fetchMock);
 
-    await api.get("/missions");
+    await createApi(fakeRequest()).get("/missions");
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://fake-api.test/missions",
-      expect.objectContaining({ method: "GET" })
-    );
+    expect(fetchMock).toHaveBeenCalledWith("http://fake-api.test/missions", expect.objectContaining({ method: "GET" }));
   });
 
   it("inclut le header x-api-key", async () => {
     const fetchMock = mockFetch(200, { ok: true, data: {} });
     vi.stubGlobal("fetch", fetchMock);
 
-    await api.get("/missions");
+    await createApi(fakeRequest()).get("/missions");
 
     const [, options] = fetchMock.mock.calls[0];
     expect(options.headers).toMatchObject({ "x-api-key": "test-key" });
@@ -45,13 +47,14 @@ describe("api.get", () => {
   it("retourne data de l'enveloppe JSON", async () => {
     vi.stubGlobal("fetch", mockFetch(200, { ok: true, data: { id: 42, title: "Test" } }));
 
-    const result = await api.get<{ id: number; title: string }>("/missions/42");
+    const result = await createApi(fakeRequest()).get<{ id: number; title: string }>("/missions/42");
 
     expect(result).toEqual({ id: 42, title: "Test" });
   });
 
   it("lève UpstreamApiError si response.ok est false", async () => {
     vi.stubGlobal("fetch", mockFetch(404, { ok: false, code: "NOT_FOUND" }, false));
+    const api = createApi(fakeRequest());
 
     await expect(api.get("/missions/999")).rejects.toThrow(UpstreamApiError);
     await expect(api.get("/missions/999")).rejects.toMatchObject({ status: 404 });
@@ -60,13 +63,13 @@ describe("api.get", () => {
   it("lève UpstreamApiError si json.ok est false même avec HTTP 200", async () => {
     vi.stubGlobal("fetch", mockFetch(200, { ok: false, code: "BUSINESS_ERROR" }));
 
-    await expect(api.get("/missions")).rejects.toThrow(UpstreamApiError);
+    await expect(createApi(fakeRequest()).get("/missions")).rejects.toThrow(UpstreamApiError);
   });
 
   it("lève UpstreamApiError(502) en cas d'erreur réseau", async () => {
     vi.stubGlobal("fetch", mockFetchNetworkError());
 
-    await expect(api.get("/missions")).rejects.toMatchObject({ status: 502 });
+    await expect(createApi(fakeRequest()).get("/missions")).rejects.toMatchObject({ status: 502 });
   });
 
   it("gère un body 401 sans JSON valide (retourne UNAUTHORIZED)", async () => {
@@ -74,15 +77,40 @@ describe("api.get", () => {
       ...vi.fn(),
       mockResolvedValue: undefined,
     });
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
-      ok: false,
-      status: 401,
-      json: () => Promise.reject(new Error("no json")),
-    } as unknown as Response));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.reject(new Error("no json")),
+      } as unknown as Response),
+    );
 
-    const err = await api.get("/missions").catch((e) => e);
+    const err = await createApi(fakeRequest())
+      .get("/missions")
+      .catch((e: unknown) => e);
     expect(err).toBeInstanceOf(UpstreamApiError);
-    expect(err.body.code).toBe("UNAUTHORIZED");
+    expect((err as UpstreamApiError).body.code).toBe("UNAUTHORIZED");
+  });
+
+  it("forwarde x-platform-client-ip quand l'IP est fournie via x-envoy-external-address", async () => {
+    const fetchMock = mockFetch(200, { ok: true, data: {} });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createApi(fakeRequest("1.2.3.4")).get("/missions");
+
+    const [, options] = fetchMock.mock.calls[0];
+    expect(options.headers).toMatchObject({ "x-platform-client-ip": "1.2.3.4" });
+  });
+
+  it("n'inclut pas x-platform-client-ip si x-envoy-external-address est absent", async () => {
+    const fetchMock = mockFetch(200, { ok: true, data: {} });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createApi(fakeRequest()).get("/missions");
+
+    const [, options] = fetchMock.mock.calls[0];
+    expect(options.headers?.["x-platform-client-ip"]).toBeUndefined();
   });
 });
 
@@ -91,7 +119,7 @@ describe("api.post", () => {
     const fetchMock = mockFetch(200, { ok: true, data: { id: 1 } });
     vi.stubGlobal("fetch", fetchMock);
 
-    await api.post("/user-scoring", { answers: [] });
+    await createApi(fakeRequest()).post("/user-scoring", { answers: [] });
 
     const [, options] = fetchMock.mock.calls[0];
     expect(options.method).toBe("POST");
@@ -103,7 +131,7 @@ describe("api.post", () => {
     const fetchMock = mockFetch(200, { ok: true, data: {} });
     vi.stubGlobal("fetch", fetchMock);
 
-    await api.post("/user-scoring");
+    await createApi(fakeRequest()).post("/user-scoring");
 
     const [, options] = fetchMock.mock.calls[0];
     expect(options.headers?.["Content-Type"]).toBeUndefined();
@@ -115,7 +143,7 @@ describe("api.put", () => {
     const fetchMock = mockFetch(200, { ok: true, data: {} });
     vi.stubGlobal("fetch", fetchMock);
 
-    await api.put("/user-scoring/123", { answers: [] });
+    await createApi(fakeRequest()).put("/user-scoring/123", { answers: [] });
 
     const [, options] = fetchMock.mock.calls[0];
     expect(options.method).toBe("PUT");

--- a/plateform/app/services/api/index.ts
+++ b/plateform/app/services/api/index.ts
@@ -11,7 +11,7 @@ type ApiEnvelope<T = unknown> = {
 export class UpstreamApiError extends Error {
   constructor(
     public readonly status: number,
-    public readonly body: ApiEnvelope
+    public readonly body: ApiEnvelope,
   ) {
     super(body.code ?? body.message ?? `API error ${status}`);
   }
@@ -34,10 +34,14 @@ const readJsonEnvelope = async <T>(response: Response): Promise<ApiEnvelope<T>> 
   }
 };
 
-async function serverRequest<T>(method: string, path: string, body?: unknown, signal?: AbortSignal): Promise<T> {
+async function serverRequest<T>(method: string, path: string, body?: unknown, signal?: AbortSignal, clientIp?: string): Promise<T> {
   const headers: Record<string, string> = {};
   if (apiKey) headers["x-api-key"] = apiKey;
   if (body !== undefined) headers["Content-Type"] = "application/json";
+  // Forwarde l'IP réelle du navigateur (X-Envoy-External-Address injecté par Scaleway,
+  // non-spoofable) pour que le rate-limit côté API opère par utilisateur final
+  // et non par container plateform.
+  if (clientIp) headers["x-platform-client-ip"] = clientIp;
 
   let response: Response;
   try {
@@ -65,8 +69,22 @@ export const upstreamErrorResponse = (error: unknown) => {
   return Response.json({ ok: false, code: "upstream_error", message: "Upstream API unavailable" }, { status: 502 });
 };
 
-export const api = {
-  get: <T>(path: string, signal?: AbortSignal) => serverRequest<T>("GET", path, undefined, signal),
-  post: <T>(path: string, body?: unknown, signal?: AbortSignal) => serverRequest<T>("POST", path, body, signal),
-  put: <T>(path: string, body?: unknown, signal?: AbortSignal) => serverRequest<T>("PUT", path, body, signal),
+/**
+ * Crée une instance de l'API client liée à la requête entrante.
+ * Le signal d'annulation et l'IP cliente (X-Envoy-External-Address) sont
+ * extraits automatiquement — les routes n'ont pas à les passer explicitement.
+ *
+ * Usage dans un loader/action :
+ *   const api = createApi(request);
+ *   const data = await api.get<MyType>("/path");
+ */
+export const createApi = (request: Request) => {
+  const clientIp = request.headers.get("x-envoy-external-address") ?? undefined;
+  const { signal } = request;
+
+  return {
+    get: <T>(path: string) => serverRequest<T>("GET", path, undefined, signal, clientIp),
+    post: <T>(path: string, body?: unknown) => serverRequest<T>("POST", path, body, signal, clientIp),
+    put: <T>(path: string, body?: unknown) => serverRequest<T>("PUT", path, body, signal, clientIp),
+  };
 };

--- a/plateform/app/services/api/missions.ts
+++ b/plateform/app/services/api/missions.ts
@@ -1,12 +1,14 @@
 import type { MissionBrowseFilters, MissionBrowseResponse } from "@engagement/dto";
-import { api } from "~/services/api";
+
+import { createApi } from "~/services/api";
 
 const appendMulti = (params: URLSearchParams, key: string, values?: string | string[]) => {
   if (!values?.length) return;
   for (const value of Array.isArray(values) ? values : [values]) params.append(key, value);
 };
 
-export async function browseMissions(filters: MissionBrowseFilters, signal?: AbortSignal): Promise<MissionBrowseResponse> {
+export async function browseMissions(filters: MissionBrowseFilters, request: Request): Promise<MissionBrowseResponse> {
+  const api = createApi(request);
   const params = new URLSearchParams();
   if (filters.page) params.set("page", String(filters.page));
   if (filters.pageSize) params.set("pageSize", String(filters.pageSize));
@@ -17,5 +19,5 @@ export async function browseMissions(filters: MissionBrowseFilters, signal?: Abo
   appendMulti(params, "type_mission", filters.type_mission);
   appendMulti(params, "tranche_age", filters.tranche_age);
 
-  return api.get<MissionBrowseResponse>(`/missions/browse?${params.toString()}`, signal);
+  return api.get<MissionBrowseResponse>(`/missions/browse?${params.toString()}`);
 }


### PR DESCRIPTION
## Description

Les routes de la plateform (`/missions/browse`, `/missions/match`, `/email/mission`, `/user-scoring`) sont appelées en **serveur-à-serveur** par le proxy de la plateform. Sans modification, tous ces appels arrivaient sur l'API avec la même IP (celle du container plateform), ce qui faisait tomber l'ensemble des utilisateurs finaux dans un unique bucket de rate limiting.

### Solution mise en place

**Côté plateform (`app`) :**

- Remplacement du singleton `api` par une factory `createApi(request)` qui extrait automatiquement deux informations de la requête entrante :
  - le signal d'annulation (`request.signal`) pour propager les déconnexions client
  - l'IP réelle de l'utilisateur final via le header **`X-Envoy-External-Address`**, injecté par le proxy Envoy de Scaleway et non spoofable côté navigateur
- Cette IP est forwardée vers l'API sous le header custom `x-platform-client-ip`
- Toutes les routes proxy (`api.*`) et le loader de la landing page utilisent désormais `createApi(request)`

**Côté API :**

- Ajout d'un nouveau middleware `plateformRateLimiter` (120 req/min) dont la clé est `x-platform-client-ip` si présent, avec fallback sur `req.ip`
- Ce middleware est appliqué **après** `passport.authenticate` sur les 4 controllers concernés — seul un appelant avec une clé publisher valide peut l'atteindre, ce qui garantit que le header ne peut pas être injecté par un utilisateur final

### Garanties de sécurité

| Scénario | Protection |
|---|---|
| Utilisateur final via plateform | Rate limit par IP réelle (Envoy) |
| Partenaire direct sans clé | Bloqué par `passport.authenticate` |
| Partenaire direct avec clé | Fallback sur `req.ip` (IP du partenaire) |


## Liens utiles

- 📝 Ticket Notion : https://www.notion.so/jeveuxaider/Rate-limit-observabilit-plateform-36872a322d50801e9fa9e748ede1626f?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Le header `X-Envoy-External-Address` est utilisé à la place de `X-Forwarded-For` car Scaleway **remplace** ce header (ne l'append pas), ce qui en fait la source de vérité non manipulable pour l'IP cliente. Référence : [Scaleway — request headers](https://www.scaleway.com/en/docs/serverless-containers/reference-content/request-headers/).