### PR TITLE
fix(api): returns HTTP 400 on v0/mission with incorrect type

### DIFF
--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -1605,10 +1605,12 @@ paths:
           schema:
             oneOf:
               - type: string
+                enum: [benevolat, volontariat_service_civique, volontariat_sapeurs_pompiers, volontariat_reserve_operationnelle]
               - type: array
                 items:
                   type: string
-          description: "Type d'engagement : benevolat, volontariat_service_civique, volontariat_sapeurs_pompiers, volontariat_reserve_operationnelle"
+                  enum: [benevolat, volontariat_service_civique, volontariat_sapeurs_pompiers, volontariat_reserve_operationnelle]
+          description: "Type d'engagement"
         - name: remote
           in: query
           schema:

--- a/api/src/v0/mission/controller.ts
+++ b/api/src/v0/mission/controller.ts
@@ -37,6 +37,8 @@ const toYesNo = (value: unknown) => {
   return value;
 };
 
+const MISSION_TYPES = ["benevolat", "volontariat_service_civique", "volontariat_sapeurs_pompiers", "volontariat_reserve_operationnelle"] as const;
+
 export const missionQuerySchema = zod.object({
   activity: zod.union([zod.string(), zod.array(zod.string())]).optional(),
   city: zod.union([zod.string(), zod.array(zod.string())]).optional(),
@@ -62,7 +64,7 @@ export const missionQuerySchema = zod.object({
     .transform((value) => value === "true")
     .optional(),
   startAt: zod.string().optional(),
-  type: zod.union([zod.string(), zod.array(zod.string())]).optional(),
+  type: zod.union([zod.enum(MISSION_TYPES), zod.array(zod.enum(MISSION_TYPES))]).optional(),
 });
 
 const router = Router();

--- a/api/src/v0/mission/controller.ts
+++ b/api/src/v0/mission/controller.ts
@@ -2,6 +2,7 @@ import { NextFunction, Response, Router } from "express";
 import passport from "passport";
 import zod from "zod";
 
+import { MissionType } from "@/db/core";
 import { INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
 import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { missionService } from "@/services/mission";
@@ -37,8 +38,6 @@ const toYesNo = (value: unknown) => {
   return value;
 };
 
-const MISSION_TYPES = ["benevolat", "volontariat_service_civique", "volontariat_sapeurs_pompiers", "volontariat_reserve_operationnelle"] as const;
-
 export const missionQuerySchema = zod.object({
   activity: zod.union([zod.string(), zod.array(zod.string())]).optional(),
   city: zod.union([zod.string(), zod.array(zod.string())]).optional(),
@@ -64,7 +63,7 @@ export const missionQuerySchema = zod.object({
     .transform((value) => value === "true")
     .optional(),
   startAt: zod.string().optional(),
-  type: zod.union([zod.enum(MISSION_TYPES), zod.array(zod.enum(MISSION_TYPES))]).optional(),
+  type: zod.union([zod.enum(MissionType), zod.array(zod.enum(MissionType))]).optional(),
 });
 
 const router = Router();

--- a/api/tests/integration/api/endpoints/v0/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v0/mission.test.ts
@@ -308,6 +308,11 @@ describe("Mission API Integration Tests", () => {
       expect(response.body.data[0].type).toBe("volontariat_service_civique");
     });
 
+    it("should return 400 for an invalid type value", async () => {
+      const response = await request(app).get("/v0/mission?type=volontariat").set("x-api-key", apiKey);
+      expect(response.status).toBe(400);
+    });
+
     it("should filter by createdAt (gt)", async () => {
       const date = new Date();
       date.setSeconds(date.getSeconds() - 1);


### PR DESCRIPTION
## Description

Le paramètre `type` de l'endpoint `GET /v0/mission` acceptait n'importe quelle chaîne sans validation. Quand un partenaire passait une valeur invalide (ex. `type=volontariat`), la requête atteignait Prisma qui levait une `PrismaClientValidationError` — remontée en 500 dans Sentry.

**Changements :**
- Validation Zod du paramètre `type` avec `z.enum(MissionType)` (enum Prisma) → renvoie un 400 `INVALID_QUERY` sur valeur invalide
- Mise à jour de la doc OpenAPI : le schéma du paramètre `type` expose maintenant les 4 valeurs comme enum (pas seulement dans la description textuelle)
- Ajout d'un test d'intégration couvrant le cas `type=volontariat` → 400

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/Erreur-Sentry-v2-mission-36d72a322d50808cbe2cf0b60d6138fc?source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Les valeurs valides pour `type` sont : `benevolat`, `volontariat_service_civique`, `volontariat_sapeurs_pompiers`, `volontariat_reserve_operationnelle`.