### PR TITLE
fix(app): associate labels with form fields

### DIFF
--- a/app/src/components/SearchInput.jsx
+++ b/app/src/components/SearchInput.jsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 
 import MagnifyIconSvg from "@/assets/svg/magnify-icon.svg";
 
-const SearchInput = ({ value, onChange, className, placeholder, timeout = 400, ...props }) => {
+const SearchInput = ({ id, label = "Rechercher", value, onChange, className, placeholder, timeout = 400, ...props }) => {
+  const generatedId = useId();
+  const inputId = id || generatedId;
   const [input, setInput] = useState(value);
 
   useEffect(() => {
@@ -18,7 +20,10 @@ const SearchInput = ({ value, onChange, className, placeholder, timeout = 400, .
 
   return (
     <div role="search" className={`relative ${className || "w-full"}`}>
-      <input {...props} className="input w-full" value={input} onChange={(e) => setInput(e.target.value)} placeholder={placeholder} />
+      <label htmlFor={inputId} className="sr-only">
+        {label}
+      </label>
+      <input {...props} id={inputId} className="input w-full" value={input} onChange={(e) => setInput(e.target.value)} placeholder={placeholder} />
       <img src={MagnifyIconSvg} className="absolute top-1/2 right-4 -translate-y-1/2 transform" alt="" aria-hidden="true" />
     </div>
   );

--- a/app/src/scenes/broadcast/moderation/components/Filters.jsx
+++ b/app/src/scenes/broadcast/moderation/components/Filters.jsx
@@ -67,7 +67,13 @@ const Filters = ({ filters, onChange, reload }) => {
         </div>
       </div>
       <div className="mt-4 mb-4 flex w-full justify-start sm:mt-0">
-        <SearchInput value={filters.search} onChange={(e) => onChange({ ...filters, search: e })} placeholder="Rechercher" className="w-full sm:w-[40%]" />
+        <SearchInput
+          label="Rechercher une mission"
+          value={filters.search}
+          onChange={(e) => onChange({ ...filters, search: e })}
+          placeholder="Rechercher"
+          className="w-full sm:w-[40%]"
+        />
       </div>
       <div className="grid grid-cols-1 gap-4 pb-4 md:grid-cols-2 lg:grid-cols-4">
         <Select

--- a/app/src/scenes/broadcast/moderation/modal/components/Note.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/components/Note.jsx
@@ -1,6 +1,6 @@
+import { toast } from "@/services/toast";
 import { useEffect, useState } from "react";
 import { RiPencilFill } from "react-icons/ri";
-import { toast } from "@/services/toast";
 
 import api from "@/services/api";
 import { captureError } from "@/services/error";
@@ -61,6 +61,9 @@ const Note = ({ data, onChange }) => {
 
       {editing && (
         <>
+          <label htmlFor="note" className="mb-1 text-sm">
+            Note
+          </label>
           <textarea id="note" className="textarea mb-2 border-b-black" name="note" value={note} onChange={(e) => setNote(e.target.value)} rows={4} placeholder="Ajouter une note" />
           <button className="primary-btn w-1/2" onClick={handleSave}>
             Enregistrer

--- a/app/src/scenes/my-missions/Flux.jsx
+++ b/app/src/scenes/my-missions/Flux.jsx
@@ -138,7 +138,13 @@ const Flux = ({ moderated }) => {
         </InfoAlert>
       )}
       <div className="flex flex-col gap-6">
-        <SearchInput className="w-full sm:w-96" value={filters.search} onChange={(search) => setFilters({ ...filters, search })} placeholder="Rechercher par mot-clé" />
+        <SearchInput
+          label="Rechercher une mission par mot-clé"
+          className="w-full sm:w-96"
+          value={filters.search}
+          onChange={(search) => setFilters({ ...filters, search })}
+          placeholder="Rechercher par mot-clé"
+        />
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
           <Select
             options={options.status.map((e) => ({ value: e.key, label: STATUS_PLR[e.key], count: e.doc_count }))}

--- a/app/src/scenes/widget/components/Settings.jsx
+++ b/app/src/scenes/widget/components/Settings.jsx
@@ -196,9 +196,9 @@ const Settings = ({ widget, values, onChange, loading }) => {
             ) : (
               <div className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2 lg:grid-cols-3">
                 {filteredPublishers.slice(0, showAll ? filteredPublishers.length : 15).map((item, i) => (
-                  <label
+                  <div
                     key={i}
-                    className={`hover:border-blue-france flex cursor-pointer gap-4 rounded border p-4 ${values.publishers.includes(item.key) ? "border-blue-france" : "border-gray-300"}`}
+                    className={`hover:border-blue-france flex gap-4 rounded border p-4 ${values.publishers.includes(item.key) ? "border-blue-france" : "border-gray-300"}`}
                   >
                     <div className="flex items-center gap-2">
                       <input
@@ -214,7 +214,12 @@ const Settings = ({ widget, values, onChange, loading }) => {
                     </div>
 
                     <div className="flex flex-col truncate">
-                      <span className={`line-clamp-2 truncate text-sm ${values.publishers.includes(item.key) ? "text-blue-france" : "text-black"}`}>{item.label}</span>
+                      <label
+                        htmlFor={`${i}-publishers`}
+                        className={`line-clamp-2 cursor-pointer truncate text-sm ${values.publishers.includes(item.key) ? "text-blue-france" : "text-black"}`}
+                      >
+                        {item.label}
+                      </label>
                     </div>
 
                     {item.moderation && item.moderation.length > 0 && values.publishers.includes(item.key) && (
@@ -242,7 +247,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
                         ))}
                       </div>
                     )}
-                  </label>
+                  </div>
                 ))}
               </div>
             );


### PR DESCRIPTION
## Description

Traite les **critères RGAA 11.1** (liaison étiquette/champ) et **11.4** (étiquette accolée à son champ). Deuxième PR de la série accessibilité (sévérité bloquante) sur `app/`.

Partie de ce ticket Notion : https://app.notion.com/p/jeveuxaider/Tableau-de-bord-008-Les-formulaires-ne-sont-pas-accessibles-3-1-11-1-11-2-11-5-11-9-11-10-1-23172a322d5080128c6ae12f9346d560?source=copy_link

### Changements

- **`SearchInput` (composant partagé)** : ajout d'un `<label>` masqué visuellement (`sr-only`) relié au champ via `htmlFor` (id généré par `useId` si non fourni, prop `label` personnalisable). Répercuté sur :
  - **P09** — Modération diffuseur (`Filters.jsx`)
  - **P13** — Vos missions (`Flux.jsx`)
- **P08 — Création de widget (`widget/components/Settings.jsx`)** : la `<label>` qui enveloppait la case à cocher d'un diffuseur contenait aussi les cases à cocher imbriquées de modération (HTML invalide, association implicite cassée). Conteneur converti en `<div>` et intitulé relié explicitement au champ via `htmlFor`.
- **P10 — Page mission / note (`moderation/modal/components/Note.jsx`)** : ajout d'un `<label for="note">` accolé à la zone de texte (la textarea n'avait aucune étiquette).

### Déjà conforme (vérifié)

- **P08 — champ « Code hexadécimal couleur »** : l'`<input>` porte déjà `id="color"` correspondant au `htmlFor="color"` du label. Aucun changement nécessaire.

## Type de changement

- [x] Correction de bug (accessibilité)

## Checklist

- [x] Code testé localement (`vite build` OK)
- [x] Respect des standards de code (ESLint)

## Notes complémentaires

Le regroupement par `<fieldset>` (critère 11.5) des cases/radios de cette page fait l'objet d'une PR distincte.