### PR TITLE
chore(plateform): add package tests & lint workflows

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -37,6 +37,7 @@ jobs:
               - 'widget/**'
             plateform:
               - 'plateform/**'
+              - 'packages/**'
 
   api-build:
     name: API build

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -20,6 +20,7 @@ on:
       - "analytics/**"
       - "widget/**"
       - "plateform/**"
+      - "packages/**"
       - "terraform/**"
 
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       app: ${{ steps.filter.outputs.app }}
       api_prisma_schema: ${{ steps.filter.outputs.api_prisma_schema }}
       plateform: ${{ steps.filter.outputs.plateform }}
+      taxonomy: ${{ steps.filter.outputs.taxonomy }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4.0.1
@@ -44,6 +45,8 @@ jobs:
             plateform:
               - 'plateform/**'
               - 'packages/**'
+            taxonomy:
+              - 'packages/taxonomy/**'
 
   api-migrations:
     name: Verify API migrations
@@ -310,3 +313,23 @@ jobs:
 
       - name: Run tests
         run: npm --workspace plateform run test
+
+  taxonomy-tests:
+    name: Taxonomy Tests
+    needs: changes
+    if: needs.changes.outputs.taxonomy == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: "package-lock.json"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm --workspace @engagement/taxonomy run test

--- a/analytics/eslint.config.cjs
+++ b/analytics/eslint.config.cjs
@@ -6,7 +6,7 @@ const importPlugin = require("eslint-plugin-import");
 module.exports = [
   // Ignores
   {
-    ignores: ["node_modules", "dist", "scripts", "src/static", "coverage", ".github", "*.js.map", "*.d.ts", "eslint.config.*", ".eslintrc.*"],
+    ignores: ["node_modules", "dist", "scripts", "src/static", "coverage", ".github", "dbt/**/.venv/**", "*.js.map", "*.d.ts", "eslint.config.*", ".eslintrc.*"],
   },
 
   // Base JS recommended

--- a/package-lock.json
+++ b/package-lock.json
@@ -21654,6 +21654,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -25889,14 +25890,209 @@
       "name": "@engagement/dto",
       "version": "0.1.0",
       "devDependencies": {
+        "@eslint/js": "10.0.1",
+        "@typescript-eslint/eslint-plugin": "8.59.0",
+        "@typescript-eslint/parser": "8.59.0",
+        "eslint": "10.2.1",
         "typescript": "6.0.3"
+      }
+    },
+    "packages/dto/node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "packages/dto/node_modules/eslint": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "packages/dto/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/taxonomy": {
       "name": "@engagement/taxonomy",
       "version": "0.1.0",
       "devDependencies": {
-        "typescript": "6.0.3"
+        "@eslint/js": "10.0.1",
+        "@typescript-eslint/eslint-plugin": "8.59.0",
+        "@typescript-eslint/parser": "8.59.0",
+        "eslint": "10.2.1",
+        "typescript": "6.0.3",
+        "vitest": "4.1.5"
+      }
+    },
+    "packages/taxonomy/node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "packages/taxonomy/node_modules/eslint": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "packages/taxonomy/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "plateform": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "version": "1.7.0",
   "workspaces": ["packages/*", "api", "app", "widget", "analytics", "plateform"],
   "scripts": {
-    "lint": "npm run lint:api && npm run lint:app && npm run lint:analytics && npm run lint:widget && npm run lint:plateform",
+    "lint": "npm run lint:api && npm run lint:app && npm run lint:analytics && npm run lint:widget && npm run lint:plateform && npm run lint:packages",
     "lint:api": "cd api && npm run lint",
     "lint:app": "cd app && npm run lint",
     "lint:analytics": "cd analytics && npm run lint",
     "lint:widget": "cd widget && npm run lint",
     "lint:plateform": "cd plateform && npm run lint",
+    "lint:packages": "npm run lint --workspace @engagement/taxonomy && npm run lint --workspace @engagement/dto",
     "format": "sh -c 'test -x node_modules/.bin/prettier || { echo \"prettier introuvable. Lance npm install depuis la racine du dépôt.\"; exit 1; }; node_modules/.bin/prettier --write \"**/*.{js,jsx,ts,tsx,json,md,yml}\" --ignore-path .prettierignore \"$@\"' --",
     "commit": "cz",
     "prepare": "command -v husky >/dev/null 2>&1 && husky || true"

--- a/packages/dto/eslint.config.cjs
+++ b/packages/dto/eslint.config.cjs
@@ -1,0 +1,26 @@
+const js = require("@eslint/js");
+const tsParser = require("@typescript-eslint/parser");
+const tsPlugin = require("@typescript-eslint/eslint-plugin");
+
+module.exports = [
+  {
+    ignores: ["node_modules/", "dist/", "eslint.config.cjs"],
+  },
+
+  js.configs.recommended,
+
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2022,
+      sourceType: "module",
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+    },
+  },
+];

--- a/packages/dto/package.json
+++ b/packages/dto/package.json
@@ -6,9 +6,14 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "build:watch": "tsc --watch"
+    "build:watch": "tsc --watch",
+    "lint": "eslint ."
   },
   "devDependencies": {
+    "@eslint/js": "10.0.1",
+    "@typescript-eslint/eslint-plugin": "8.59.0",
+    "@typescript-eslint/parser": "8.59.0",
+    "eslint": "10.2.1",
     "typescript": "6.0.3"
   }
 }

--- a/packages/taxonomy/eslint.config.cjs
+++ b/packages/taxonomy/eslint.config.cjs
@@ -1,0 +1,26 @@
+const js = require("@eslint/js");
+const tsParser = require("@typescript-eslint/parser");
+const tsPlugin = require("@typescript-eslint/eslint-plugin");
+
+module.exports = [
+  {
+    ignores: ["node_modules/", "dist/", "eslint.config.cjs"],
+  },
+
+  js.configs.recommended,
+
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 2022,
+      sourceType: "module",
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+    },
+  },
+];

--- a/packages/taxonomy/package.json
+++ b/packages/taxonomy/package.json
@@ -6,9 +6,17 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "build:watch": "tsc --watch"
+    "build:watch": "tsc --watch",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
-    "typescript": "6.0.3"
+    "@eslint/js": "10.0.1",
+    "@typescript-eslint/eslint-plugin": "8.59.0",
+    "@typescript-eslint/parser": "8.59.0",
+    "eslint": "10.2.1",
+    "typescript": "6.0.3",
+    "vitest": "4.1.5"
   }
 }

--- a/packages/taxonomy/src/__tests__/utils.test.ts
+++ b/packages/taxonomy/src/__tests__/utils.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { TAXONOMY } from "../taxonomy";
+import type { TaxonomyKey } from "../types";
+import { ENRICHABLE_TAXONOMIES, GATE_TAXONOMIES, getTaxonomyList, isValidTaxonomyValueKey, parseTaxonomyValueKey } from "../utils";
+
+describe("parseTaxonomyValueKey", () => {
+  it("découpe une clé plate valide en taxonomie + valeur", () => {
+    expect(parseTaxonomyValueKey("domaine.sante_soins")).toEqual({
+      taxonomyKey: "domaine",
+      valueKey: "sante_soins",
+    });
+  });
+
+  it("ne découpe qu'au premier point", () => {
+    expect(parseTaxonomyValueKey("a.b.c")).toEqual({ taxonomyKey: "a", valueKey: "b.c" });
+  });
+
+  it("retourne null sans point", () => {
+    expect(parseTaxonomyValueKey("abc")).toBeNull();
+  });
+
+  it("retourne null si le point est en tête", () => {
+    expect(parseTaxonomyValueKey(".b")).toBeNull();
+  });
+
+  it("retourne null si le point est en fin", () => {
+    expect(parseTaxonomyValueKey("a.")).toBeNull();
+  });
+});
+
+describe("isValidTaxonomyValueKey", () => {
+  it("accepte une clé réelle issue de TAXONOMY", () => {
+    expect(isValidTaxonomyValueKey("domaine.sante_soins")).toBe(true);
+  });
+
+  it("rejette une taxonomie inconnue", () => {
+    expect(isValidTaxonomyValueKey("inconnue.valeur")).toBe(false);
+  });
+
+  it("rejette une valeur inconnue d'une taxonomie connue", () => {
+    expect(isValidTaxonomyValueKey("domaine.valeur_qui_nexiste_pas")).toBe(false);
+  });
+
+  it("rejette une clé malformée", () => {
+    expect(isValidTaxonomyValueKey("domaine")).toBe(false);
+  });
+});
+
+describe("getTaxonomyList", () => {
+  const list = getTaxonomyList();
+
+  it("retourne une entrée par taxonomie", () => {
+    expect(list).toHaveLength(Object.keys(TAXONOMY).length);
+  });
+
+  it("expose key/label/type/values pour chaque entrée", () => {
+    for (const item of list) {
+      expect(typeof item.key).toBe("string");
+      expect(typeof item.label).toBe("string");
+      expect(typeof item.type).toBe("string");
+      expect(Array.isArray(item.values)).toBe(true);
+    }
+  });
+
+  it("attribue un order croissant et contigu aux valeurs", () => {
+    for (const item of list) {
+      item.values.forEach((value, index) => {
+        expect(value.order).toBe(index);
+      });
+    }
+  });
+});
+
+describe("ENRICHABLE_TAXONOMIES / GATE_TAXONOMIES", () => {
+  it("ENRICHABLE_TAXONOMIES contient exactement les taxonomies enrichable", () => {
+    const expected = (Object.keys(TAXONOMY) as TaxonomyKey[]).filter((key) => TAXONOMY[key].enrichable);
+    expect([...ENRICHABLE_TAXONOMIES].sort()).toEqual(expected.sort());
+  });
+
+  it("GATE_TAXONOMIES contient exactement les taxonomies gate", () => {
+    const expected = (Object.keys(TAXONOMY) as TaxonomyKey[]).filter((key) => TAXONOMY[key].gate);
+    expect([...GATE_TAXONOMIES].sort()).toEqual(expected.sort());
+  });
+});

--- a/packages/taxonomy/src/transformers/__tests__/department-code.test.ts
+++ b/packages/taxonomy/src/transformers/__tests__/department-code.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { resolveDepartmentCodeValues } from "../department-code";
+
+describe("resolveDepartmentCodeValues", () => {
+  it("résout un code unique passé en chaîne", () => {
+    expect(resolveDepartmentCodeValues({ code: "75" })).toEqual(["75"]);
+  });
+
+  it("résout un tableau de codes", () => {
+    expect(resolveDepartmentCodeValues({ codes: ["75", "13"] })).toEqual(["75", "13"]);
+  });
+
+  it("retire le préfixe FR- et met en majuscules", () => {
+    expect(resolveDepartmentCodeValues({ code: "fr-2a" })).toEqual(["2A"]);
+  });
+
+  it("trim les espaces", () => {
+    expect(resolveDepartmentCodeValues({ code: "  75  " })).toEqual(["75"]);
+  });
+
+  it("lève une erreur pour un code inconnu", () => {
+    expect(() => resolveDepartmentCodeValues({ code: "999" })).toThrow(/Unknown departmentCode/);
+  });
+
+  it("lève une erreur si params n'est pas un objet", () => {
+    expect(() => resolveDepartmentCodeValues("75")).toThrow(/must be an object/);
+  });
+
+  it("lève une erreur si la liste de codes est vide", () => {
+    expect(() => resolveDepartmentCodeValues({ codes: [] })).toThrow(/string or an array of strings/);
+  });
+
+  it("lève une erreur si un élément n'est pas une chaîne", () => {
+    expect(() => resolveDepartmentCodeValues({ codes: ["75", 13] })).toThrow(/string or an array of strings/);
+  });
+});

--- a/packages/taxonomy/src/transformers/__tests__/location.test.ts
+++ b/packages/taxonomy/src/transformers/__tests__/location.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveLocationValues } from "../location";
+
+describe("resolveLocationValues", () => {
+  it("résout des coordonnées valides", () => {
+    expect(resolveLocationValues({ lat: 48.85, lon: 2.35 })).toEqual({ geo: { lat: 48.85, lon: 2.35 } });
+  });
+
+  it("reprend radius_km quand fourni", () => {
+    expect(resolveLocationValues({ lat: 48.85, lon: 2.35, radius_km: 10 })).toEqual({
+      geo: { lat: 48.85, lon: 2.35, radiusKm: 10 },
+    });
+  });
+
+  it("met country_code en majuscules", () => {
+    expect(resolveLocationValues({ lat: 48.85, lon: 2.35, country_code: "fr" })).toEqual({
+      geo: { lat: 48.85, lon: 2.35, countryCode: "FR" },
+    });
+  });
+
+  it("lève une erreur si lat est hors bornes", () => {
+    expect(() => resolveLocationValues({ lat: 91, lon: 2.35 })).toThrow(/lat must be a number between -90 and 90/);
+  });
+
+  it("lève une erreur si lon est hors bornes", () => {
+    expect(() => resolveLocationValues({ lat: 48.85, lon: 181 })).toThrow(/lon must be a number between -180 and 180/);
+  });
+
+  it("lève une erreur si radius_km n'est pas positif", () => {
+    expect(() => resolveLocationValues({ lat: 48.85, lon: 2.35, radius_km: 0 })).toThrow(/radius_km must be a positive number/);
+  });
+
+  it("lève une erreur si country_code est invalide", () => {
+    expect(() => resolveLocationValues({ lat: 48.85, lon: 2.35, country_code: "fra" })).toThrow(/two-letter country code/);
+  });
+
+  it("lève une erreur si params n'est pas un objet", () => {
+    expect(() => resolveLocationValues(null)).toThrow(/must be an object/);
+  });
+});

--- a/packages/taxonomy/src/transformers/__tests__/tranche-age.test.ts
+++ b/packages/taxonomy/src/transformers/__tests__/tranche-age.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { resolveTrancheAgeValues } from "../tranche-age";
+
+describe("resolveTrancheAgeValues", () => {
+  it("classe les moins de 16 ans", () => {
+    expect(resolveTrancheAgeValues({ age: 15 })).toEqual(["moins_18_ans"]);
+  });
+
+  it("ajoute le bucket caché 16-17 ans", () => {
+    expect(resolveTrancheAgeValues({ age: 16 })).toEqual(["moins_18_ans", "entre_16_17_ans"]);
+  });
+
+  it("classe les 18-25 ans", () => {
+    expect(resolveTrancheAgeValues({ age: 18 })).toEqual(["entre_18_25_ans"]);
+  });
+
+  it("classe les 25-30 ans", () => {
+    expect(resolveTrancheAgeValues({ age: 30 })).toEqual(["entre_25_30_ans"]);
+  });
+
+  it("classe les 30-45 ans", () => {
+    expect(resolveTrancheAgeValues({ age: 45 })).toEqual(["entre_30_45_ans"]);
+  });
+
+  it("ajoute le bucket caché 46-66 ans sous 67 ans", () => {
+    expect(resolveTrancheAgeValues({ age: 66 })).toEqual(["entre_46_67_ans", "entre_46_66_ans"]);
+  });
+
+  it("n'ajoute pas le bucket caché à 67 ans pile", () => {
+    expect(resolveTrancheAgeValues({ age: 67 })).toEqual(["entre_46_67_ans"]);
+  });
+
+  it("classe les 68-72 ans", () => {
+    expect(resolveTrancheAgeValues({ age: 72 })).toEqual(["entre_68_72_ans"]);
+  });
+
+  it("classe les plus de 72 ans", () => {
+    expect(resolveTrancheAgeValues({ age: 73 })).toEqual(["plus_72_ans"]);
+  });
+
+  it("ajoute moins_31_ans_handicap pour les moins de 31 ans en situation de handicap", () => {
+    expect(resolveTrancheAgeValues({ age: 25, handicap: true })).toEqual(["entre_18_25_ans", "moins_31_ans_handicap"]);
+  });
+
+  it("n'ajoute pas le bucket handicap à 31 ans et plus", () => {
+    expect(resolveTrancheAgeValues({ age: 31, handicap: true })).toEqual(["entre_30_45_ans"]);
+  });
+
+  it("lève une erreur si l'âge n'est pas un entier", () => {
+    expect(() => resolveTrancheAgeValues({ age: 25.5 })).toThrow(/integer between 0 and 120/);
+  });
+
+  it("lève une erreur si l'âge est hors bornes", () => {
+    expect(() => resolveTrancheAgeValues({ age: 121 })).toThrow(/integer between 0 and 120/);
+  });
+
+  it("lève une erreur si handicap n'est pas un booléen", () => {
+    expect(() => resolveTrancheAgeValues({ age: 25, handicap: "oui" })).toThrow(/must be a boolean/);
+  });
+
+  it("lève une erreur si params n'est pas un objet", () => {
+    expect(() => resolveTrancheAgeValues(25)).toThrow(/must be an object/);
+  });
+});

--- a/packages/taxonomy/tsconfig.json
+++ b/packages/taxonomy/tsconfig.json
@@ -11,5 +11,6 @@
     "rootDir": "./src",
     "ignoreDeprecations": "6.0"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__/**"]
 }

--- a/packages/taxonomy/vitest.config.ts
+++ b/packages/taxonomy/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/__tests__/**/*.{test,spec}.ts"],
+  },
+});


### PR DESCRIPTION
## Description

Cette Pull Request ajoute une couverture de tests et de lint pour les packages partagés du monorepo.

Elle introduit une suite Vitest pour `@engagement/taxonomy`, centrée sur la logique runtime exposée aux consommateurs API et plateform : parsing/validation des clés de taxonomie, génération de la liste de taxonomie, taxonomies enrichissables/gate, et transformers `department-code`, `location` et `tranche-age`.

Elle ajoute aussi le lint ESLint sur `@engagement/taxonomy` et `@engagement/dto`, l’intègre à la commande `npm run lint` racine, et branche un job CI dédié aux tests taxonomy sur les changements `packages/taxonomy/**`.

Côté CI/build, les changements `packages/**` déclenchent désormais aussi le build `plateform`, puisque `plateform` consomme `@engagement/taxonomy` et `@engagement/dto`. Les tests taxonomy sont exclus du build package afin de ne pas émettre les fichiers `__tests__` dans `dist`. La config ESLint analytics ignore également `dbt/**/.venv/**` pour éviter de linter les dépendances Python locales.

## Liens utiles

- 📝 Ticket Notion : non renseigné

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation
- [x] Maintenance / CI

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

`@engagement/dto` reste sans tests runtime dédiés car le package ne contient que des types ; sa validité reste couverte par `tsc` et par le lint ajouté dans cette PR.