### PR TITLE
feat(app): add autocomplete attributes on auth & account forms

### DIFF
--- a/app/src/scenes/account/index.jsx
+++ b/app/src/scenes/account/index.jsx
@@ -80,6 +80,7 @@ const Account = () => {
               id="firstname"
               className={`input mb-2 ${errors.firstname ? "border-b-error" : "border-b-black"}`}
               name="firstname"
+              autoComplete="given-name"
               value={values.firstname}
               onChange={(e) => setValues({ ...values, firstname: e.target.value })}
             />
@@ -99,6 +100,7 @@ const Account = () => {
               id="lastname"
               className={`input mb-2 ${errors.lastname ? "border-b-error" : "border-b-black"}`}
               name="lastname"
+              autoComplete="family-name"
               value={values.lastname}
               onChange={(e) => setValues({ ...values, lastname: e.target.value })}
             />

--- a/app/src/scenes/auth/Login.jsx
+++ b/app/src/scenes/auth/Login.jsx
@@ -64,7 +64,7 @@ const Login = () => {
       <label className="mt-6 mb-2 text-sm" htmlFor="email">
         E-mail
       </label>
-      <input className={`input mb-2 ${errors.email ? "border-b-error" : "border-b-black"}`} name="email" id="email" type="email" />
+      <input className={`input mb-2 ${errors.email ? "border-b-error" : "border-b-black"}`} name="email" id="email" type="email" autoComplete="email" />
       {errors.email && (
         <div className="text-error flex items-center text-sm">
           <RiErrorWarningFill className="mr-2" aria-hidden="true" />
@@ -75,7 +75,7 @@ const Login = () => {
       <label className="mt-6 mb-2 text-sm" htmlFor="password">
         Mot de passe
       </label>
-      <input className={`input mb-2 ${errors.password ? "border-b-error" : "border-b-black"}`} name="password" type="password" id="password" />
+      <input className={`input mb-2 ${errors.password ? "border-b-error" : "border-b-black"}`} name="password" type="password" id="password" autoComplete="current-password" />
       {errors.password && (
         <div className="text-error flex items-center text-sm">
           <RiErrorWarningFill className="mr-2" aria-hidden="true" />


### PR DESCRIPTION
## Description

Ajout des attributs `autocomplete` sur les formulaires d'authentification et de compte pour traiter le **critère RGAA 11.13** (remplissage automatique). Première PR d'une série traitant les retours d'accessibilité RGAA (sévérité bloquante) sur le périmètre `app/`.

- **Login (P01)** — `app/src/scenes/auth/Login.jsx` : `autocomplete="email"` sur le champ e-mail, `autocomplete="current-password"` sur le champ mot de passe.
- **Mon compte (P02)** — `app/src/scenes/account/index.jsx` : `autocomplete="given-name"` sur le prénom, `autocomplete="family-name"` sur le nom de famille.

Partie de ce ticket Notion : https://app.notion.com/p/jeveuxaider/Tableau-de-bord-008-Les-formulaires-ne-sont-pas-accessibles-3-1-11-1-11-2-11-5-11-9-11-10-1-23172a322d5080128c6ae12f9346d560?source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité (accessibilité)

## Checklist

- [x] Code testé localement
- [x] Respect des standards de code (ESLint)

## Notes complémentaires

Le champ e-mail de la page "Mon compte" est en `readOnly` → `autocomplete` non pertinent.