### PR TITLE
feat(api): make v2/activity endpoint compatible for diffuseur usage

### DIFF
--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -755,6 +755,17 @@ components:
             code: "NOT_FOUND"
             message: "Mission not found"
 
+    Forbidden:
+      description: Accès refusé
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            ok: false
+            code: "FORBIDDEN"
+            message: "Mission not accessible"
+
     Conflict:
       description: Conflit — la ressource existe déjà
       content:
@@ -1495,6 +1506,7 @@ paths:
         Le "missionId" permet à un diffuseur autorisé de déclarer une activité sans clic.
         Le "missionClientId" correspond à l'identifiant métier d'une mission du publisher authentifié.
         Au moins un champ parmi "clickId", "missionId" et "missionClientId" doit être fourni.
+        Le champ "missionId" ne doit pas être combiné avec "clickId" ou "missionClientId".
       operationId: createActivity
       tags: [Activités]
       requestBody:
@@ -1503,10 +1515,18 @@ paths:
           application/json:
             schema:
               type: object
-              anyOf:
+              oneOf:
                 - required: [clickId]
+                  not:
+                    required: [missionId]
                 - required: [missionId]
+                  not:
+                    anyOf:
+                      - required: [clickId]
+                      - required: [missionClientId]
                 - required: [missionClientId]
+                  not:
+                    required: [missionId]
               properties:
                 type:
                   type: string
@@ -1544,6 +1564,8 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           description: Clic ou mission introuvable
           content:

--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -1515,18 +1515,14 @@ paths:
           application/json:
             schema:
               type: object
-              oneOf:
+              anyOf:
                 - required: [clickId]
-                  not:
-                    required: [missionId]
                 - required: [missionId]
-                  not:
-                    anyOf:
-                      - required: [clickId]
-                      - required: [missionClientId]
                 - required: [missionClientId]
-                  not:
-                    required: [missionId]
+              not:
+                anyOf:
+                  - required: [clickId, missionId]
+                  - required: [missionId, missionClientId]
               properties:
                 type:
                   type: string

--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -1489,10 +1489,12 @@ paths:
       summary: Créer une activité
       description: |
         Enregistre un événement d'engagement (candidature ou création de compte)
-        lié à un clic tracé par l'API.
+        lié à un clic tracé par l'API ou directement à une mission.
 
         Le "clickId" doit correspondre à un clic enregistré par l'API Engagement.
-        Si "missionClientId" est fourni, l'activité sera enrichie avec les données de la mission correspondante.
+        Le "missionId" permet à un diffuseur autorisé de déclarer une activité sans clic.
+        Le "missionClientId" correspond à l'identifiant métier d'une mission du publisher authentifié.
+        Au moins un champ parmi "clickId", "missionId" et "missionClientId" doit être fourni.
       operationId: createActivity
       tags: [Activités]
       requestBody:
@@ -1501,7 +1503,10 @@ paths:
           application/json:
             schema:
               type: object
-              required: [clickId]
+              anyOf:
+                - required: [clickId]
+                - required: [missionId]
+                - required: [missionClientId]
               properties:
                 type:
                   type: string
@@ -1510,11 +1515,15 @@ paths:
                   description: Type d'événement (défaut "apply")
                 clickId:
                   type: string
-                  description: Identifiant du clic d'origine (obligatoire)
+                  description: Identifiant du clic d'origine
                   example: "64a1b2c3d4e5f6789abc0088"
+                missionId:
+                  type: string
+                  description: Identifiant interne API Engagement de la mission, utilisable par un diffuseur autorisé sans clickId
+                  example: "64a1b2c3d4e5f6789abc0001"
                 missionClientId:
                   type: string
-                  description: Identifiant client de la mission concernée (optionnel)
+                  description: Identifiant métier de la mission côté publisher authentifié
                 tag:
                   type: string
                   description: Tag libre (optionnel)

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -7,6 +7,9 @@ const prismaMock = prisma as unknown as {
   publisherDiffusionRule: {
     findMany: ReturnType<typeof vi.fn>;
   };
+  mission: {
+    count: ReturnType<typeof vi.fn>;
+  };
 };
 
 const getSqlText = (query: unknown): string => {
@@ -42,6 +45,7 @@ const buildRule = (overrides: Record<string, unknown> = {}) => ({
 describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere", () => {
   beforeEach(() => {
     prismaMock.publisherDiffusionRule.findMany.mockReset();
+    prismaMock.mission.count.mockReset();
   });
 
   it("loads the publisher's rules sorted by position", async () => {
@@ -189,5 +193,53 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     const sql = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleSql("publisher-1", { missionAlias: "m" });
 
     expect(getSqlText(sql)).toBe("AND FALSE");
+  });
+});
+
+describe("publisherDiffusionRuleService.canPublisherAccessMission", () => {
+  beforeEach(() => {
+    prismaMock.publisherDiffusionRule.findMany.mockReset();
+    prismaMock.mission.count.mockReset();
+  });
+
+  it("allows access when the publisher has no diffusion rules", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([]);
+
+    const canAccess = await publisherDiffusionRuleService.canPublisherAccessMission({ publisherId: "publisher-1", missionId: "mission-1" });
+
+    expect(canAccess).toBe(true);
+    expect(prismaMock.mission.count).not.toHaveBeenCalled();
+  });
+
+  it("blocks access when rules exist but none can be applied", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ field: "unknownField" })]);
+
+    const canAccess = await publisherDiffusionRuleService.canPublisherAccessMission({ publisherId: "publisher-1", missionId: "mission-1" });
+
+    expect(canAccess).toBe(false);
+    expect(prismaMock.mission.count).not.toHaveBeenCalled();
+  });
+
+  it("checks the mission against applicable diffusion rules", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ value: "annonceur-1" })]);
+    prismaMock.mission.count.mockResolvedValue(1);
+
+    const canAccess = await publisherDiffusionRuleService.canPublisherAccessMission({ publisherId: "publisher-1", missionId: "mission-1" });
+
+    expect(canAccess).toBe(true);
+    expect(prismaMock.mission.count).toHaveBeenCalledWith({
+      where: {
+        AND: [{ id: "mission-1" }, { OR: [{ publisherId: "annonceur-1" }] }],
+      },
+    });
+  });
+
+  it("rejects access when the mission does not match applicable diffusion rules", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ value: "annonceur-1" })]);
+    prismaMock.mission.count.mockResolvedValue(0);
+
+    const canAccess = await publisherDiffusionRuleService.canPublisherAccessMission({ publisherId: "publisher-1", missionId: "mission-1" });
+
+    expect(canAccess).toBe(false);
   });
 });

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -211,15 +211,6 @@ describe("publisherDiffusionRuleService.canPublisherAccessMission", () => {
     expect(prismaMock.mission.count).not.toHaveBeenCalled();
   });
 
-  it("blocks access when rules exist but none can be applied", async () => {
-    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ field: "unknownField" })]);
-
-    const canAccess = await publisherDiffusionRuleService.canPublisherAccessMission({ publisherId: "publisher-1", missionId: "mission-1" });
-
-    expect(canAccess).toBe(false);
-    expect(prismaMock.mission.count).not.toHaveBeenCalled();
-  });
-
   it("checks the mission against applicable diffusion rules", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ value: "annonceur-1" })]);
     prismaMock.mission.count.mockResolvedValue(1);

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -8,8 +8,6 @@ const findRulesByPublisherId = async (publisherId: string): Promise<PublisherDif
     orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
   });
 
-const MISSION_ACCESS_RULE_FIELDS = new Set(["publisherId", "publisherOrganizationId", "type", "title", "publisherOrganization.clientId", "publisherOrganization.parentOrganizations"]);
-
 export const publisherDiffusionRuleService = {
   async buildMissionPublisherDiffusionRuleWhere(publisherId: string): Promise<Prisma.MissionWhereInput> {
     const rules = await findRulesByPublisherId(publisherId);
@@ -23,12 +21,7 @@ export const publisherDiffusionRuleService = {
       return true;
     }
 
-    const accessRules = rules.filter((rule) => MISSION_ACCESS_RULE_FIELDS.has(rule.field));
-    if (accessRules.length === 0) {
-      return false;
-    }
-
-    const diffusionRuleWhere = buildMissionPublisherDiffusionRuleWhereFromRules(accessRules);
+    const diffusionRuleWhere = buildMissionPublisherDiffusionRuleWhereFromRules(rules);
     if (Object.keys(diffusionRuleWhere).length === 0) {
       return false;
     }

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -8,11 +8,38 @@ const findRulesByPublisherId = async (publisherId: string): Promise<PublisherDif
     orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
   });
 
+const MISSION_ACCESS_RULE_FIELDS = new Set(["publisherId", "publisherOrganizationId", "type", "title", "publisherOrganization.clientId", "publisherOrganization.parentOrganizations"]);
+
 export const publisherDiffusionRuleService = {
   async buildMissionPublisherDiffusionRuleWhere(publisherId: string): Promise<Prisma.MissionWhereInput> {
     const rules = await findRulesByPublisherId(publisherId);
 
     return buildMissionPublisherDiffusionRuleWhereFromRules(rules);
+  },
+
+  async canPublisherAccessMission({ publisherId, missionId }: { publisherId: string; missionId: string }): Promise<boolean> {
+    const rules = await findRulesByPublisherId(publisherId);
+    if (rules.length === 0) {
+      return true;
+    }
+
+    const accessRules = rules.filter((rule) => MISSION_ACCESS_RULE_FIELDS.has(rule.field));
+    if (accessRules.length === 0) {
+      return false;
+    }
+
+    const diffusionRuleWhere = buildMissionPublisherDiffusionRuleWhereFromRules(accessRules);
+    if (Object.keys(diffusionRuleWhere).length === 0) {
+      return false;
+    }
+
+    const count = await prisma.mission.count({
+      where: {
+        AND: [{ id: missionId }, diffusionRuleWhere],
+      },
+    });
+
+    return count > 0;
   },
 
   async buildMissionPublisherDiffusionRuleSql(publisherId: string, options: { missionAlias?: string } = {}): Promise<Prisma.Sql> {

--- a/api/src/v2/activity.ts
+++ b/api/src/v2/activity.ts
@@ -70,6 +70,9 @@ router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction
       .refine((data) => data.clickId || data.missionId || data.missionClientId, {
         message: "clickId, missionId or missionClientId is required",
       })
+      .refine((data) => !data.clickId || !data.missionId, {
+        message: "missionId cannot be used together with clickId",
+      })
       .refine((data) => data.clickId || !data.missionId || !data.missionClientId, {
         message: "missionId and missionClientId cannot be used together without clickId",
       })

--- a/api/src/v2/activity.ts
+++ b/api/src/v2/activity.ts
@@ -3,11 +3,12 @@ import passport from "passport";
 import zod from "zod";
 
 import { INVALID_BODY, INVALID_PARAMS, NOT_FOUND } from "@/error";
+import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import missionService from "@/services/mission";
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import { statEventService } from "@/services/stat-event";
 import { StatEventRecord } from "@/types";
 import { PublisherRequest } from "@/types/passport";
-import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import type { PublisherRecord } from "@/types/publisher";
 
 const router = Router();
@@ -55,35 +56,36 @@ router.get("/:id", async (req: PublisherRequest, res: Response, next: NextFuncti
   }
 });
 
-
 router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
     const user = req.user as PublisherRecord;
     const body = zod
       .object({
         type: zod.enum(["apply", "account"]).default("apply"),
-        clickId: zod.string(),
+        clickId: zod.string().optional(),
+        missionId: zod.string().optional(),
         missionClientId: zod.string().optional(),
         tag: zod.string().optional(),
       })
+      .refine((data) => data.clickId || data.missionId || data.missionClientId, {
+        message: "clickId, missionId or missionClientId is required",
+      })
       .safeParse(req.body);
-
 
     if (!body.success) {
       return res.status(400).send({ ok: false, code: INVALID_BODY, error: JSON.parse(body.error.message) });
     }
 
-    const click:StatEventRecord | null = await statEventService.findOneStatEventById(body.data.clickId);
-    if (!click) {
-      return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Click not found" });
+    let click: StatEventRecord | null = null;
+    if (body.data.clickId) {
+      click = await statEventService.findOneStatEventById(body.data.clickId);
+      if (!click) {
+        return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Click not found" });
+      }
     }
 
     const obj = {
-      clickId: click._id,
-      fromPublisherId: click.fromPublisherId,
-      toPublisherId: user.id || null,
-
-      tag: body.data.tag || click.tag || "",
+      tag: body.data.tag || click?.tag || "",
       isBot: false,
       isHuman: true,
 
@@ -98,13 +100,47 @@ router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction
       status: "PENDING",
     } as StatEventRecord;
 
-    if (body.data.missionClientId) {
+    if (click) {
+      obj.clickId = click._id;
+      obj.fromPublisherId = click.fromPublisherId;
+      obj.toPublisherId = user.id;
+    }
+
+    if (click && body.data.missionClientId) {
       const mission = await missionService.findOneMissionBy({ clientId: body.data.missionClientId, publisherId: user.id });
       if (!mission) {
         return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Mission not found" });
       }
 
       obj.missionId = mission.id;
+    }
+
+    if (!click && body.data.missionClientId) {
+      const mission = await missionService.findOneMissionBy({ clientId: body.data.missionClientId, publisherId: user.id });
+      if (!mission) {
+        return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Mission not found" });
+      }
+
+      obj.missionId = mission.id;
+      obj.fromPublisherId = user.id;
+      obj.toPublisherId = mission.publisherId;
+    }
+
+    if (!click && body.data.missionId) {
+      const diffusionRuleWhere = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere(user.id);
+      const mission = await missionService.findOneMissionBy({
+        id: body.data.missionId,
+        statusCode: "ACCEPTED",
+        deletedAt: null,
+        ...diffusionRuleWhere,
+      });
+      if (!mission) {
+        return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Mission not found" });
+      }
+
+      obj.missionId = mission.id;
+      obj.fromPublisherId = user.id;
+      obj.toPublisherId = mission.publisherId;
     }
 
     const id = await statEventService.createStatEvent(obj);

--- a/api/src/v2/activity.ts
+++ b/api/src/v2/activity.ts
@@ -70,6 +70,9 @@ router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction
       .refine((data) => data.clickId || data.missionId || data.missionClientId, {
         message: "clickId, missionId or missionClientId is required",
       })
+      .refine((data) => data.clickId || !data.missionId || !data.missionClientId, {
+        message: "missionId and missionClientId cannot be used together without clickId",
+      })
       .safeParse(req.body);
 
     if (!body.success) {
@@ -126,7 +129,7 @@ router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction
       obj.toPublisherId = mission.publisherId;
     }
 
-    if (!click && body.data.missionId) {
+    } else if (!click && body.data.missionId) {
       const diffusionRuleWhere = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere(user.id);
       const mission = await missionService.findOneMissionBy({
         id: body.data.missionId,

--- a/api/src/v2/activity.ts
+++ b/api/src/v2/activity.ts
@@ -2,7 +2,7 @@ import { NextFunction, Response, Router } from "express";
 import passport from "passport";
 import zod from "zod";
 
-import { INVALID_BODY, INVALID_PARAMS, NOT_FOUND } from "@/error";
+import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, NOT_FOUND } from "@/error";
 import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import missionService from "@/services/mission";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
@@ -127,18 +127,19 @@ router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction
       obj.missionId = mission.id;
       obj.fromPublisherId = user.id;
       obj.toPublisherId = mission.publisherId;
-    }
-
     } else if (!click && body.data.missionId) {
-      const diffusionRuleWhere = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere(user.id);
       const mission = await missionService.findOneMissionBy({
         id: body.data.missionId,
         statusCode: "ACCEPTED",
         deletedAt: null,
-        ...diffusionRuleWhere,
       });
       if (!mission) {
         return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Mission not found" });
+      }
+
+      const canAccessMission = await publisherDiffusionRuleService.canPublisherAccessMission({ publisherId: user.id, missionId: mission.id });
+      if (!canAccessMission) {
+        return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Mission not accessible" });
       }
 
       obj.missionId = mission.id;

--- a/api/tests/integration/api/endpoints/v2/activity.test.ts
+++ b/api/tests/integration/api/endpoints/v2/activity.test.ts
@@ -281,7 +281,7 @@ describe("Activity V2 controller", () => {
       });
     });
 
-    it("returns 404 when missionId is outside the publisher diffusion rules", async () => {
+    it("returns 403 when missionId is outside the publisher diffusion rules", async () => {
       const allowedOwner = await publisherService.createPublisher({ name: "Allowed Owner", apikey: "allowed-owner-key" });
       const otherOwner = await publisherService.createPublisher({ name: "Other Owner", apikey: "other-owner-key" });
       const diffuser = await publisherService.createPublisher({ name: "Restricted Diffuser", apikey: "restricted-diffuser-key" });
@@ -308,8 +308,38 @@ describe("Activity V2 controller", () => {
         .set("apikey", diffuser.apikey || "")
         .send({ missionId: mission.id, tag: "MIG" });
 
-      expect(response.status).toBe(404);
-      expect(response.body).toEqual({ ok: false, code: "NOT_FOUND", message: "Mission not found" });
+      expect(response.status).toBe(403);
+      expect(response.body).toEqual({ ok: false, code: "FORBIDDEN", message: "Mission not accessible" });
+    });
+
+    it("returns 403 when the diffuser has rules that cannot be applied", async () => {
+      const owner = await publisherService.createPublisher({ name: "Invalid Rule Mission Owner", apikey: "invalid-rule-owner-key" });
+      const diffuser = await publisherService.createPublisher({ name: "Invalid Rule Diffuser", apikey: "invalid-rule-diffuser-key" });
+      const mission = await createTestMission({
+        clientId: "invalid-rule-mission",
+        title: "Invalid Rule Mission",
+        publisherId: owner.id,
+        statusCode: "ACCEPTED",
+      });
+
+      await prisma.publisherDiffusionRule.create({
+        data: {
+          publisherId: diffuser.id,
+          field: "unknownField",
+          fieldType: "string",
+          operator: "is",
+          value: owner.id,
+          combinator: "or",
+        },
+      });
+
+      const response = await request(app)
+        .post("/v2/activity/")
+        .set("apikey", diffuser.apikey || "")
+        .send({ missionId: mission.id, tag: "MIG" });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toEqual({ ok: false, code: "FORBIDDEN", message: "Mission not accessible" });
     });
 
     it("returns 404 when missionId targets a deleted or non accepted mission", async () => {

--- a/api/tests/integration/api/endpoints/v2/activity.test.ts
+++ b/api/tests/integration/api/endpoints/v2/activity.test.ts
@@ -312,36 +312,6 @@ describe("Activity V2 controller", () => {
       expect(response.body).toEqual({ ok: false, code: "FORBIDDEN", message: "Mission not accessible" });
     });
 
-    it("returns 403 when the diffuser has rules that cannot be applied", async () => {
-      const owner = await publisherService.createPublisher({ name: "Invalid Rule Mission Owner", apikey: "invalid-rule-owner-key" });
-      const diffuser = await publisherService.createPublisher({ name: "Invalid Rule Diffuser", apikey: "invalid-rule-diffuser-key" });
-      const mission = await createTestMission({
-        clientId: "invalid-rule-mission",
-        title: "Invalid Rule Mission",
-        publisherId: owner.id,
-        statusCode: "ACCEPTED",
-      });
-
-      await prisma.publisherDiffusionRule.create({
-        data: {
-          publisherId: diffuser.id,
-          field: "unknownField",
-          fieldType: "string",
-          operator: "is",
-          value: owner.id,
-          combinator: "or",
-        },
-      });
-
-      const response = await request(app)
-        .post("/v2/activity/")
-        .set("apikey", diffuser.apikey || "")
-        .send({ missionId: mission.id, tag: "MIG" });
-
-      expect(response.status).toBe(403);
-      expect(response.body).toEqual({ ok: false, code: "FORBIDDEN", message: "Mission not accessible" });
-    });
-
     it("returns 404 when missionId targets a deleted or non accepted mission", async () => {
       const owner = await publisherService.createPublisher({ name: "Unavailable Mission Owner", apikey: "unavailable-owner-key" });
       const diffuser = await publisherService.createPublisher({ name: "Unavailable Mission Diffuser", apikey: "unavailable-diffuser-key" });

--- a/api/tests/integration/api/endpoints/v2/activity.test.ts
+++ b/api/tests/integration/api/endpoints/v2/activity.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { describe, expect, it } from "vitest";
 
+import { prisma } from "@/db/postgres";
 import { publisherService } from "@/services/publisher";
 import { statEventService } from "@/services/stat-event";
 import { createTestMission } from "../../../../fixtures";
@@ -183,6 +184,177 @@ describe("Activity V2 controller", () => {
         toPublisherId: publisher.id,
       });
       expect(createdApply?.missionId).toBeNull();
+    });
+
+    it("records apply events without clickId using missionClientId for the authenticated publisher", async () => {
+      const publisher = await publisherService.createPublisher({ name: "Apply Publisher Mission Client", apikey: "apply-mission-client-key" });
+      const mission = await createTestMission({
+        clientId: "direct-apply-mission-client",
+        title: "Direct Apply Mission Client",
+        publisherId: publisher.id,
+        statusCode: "ACCEPTED",
+      });
+
+      const response = await request(app)
+        .post("/v2/activity/")
+        .set("apikey", publisher.apikey || "")
+        .send({ missionClientId: mission.clientId, tag: "owner-tag" });
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data).toMatchObject({ type: "apply", tag: "owner-tag", missionId: mission.id });
+
+      const createdApply = await statEventService.findOneStatEventById(response.body.data._id);
+      expect(createdApply).toMatchObject({
+        type: "apply",
+        fromPublisherId: publisher.id,
+        toPublisherId: publisher.id,
+        missionId: mission.id,
+      });
+      expect(createdApply?.clickId).toBeNull();
+    });
+
+    it("records apply events without clickId using missionId when diffusion rules allow the mission", async () => {
+      const owner = await publisherService.createPublisher({ name: "Mission Owner Publisher", apikey: "mission-owner-key" });
+      const diffuser = await publisherService.createPublisher({ name: "Allowed Diffuser Publisher", apikey: "allowed-diffuser-key" });
+      const mission = await createTestMission({
+        clientId: "allowed-diffusion-mission",
+        title: "Allowed Diffusion Mission",
+        publisherId: owner.id,
+        statusCode: "ACCEPTED",
+      });
+
+      await prisma.publisherDiffusionRule.create({
+        data: {
+          publisherId: diffuser.id,
+          field: "publisherId",
+          fieldType: "string",
+          operator: "is",
+          value: owner.id,
+          combinator: "or",
+        },
+      });
+
+      const response = await request(app)
+        .post("/v2/activity/")
+        .set("apikey", diffuser.apikey || "")
+        .send({ missionId: mission.id, tag: "MIG" });
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data).toMatchObject({ type: "apply", tag: "MIG", missionId: mission.id });
+
+      const createdApply = await statEventService.findOneStatEventById(response.body.data._id);
+      expect(createdApply).toMatchObject({
+        type: "apply",
+        fromPublisherId: diffuser.id,
+        toPublisherId: owner.id,
+        missionId: mission.id,
+      });
+      expect(createdApply?.clickId).toBeNull();
+    });
+
+    it("records apply events without clickId using missionId when the diffuser has no rules", async () => {
+      const owner = await publisherService.createPublisher({ name: "No Rules Mission Owner", apikey: "no-rules-owner-key" });
+      const diffuser = await publisherService.createPublisher({ name: "No Rules Diffuser", apikey: "no-rules-diffuser-key" });
+      const mission = await createTestMission({
+        clientId: "no-rules-mission",
+        title: "No Rules Mission",
+        publisherId: owner.id,
+        statusCode: "ACCEPTED",
+      });
+
+      const response = await request(app)
+        .post("/v2/activity/")
+        .set("apikey", diffuser.apikey || "")
+        .send({ missionId: mission.id, tag: "MIG" });
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+
+      const createdApply = await statEventService.findOneStatEventById(response.body.data._id);
+      expect(createdApply).toMatchObject({
+        type: "apply",
+        fromPublisherId: diffuser.id,
+        toPublisherId: owner.id,
+        missionId: mission.id,
+      });
+    });
+
+    it("returns 404 when missionId is outside the publisher diffusion rules", async () => {
+      const allowedOwner = await publisherService.createPublisher({ name: "Allowed Owner", apikey: "allowed-owner-key" });
+      const otherOwner = await publisherService.createPublisher({ name: "Other Owner", apikey: "other-owner-key" });
+      const diffuser = await publisherService.createPublisher({ name: "Restricted Diffuser", apikey: "restricted-diffuser-key" });
+      const mission = await createTestMission({
+        clientId: "outside-rules-mission",
+        title: "Outside Rules Mission",
+        publisherId: otherOwner.id,
+        statusCode: "ACCEPTED",
+      });
+
+      await prisma.publisherDiffusionRule.create({
+        data: {
+          publisherId: diffuser.id,
+          field: "publisherId",
+          fieldType: "string",
+          operator: "is",
+          value: allowedOwner.id,
+          combinator: "or",
+        },
+      });
+
+      const response = await request(app)
+        .post("/v2/activity/")
+        .set("apikey", diffuser.apikey || "")
+        .send({ missionId: mission.id, tag: "MIG" });
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({ ok: false, code: "NOT_FOUND", message: "Mission not found" });
+    });
+
+    it("returns 404 when missionId targets a deleted or non accepted mission", async () => {
+      const owner = await publisherService.createPublisher({ name: "Unavailable Mission Owner", apikey: "unavailable-owner-key" });
+      const diffuser = await publisherService.createPublisher({ name: "Unavailable Mission Diffuser", apikey: "unavailable-diffuser-key" });
+      const refusedMission = await createTestMission({
+        clientId: "refused-direct-apply-mission",
+        title: "Refused Direct Apply Mission",
+        publisherId: owner.id,
+        statusCode: "REFUSED",
+      });
+      const deletedMission = await createTestMission({
+        clientId: "deleted-direct-apply-mission",
+        title: "Deleted Direct Apply Mission",
+        publisherId: owner.id,
+        statusCode: "ACCEPTED",
+        deleted: true,
+      });
+
+      const refusedResponse = await request(app)
+        .post("/v2/activity/")
+        .set("apikey", diffuser.apikey || "")
+        .send({ missionId: refusedMission.id });
+      const deletedResponse = await request(app)
+        .post("/v2/activity/")
+        .set("apikey", diffuser.apikey || "")
+        .send({ missionId: deletedMission.id });
+
+      expect(refusedResponse.status).toBe(404);
+      expect(refusedResponse.body).toEqual({ ok: false, code: "NOT_FOUND", message: "Mission not found" });
+      expect(deletedResponse.status).toBe(404);
+      expect(deletedResponse.body).toEqual({ ok: false, code: "NOT_FOUND", message: "Mission not found" });
+    });
+
+    it("returns 400 when no clickId, missionId or missionClientId is provided", async () => {
+      const publisher = await publisherService.createPublisher({ name: "Apply Publisher Missing Link", apikey: "apply-missing-link-key" });
+
+      const response = await request(app)
+        .post("/v2/activity/")
+        .set("apikey", publisher.apikey || "")
+        .send({ tag: "missing-link" });
+
+      expect(response.status).toBe(400);
+      expect(response.body.ok).toBe(false);
+      expect(response.body.code).toBe("INVALID_BODY");
     });
 
     it("returns 404 when clickId does not exist", async () => {

--- a/api/tests/integration/api/endpoints/v2/activity.test.ts
+++ b/api/tests/integration/api/endpoints/v2/activity.test.ts
@@ -357,6 +357,19 @@ describe("Activity V2 controller", () => {
       expect(response.body.code).toBe("INVALID_BODY");
     });
 
+    it("returns 400 when missionId and missionClientId are provided without clickId", async () => {
+      const publisher = await publisherService.createPublisher({ name: "Apply Publisher Ambiguous Mission", apikey: "apply-ambiguous-mission-key" });
+
+      const response = await request(app)
+        .post("/v2/activity/")
+        .set("apikey", publisher.apikey || "")
+        .send({ missionId: "mission-id", missionClientId: "mission-client-id" });
+
+      expect(response.status).toBe(400);
+      expect(response.body.ok).toBe(false);
+      expect(response.body.code).toBe("INVALID_BODY");
+    });
+
     it("returns 404 when clickId does not exist", async () => {
       const publisher = await publisherService.createPublisher({ name: "Apply Publisher Missing Click", apikey: "apply-missing-click-key" });
 

--- a/api/tests/integration/api/endpoints/v2/activity.test.ts
+++ b/api/tests/integration/api/endpoints/v2/activity.test.ts
@@ -370,6 +370,22 @@ describe("Activity V2 controller", () => {
       expect(response.body.code).toBe("INVALID_BODY");
     });
 
+    it("returns 400 when missionId is provided with clickId", async () => {
+      const publisher = await publisherService.createPublisher({ name: "Apply Publisher Click Mission", apikey: "apply-click-mission-key" });
+      const clickStat = await createClickStat("click-with-mission-id", {
+        fromPublisherId: "click-from-with-mission-id",
+      });
+
+      const response = await request(app)
+        .post("/v2/activity/")
+        .set("apikey", publisher.apikey || "")
+        .send({ clickId: clickStat._id, missionId: "mission-id" });
+
+      expect(response.status).toBe(400);
+      expect(response.body.ok).toBe(false);
+      expect(response.body.code).toBe("INVALID_BODY");
+    });
+
     it("returns 404 when clickId does not exist", async () => {
       const publisher = await publisherService.createPublisher({ name: "Apply Publisher Missing Click", apikey: "apply-missing-click-key" });
 


### PR DESCRIPTION
## Description

Cette PR étend `POST /v2/activity` pour permettre à un diffuseur de déclarer une activité sans `clickId`, tout en conservant le comportement existant pour les intégrations déjà branchées sur le endpoint.

Le endpoint accepte désormais trois modes de rattachement :

- `clickId` : comportement existant, le clic reste la source de vérité pour le diffuseur (`fromPublisherId`) et `missionClientId` conserve sa sémantique actuelle.
- `missionClientId` sans `clickId` : compatibilité propriétaire, la mission est résolue via `{ clientId, publisherId: user.id }`.
- `missionId` sans `clickId` : nouveau mode diffuseur, la mission est résolue uniquement si elle est acceptée, non supprimée et autorisée par les règles de diffusion du publisher authentifié via `publisherDiffusionRuleService`.

La documentation OpenAPI de `POST /v2/activity` est mise à jour pour expliciter ces trois champs et indiquer qu’au moins l’un d’eux est requis.

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/R-trocompatibilit-v2-activity-pour-le-SNU-36c72a322d5080f5b960d4a5f94b805d?source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [x] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Besoin SNU (diffuseur JVA) qui : 
- Ne possède pas forcément de `clickId` dans certaines étapes du flow
- Souhaite créer des candidatures en tant que diffuseur, sans avoir le bon couple `missionClientId` / `publisherId`.