### PR TITLE
fix(app): group related form fields with fieldset/legend

### DIFF
--- a/app/src/scenes/broadcast/moderation/components/SettingsModal.jsx
+++ b/app/src/scenes/broadcast/moderation/components/SettingsModal.jsx
@@ -14,10 +14,8 @@ const SettingsModal = () => {
 
       <Modal open={open} onClose={() => setOpen(false)} className="min-w-5xl" title="Paramétrages de la modération automatique">
         <div className="border-grey-border mb-10 flex flex-col border p-4">
-          <div className="flex items-start gap-3">
-            <div className="w-[20%]">
-              <h3 className="text-lg">Conditions</h3>
-            </div>
+          <fieldset className="flex items-start gap-3">
+            <legend className="w-[20%] text-lg">Conditions</legend>
             <div className="flex w-[20%] flex-col gap-2">
               <select className="select" disabled defaultValue="">
                 <option value="">createdAt</option>
@@ -38,12 +36,10 @@ const SettingsModal = () => {
               <input className="input" type="text" defaultValue="6 mois" readOnly />
               <input className="input" type="text" defaultValue="À modérer" readOnly />
             </div>
-          </div>
+          </fieldset>
           <div className="border-grey-border my-4 border-t" />
-          <div className="flex items-start gap-3">
-            <div className="w-[20%]">
-              <h3 className="text-lg">Action</h3>
-            </div>
+          <fieldset className="flex items-start gap-3">
+            <legend className="w-[20%] text-lg">Action</legend>
             <div className="flex w-[20%] flex-col gap-2">
               <select className="select" disabled defaultValue="">
                 <option value="">modération</option>
@@ -64,13 +60,11 @@ const SettingsModal = () => {
               <input className="input" type="text" defaultValue="Refusée" readOnly />
               <input className="input" type="text" defaultValue="La mission est refusée car la date de création est trop ancienne (> 6 mois)" readOnly />
             </div>
-          </div>
+          </fieldset>
         </div>
         <div className="border-grey-border flex flex-col border p-4">
-          <div className="flex items-start gap-3">
-            <div className="w-[20%]">
-              <h3 className="text-lg">Conditions</h3>
-            </div>
+          <fieldset className="flex items-start gap-3">
+            <legend className="w-[20%] text-lg">Conditions</legend>
             <div className="flex w-[20%] flex-col gap-2">
               <select className="select" disabled defaultValue="">
                 <option value="">startAt</option>
@@ -98,12 +92,10 @@ const SettingsModal = () => {
               <input className="input" type="text" defaultValue="21 jours" readOnly />
               <input className="input" type="text" defaultValue="À modérer" readOnly />
             </div>
-          </div>
+          </fieldset>
           <div className="border-grey-border my-4 border-t" />
-          <div className="flex items-start gap-3">
-            <div className="w-[20%]">
-              <h3 className="text-lg">Action</h3>
-            </div>
+          <fieldset className="flex items-start gap-3">
+            <legend className="w-[20%] text-lg">Action</legend>
             <div className="flex w-[20%] flex-col gap-2">
               <select className="select" disabled defaultValue="">
                 <option value="">modération</option>
@@ -124,13 +116,11 @@ const SettingsModal = () => {
               <input className="input" type="text" defaultValue="Refusée" readOnly />
               <input className="input" type="text" defaultValue="La date de la mission n’est pas compatible avec le recrutement de bénévoles" readOnly />
             </div>
-          </div>
+          </fieldset>
         </div>
         <div className="border-grey-border flex flex-col border p-4">
-          <div className="flex items-start gap-3">
-            <div className="w-[20%]">
-              <h3 className="text-lg">Conditions</h3>
-            </div>
+          <fieldset className="flex items-start gap-3">
+            <legend className="w-[20%] text-lg">Conditions</legend>
             <div className="flex w-[20%] flex-col gap-2">
               <select className="select" disabled defaultValue="">
                 <option value="">description</option>
@@ -151,12 +141,10 @@ const SettingsModal = () => {
               <input className="input" type="text" defaultValue="300 caractères" readOnly />
               <input className="input" type="text" defaultValue="À modérer" readOnly />
             </div>
-          </div>
+          </fieldset>
           <div className="border-grey-border my-4 border-t" />
-          <div className="flex items-start gap-3">
-            <div className="w-[20%]">
-              <h3 className="text-lg">Action</h3>
-            </div>
+          <fieldset className="flex items-start gap-3">
+            <legend className="w-[20%] text-lg">Action</legend>
             <div className="flex w-[20%] flex-col gap-2">
               <select className="select" disabled defaultValue="">
                 <option value="">modération</option>
@@ -177,13 +165,11 @@ const SettingsModal = () => {
               <input className="input" type="text" defaultValue="Refusée" readOnly />
               <input className="input" type="text" defaultValue="Le contenu est insuffisant / non qualitatif" readOnly />
             </div>
-          </div>
+          </fieldset>
         </div>
         <div className="border-grey-border flex flex-col border p-4">
-          <div className="flex items-start gap-3">
-            <div className="w-[20%]">
-              <h3 className="text-lg">Conditions</h3>
-            </div>
+          <fieldset className="flex items-start gap-3">
+            <legend className="w-[20%] text-lg">Conditions</legend>
             <div className="flex w-[20%] flex-col gap-2">
               <select className="select" disabled defaultValue="">
                 <option value="">city</option>
@@ -204,12 +190,10 @@ const SettingsModal = () => {
               <div className="h-9" />
               <input className="input" type="text" defaultValue="À modérer" readOnly />
             </div>
-          </div>
+          </fieldset>
           <div className="border-grey-border my-4 border-t" />
-          <div className="flex items-start gap-3">
-            <div className="w-[20%]">
-              <h3 className="text-lg">Action</h3>
-            </div>
+          <fieldset className="flex items-start gap-3">
+            <legend className="w-[20%] text-lg">Action</legend>
             <div className="flex w-[20%] flex-col gap-2">
               <select className="select" disabled defaultValue="">
                 <option value="">modération</option>
@@ -231,7 +215,7 @@ const SettingsModal = () => {
               <input className="input" type="text" defaultValue="Refusée" readOnly />
               <input className="input" type="text" defaultValue="Le contenu est insuffisant / non qualitatif" readOnly />
             </div>
-          </div>
+          </fieldset>
         </div>
       </Modal>
     </>

--- a/app/src/scenes/settings/RealTime.jsx
+++ b/app/src/scenes/settings/RealTime.jsx
@@ -124,7 +124,8 @@ const RealTime = () => {
               </p>
             )}
           </div>
-          <div className="flex flex-wrap items-center gap-3 lg:justify-end lg:gap-4">
+          <fieldset className="flex flex-wrap items-center gap-3 lg:justify-end lg:gap-4">
+            <legend className="sr-only">Type d'événement</legend>
             <RadioInput id="type-all" name="type" value="" label="Tous" checked={type === ""} onChange={(e) => setType(e.target.value)} />
             {sourceType !== "campaign" && (
               <RadioInput id="type-print" name="type" value="print" label="Impressions" checked={type === "print"} onChange={(e) => setType(e.target.value)} />
@@ -132,7 +133,7 @@ const RealTime = () => {
             <RadioInput id="type-click" name="type" value="click" label="Redirections" checked={type === "click"} onChange={(e) => setType(e.target.value)} />
             <RadioInput id="type-apply" name="type" value="apply" label="Candidatures" checked={type === "apply"} onChange={(e) => setType(e.target.value)} />
             <RadioInput id="type-account" name="type" value="account" label="Créations de compte" checked={type === "account"} onChange={(e) => setType(e.target.value)} />
-          </div>
+          </fieldset>
         </div>
 
         <Table

--- a/app/src/scenes/widget/components/Settings.jsx
+++ b/app/src/scenes/widget/components/Settings.jsx
@@ -117,10 +117,10 @@ const Settings = ({ widget, values, onChange, loading }) => {
         <h2 className="text-2xl font-bold">Missions à diffuser</h2>
 
         <div className="grid grid-cols-1 gap-10 sm:grid-cols-2">
-          <div className="flex flex-col gap-1">
-            <label className="text-base">
+          <fieldset className="flex flex-col gap-1">
+            <legend className="text-base">
               Type de mission<span className="text-error ml-1">*</span>
-            </label>
+            </legend>
             <div className="flex items-center">
               {availableTypes.map((type) => (
                 <RadioInput
@@ -136,7 +136,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
                 />
               ))}
             </div>
-          </div>
+          </fieldset>
           <div />
 
           <div className="flex flex-col gap-1">
@@ -171,11 +171,11 @@ const Settings = ({ widget, values, onChange, loading }) => {
           </div>
         </div>
 
-        <div className="flex flex-col gap-1">
-          <label className="text-base" htmlFor="location">
+        <fieldset className="flex flex-col gap-1">
+          <legend className="text-base">
             Diffuser des missions de
             <span className="text-error ml-1">*</span>
-          </label>
+          </legend>
 
           <div>
             <button
@@ -267,7 +267,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
               </div>
             </div>
           )}
-        </div>
+        </fieldset>
 
         <div className="space-y-4">
           <div className="space-y-2">
@@ -288,10 +288,10 @@ const Settings = ({ widget, values, onChange, loading }) => {
         <h2 className="text-2xl font-bold">Personnalisation</h2>
 
         <div className="grid grid-cols-1 gap-10 sm:grid-cols-2">
-          <div className="flex flex-col gap-4">
-            <label className="text-base" htmlFor="style">
+          <fieldset className="flex flex-col gap-4">
+            <legend className="text-base">
               Mode d'affichage<span className="text-error ml-1">*</span>
-            </label>
+            </legend>
             <div className="flex items-center justify-between">
               <div>
                 <RadioInput
@@ -317,7 +317,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
                 <span className="text-text-mention text-xs">Fait défiler les missions 3 par 3</span>
               </div>
             </div>
-          </div>
+          </fieldset>
 
           <div className="flex flex-col gap-4">
             <label className="text-base" htmlFor="color">


### PR DESCRIPTION
## Description

Traite le **critère RGAA 11.5** (regroupement des champs de même nature). Troisième PR de la série accessibilité (sévérité bloquante) sur `app/`.

Partie de ce ticket Notion : https://app.notion.com/p/jeveuxaider/Tableau-de-bord-008-Les-formulaires-ne-sont-pas-accessibles-3-1-11-1-11-2-11-5-11-9-11-10-1-23172a322d5080128c6ae12f9346d560?source=copy_link

### Changements

- **P08 — Création de widget (`widget/components/Settings.jsx`)** : les groupes « Type de mission », « Mode d'affichage » (boutons radio) et « Diffuser des missions de » (cases à cocher) passent de `<div>`+`<label>` à `<fieldset>`+`<legend>`. Cela corrige aussi des `htmlFor` qui pointaient vers des champs inexistants (`#style`) ou erronés (`#location` dupliqué).
- **P09 — Modération automatique (`moderation/components/SettingsModal.jsx`)** : chaque section « Conditions » et « Action » des 4 règles est regroupée dans un `<fieldset>`+`<legend>`. La `<legend>` reste un élément flex (le `<fieldset>` est en `display:flex`) pour préserver la disposition en colonnes existante.
- **P19 — Événements en temps réel (`settings/RealTime.jsx`)** : les boutons radio du type d'événement sont regroupés dans un `<fieldset>` avec une `<legend>` masquée visuellement (`sr-only`) afin de ne pas perturber la barre de filtres.

## Type de changement

- [x] Correction de bug (accessibilité)

## Checklist

- [x] Code testé localement (`vite build` OK)
- [x] Respect des standards de code (ESLint)

## Notes complémentaires

- Le `SettingsModal` (P09) est une prévisualisation en lecture seule des règles (tous les `select` sont `disabled`, inputs `readOnly`) ; seul le regroupement sémantique est ajouté.
- ⚠️ Touche `Settings.jsx`, également modifié par la PR `fix(app): associate labels with form fields` (#1087). Prévoir un merge dans l'ordre de la série pour limiter les conflits.