### PR TITLE
fix(app): distinguish password criteria beyond color

### DIFF
--- a/app/src/scenes/account/index.jsx
+++ b/app/src/scenes/account/index.jsx
@@ -123,6 +123,16 @@ const Account = () => {
   );
 };
 
+const PasswordCriterion = ({ valid, children }) => (
+  <div className="flex items-center gap-2">
+    {valid ? <RiCheckboxCircleFill className="text-success" aria-hidden="true" /> : <RiCloseCircleFill className="text-text-mention" aria-hidden="true" />}
+    <span className={`align-middle text-sm ${valid ? "text-success" : "text-text-mention"}`}>
+      {children}
+      <span className="sr-only"> : {valid ? "critère validé" : "critère non validé"}</span>
+    </span>
+  </div>
+);
+
 const ResetPasswordModal = () => {
   const [open, setOpen] = useState(false);
   const [values, setValues] = useState({
@@ -269,42 +279,10 @@ const ResetPasswordModal = () => {
         </div>
 
         <div className="flex flex-col gap-2">
-          <div className="flex items-center gap-2">
-            {(values.newPassword || "").length >= 12 ? (
-              <RiCheckboxCircleFill className="text-success" aria-hidden="true" />
-            ) : (
-              <RiCheckboxCircleFill className="text-text-mention" aria-hidden="true" />
-            )}
-            <span className={`align-middle text-sm ${values.newPassword && (values.newPassword || "").length >= 12 ? "text-success" : "text-text-mention"}`}>
-              Au moins 12 caractères
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
-            {/[a-zA-Z]/.test(values.newPassword) ? (
-              <RiCheckboxCircleFill className="text-success" aria-hidden="true" />
-            ) : (
-              <RiCheckboxCircleFill className="text-text-mention" aria-hidden="true" />
-            )}
-            <span className={`align-middle text-sm ${values.newPassword && /[a-zA-Z]/.test(values.newPassword) ? "text-success" : "text-text-mention"}`}>Au moins une lettre</span>
-          </div>
-          <div className="flex items-center gap-2">
-            {/[0-9]/.test(values.newPassword) ? (
-              <RiCheckboxCircleFill className="text-success" aria-hidden="true" />
-            ) : (
-              <RiCheckboxCircleFill className="text-text-mention" aria-hidden="true" />
-            )}
-            <span className={`align-middle text-sm ${values.newPassword && /[0-9]/.test(values.newPassword) ? "text-success" : "text-text-mention"}`}>Au moins un chiffre</span>
-          </div>
-          <div className="flex items-center gap-2">
-            {/[!-@#$%^&*(),.?":{}|<>]/.test(values.newPassword) ? (
-              <RiCheckboxCircleFill className="text-success" aria-hidden="true" />
-            ) : (
-              <RiCheckboxCircleFill className="text-text-mention" aria-hidden="true" />
-            )}
-            <span className={`align-middle text-sm ${values.newPassword && /[!-@#$%^&*(),.?":{}|<>]/.test(values.newPassword) ? "text-success" : "text-text-mention"}`}>
-              Au moins un caractère spécial
-            </span>
-          </div>
+          <PasswordCriterion valid={(values.newPassword || "").length >= 12}>Au moins 12 caractères</PasswordCriterion>
+          <PasswordCriterion valid={/[a-zA-Z]/.test(values.newPassword)}>Au moins une lettre</PasswordCriterion>
+          <PasswordCriterion valid={/[0-9]/.test(values.newPassword)}>Au moins un chiffre</PasswordCriterion>
+          <PasswordCriterion valid={/[!-@#$%^&*(),.?":{}|<>]/.test(values.newPassword)}>Au moins un caractère spécial</PasswordCriterion>
         </div>
 
         <div className="flex justify-end gap-2">

--- a/app/src/scenes/account/index.jsx
+++ b/app/src/scenes/account/index.jsx
@@ -1,7 +1,7 @@
 import { toast } from "@/services/toast";
 import { useState } from "react";
 import { IoMdEye, IoMdEyeOff } from "react-icons/io";
-import { RiCheckboxCircleFill, RiErrorWarningFill } from "react-icons/ri";
+import { RiCheckboxCircleFill, RiCloseCircleFill, RiErrorWarningFill } from "react-icons/ri";
 import { TiDeleteOutline } from "react-icons/ti";
 import { Navigate } from "react-router-dom";
 


### PR DESCRIPTION
## Description

Traite le **critère RGAA 3.1** (l'information validé/non validé ne doit pas reposer uniquement sur la couleur). Quatrième PR de la série accessibilité (sévérité bloquante) sur `app/`.

Partie de ce ticket Notion : https://app.notion.com/p/jeveuxaider/Tableau-de-bord-008-Les-formulaires-ne-sont-pas-accessibles-3-1-11-1-11-2-11-5-11-9-11-10-1-23172a322d5080128c6ae12f9346d560?source=copy_link

### Contexte

Dans la modale de réinitialisation du mot de passe (**P02 — Mon compte**), les critères de sécurité (12 caractères, une lettre, un chiffre, un caractère spécial) étaient distingués par la seule **couleur** de l'icône (coche verte si validé / coche grise sinon).

### Changements (`scenes/account/index.jsx`)

- **Critère validé** → coche (`RiCheckboxCircleFill`, verte).
- **Critère non validé** → croix (`RiCloseCircleFill`, grise) — la forme distingue désormais l'état, pas seulement la couleur.
- Ajout pour chaque critère d'un texte masqué `sr-only` (« critère validé » / « critère non validé ») pour les technologies d'assistance.
- Les 4 critères sont factorisés dans un composant local `PasswordCriterion`.

## Type de changement

- [x] Correction de bug (accessibilité)

## Checklist

- [x] Code testé localement (`vite build` OK)
- [x] Respect des standards de code (ESLint)