### PR TITLE
fix(plateform): mission map RGAA

### DIFF
--- a/plateform/app/components/results/mission-map.tsx
+++ b/plateform/app/components/results/mission-map.tsx
@@ -1,6 +1,6 @@
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
-import { useEffect, useMemo } from "react";
+import { useEffect, useId, useMemo } from "react";
 import { MapContainer, Marker, Popup, TileLayer, useMap } from "react-leaflet";
 import { TILE_LAYER_PROPS, createEmojiIcon } from "~/components/ui/location-map";
 import type { MissionMatchItem } from "@engagement/dto";
@@ -69,36 +69,44 @@ export default function MissionMap({ items, center, onMarkerClick }: Props) {
 
   const boundsPositions = missions.length > 0 ? missions.map((mission) => mission.position) : [center];
 
+  const descriptionId = useId();
+  const accessibleLabel = `Carte des ${items.length} mission${items.length > 1 ? "s" : ""} proposée${items.length > 1 ? "s" : ""}`;
+
   return (
-    <MapContainer center={center} zoom={12} className="mission-map" zoomControl={false}>
-      <TileLayer {...TILE_LAYER_PROPS} />
-      <BoundsFitter positions={boundsPositions} />
-      {missions.map(({ item, position, hasRealAddress }) => (
-        <Marker
-          key={item.mission.id}
-          position={position}
-          icon={hasRealAddress ? classicIcon : remoteIcon}
-          eventHandlers={onMarkerClick ? { click: () => onMarkerClick(item) } : undefined}
-        >
-          {!onMarkerClick && (
-            <Popup>
-              <strong>{item.mission.title}</strong>
-              {hasRealAddress && getAddressLabel(item) && (
-                <>
-                  <br />
-                  {getAddressLabel(item)}
-                </>
-              )}
-              {!hasRealAddress && (
-                <>
-                  <br />
-                  Mission à distance ou sans adresse précise
-                </>
-              )}
-            </Popup>
-          )}
-        </Marker>
-      ))}
-    </MapContainer>
+    <div role="region" aria-label={accessibleLabel} aria-describedby={descriptionId} className="relative h-full w-full">
+      <p id={descriptionId} className="sr-only">
+        Carte interactive localisant les missions proposées. La liste des missions présente les mêmes informations sous forme textuelle accessible.
+      </p>
+      <MapContainer center={center} zoom={12} className="mission-map" zoomControl={false}>
+        <TileLayer {...TILE_LAYER_PROPS} />
+        <BoundsFitter positions={boundsPositions} />
+        {missions.map(({ item, position, hasRealAddress }) => (
+          <Marker
+            key={item.mission.id}
+            position={position}
+            icon={hasRealAddress ? classicIcon : remoteIcon}
+            eventHandlers={onMarkerClick ? { click: () => onMarkerClick(item) } : undefined}
+          >
+            {!onMarkerClick && (
+              <Popup>
+                <strong>{item.mission.title}</strong>
+                {hasRealAddress && getAddressLabel(item) && (
+                  <>
+                    <br />
+                    {getAddressLabel(item)}
+                  </>
+                )}
+                {!hasRealAddress && (
+                  <>
+                    <br />
+                    Mission à distance ou sans adresse précise
+                  </>
+                )}
+              </Popup>
+            )}
+          </Marker>
+        ))}
+      </MapContainer>
+    </div>
   );
 }


### PR DESCRIPTION
## Description

Correction d'accessibilité (RGAA) sur la carte interactive des missions (`MissionMap`, utilisée dans la page de résultats sur mobile et desktop).

La carte Leaflet était un composant interactif riche **sans nom accessible ni alternative explicitement annoncée** : un utilisateur de lecteur d'écran ne savait pas ce qu'était cette zone, ni que la liste des missions affichée à côté en constitue l'équivalent textuel.

Changements (un seul fichier, `plateform/app/components/results/mission-map.tsx`) :

- Enveloppe de `MapContainer` dans un `<div role="region">` avec un **`aria-label` dynamique** (« Carte des N missions proposées ») → la carte devient un repère nommé.
- **`aria-describedby`** pointant vers un paragraphe `sr-only` qui **annonce explicitement l'alternative textuelle** (la liste des missions).
- Aucun changement visuel : le wrapper est transparent (`relative h-full w-full`) et préserve le `height:100%` de `.mission-map`, sur les deux layouts.

> ℹ️ Détail technique : en `react-leaflet@5`, `MapContainer` ne propage au DOM que `className`/`id`/`style` — passer `aria-*` directement dessus est inopérant et casse le typage, d'où l'enveloppe dédiée.

## Liens utiles

- 📝 Partie de https://app.notion.com/p/jeveuxaider/Etat-des-lieux-accessibilit-36472a322d508013ad1afec971649088?source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- **Hors périmètre** : l'accessibilité clavier fine des marqueurs/popups Leaflet n'a pas été retravaillée ; la liste textuelle reste l'alternative opérable.
