### PR TITLE
refactor(plateform): no user scoring expiration anymore

### DIFF
--- a/analytics/db/migrations/20260602131500_drop_user_scoring_expires_at.sql
+++ b/analytics/db/migrations/20260602131500_drop_user_scoring_expires_at.sql
@@ -1,0 +1,8 @@
+-- migrate:up
+ALTER TABLE "analytics_raw"."user_scoring"
+DROP COLUMN IF EXISTS "expires_at" CASCADE;
+
+
+-- migrate:down
+ALTER TABLE "analytics_raw"."user_scoring"
+ADD COLUMN IF NOT EXISTS "expires_at" TIMESTAMP(3);

--- a/analytics/dbt/analytics/models/marts/user/__models.yml
+++ b/analytics/dbt/analytics/models/marts/user/__models.yml
@@ -98,8 +98,6 @@ models:
         description: Timestamp de création du scoring utilisateur.
         tests:
           - not_null
-      - name: expires_at
-        description: Timestamp d'expiration du scoring, si une limite de validité est définie.
       - name: updated_at
         description: Timestamp de dernière mise à jour du scoring utilisateur.
         tests:

--- a/analytics/dbt/analytics/models/marts/user/user_scoring.sql
+++ b/analytics/dbt/analytics/models/marts/user/user_scoring.sql
@@ -5,6 +5,5 @@ select
   distinct_id,
   mission_alert_enabled,
   created_at,
-  expires_at,
   updated_at
 from {{ ref('stg_user_scoring') }}

--- a/analytics/dbt/analytics/models/raw.yml
+++ b/analytics/dbt/analytics/models/raw.yml
@@ -711,8 +711,6 @@ sources:
             description: Indique si l'utilisateur a activé l'alerte mission associée à ce scoring.
           - name: created_at
             description: Timestamp de création du scoring.
-          - name: expires_at
-            description: Timestamp d'expiration du scoring, si défini.
           - name: updated_at
             description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
       - name: user_scoring_value

--- a/analytics/dbt/analytics/models/staging/user/__models.yml
+++ b/analytics/dbt/analytics/models/staging/user/__models.yml
@@ -81,8 +81,6 @@ models:
         description: Timestamp de création du scoring utilisateur.
         tests:
           - not_null
-      - name: expires_at
-        description: Timestamp d'expiration du scoring, si une limite de validité est définie.
       - name: updated_at
         description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
         tests:

--- a/analytics/dbt/analytics/models/staging/user/stg_user_scoring.sql
+++ b/analytics/dbt/analytics/models/staging/user/stg_user_scoring.sql
@@ -3,6 +3,5 @@ select
   distinct_id,
   mission_alert_enabled::boolean as mission_alert_enabled,
   created_at::timestamp as created_at,
-  expires_at::timestamp as expires_at,
   updated_at::timestamp as updated_at
 from {{ source('analytics_raw', 'user_scoring') }}

--- a/analytics/dbt/analytics/requirements.txt
+++ b/analytics/dbt/analytics/requirements.txt
@@ -1,3 +1,7 @@
+# dbt-core est épinglé explicitement : dbt-postgres déclare `dbt-core>=1.8.0rc1`,
+# ce qui autorise les pré-versions et fait sélectionner par pip le moteur Fusion
+# (dbt-core 2.0.0a1) qui ne supporte pas l'adapter postgres. On reste sur la 1.10.x.
+dbt-core==1.10.22
 dbt-postgres==1.10.0
 dbt-metabase==1.7.5
 sqlfluff==3.5.0

--- a/analytics/dbt/analytics/requirements.txt
+++ b/analytics/dbt/analytics/requirements.txt
@@ -1,6 +1,3 @@
-# dbt-core est épinglé explicitement : dbt-postgres déclare `dbt-core>=1.8.0rc1`,
-# ce qui autorise les pré-versions et fait sélectionner par pip le moteur Fusion
-# (dbt-core 2.0.0a1) qui ne supporte pas l'adapter postgres. On reste sur la 1.10.x.
 dbt-core==1.10.22
 dbt-postgres==1.10.0
 dbt-metabase==1.7.5

--- a/analytics/src/jobs/export-to-analytics-raw/config.ts
+++ b/analytics/src/jobs/export-to-analytics-raw/config.ts
@@ -638,7 +638,7 @@ export const exportDefinitions: ExportDefinition[] = [
         field: "updated_at",
         idField: "id",
       },
-      columns: ["id", "distinct_id", "mission_alert_enabled", "created_at", "expires_at", "updated_at"],
+      columns: ["id", "distinct_id", "mission_alert_enabled", "created_at", "updated_at"],
     },
     destination: {
       table: "user_scoring",

--- a/api/prisma/migrations/20260602130822_remove_user_scoring_expires_at/migration.sql
+++ b/api/prisma/migrations/20260602130822_remove_user_scoring_expires_at/migration.sql
@@ -1,0 +1,4 @@
+-- Remove the user_scoring expiration date: scorings no longer expire.
+DROP INDEX IF EXISTS "user_scoring_expires_at_idx";
+
+ALTER TABLE "user_scoring" DROP COLUMN IF EXISTS "expires_at";

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1047,14 +1047,12 @@ model UserScoring {
   distinctId          String?   @map("distinct_id")
   missionAlertEnabled Boolean   @default(false) @map("mission_alert_enabled")
   createdAt           DateTime  @default(now()) @map("created_at")
-  expiresAt           DateTime? @map("expires_at")
   updatedAt           DateTime  @updatedAt @map("updated_at")
 
   values          UserScoringValue[]
   geo             UserScoringGeo?
   matchingResults MissionMatchingResult[]
 
-  @@index([expiresAt], map: "user_scoring_expires_at_idx")
   @@map("user_scoring")
 }
 

--- a/api/scripts/benchmark-matching-engine.ts
+++ b/api/scripts/benchmark-matching-engine.ts
@@ -265,7 +265,6 @@ const getExplicitUserScorings = async (userScoringIds: string[]): Promise<UserSc
     LEFT JOIN "taxonomy" t
       ON t."key"::text = usv."taxonomy_key"
     WHERE us."id" IN (${Prisma.join(userScoringIds)})
-      AND (us."expires_at" IS NULL OR us."expires_at" > NOW())
     GROUP BY us."id"
     ORDER BY us."id" ASC
   `;
@@ -289,7 +288,6 @@ const getSampledUserScorings = async (sampleSize: number): Promise<UserScoringCa
         ON usv."user_scoring_id" = us."id"
       LEFT JOIN "taxonomy" t
         ON t."key"::text = usv."taxonomy_key"
-      WHERE us."expires_at" IS NULL OR us."expires_at" > NOW()
       GROUP BY us."id"
     ),
     ranked AS (

--- a/api/src/repositories/user-scoring.ts
+++ b/api/src/repositories/user-scoring.ts
@@ -10,7 +10,6 @@ export const userScoringRepository = {
   },
 
   create(params: {
-    expiresAt: Date;
     values: Array<{ taxonomyKey: string; valueKey: string; score?: number }>;
     geo?: { lat: number; lon: number; radiusKm?: number; countryCode?: string };
     distinctId?: string;
@@ -18,7 +17,6 @@ export const userScoringRepository = {
   }): Promise<UserScoring> {
     return prisma.userScoring.create({
       data: {
-        expiresAt: params.expiresAt,
         distinctId: params.distinctId,
         missionAlertEnabled: params.missionAlertEnabled,
         ...(params.values.length

--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -67,29 +67,11 @@ describe("matchingEngineService", () => {
       expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(1);
     });
 
-    it("throws when the user scoring is expired", async () => {
-      prismaMock.$queryRaw.mockResolvedValueOnce([
-        {
-          id: "user-scoring-expired",
-          expires_at: new Date(Date.now() - 60_000),
-        },
-      ]);
-
-      await expect(
-        matchingEngineService.rankMissionsByUserScoring({
-          userScoringId: "user-scoring-expired",
-        })
-      ).rejects.toThrow("[matchingEngineService] user_scoring 'user-scoring-expired' is expired.");
-
-      expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(1);
-    });
-
     it("returns ranked missions with clamped scores and indexed taxonomy scores", async () => {
       prismaMock.$queryRaw
         .mockResolvedValueOnce([
           {
             id: "user-scoring-1",
-            expires_at: new Date(Date.now() + 60_000),
           },
         ])
         .mockResolvedValueOnce([
@@ -186,7 +168,6 @@ describe("matchingEngineService", () => {
         .mockResolvedValueOnce([
           {
             id: "user-scoring-publisher-filter",
-            expires_at: null,
           },
         ])
         .mockResolvedValueOnce([]);
@@ -211,7 +192,6 @@ describe("matchingEngineService", () => {
         .mockResolvedValueOnce([
           {
             id: "user-scoring-empty",
-            expires_at: null,
           },
         ])
         .mockResolvedValueOnce([]);
@@ -237,7 +217,6 @@ describe("matchingEngineService", () => {
         .mockResolvedValueOnce([
           {
             id: "user-scoring-gate-filtered",
-            expires_at: null,
           },
         ])
         .mockResolvedValueOnce([
@@ -296,7 +275,6 @@ describe("matchingEngineService", () => {
         .mockResolvedValueOnce([
           {
             id: "user-scoring-gate-taxonomies",
-            expires_at: null,
           },
         ])
         .mockResolvedValueOnce([
@@ -362,7 +340,6 @@ describe("matchingEngineService", () => {
         .mockResolvedValueOnce([
           {
             id: "user-scoring-or-taxonomy",
-            expires_at: null,
           },
         ])
         .mockResolvedValueOnce([
@@ -406,7 +383,6 @@ describe("matchingEngineService", () => {
         .mockResolvedValueOnce([
           {
             id: "user-scoring-page-2",
-            expires_at: null,
           },
         ])
         .mockResolvedValueOnce([

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -28,7 +28,6 @@ type DbTaxonomyScoreRow = {
 
 type UserScoringStateRow = {
   id: string;
-  expires_at: Date | null;
 };
 
 const clampScore = (value: number | null): number => {
@@ -59,9 +58,9 @@ const buildTaxonomyWeightsValuesSql = (taxonomyWeights: Record<MatchingEngineTax
 
 const buildGateTaxonomiesSql = () => Prisma.join(GATE_TAXONOMIES.map((taxonomy) => Prisma.sql`${taxonomy}`));
 
-const assertUserScoringIsQueryable = async (userScoringId: string): Promise<void> => {
+const assertUserScoringExists = async (userScoringId: string): Promise<void> => {
   const rows = await prisma.$queryRaw<UserScoringStateRow[]>`
-    SELECT "id", "expires_at"
+    SELECT "id"
     FROM "user_scoring"
     WHERE "id" = ${userScoringId}
     LIMIT 1
@@ -70,10 +69,6 @@ const assertUserScoringIsQueryable = async (userScoringId: string): Promise<void
 
   if (!userScoring) {
     throw new Error(`[matchingEngineService] user_scoring '${userScoringId}' not found.`);
-  }
-
-  if (userScoring.expires_at && userScoring.expires_at.getTime() <= Date.now()) {
-    throw new Error(`[matchingEngineService] user_scoring '${userScoringId}' is expired.`);
   }
 };
 
@@ -550,7 +545,7 @@ export const matchingEngineService = {
     const taxonomyCandidateLimit = getTaxonomyCandidateLimit({ limit: rankingLimit, offset });
     const geoCandidateLimit = getGeoCandidateLimit({ limit: rankingLimit, offset });
 
-    await assertUserScoringIsQueryable(input.userScoringId);
+    await assertUserScoringExists(input.userScoringId);
     const publisherRuleSql = await buildPublisherRuleSql(input.publisherId);
 
     const rows = await prisma.$queryRaw<DbRankRow[]>(

--- a/api/src/services/user-scoring/index.ts
+++ b/api/src/services/user-scoring/index.ts
@@ -3,8 +3,6 @@ import { TAXONOMY } from "@engagement/taxonomy";
 
 import { userScoringRepository } from "@/repositories/user-scoring";
 
-const USER_SCORING_TTL_DAYS = 7;
-
 type UserScoringAnswerInput = {
   taxonomy: string;
   value?: string;
@@ -152,10 +150,8 @@ export const userScoringService = {
 
   async create(input: CreateUserScoringInput) {
     const scoringData = buildValuesToPersist(input.answers);
-    const expiresAt = new Date(Date.now() + USER_SCORING_TTL_DAYS * 24 * 60 * 60 * 1000);
 
     const userScoring = await userScoringRepository.create({
-      expiresAt,
       values: scoringData.values,
       geo: scoringData.geo,
       distinctId: input?.distinctId,

--- a/api/tests/integration/api/user-scoring.test.ts
+++ b/api/tests/integration/api/user-scoring.test.ts
@@ -181,21 +181,6 @@ describe("POST /user-scoring", () => {
     expect(values).toHaveLength(1);
   });
 
-  it("should set expiresAt on the created user scoring", async () => {
-    const before = Date.now();
-    const res = await postUserScoringRequest().send({ answers: [taxonomyAnswer] });
-
-    const userScoring = await prisma.userScoring.findUniqueOrThrow({
-      where: { id: res.body.data.id },
-    });
-    expect(userScoring.expiresAt).not.toBeNull();
-    // Should expire in roughly 7 days
-    const diffMs = userScoring.expiresAt!.getTime() - before;
-    const diffDays = diffMs / (1000 * 60 * 60 * 24);
-    expect(diffDays).toBeGreaterThan(6);
-    expect(diffDays).toBeLessThan(8);
-  });
-
   // ─── Validation errors ──────────────────────────────────────────────────────
 
   it("should return 400 when answers is empty", async () => {


### PR DESCRIPTION
## Description

Supprime la notion de péremption des **user-scoring** : un scoring n'expire plus et reste valide indéfiniment.

Auparavant, chaque user-scoring se voyait attribuer une `expiresAt` à 7 jours (`USER_SCORING_TTL_DAYS`) à la création, et le matching engine refusait de classer des missions pour un scoring expiré. Ce comportement est entièrement retiré, côté API **et** côté analytics.

### API (`api/`)

- **Schéma & BDD** : suppression du champ `expiresAt` et de l'index `user_scoring_expires_at_idx` du modèle `UserScoring` + migration destructive (`DROP INDEX` / `DROP COLUMN`).
- **Service** (`services/user-scoring`) : suppression de la constante `USER_SCORING_TTL_DAYS` et du calcul de la date d'expiration à la création.
- **Repository** (`repositories/user-scoring`) : suppression du paramètre `expiresAt`.
- **Matching engine** : suppression du contrôle « scoring expiré » ; `assertUserScoringIsQueryable` est renommée `assertUserScoringExists` (elle ne vérifie plus que l'existence).
- **Script de benchmark** (`scripts/benchmark-matching-engine.ts`) : retrait des filtres `expires_at` dans les requêtes d'échantillonnage/sélection des scorings (la colonne n'existe plus).
- **Tests** : retrait des tests liés à l'expiration (unitaires matching-engine + intégration user-scoring) et nettoyage des mocks.

### Analytics (`analytics/`)

- **Job d'export** (`export-to-analytics-raw/config.ts`) : retrait de `expires_at` des colonnes exportées pour `user_scoring`.
- **Migration dbmate** : `DROP COLUMN expires_at` sur `analytics_raw.user_scoring` (avec migration down).
- **Modèles dbt** : suppression de `expires_at` dans `stg_user_scoring`, `user_scoring` (marts) et les schémas associés (`raw.yml`, `__models.yml` staging & marts).

### CI

- **`Check dbt compile`** : pin de `dbt-core==1.10.22` dans `analytics/dbt/analytics/requirements.txt` (voir Notes).

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

⚠️ **Migrations destructives** :
- `api` : suppression de la colonne `user_scoring.expires_at` et de son index.
- `analytics` : suppression de la colonne `analytics_raw.user_scoring.expires_at`.

Aucune donnée métier utile n'est perdue (le champ ne servait qu'au TTL).

🔧 **Fix CI `Check dbt compile`** (nouvelle erreur apparue sur cette PR) : `dbt-postgres==1.10.0` déclare `dbt-core>=1.8.0rc1` (borne contenant une pré-version), ce qui a poussé pip à sélectionner le moteur **Fusion** fraîchement publié (`dbt-core==2.0.0a1`), incompatible avec l'adapter postgres → `[InvalidConfig (dbt1005)]`. On épingle `dbt-core==1.10.22` (pin exact nécessaire : `<2.0.0` laisserait passer `2.0.0a1`). La résolution repart sur le wheel pur Python classique.
