### PR TITLE
fix(plateform): quiz ui improvments

### DIFF
--- a/packages/taxonomy/src/taxonomy.ts
+++ b/packages/taxonomy/src/taxonomy.ts
@@ -207,12 +207,11 @@ export const TAXONOMY = {
     enrichable: true,
     gate: false,
     values: {
-      // Branche "Partir à l'étranger" pas encore disponible : options grisées (cf. `disabled`).
-      europe: { label: "Europe", icon: null, enrichable: true, disabled: true },
-      afrique: { label: "Afrique", icon: null, enrichable: true, disabled: true },
-      amerique: { label: "Amérique", icon: null, enrichable: true, disabled: true },
-      asie: { label: "Asie", icon: null, enrichable: true, disabled: true },
-      je_ne_sais_pas: { label: "Je ne sais pas encore", icon: null, enrichable: false, disabled: true },
+      europe: { label: "Europe", icon: null, enrichable: true },
+      afrique: { label: "Afrique", icon: null, enrichable: true },
+      amerique: { label: "Amérique", icon: null, enrichable: true },
+      asie: { label: "Asie", icon: null, enrichable: true },
+      je_ne_sais_pas: { label: "Je ne sais pas encore", icon: null, enrichable: false },
     },
   },
 

--- a/packages/taxonomy/src/taxonomy.ts
+++ b/packages/taxonomy/src/taxonomy.ts
@@ -198,6 +198,7 @@ export const TAXONOMY = {
       relation_client_commerce_strategie: { label: "Relation client, commerce, stratégie", icon: "📈", enrichable: true },
       cooperation_organisation_soft_skills: { label: "Coopération, organisation, soft skills", icon: "🤝", enrichable: true },
       securite_environnement_action_publique: { label: "Protection des personnes, de la société ou de l'environnement", icon: "🛡️", enrichable: true },
+      je_ne_sais_pas: { label: "Autre / Je ne sais pas", icon: "‍‍🤔‍", enrichable: false },
     },
   },
 

--- a/packages/taxonomy/src/taxonomy.ts
+++ b/packages/taxonomy/src/taxonomy.ts
@@ -12,6 +12,7 @@
 //   sublabel   — aide contextuelle optionnelle pour les UIs
 //   icon       — emoji optionnel
 //   enrichable — false pour les valeurs exclues de l'enrichissement (ex : je_ne_sais_pas)
+//   disabled   — true pour griser l'option en UI (fonctionnalité pas encore disponible)
 
 import { DEPARTMENT_CODE_VALUES, resolveDepartmentCodeValues } from "./transformers/department-code";
 import { resolveLocationValues } from "./transformers/location";
@@ -206,11 +207,12 @@ export const TAXONOMY = {
     enrichable: true,
     gate: false,
     values: {
-      europe: { label: "Europe", icon: null, enrichable: true },
-      afrique: { label: "Afrique", icon: null, enrichable: true },
-      amerique: { label: "Amérique", icon: null, enrichable: true },
-      asie: { label: "Asie", icon: null, enrichable: true },
-      je_ne_sais_pas: { label: "Je ne sais pas encore", icon: null, enrichable: false },
+      // Branche "Partir à l'étranger" pas encore disponible : options grisées (cf. `disabled`).
+      europe: { label: "Europe", icon: null, enrichable: true, disabled: true },
+      afrique: { label: "Afrique", icon: null, enrichable: true, disabled: true },
+      amerique: { label: "Amérique", icon: null, enrichable: true, disabled: true },
+      asie: { label: "Asie", icon: null, enrichable: true, disabled: true },
+      je_ne_sais_pas: { label: "Je ne sais pas encore", icon: null, enrichable: false, disabled: true },
     },
   },
 
@@ -336,6 +338,7 @@ export const TAXONOMY = {
         sublabel: "Vivre une expérience d'engagement dans un autre pays",
         icon: "🌍",
         enrichable: false,
+        disabled: true,
       },
       competences_interet_general: {
         label: "Utiliser mes compétences pour l'intérêt général",

--- a/packages/taxonomy/src/taxonomy.ts
+++ b/packages/taxonomy/src/taxonomy.ts
@@ -285,7 +285,7 @@ export const TAXONOMY = {
     gate: false,
     values: {
       me_sentir_utile: {
-        label: "Aider les autres",
+        label: "Me sentir utile, rencontrer de nouvelles personnes",
         sublabel: "Être utile à des personnes ou à une cause",
         icon: "🙏🏻",
         enrichable: false,
@@ -389,12 +389,12 @@ export const TAXONOMY = {
     enrichable: false,
     gate: false,
     values: {
-      armee: { label: "Armée", sublabel: "Marine, Air, Santé...", icon: null, enrichable: false },
-      pompiers: { label: "Pompiers", icon: null, enrichable: false },
-      gendarmerie: { label: "Gendarmerie", icon: null, enrichable: false },
-      police: { label: "Police", icon: null, enrichable: false },
-      ne_sais_pas: { label: "Je ne sais pas", icon: null, enrichable: false },
-      aucun: { label: "Aucun de ces choix", icon: null, enrichable: false },
+      armee: { label: "Armée", sublabel: "Marine, Air, Santé...", icon: "🪖", enrichable: false },
+      pompiers: { label: "Pompiers", sublabel: "Aide à la personne, secours, urgences...", icon: "🚒", enrichable: false },
+      gendarmerie: { label: "Gendarmerie", sublabel: "Sécurité, territoire, enquêtes...", icon: "⚖️", enrichable: false },
+      police: { label: "Police", sublabel: "Ordre public, investigation, protection...", icon: "🚔", enrichable: false },
+      ne_sais_pas: { label: "Je ne sais pas", sublabel: "Aidez-moi à découvrir ma voie", icon: "🤔", enrichable: false },
+      aucun: { label: "Aucun de ces choix", sublabel: "Je cherche autre chose", icon: "🙅", enrichable: false },
     },
   },
 

--- a/packages/taxonomy/src/taxonomy.ts
+++ b/packages/taxonomy/src/taxonomy.ts
@@ -261,7 +261,6 @@ export const TAXONOMY = {
       etudiant: { label: "Je fais des études", icon: "🎓", enrichable: false },
       demandeur_emploi: { label: "Je recherche un emploi", icon: "🕵️‍♂️", enrichable: false },
       actif: { label: "J’ai une activité professionnelle", icon: "💼", enrichable: false },
-      retraite: { label: "Je suis à la retraite", icon: "👴", enrichable: false },
       autre: { label: "Autre situation", icon: "🤷", enrichable: false },
     },
   },

--- a/packages/taxonomy/src/types.ts
+++ b/packages/taxonomy/src/types.ts
@@ -31,6 +31,7 @@ export type TaxonomyValueItem = {
   order: number;
   enrichable: boolean;
   hidden?: boolean;
+  disabled?: boolean;
 };
 
 export type TaxonomyListItem = {

--- a/packages/taxonomy/src/utils.ts
+++ b/packages/taxonomy/src/utils.ts
@@ -46,14 +46,17 @@ export function getTaxonomyList(): TaxonomyListItem[] {
     type: dim.type,
     enrichable: dim.enrichable,
     gate: dim.gate,
-    values: (Object.entries(dim.values) as [string, { label: string; sublabel?: string; icon: string | null; enrichable: boolean; hidden?: boolean }][]).map(([vKey, val], i) => ({
-      key: vKey,
-      label: val.label,
-      sublabel: val.sublabel,
-      icon: val.icon,
-      order: i,
-      enrichable: val.enrichable,
-      hidden: val.hidden,
-    })),
+    values: (Object.entries(dim.values) as [string, { label: string; sublabel?: string; icon: string | null; enrichable: boolean; hidden?: boolean; disabled?: boolean }][]).map(
+      ([vKey, val], i) => ({
+        key: vKey,
+        label: val.label,
+        sublabel: val.sublabel,
+        icon: val.icon,
+        order: i,
+        enrichable: val.enrichable,
+        hidden: val.hidden,
+        disabled: val.disabled,
+      })
+    ),
   }));
 }

--- a/plateform/app/components/quiz/checkbox-group-rich.tsx
+++ b/plateform/app/components/quiz/checkbox-group-rich.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { DISABLED_OPTION_HINT } from "~/config/quiz-options";
 import type { StepOption } from "~/types/quiz";
 
 type Props = {
@@ -29,7 +30,7 @@ export default function CheckboxGroupRich({ title, subtitle, onChange, options, 
       </legend>
       <div className="fr-fieldset__content grid grid-cols-1 md:grid-cols-2 max-w-4xl! mx-0! gap-x-6 gap-y-4!">
         {options.map((o) => (
-          <div key={o.value} className="fr-fieldset__element mb-0!">
+          <div key={o.value} className={`fr-fieldset__element mb-0! ${o.disabled ? "opacity-60" : ""}`}>
             <div className="fr-checkbox-group fr-checkbox-rich mt-0! mb-0!">
               <input
                 value={o.value}
@@ -37,11 +38,15 @@ export default function CheckboxGroupRich({ title, subtitle, onChange, options, 
                 id={`checkbox-group-rich-${o.value}`}
                 name="checkbox-group-rich"
                 onChange={() => toggle(o.value)}
-                checked={selected.includes(o.value)}
+                checked={!o.disabled && selected.includes(o.value)}
+                disabled={o.disabled}
               />
-              <label className="fr-label text-base before:size-4! after:absolute after:inset-0 after:right-[-5.5rem] after:content-['']" htmlFor={`checkbox-group-rich-${o.value}`}>
+              <label
+                className={`fr-label text-base before:size-4! after:absolute after:inset-0 after:right-[-5.5rem] after:content-[''] ${o.disabled ? "cursor-not-allowed!" : ""}`}
+                htmlFor={`checkbox-group-rich-${o.value}`}
+              >
                 {o.label}
-                {o.sublabel && <span className="fr-hint-text">{o.sublabel}</span>}
+                {o.disabled ? <span className="fr-hint-text">{DISABLED_OPTION_HINT}</span> : o.sublabel && <span className="fr-hint-text">{o.sublabel}</span>}
               </label>
               <div className="fr-checkbox-rich__pictogram">{o.icon && <div className="text-2xl">{o.icon}</div>}</div>
             </div>

--- a/plateform/app/components/quiz/loading-recap.tsx
+++ b/plateform/app/components/quiz/loading-recap.tsx
@@ -1,29 +1,79 @@
-import { useEffect, useState } from "react";
+import type { TaxonomyValueKey } from "@engagement/taxonomy";
+import { useEffect, useMemo, useState } from "react";
+import { OPTIONS } from "~/config/quiz-options";
+import { prefetchInitialMatches } from "~/services/matching";
+import { useQuizStore } from "~/stores/quiz";
 
 type Props = {
-  items: string[];
   onComplete: () => void;
 };
 
-export default function LoadingRecap({ items, onComplete }: Props) {
+// Steps résumés à l'écran, dans l'ordre d'affichage.
+const RECAP_STEP_IDS = ["statut", "duree", "motivation"] as const;
+
+const REVEAL_INTERVAL_MS = 900;
+const POST_REVEAL_PAUSE_MS = 800;
+const EXIT_DURATION_MS = 700;
+
+export default function LoadingRecap({ onComplete }: Props) {
+  const answers = useQuizStore((s) => s.answers);
+
+  // Une ligne par question ; les réponses multiples d'une même question
+  // sont regroupées sur la même ligne, séparées par des virgules.
+  const items = useMemo(
+    () =>
+      RECAP_STEP_IDS.flatMap((stepId) => {
+        const answer = answers[stepId];
+        if (!answer || answer.type !== "options") return [];
+        const labels = answer.option_ids.map((id) => OPTIONS[`${answer.taxonomy}.${id}` as TaxonomyValueKey]?.label).filter(Boolean) as string[];
+        return labels.length > 0 ? [labels.join(", ")] : [];
+      }),
+    [answers],
+  );
+
   const [revealed, setRevealed] = useState(0);
+  const [loadDone, setLoadDone] = useState(false);
   const [exiting, setExiting] = useState(false);
 
+  // Démarre le chargement des résultats dès l'affichage, en parallèle de l'animation.
+  // La promesse vit dans un cache module → réutilisée à l'arrivée sur /results/:id.
+  useEffect(() => {
+    const userScoringId = useQuizStore.getState().userScoringId;
+    if (!userScoringId) {
+      setLoadDone(true);
+      return;
+    }
+    let active = true;
+    prefetchInitialMatches(userScoringId)
+      .catch(() => {
+        // L'erreur sera ré-affichée à l'arrivée sur /results/:id (le cache a été vidé).
+      })
+      .finally(() => {
+        if (active) setLoadDone(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Révèle les items un à un.
   useEffect(() => {
     if (revealed >= items.length) return;
-    const timer = setTimeout(() => setRevealed((r) => r + 1), 900);
+    const timer = setTimeout(() => setRevealed((r) => r + 1), REVEAL_INTERVAL_MS);
     return () => clearTimeout(timer);
   }, [revealed, items.length]);
 
+  // Sortie : seulement quand l'animation est terminée ET les résultats chargés.
+  // → durée d'affichage = max(temps de chargement, temps d'animation).
   useEffect(() => {
-    if (revealed < items.length) return;
-    const exitTimer = setTimeout(() => setExiting(true), 800);
-    const completeTimer = setTimeout(onComplete, 1500);
+    if (revealed < items.length || !loadDone) return;
+    const exitTimer = setTimeout(() => setExiting(true), POST_REVEAL_PAUSE_MS);
+    const completeTimer = setTimeout(onComplete, POST_REVEAL_PAUSE_MS + EXIT_DURATION_MS);
     return () => {
       clearTimeout(exitTimer);
       clearTimeout(completeTimer);
     };
-  }, [revealed, items.length, onComplete]);
+  }, [revealed, items.length, loadDone, onComplete]);
 
   return (
     <div className={`flex flex-col gap-10 transition-all duration-700 ease-in ${exiting ? "opacity-0 translate-y-8" : "opacity-100 translate-y-0"}`}>

--- a/plateform/app/components/quiz/radio-group-rich.tsx
+++ b/plateform/app/components/quiz/radio-group-rich.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { DISABLED_OPTION_HINT } from "~/config/quiz-options";
 import type { StepOption } from "~/types/quiz";
 
 type Props = {
@@ -24,12 +25,20 @@ export default function RadioGroupRich({ title, subtitle, onChange, options, sel
       </legend>
       <div className="fr-fieldset__content grid grid-cols-1 md:grid-cols-2 max-w-4xl! mx-0! gap-x-6 gap-y-4!">
         {options.map((o) => (
-          <div key={o.value} className="fr-fieldset__element mb-0!">
+          <div key={o.value} className={`fr-fieldset__element mb-0! ${o.disabled ? "opacity-60" : ""}`}>
             <div className="fr-radio-group fr-radio-rich mb-0!">
-              <input value={o.value} type="radio" id={`radio-group-rich-${o.value}`} name="radio-group-rich" onChange={() => onChange(o.value)} checked={selected === o.value} />
-              <label className="fr-label text-base" htmlFor={`radio-group-rich-${o.value}`}>
+              <input
+                value={o.value}
+                type="radio"
+                id={`radio-group-rich-${o.value}`}
+                name="radio-group-rich"
+                onChange={() => onChange(o.value)}
+                checked={!o.disabled && selected === o.value}
+                disabled={o.disabled}
+              />
+              <label className={`fr-label text-base ${o.disabled ? "cursor-not-allowed!" : ""}`} htmlFor={`radio-group-rich-${o.value}`}>
                 {o.label}
-                {o.sublabel && <span className="fr-hint-text">{o.sublabel}</span>}
+                {o.disabled ? <span className="fr-hint-text">{DISABLED_OPTION_HINT}</span> : o.sublabel && <span className="fr-hint-text">{o.sublabel}</span>}
               </label>
               <div className="fr-radio-rich__pictogram">{o.icon && <div className="text-2xl">{o.icon}</div>}</div>
             </div>

--- a/plateform/app/components/quiz/radio-group.tsx
+++ b/plateform/app/components/quiz/radio-group.tsx
@@ -25,9 +25,9 @@ export default function RadioGroup({ title, subtitle, onChange, options, selecte
       <div className="fr-fieldset__content flex flex-col gap-4 max-w-sm! mx-0! ml-2!">
         {options.map((o) => (
           <div key={o.value} className={`fr-fieldset__element mb-0! border bg-white px-4! ${error ? "border-border-plain-error" : "border-border-default-grey"}`}>
-            <div className="fr-radio-group mt-0! mb-0!">
+            <div className="fr-radio-group fr-radio-group--sm mt-0! mb-0! w-full max-w-none!">
               <input value={o.value} type="radio" id={`radio-group-${o.value}`} name="radio-group" onChange={() => onChange(o.value)} checked={selected === o.value} />
-              <label className="fr-label text-sm" htmlFor={`radio-group-${o.value}`}>
+              <label className="fr-label text-sm w-full" htmlFor={`radio-group-${o.value}`}>
                 {o.label}
                 {o.sublabel && <span className="fr-hint-text">{o.sublabel}</span>}
               </label>

--- a/plateform/app/components/quiz/radio-group.tsx
+++ b/plateform/app/components/quiz/radio-group.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { DISABLED_OPTION_HINT } from "~/config/quiz-options";
 import type { StepOption } from "~/types/quiz";
 
 type Props = {
@@ -24,12 +25,23 @@ export default function RadioGroup({ title, subtitle, onChange, options, selecte
       </legend>
       <div className="fr-fieldset__content flex flex-col gap-4 max-w-sm! mx-0! ml-2!">
         {options.map((o) => (
-          <div key={o.value} className={`fr-fieldset__element mb-0! border bg-white px-4! ${error ? "border-border-plain-error" : "border-border-default-grey"}`}>
+          <div
+            key={o.value}
+            className={`fr-fieldset__element mb-0! border bg-white px-4! ${error ? "border-border-plain-error" : "border-border-default-grey"} ${o.disabled ? "opacity-60" : ""}`}
+          >
             <div className="fr-radio-group fr-radio-group--sm mt-0! mb-0! w-full max-w-none!">
-              <input value={o.value} type="radio" id={`radio-group-${o.value}`} name="radio-group" onChange={() => onChange(o.value)} checked={selected === o.value} />
-              <label className="fr-label text-sm w-full" htmlFor={`radio-group-${o.value}`}>
+              <input
+                value={o.value}
+                type="radio"
+                id={`radio-group-${o.value}`}
+                name="radio-group"
+                onChange={() => onChange(o.value)}
+                checked={!o.disabled && selected === o.value}
+                disabled={o.disabled}
+              />
+              <label className={`fr-label text-sm w-full ${o.disabled ? "cursor-not-allowed!" : ""}`} htmlFor={`radio-group-${o.value}`}>
                 {o.label}
-                {o.sublabel && <span className="fr-hint-text">{o.sublabel}</span>}
+                {o.disabled ? <span className="fr-hint-text">{DISABLED_OPTION_HINT}</span> : o.sublabel && <span className="fr-hint-text">{o.sublabel}</span>}
               </label>
             </div>
           </div>

--- a/plateform/app/components/results/pinned-missions.tsx
+++ b/plateform/app/components/results/pinned-missions.tsx
@@ -14,6 +14,12 @@ interface PinnedMissionsProps {
 export default function PinnedMissions({ items, loading, error, userScoringId }: PinnedMissionsProps) {
   return (
     <div className="relative w-full px-6">
+      {!loading && error && (
+        <div className="fr-alert fr-alert--error my-6" role="alert">
+          <h3 className="fr-alert__title">Une erreur est survenue</h3>
+          <p>{error}</p>
+        </div>
+      )}
       {!loading && !error && items.length > 0 && (
         <>
           <div className="grid grid-cols-1 gap-6 pb-6 md:grid-cols-2 md:px-4">

--- a/plateform/app/config/quiz-options.ts
+++ b/plateform/app/config/quiz-options.ts
@@ -9,9 +9,12 @@ export const OPTIONS = Object.fromEntries(
   getTaxonomyList().flatMap((taxonomy) =>
     taxonomy.values.map((value) => {
       const key = `${taxonomy.key}.${value.key}` as TaxonomyValueKey;
-      return [key, { label: value.label, sublabel: value.sublabel, icon: value.icon, taxonomy: taxonomy.key, value: value.key }];
+      return [key, { label: value.label, sublabel: value.sublabel, icon: value.icon, taxonomy: taxonomy.key, value: value.key, disabled: value.disabled }];
     }),
   ),
 ) as Record<TaxonomyValueKey, StepOption>;
 
 export type QuizOptionKey = TaxonomyValueKey;
+
+// Sous-titre affiché dans les cartes d'options grisées (cf. `StepOption.disabled`).
+export const DISABLED_OPTION_HINT = "Ces options seront bientôt disponibles";

--- a/plateform/app/hooks/useMissionResults.ts
+++ b/plateform/app/hooks/useMissionResults.ts
@@ -1,9 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import type { MissionMatchItem } from "@engagement/dto";
-import { fetchMatches } from "~/services/matching";
+import { fetchMatches, OTHER_RESULTS_PAGE_SIZE, PINNED_RESULTS_LIMIT, prefetchInitialMatches } from "~/services/matching";
 
-export const PINNED_RESULTS_LIMIT = 5;
-export const OTHER_RESULTS_PAGE_SIZE = 8;
+export { OTHER_RESULTS_PAGE_SIZE, PINNED_RESULTS_LIMIT };
 export const VISIBLE_PAGE_COUNT = 6;
 
 export function useMissionResults(userScoringId: string | undefined) {
@@ -42,13 +41,15 @@ export function useMissionResults(userScoringId: string | undefined) {
     setOtherItems([]);
     setHasNextPage(false);
 
-    Promise.all([fetchMatches(userScoringId, PINNED_RESULTS_LIMIT), fetchMatches(userScoringId, OTHER_RESULTS_PAGE_SIZE, PINNED_RESULTS_LIMIT)])
-      .then(([pinnedRes, otherRes]) => {
+    // Réutilise le préchargement lancé pendant l'écran de transition si disponible,
+    // sinon déclenche le chargement (accès direct à /results/:id).
+    prefetchInitialMatches(userScoringId)
+      .then(({ pinned, other }) => {
         if (!active) return;
-        setPinnedItems(pinnedRes.items);
-        setFirstOtherItems(otherRes.items);
-        setOtherItems(otherRes.items);
-        setHasNextPage(otherRes.items.length === OTHER_RESULTS_PAGE_SIZE);
+        setPinnedItems(pinned.items);
+        setFirstOtherItems(other.items);
+        setOtherItems(other.items);
+        setHasNextPage(other.items.length === OTHER_RESULTS_PAGE_SIZE);
       })
       .catch(() => {
         if (!active) return;

--- a/plateform/app/routes/quiz/_layout.tsx
+++ b/plateform/app/routes/quiz/_layout.tsx
@@ -81,13 +81,15 @@ export default function QuizLayout() {
 
   const goNext = async () => {
     if (!currentStep) return;
-    setTransitioning(false);
     setScoringError(null);
     const freshAnswers = useQuizStore.getState().answers;
+    // On garde `transitioning` à true pendant la sauvegarde (appel réseau) : sinon le step
+    // courant ré-afficherait sa question le temps de la requête, avant la navigation (glitch).
     const scoringSaved = await saveCurrentScoring();
 
     if (!scoringSaved) {
       setScoringError("Impossible d'enregistrer tes réponses. Réessaie dans quelques instants.");
+      setTransitioning(false);
       return;
     }
 
@@ -98,6 +100,8 @@ export default function QuizLayout() {
     } else {
       setLoadingResults(true);
     }
+    // Réinitialisé après la navigation (batché avec elle) → le step suivant s'affiche directement.
+    setTransitioning(false);
   };
 
   const handleLoadingComplete = () => {

--- a/plateform/app/routes/quiz/_layout.tsx
+++ b/plateform/app/routes/quiz/_layout.tsx
@@ -1,11 +1,9 @@
-import type { TaxonomyValueKey } from "@engagement/taxonomy";
 import { useEffect, useMemo, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router";
 import BackButton from "~/components/quiz/back-button";
 import QuizHeader from "~/components/quiz/header";
 import LoadingRecap from "~/components/quiz/loading-recap";
 import { QUIZ_FLOW, type StepDef } from "~/config/quiz-flow";
-import { OPTIONS } from "~/config/quiz-options";
 import { createUserScoring, updateUserScoring } from "~/services/user-scoring";
 import { useQuizStore } from "~/stores/quiz";
 import { evalCondition } from "~/utils/conditions";
@@ -108,12 +106,6 @@ export default function QuizLayout() {
     navigate(id ? `/results/${id}` : "/");
   };
 
-  const recapItems = (["statut", "duree", "motivation"] as const).flatMap((stepId) => {
-    const answer = answers[stepId];
-    if (!answer || answer.type !== "options") return [];
-    return answer.option_ids.map((id) => OPTIONS[`${answer.taxonomy}.${id}` as TaxonomyValueKey]?.label).filter(Boolean) as string[];
-  });
-
   const goBack = () => {
     if (!currentStep) return;
     setTransitioning(false);
@@ -135,7 +127,7 @@ export default function QuizLayout() {
             </div>
           )}
           {loadingResults ? (
-            <LoadingRecap items={recapItems} onComplete={handleLoadingComplete} />
+            <LoadingRecap onComplete={handleLoadingComplete} />
           ) : (
             // `goNext` / `goBack` exposés aux routes enfants via Outlet context — elles les appellent après validation.
             <Outlet context={{ goNext, goBack, transitioning, setTransitioning } satisfies QuizOutletContext} />

--- a/plateform/app/routes/quiz/_layout.tsx
+++ b/plateform/app/routes/quiz/_layout.tsx
@@ -4,6 +4,7 @@ import BackButton from "~/components/quiz/back-button";
 import QuizHeader from "~/components/quiz/header";
 import LoadingRecap from "~/components/quiz/loading-recap";
 import { QUIZ_FLOW, type StepDef } from "~/config/quiz-flow";
+import { invalidateInitialMatches } from "~/services/matching";
 import { createUserScoring, updateUserScoring } from "~/services/user-scoring";
 import { useQuizStore } from "~/stores/quiz";
 import { evalCondition } from "~/utils/conditions";
@@ -72,6 +73,7 @@ export default function QuizLayout() {
       }
 
       await updateUserScoring(freshUserScoringId, { ...payload, distinctId: freshDistinctId });
+      invalidateInitialMatches(freshUserScoringId);
       return true;
     } catch (err) {
       console.error("[quiz] saveCurrentScoring failed", err);

--- a/plateform/app/routes/quiz/age.tsx
+++ b/plateform/app/routes/quiz/age.tsx
@@ -46,7 +46,7 @@ export default function AgeStep() {
           </option>
         ))}
       </select>
-      <NextButton onClick={goNext} type="submit" disabled={!valid} />
+      <NextButton type="submit" disabled={!valid} />
     </form>
   );
 }

--- a/plateform/app/routes/quiz/duree.tsx
+++ b/plateform/app/routes/quiz/duree.tsx
@@ -5,7 +5,7 @@ import NextButton from "~/components/quiz/next-button";
 import { OPTIONS } from "~/config/quiz-options";
 import { useQuizStore } from "~/stores/quiz";
 import type { StepOption } from "~/types/quiz";
-import { evalCondition, numericRange } from "~/utils/conditions";
+import { evalCondition } from "~/utils/conditions";
 import type { QuizOutletContext } from "./_layout";
 
 const STEP_ID = "duree";
@@ -14,7 +14,7 @@ const STEP_OPTIONS: StepOption[] = [
   OPTIONS["type_mission.ponctuelle"],
   OPTIONS["type_mission.temps_plein"],
   OPTIONS["type_mission.reguliere"],
-  { ...OPTIONS["type_mission.je_ne_sais_pas"], hiddenIf: numericRange("age", 16, 25) },
+  OPTIONS["type_mission.je_ne_sais_pas"],
 ];
 
 export default function DureeStep() {

--- a/plateform/app/routes/quiz/localisation.tsx
+++ b/plateform/app/routes/quiz/localisation.tsx
@@ -13,7 +13,9 @@ import { QUIZ_TRANSITION_MS } from "~/services/config";
 type Suggestion = { label: string; lat: number; lon: number; country_code?: string };
 
 type AddressFeature = {
-  properties: { name: string; postcode: string; id: string };
+  // `label` = adresse complète formatée par l'API (ex: "8 Boulevard du Port 80000 Amiens").
+  // `type`  = housenumber | street | locality | municipality.
+  properties: { label: string; name: string; postcode: string; type: string; id: string };
   geometry: { coordinates: [number, number] };
 };
 
@@ -54,12 +56,15 @@ export default function LocalisationStep() {
       }
 
       try {
-        const res = await fetch(`https://data.geopf.fr/geocodage/search?q=${value}&type=municipality&autocomplete=1&limit=6`);
+        // Pas de filtre `type` → l'API renvoie aussi les adresses précises (numéro + rue), pas seulement les villes.
+        const res = await fetch(`https://data.geopf.fr/geocodage/search?q=${encodeURIComponent(value)}&autocomplete=1&limit=6`);
         const data: { features?: AddressFeature[] } = await res.json();
         if (!data.features) return;
         setOptions(
           data.features.map((f) => ({
-            label: `${f.properties.name} (${f.properties.postcode})`,
+            // Villes : on garde "Nom (code postal)" pour lever l'ambiguïté entre homonymes.
+            // Adresses/rues : on utilise le `label` complet fourni par l'API.
+            label: f.properties.type === "municipality" ? `${f.properties.name} (${f.properties.postcode})` : f.properties.label,
             lat: f.geometry.coordinates[1],
             lon: f.geometry.coordinates[0],
             country_code: "fr",
@@ -137,7 +142,7 @@ export default function LocalisationStep() {
 
         if (!data.features) return;
         const here: Suggestion = {
-          label: data.features[0].properties.name,
+          label: data.features[0].properties.label ?? data.features[0].properties.name,
           lat: data.features[0].geometry.coordinates[1],
           lon: data.features[0].geometry.coordinates[0],
           country_code: "fr",

--- a/plateform/app/routes/quiz/localisation.tsx
+++ b/plateform/app/routes/quiz/localisation.tsx
@@ -26,11 +26,15 @@ export default function LocalisationStep() {
   const { goNext, transitioning, setTransitioning } = useOutletContext<QuizOutletContext>();
 
   const locAnswer = answers["localisation"];
-  const savedLocation = locAnswer?.type === "params" ? (locAnswer.params as { lat: number; lon: number; country_code?: string }) : null;
+  // `label` est persisté avec les coordonnées pour ré-afficher la saisie au retour sur l'écran
+  // (ignoré côté API : le transformer `location` ne lit que lat/lon/country_code).
+  const savedLocation = locAnswer?.type === "params" ? (locAnswer.params as { lat: number; lon: number; country_code?: string; label?: string }) : null;
 
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState(savedLocation?.label ?? "");
   const [options, setOptions] = useState<Suggestion[]>([]);
-  const [selected, setSelected] = useState<Suggestion | null>(savedLocation ? { label: "", ...savedLocation } : null);
+  const [selected, setSelected] = useState<Suggestion | null>(
+    savedLocation ? { label: savedLocation.label ?? "", lat: savedLocation.lat, lon: savedLocation.lon, country_code: savedLocation.country_code } : null,
+  );
   const [showOptions, setShowOptions] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const [locating, setLocating] = useState(false);
@@ -162,7 +166,12 @@ export default function LocalisationStep() {
     setAnswer("localisation", {
       type: "params",
       taxonomy: "location",
-      params: { lat: selected.lat, lon: selected.lon, ...(selected.country_code ? { country_code: selected.country_code } : {}) },
+      params: {
+        lat: selected.lat,
+        lon: selected.lon,
+        ...(selected.country_code ? { country_code: selected.country_code } : {}),
+        ...(selected.label ? { label: selected.label } : {}),
+      },
     });
     setValue(selected.label);
     setTransitioning(true);

--- a/plateform/app/routes/quiz/localisation.tsx
+++ b/plateform/app/routes/quiz/localisation.tsx
@@ -93,6 +93,13 @@ export default function LocalisationStep() {
     setActiveIndex(-1);
   };
 
+  const handleChange = (nextValue: string) => {
+    setValue(nextValue);
+    if (selected && nextValue !== selected.label) {
+      setSelected(null);
+    }
+  };
+
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "ArrowDown") {
       if (options.length === 0) return;
@@ -200,7 +207,7 @@ export default function LocalisationStep() {
             type="text"
             placeholder="Adresse, ville ou code postal"
             value={value}
-            onChange={(e) => setValue(e.target.value)}
+            onChange={(e) => handleChange(e.target.value)}
             onKeyDown={handleKeyDown}
             autoComplete="off"
           />

--- a/plateform/app/routes/quiz/motivation.tsx
+++ b/plateform/app/routes/quiz/motivation.tsx
@@ -18,7 +18,6 @@ const lyceen = screenAnswer("statut", "lyceen");
 const etudiant = screenAnswer("statut", "etudiant");
 const demandeurEmploi = screenAnswer("statut", "demandeur_emploi");
 const actif = screenAnswer("statut", "actif");
-const retraite = screenAnswer("statut", "retraite");
 
 const STEP_OPTIONS: StepOption[] = [
   OPTIONS["motivation.me_sentir_utile"],
@@ -28,7 +27,7 @@ const STEP_OPTIONS: StepOption[] = [
   { ...OPTIONS["motivation.decouvrir_domaine"], hiddenIf: or(lyceen, demandeurEmploi) },
   { ...OPTIONS["motivation.experience_terrain"], hiddenIf: not(etudiant) },
   { ...OPTIONS["motivation.partir_etranger"], hiddenIf: not(or(etudiant, actif)) },
-  { ...OPTIONS["motivation.competences_interet_general"], hiddenIf: not(or(actif, retraite)) },
+  { ...OPTIONS["motivation.competences_interet_general"], hiddenIf: not(actif) },
   { ...OPTIONS["motivation.reprendre_confiance"], hiddenIf: not(demandeurEmploi) },
   { ...OPTIONS["motivation.reprendre_activite"], hiddenIf: not(demandeurEmploi) },
   { ...OPTIONS["motivation.enrichir_cv"], hiddenIf: not(demandeurEmploi) },

--- a/plateform/app/routes/quiz/precision-competences.tsx
+++ b/plateform/app/routes/quiz/precision-competences.tsx
@@ -19,14 +19,14 @@ const STEP_OPTIONS = [
   OPTIONS["competence_rome.relation_client_commerce_strategie"],
   OPTIONS["competence_rome.cooperation_organisation_soft_skills"],
   OPTIONS["competence_rome.securite_environnement_action_publique"],
+  OPTIONS["competence_rome.je_ne_sais_pas"],
 ];
 
 const TITLE_BY_MOTIVATION: Record<string, string> = {
   competences_interet_general: "Quel est ton domaine de compétences ?",
-  booster_cv: "Dans quel domaine souhaites-tu booster tes compétences",
 };
 
-const DEFAULT_TITLE = "Quel type de compétences t'attire le plus ?";
+const DEFAULT_TITLE = "Quel domaine de compétences t'attire le plus ?";
 
 export default function PrecisionCompetencesStep() {
   const { answers, setAnswer } = useQuizStore();

--- a/plateform/app/routes/quiz/precision-parcoursup-formation-nom.tsx
+++ b/plateform/app/routes/quiz/precision-parcoursup-formation-nom.tsx
@@ -39,7 +39,7 @@ export default function PrecisionParcoursupFormationNomStep() {
         <input id="formation-input" className="fr-input" type="text" value={value} onChange={(e) => setValue(e.target.value)} autoFocus />
       </div>
 
-      <NextButton onClick={goNext} type="submit" disabled={!valid} />
+      <NextButton type="submit" disabled={!valid} />
     </form>
   );
 }

--- a/plateform/app/routes/quiz/statut.tsx
+++ b/plateform/app/routes/quiz/statut.tsx
@@ -5,19 +5,12 @@ import RadioGroupRich from "~/components/quiz/radio-group-rich";
 import { OPTIONS } from "~/config/quiz-options";
 import { useQuizStore } from "~/stores/quiz";
 import type { StepOption } from "~/types/quiz";
-import { evalCondition, numericRange } from "~/utils/conditions";
+import { evalCondition } from "~/utils/conditions";
 import type { QuizOutletContext } from "./_layout";
 
 const STEP_ID = "statut";
 
-const STEP_OPTIONS: StepOption[] = [
-  OPTIONS["statut.lyceen"],
-  OPTIONS["statut.etudiant"],
-  OPTIONS["statut.demandeur_emploi"],
-  OPTIONS["statut.actif"],
-  { ...OPTIONS["statut.retraite"], hiddenIf: numericRange("age", 16, 25) },
-  OPTIONS["statut.autre"],
-];
+const STEP_OPTIONS: StepOption[] = [OPTIONS["statut.lyceen"], OPTIONS["statut.etudiant"], OPTIONS["statut.demandeur_emploi"], OPTIONS["statut.actif"], OPTIONS["statut.autre"]];
 
 export default function StatutStep() {
   const { answers, setAnswer } = useQuizStore();

--- a/plateform/app/routes/results.tsx
+++ b/plateform/app/routes/results.tsx
@@ -144,6 +144,7 @@ export default function ResultsPage() {
             className={`absolute inset-x-0 bottom-0 z-[1000] flex flex-col rounded-t-3xl bg-white shadow-2xl transition-[top] duration-300 ${expanded ? "top-12" : "top-[calc(100%-5rem)]"} ${selectedMission ? "hidden" : ""}`}
           >
             <div className={`flex flex-col gap-2 px-6 py-4 ${expanded ? "items-start!" : "items-center! justify-center! h-full"}`} onClick={handleToggleSheet}>
+              {!loading && error && <p className="fr-error-text m-0! text-center!">{error}</p>}
               {!loading && !error && (
                 <h2 className={`m-0! ${expanded ? "text-center!" : ""}`}>
                   <Highlight>

--- a/plateform/app/services/matching.ts
+++ b/plateform/app/services/matching.ts
@@ -34,3 +34,7 @@ export function prefetchInitialMatches(userScoringId: string): Promise<InitialMa
   initialMatchesCache.set(userScoringId, promise);
   return promise;
 }
+
+export function invalidateInitialMatches(userScoringId: string) {
+  initialMatchesCache.delete(userScoringId);
+}

--- a/plateform/app/services/matching.ts
+++ b/plateform/app/services/matching.ts
@@ -1,6 +1,36 @@
 import type { MissionMatchResponse } from "@engagement/dto";
 import { client } from "~/services/client";
 
+// Tailles de page partagées entre le préchargement (LoadingRecap) et le hook de résultats.
+export const PINNED_RESULTS_LIMIT = 5;
+export const OTHER_RESULTS_PAGE_SIZE = 8;
+
 export async function fetchMatches(userScoringId: string, limit = 5, offset = 0, signal?: AbortSignal): Promise<MissionMatchResponse> {
   return client.get<MissionMatchResponse>(`/api/missions/match?userScoringId=${encodeURIComponent(userScoringId)}&limit=${limit}&offset=${offset}`, signal);
+}
+
+export type InitialMatches = {
+  pinned: MissionMatchResponse;
+  other: MissionMatchResponse;
+};
+
+// Cache mémoire des résultats de la 1re page, indexé par userScoringId.
+// Permet de lancer le chargement pendant l'écran de transition (LoadingRecap)
+// puis de le réutiliser à l'arrivée sur /results/:id, sans re-fetch.
+const initialMatchesCache = new Map<string, Promise<InitialMatches>>();
+
+export function prefetchInitialMatches(userScoringId: string): Promise<InitialMatches> {
+  const existing = initialMatchesCache.get(userScoringId);
+  if (existing) return existing;
+
+  const promise = Promise.all([fetchMatches(userScoringId, PINNED_RESULTS_LIMIT), fetchMatches(userScoringId, OTHER_RESULTS_PAGE_SIZE, PINNED_RESULTS_LIMIT)])
+    .then(([pinned, other]) => ({ pinned, other }))
+    .catch((err) => {
+      // En cas d'échec, on vide l'entrée pour autoriser un nouvel essai.
+      initialMatchesCache.delete(userScoringId);
+      throw err;
+    });
+
+  initialMatchesCache.set(userScoringId, promise);
+  return promise;
 }

--- a/plateform/app/types/quiz.ts
+++ b/plateform/app/types/quiz.ts
@@ -22,6 +22,8 @@ export interface StepOption {
   taxonomy: string;
   value: string;
   hiddenIf?: Condition;
+  // true → option grisée et non sélectionnable (fonctionnalité pas encore disponible).
+  disabled?: boolean;
 }
 
 // DTO retourné par l'API /v0/mission.

--- a/plateform/app/types/quiz.ts
+++ b/plateform/app/types/quiz.ts
@@ -25,15 +25,3 @@ export interface StepOption {
   // true → option grisée et non sélectionnable (fonctionnalité pas encore disponible).
   disabled?: boolean;
 }
-
-// DTO retourné par l'API /v0/mission.
-export type Mission = {
-  _id: string;
-  title: string;
-  description: string;
-  city?: string;
-  department?: string;
-  organizationName: string;
-  applicationUrl: string;
-  domaine?: string;
-};


### PR DESCRIPTION
## Description

Lot de corrections et d'améliorations UX/UI sur le **quiz** et la **page de résultats** de la plateforme.

### Quiz — accessibilité & UI
- **Zone cliquable RGAA** : les radios (ex. `oui` / `non` sur `/quiz/handicap`) sont désormais cliquables sur toute la surface de la carte, plus seulement sur le texte du label.
- **Homogénéisation** de la taille des radios entre les écrans (`handicap` alignée sur `statut`).
- **Options « Partir à l'étranger »** grisées en attendant leur disponibilité : ajout d'un critère `disabled` dans `@engagement/taxonomy`, propagé jusqu'aux composants `radio-group`, `radio-group-rich` et `checkbox-group-rich` (option non sélectionnable + sous-titre « Ces options seront bientôt disponibles »).

### Quiz — routing
- **Correction du glitch de transition** : le step source ré-affichait brièvement sa question pendant la sauvegarde réseau avant la navigation. `goNext` ne réinitialise plus `transitioning` qu'après la navigation (corrige les écrans avec transition : `motivation`, `localisation`).
- Suppression du double déclenchement `onClick={goNext}` + `onSubmit` sur les formulaires (`age`, `precision-parcoursup-formation-nom`) : la soumission du formulaire est l'unique source de navigation.

### Quiz — écran de chargement des résultats (`loading-recap`)
- La dérivation des questions affichées est désormais **interne** au composant (sortie de `_layout`).
- **Préchargement des résultats pendant l'animation** : le chargement démarre dès l'affichage de l'écran et la durée d'affichage = `max(temps de chargement, temps d'animation)`. La promesse est mise en cache (`matching.ts`) et réutilisée à l'arrivée sur `/results/:id`, sans re-fetch.
- Les réponses multiples d'une même question (ex. `duree`) sont regroupées **sur une seule ligne**, séparées par des virgules.

### Résultats
- **Message d'erreur** affiché sur `/results/:id` lorsque l'appel `match/` échoue (desktop + feuille mobile), au lieu d'une page vide.

### Localisation
- **Autocomplete d'adresse précise** : suppression du filtre `type=municipality` → l'API Géoplateforme renvoie aussi les numéros/rues ; affichage du `label` complet pour les adresses, `Nom (code postal)` pour les communes ; encodage de la requête.
- **Persistance de la saisie** : le `label` est conservé avec les coordonnées pour ré-afficher l'adresse choisie au retour sur l'écran (ignoré côté API, le transformer `location` ne lit que lat/lon/country_code).

### Contenu / options du quiz
- Retrait du statut « retraité » et des conditions associées (`statut`, `motivation`).
- Simplification des options de `duree` et ajustement des libellés de `precision-competences`.

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/Retours-UI-Plateforme-Round-1-36572a322d5080f4b532f21d5618823d?source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire