### PR TITLE
refactor(api): unique index for mission_enrichment

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -982,7 +982,7 @@ model MissionEnrichment {
   values          MissionEnrichmentValue[]
   missionScorings MissionScoring[]
 
-  @@index([missionId, promptVersion], map: "mission_enrichment_mission_version_idx")
+  @@unique([missionId, promptVersion], map: "mission_enrichment_mission_version_unique")
   @@index([status], map: "mission_enrichment_status_idx")
   @@map("mission_enrichment")
 }

--- a/api/scripts/purge-duplicate-mission-enrichments.ts
+++ b/api/scripts/purge-duplicate-mission-enrichments.ts
@@ -1,0 +1,108 @@
+/**
+ * Purge des `mission_enrichment` en doublon par (mission_id, prompt_version).
+ *
+ * Contexte : avant l'ajout de la contrainte unique (mission_id, prompt_version), chaque
+ * ré-enrichissement créait une nouvelle ligne `completed` sans supprimer les précédentes
+ * (~10 par mission). Ce script ne garde que la ligne « gagnante » du matching et supprime les
+ * autres. Le cascade DB nettoie automatiquement mission_enrichment_value, mission_scoring et
+ * mission_scoring_value rattachés.
+ *
+ * On garde, par (mission_id, prompt_version), la ligne avec le MÊME ordre que le CTE
+ * active_mission_scorings du matching engine :
+ *   ORDER BY completed_at DESC NULLS LAST, created_at DESC, id DESC
+ * → aucun changement de résultat de matching.
+ *
+ * 100% set-based : aucune liste d'ids matérialisée côté JS (évite la limite de paramètres bind).
+ * La suppression est batchée via LIMIT dans la sous-requête pour limiter le lock/WAL.
+ *
+ * Exécution :
+ *   npx ts-node scripts/purge-duplicate-mission-enrichments.ts            # dry-run (défaut)
+ *   npx ts-node scripts/purge-duplicate-mission-enrichments.ts --execute  # supprime réellement
+ *   npx ts-node scripts/purge-duplicate-mission-enrichments.ts --execute --batch 5000
+ *
+ * À lancer AVANT de créer la contrainte unique (sinon la création de l'index échoue).
+ */
+import dotenv from "dotenv";
+dotenv.config();
+
+import { Prisma } from "@/db/core";
+import { prisma } from "@/db/postgres";
+
+const LABEL = "purge-duplicate-mission-enrichments";
+
+const parseFlagValue = (flag: string): string | null => {
+  const index = process.argv.indexOf(flag);
+  return index === -1 ? null : (process.argv[index + 1] ?? null);
+};
+
+const execute = process.argv.includes("--execute");
+const batchSize = Math.max(1, Number(parseFlagValue("--batch") ?? "5000"));
+
+// Lignes à supprimer = tout sauf la « gagnante » de chaque (mission, version).
+const duplicatesIdsSql = Prisma.sql`
+  SELECT "id"
+  FROM (
+    SELECT
+      "id",
+      ROW_NUMBER() OVER (
+        PARTITION BY "mission_id", "prompt_version"
+        ORDER BY "completed_at" DESC NULLS LAST, "created_at" DESC, "id" DESC
+      ) AS rn
+    FROM "mission_enrichment"
+  ) ranked
+  WHERE ranked.rn > 1
+`;
+
+const run = async () => {
+  console.log(`[${LABEL}] Mode: ${execute ? "EXECUTE (suppression réelle)" : "dry-run"} · batch=${batchSize}`);
+  await prisma.$connect();
+
+  // Comptage set-based (pas de matérialisation d'ids).
+  const [{ duplicates }] = await prisma.$queryRaw<{ duplicates: bigint }[]>(Prisma.sql`
+    SELECT COUNT(*)::bigint AS duplicates FROM (${duplicatesIdsSql}) d
+  `);
+  console.log(`[${LABEL}] Enrichissements en doublon à supprimer : ${duplicates}`);
+
+  if (duplicates === 0n) {
+    console.log(`[${LABEL}] Rien à purger.`);
+    return;
+  }
+
+  // Aperçu de l'impact cascade (lecture seule), pour valider l'ampleur avant exécution.
+  const [{ scorings }] = await prisma.$queryRaw<{ scorings: bigint }[]>(Prisma.sql`
+    SELECT COUNT(*)::bigint AS scorings
+    FROM "mission_scoring" ms
+    JOIN (${duplicatesIdsSql}) d ON d."id" = ms."mission_enrichment_id"
+  `);
+  console.log(`[${LABEL}] mission_scoring qui seront supprimés en cascade : ${scorings}`);
+
+  if (!execute) {
+    console.log(`[${LABEL}] Dry-run : aucune suppression. Relancer avec --execute pour purger.`);
+    return;
+  }
+
+  let deleted = 0;
+  for (;;) {
+    // DELETE batché : on supprime un paquet d'ids "perdants" à la fois. Le cascade nettoie les enfants.
+    const affected = await prisma.$executeRaw(Prisma.sql`
+      DELETE FROM "mission_enrichment"
+      WHERE "id" IN (${duplicatesIdsSql} LIMIT ${batchSize})
+    `);
+    deleted += affected;
+    console.log(`[${LABEL}] supprimés: ${deleted}/${duplicates}`);
+    if (affected === 0) {
+      break;
+    }
+  }
+
+  console.log(`[${LABEL}] Terminé. ${deleted} mission_enrichment supprimés (+ cascade values/scoring/scoring_value).`);
+};
+
+run()
+  .catch((error) => {
+    console.error(`[${LABEL}] Fatal error:`, error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect().catch(() => undefined);
+  });

--- a/api/src/repositories/mission-enrichment.ts
+++ b/api/src/repositories/mission-enrichment.ts
@@ -6,6 +6,34 @@ export const missionEnrichmentRepository = {
     return prisma.missionEnrichment.create(params);
   },
 
+  /**
+   * Reserves (or reuses) the single enrichment row for a (mission, version) for a run.
+   *
+   * Conditional atomic upsert: the unique constraint (mission_id, prompt_version) ensures there is
+   * only one row; the `DO UPDATE ... WHERE status NOT IN (‘pending’,'processing')` only “takes” the
+   * row if no run is already in progress. Returns the reserved ID, or `null` if another worker
+   * already holds the run (concurrency) — the caller must then stop.
+   */
+  async claimForRun(params: { missionId: string; promptVersion: string }): Promise<string | null> {
+    const rows = await prisma.$queryRaw<{ id: string }[]>`
+      INSERT INTO "mission_enrichment" ("id", "mission_id", "prompt_version", "status", "created_at", "updated_at")
+      VALUES (gen_random_uuid(), ${params.missionId}, ${params.promptVersion}, 'processing', now(), now())
+      ON CONFLICT ("mission_id", "prompt_version")
+      DO UPDATE SET
+        "status" = 'processing',
+        "completed_at" = NULL,
+        "raw_response" = NULL,
+        "input_tokens" = NULL,
+        "output_tokens" = NULL,
+        "total_tokens" = NULL,
+        "updated_at" = now()
+      WHERE "mission_enrichment"."status" NOT IN ('pending', 'processing')
+      RETURNING "id"
+    `;
+
+    return rows[0]?.id ?? null;
+  },
+
   findFirst<T extends Prisma.MissionEnrichmentFindFirstArgs>(
     params: Prisma.SelectSubset<T, Prisma.MissionEnrichmentFindFirstArgs>
   ): Promise<Prisma.MissionEnrichmentGetPayload<T> | null> {
@@ -20,6 +48,12 @@ export const missionEnrichmentRepository = {
     return prisma.missionEnrichment.deleteMany(params);
   },
 
+  /**
+   * Mark the enrichment as completed and replace its values.
+   *
+   * Since the enrichment line is reused from one run to the next (see claimForRun), we first
+   * clear its old values before inserting the new ones, all within a transaction.
+   */
   async completeWithValues(
     enrichmentId: string,
     rawResponse: string,
@@ -27,6 +61,8 @@ export const missionEnrichmentRepository = {
     values: Omit<Prisma.MissionEnrichmentValueUncheckedCreateInput, "enrichmentId">[]
   ): Promise<void> {
     await prisma.$transaction(async (tx) => {
+      await tx.missionEnrichmentValue.deleteMany({ where: { enrichmentId } });
+
       if (values.length > 0) {
         await tx.missionEnrichmentValue.createMany({
           data: values.map((value) => ({ ...value, enrichmentId })) as Prisma.MissionEnrichmentValueCreateManyInput[],
@@ -41,45 +77,6 @@ export const missionEnrichmentRepository = {
           outputTokens: tokenUsage.outputTokens,
           totalTokens: tokenUsage.totalTokens,
           completedAt: new Date(),
-        },
-      });
-    });
-  },
-
-  async completeWithValuesAndDeletePrevious(
-    params: {
-      enrichmentId: string;
-      missionId: string;
-      promptVersion: string;
-      rawResponse: string;
-      tokenUsage: { inputTokens: number | undefined; outputTokens: number | undefined; totalTokens: number | undefined };
-      values: Omit<Prisma.MissionEnrichmentValueUncheckedCreateInput, "enrichmentId">[];
-    }
-  ): Promise<void> {
-    await prisma.$transaction(async (tx) => {
-      if (params.values.length > 0) {
-        await tx.missionEnrichmentValue.createMany({
-          data: params.values.map((value) => ({ ...value, enrichmentId: params.enrichmentId })) as Prisma.MissionEnrichmentValueCreateManyInput[],
-        });
-      }
-
-      await tx.missionEnrichment.update({
-        where: { id: params.enrichmentId },
-        data: {
-          status: "completed",
-          rawResponse: params.rawResponse,
-          inputTokens: params.tokenUsage.inputTokens,
-          outputTokens: params.tokenUsage.outputTokens,
-          totalTokens: params.tokenUsage.totalTokens,
-          completedAt: new Date(),
-        },
-      });
-
-      await tx.missionEnrichment.deleteMany({
-        where: {
-          missionId: params.missionId,
-          promptVersion: params.promptVersion,
-          id: { not: params.enrichmentId },
         },
       });
     });

--- a/api/src/services/mission-enrichment/__tests__/index.test.ts
+++ b/api/src/services/mission-enrichment/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/repositories/mission", () => ({
   missionRepository: { findUnique: vi.fn() },
@@ -7,10 +7,9 @@ vi.mock("@/repositories/mission", () => ({
 vi.mock("@/repositories/mission-enrichment", () => ({
   missionEnrichmentRepository: {
     findFirst: vi.fn(),
-    create: vi.fn(),
+    claimForRun: vi.fn(),
     update: vi.fn(),
     completeWithValues: vi.fn(),
-    completeWithValuesAndDeletePrevious: vi.fn(),
   },
 }));
 
@@ -142,10 +141,21 @@ describe("missionEnrichmentService.enrich — chain propagation", () => {
     expect(providerGenerate).not.toHaveBeenCalled();
   });
 
+  it("stops the chain when claimForRun loses the race to a concurrent worker", async () => {
+    (missionRepository.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(baseMission);
+    (missionEnrichmentRepository.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (missionEnrichmentRepository.claimForRun as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    await missionEnrichmentService.enrich("mission-1");
+
+    expect(providerGenerate).not.toHaveBeenCalled();
+    expect(asyncTaskBus.publish).not.toHaveBeenCalled();
+  });
+
   it("calls LLM and forwards to scoring after successful enrichment", async () => {
     (missionRepository.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(baseMission);
     (missionEnrichmentRepository.findFirst as ReturnType<typeof vi.fn>).mockResolvedValue(null);
-    (missionEnrichmentRepository.create as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "enrichment-new" });
+    (missionEnrichmentRepository.claimForRun as ReturnType<typeof vi.fn>).mockResolvedValue("enrichment-new");
     (missionEnrichmentRepository.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
     (missionEnrichmentRepository.completeWithValues as ReturnType<typeof vi.fn>).mockResolvedValue({});
     providerGenerate.mockResolvedValue({

--- a/api/src/services/mission-enrichment/index.ts
+++ b/api/src/services/mission-enrichment/index.ts
@@ -300,33 +300,23 @@ export const missionEnrichmentService = {
     // 3. Load taxonomy from package.
     const taxonomies = getTaxonomies();
 
-    // 4. Create enrichment record (pending)
-    // The partial unique index on (mission_id, prompt_version) WHERE status IN ('pending', 'processing')
-    // enforces at DB level that no two concurrent workers can run for the same mission/version.
-    // A P2002 here means another worker won the race — skip silently.
-    let enrichment;
-    try {
-      enrichment = await missionEnrichmentRepository.create({
-        data: { missionId, promptVersion: CURRENT_PROMPT_VERSION, status: "pending" },
-      });
-    } catch (error) {
-      if ((error as { code?: string }).code === "P2002") {
-        console.log(`${LOG_PREFIX} skipping ${missionId} — lost race to concurrent worker`);
-        return;
-      }
-      throw error;
+    // 4. Reserve the single enrichment row for this (mission, version) and mark it `processing`.
+    // The unique constraint (mission_id, prompt_version) guarantees one row; claimForRun reuses it
+    // (no accumulation) and atomically blocks concurrent workers: a null id means another worker
+    // already holds the run, so we skip silently.
+    const enrichmentId = await missionEnrichmentRepository.claimForRun({ missionId, promptVersion: CURRENT_PROMPT_VERSION });
+
+    if (!enrichmentId) {
+      console.log(`${LOG_PREFIX} skipping ${missionId} — enrichment already in-flight (concurrent worker)`);
+      return;
     }
+
+    const enrichment = { id: enrichmentId };
 
     // Declared outside try/catch so the catch block can persist them on failure
     let providerResult: MissionEnrichmentProviderResult | undefined;
 
     try {
-      // 5. Mark as processing
-      await missionEnrichmentRepository.update({
-        where: { id: enrichment.id },
-        data: { status: "processing" },
-      });
-
       // 6. Build prompts
       const promptVersion = PROMPT_REGISTRY[CURRENT_PROMPT_VERSION];
       const systemPrompt = promptVersion.buildSystemPrompt(buildTaxonomyBlock(toTaxonomyForPrompt(taxonomies)));
@@ -352,7 +342,8 @@ export const missionEnrichmentService = {
         );
       }
 
-      // 9. Persist values + mark completed (atomic)
+      // 9. Persist values (replace) + mark as completed (atomic). Since the enrichment line is
+      // reused (claimForRun), completeWithValues clears the old values before inserting.
       const persistedValues = valid.map((v) => ({
         taxonomyKey: v.taxonomy_key,
         valueKey: v.value_key,
@@ -360,18 +351,7 @@ export const missionEnrichmentService = {
         evidence: v.evidence,
       }));
 
-      if (options.force) {
-        await missionEnrichmentRepository.completeWithValuesAndDeletePrevious({
-          enrichmentId: enrichment.id,
-          missionId,
-          promptVersion: CURRENT_PROMPT_VERSION,
-          rawResponse: JSON.stringify(providerResult.object),
-          tokenUsage: { inputTokens, outputTokens, totalTokens },
-          values: persistedValues,
-        });
-      } else {
-        await missionEnrichmentRepository.completeWithValues(enrichment.id, JSON.stringify(providerResult.object), { inputTokens, outputTokens, totalTokens }, persistedValues);
-      }
+      await missionEnrichmentRepository.completeWithValues(enrichment.id, JSON.stringify(providerResult.object), { inputTokens, outputTokens, totalTokens }, persistedValues);
 
       console.log(`${LOG_PREFIX} ${missionId}: enrichment completed — ${valid.length} values persisted`);
     } catch (error) {


### PR DESCRIPTION
## Description

Garantit au plus un mission_enrichment par (missionId, promptVersion) via une contrainte unique + un upsert atomique, au lieu d'empiler une nouvelle ligne à chaque ré-enrichissement.

Problème : à chaque mise à jour de mission (import/sync → updatedAt avance), le chemin non-force d'enrich() créait une nouvelle ligne mission_enrichment completed sans supprimer la précédente.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires
Ordre de déploiement (critique) : la contrainte unique ne peut pas être créée tant que des doublons existent.
1. Lancer scripts/purge-duplicate-mission-enrichments.ts --dry-run (constater le volume), puis --execute.
2. Déployer le code (claimForRun + upsert).

Concurrence : la garantie « un seul worker traite à la fois » est désormais assurée par `claimForRun` (DO UPDATE conditionnel) au lieu de l'index partiel inflight (supprimé).

Lectures non impactées : findFirst orderBy createdAt desc / distinct: ["missionId"] restent valides avec une seule ligne par version.