### PR TITLE
fix(api): missing migration script for unique index

### DIFF
--- a/api/prisma/migrations/20260601131722_add_unique_mission_enrichment_mission_version/migration.sql
+++ b/api/prisma/migrations/20260601131722_add_unique_mission_enrichment_mission_version/migration.sql
@@ -1,0 +1,30 @@
+-- Dédup avant contrainte : garde, par (mission_id, prompt_version), la ligne « gagnante » du
+-- matching (même ordre que le CTE active_mission_scorings : completed_at DESC NULLS LAST,
+-- created_at DESC, id DESC) et supprime les doublons. Le cascade DB nettoie automatiquement
+-- mission_enrichment_value, mission_scoring et mission_scoring_value rattachés.
+-- En prod : lancer d'abord scripts/purge-duplicate-mission-enrichments.ts (batché) pour que ce
+-- DELETE soit quasi no-op ; en CI/dev (base vierge) il est no-op.
+DELETE FROM "mission_enrichment" me
+USING (
+  SELECT "id",
+    ROW_NUMBER() OVER (
+      PARTITION BY "mission_id", "prompt_version"
+      ORDER BY "completed_at" DESC NULLS LAST, "created_at" DESC, "id" DESC
+    ) AS rn
+  FROM "mission_enrichment"
+) ranked
+WHERE me."id" = ranked."id" AND ranked.rn > 1;
+
+-- L'index non-unique (mission_id, prompt_version) devient redondant avec la contrainte unique.
+DROP INDEX IF EXISTS "mission_enrichment_mission_version_idx";
+
+-- L'unique PARTIEL (WHERE status IN ('pending','processing')) est subsumé par l'unique complet.
+DROP INDEX IF EXISTS "mission_enrichment_inflight_unique";
+
+-- Contrainte unique COMPLÈTE : au plus une ligne par (mission, version), tous statuts confondus.
+-- En prod, préférer un build en ligne :
+--   CREATE UNIQUE INDEX CONCURRENTLY "mission_enrichment_mission_version_unique"
+--     ON "mission_enrichment" ("mission_id", "prompt_version");
+-- puis `prisma migrate resolve --applied 20260601131722_add_unique_mission_enrichment_mission_version`.
+CREATE UNIQUE INDEX "mission_enrichment_mission_version_unique"
+  ON "mission_enrichment" ("mission_id", "prompt_version");


### PR DESCRIPTION
## Description

Suite à cette PR https://github.com/betagouv/api-engagement/pull/1092 oublie du script de migration pour créer l'index unique.


## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
