### PR TITLE
fix(api): make mission enqueue best-effort to survive queue outages

### DIFF
--- a/api/src/services/__tests__/mission.test.ts
+++ b/api/src/services/__tests__/mission.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { enqueueMock, captureExceptionMock } = vi.hoisted(() => ({
+  enqueueMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
+}));
+
+// On isole missionService du bus SQS réel : seul le contrat enqueue/erreur nous intéresse ici.
+vi.mock("@/services/mission-enrichment", () => ({
+  missionEnrichmentService: { enqueue: enqueueMock },
+  buildMissionEnrichmentScoringWhere: vi.fn(),
+}));
+
+vi.mock("@/error", () => ({
+  captureException: captureExceptionMock,
+}));
+
+import { missionService } from "@/services/mission";
+
+describe("missionService.enqueueMissionProcessing", () => {
+  beforeEach(() => {
+    enqueueMock.mockReset();
+    captureExceptionMock.mockReset();
+  });
+
+  it("délègue l'enqueue au service d'enrichissement", async () => {
+    enqueueMock.mockResolvedValue(undefined);
+
+    await missionService.enqueueMissionProcessing("mission-1");
+
+    expect(enqueueMock).toHaveBeenCalledWith("mission-1");
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("ne propage pas l'erreur si la queue est indisponible (best-effort)", async () => {
+    const error = new Error("You do not have sufficient access to perform this action.");
+    enqueueMock.mockRejectedValue(error);
+
+    await expect(missionService.enqueueMissionProcessing("mission-1")).resolves.toBeUndefined();
+
+    expect(captureExceptionMock).toHaveBeenCalledWith(error, {
+      extra: { context: "enqueueMissionProcessing", missionId: "mission-1" },
+    });
+  });
+});

--- a/api/src/services/__tests__/mission.test.ts
+++ b/api/src/services/__tests__/mission.test.ts
@@ -5,7 +5,6 @@ const { enqueueMock, captureExceptionMock } = vi.hoisted(() => ({
   captureExceptionMock: vi.fn(),
 }));
 
-// On isole missionService du bus SQS réel : seul le contrat enqueue/erreur nous intéresse ici.
 vi.mock("@/services/mission-enrichment", () => ({
   missionEnrichmentService: { enqueue: enqueueMock },
   buildMissionEnrichmentScoringWhere: vi.fn(),

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -566,9 +566,6 @@ const baseInclude: MissionInclude = {
 
 export const missionService = {
   async enqueueMissionProcessing(missionId: string): Promise<void> {
-    // Best-effort : déclencher le traitement async ne doit jamais faire échouer
-    // l'écriture de la mission (création/mise à jour, donc l'import des flux).
-    // Une indisponibilité de la queue est capturée mais n'interrompt pas le flux.
     try {
       await missionEnrichmentService.enqueue(missionId);
     } catch (error) {

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 
 import { Mission, Prisma } from "@/db/core";
 import { prisma } from "@/db/postgres";
+import { captureException } from "@/error";
 import { missionRepository } from "@/repositories/mission";
 import { activityService } from "@/services/activity";
 import { buildMissionEnrichmentScoringWhere, missionEnrichmentService } from "@/services/mission-enrichment";
@@ -565,7 +566,14 @@ const baseInclude: MissionInclude = {
 
 export const missionService = {
   async enqueueMissionProcessing(missionId: string): Promise<void> {
-    await missionEnrichmentService.enqueue(missionId);
+    // Best-effort : déclencher le traitement async ne doit jamais faire échouer
+    // l'écriture de la mission (création/mise à jour, donc l'import des flux).
+    // Une indisponibilité de la queue est capturée mais n'interrompt pas le flux.
+    try {
+      await missionEnrichmentService.enqueue(missionId);
+    } catch (error) {
+      captureException(error, { extra: { context: "enqueueMissionProcessing", missionId } });
+    }
   },
 
   async findMissionsByIds(ids: string[]): Promise<MissionRecord[]> {

--- a/terraform/queues.tf
+++ b/terraform/queues.tf
@@ -1,3 +1,16 @@
+# ⚠️ NE PAS reconvertir en `resource "scaleway_mnq_sqs"`.
+#
+# L'activation MNQ SQS est un SINGLETON PAR PROJET. Or staging et production
+# partagent le MÊME projet Scaleway (seuls les workspaces Terraform diffèrent),
+# donc une `resource` provoque un `409 Conflict: resource already exists` dès
+# que le 2ᵉ workspace s'applique (cf. PR #1047).
+#
+# Conséquence : l'activation SQS est volontairement gérée HORS Terraform (bootstrap
+# manuel unique par projet). À refaire uniquement sur un projet neuf :
+#   scw mnq sqs activate region=fr-par project-id=<PROJECT_ID>
+# Un `data` source ne fait que lire le statut ; il ne (dé)active jamais. Repasser en
+# `resource` ré-introduirait le 409 ET, au retrait, désactiverait SQS pour TOUT le
+# projet (suppression de toutes les queues + credentials, staging comme prod).
 data "scaleway_mnq_sqs" "main" {
   project_id = var.project_id
 }

--- a/terraform/queues.tf
+++ b/terraform/queues.tf
@@ -1,16 +1,3 @@
-# ⚠️ NE PAS reconvertir en `resource "scaleway_mnq_sqs"`.
-#
-# L'activation MNQ SQS est un SINGLETON PAR PROJET. Or staging et production
-# partagent le MÊME projet Scaleway (seuls les workspaces Terraform diffèrent),
-# donc une `resource` provoque un `409 Conflict: resource already exists` dès
-# que le 2ᵉ workspace s'applique (cf. PR #1047).
-#
-# Conséquence : l'activation SQS est volontairement gérée HORS Terraform (bootstrap
-# manuel unique par projet). À refaire uniquement sur un projet neuf :
-#   scw mnq sqs activate region=fr-par project-id=<PROJECT_ID>
-# Un `data` source ne fait que lire le statut ; il ne (dé)active jamais. Repasser en
-# `resource` ré-introduirait le 409 ET, au retrait, désactiverait SQS pour TOUT le
-# projet (suppression de toutes les queues + credentials, staging comme prod).
 data "scaleway_mnq_sqs" "main" {
   project_id = var.project_id
 }


### PR DESCRIPTION
## Description

Corrige la régression du job `import-missions` consécutive à la mise en place des queues SQS.

**Contexte de l'incident (prod)** : `missionService.create/update` déclenche `enqueueMissionProcessing` → `asyncTaskBus.publish("mission.enrichment")`. Quand le publish SQS échouait (`AccessDeniedException: You do not have sufficient access…`), l'exception remontait et **avortait tout l'import du flux** dès la 1ʳᵉ mission écrite. 

**`fix(api)`** : `enqueueMissionProcessing` devient **best-effort**. Une indisponibilité de la queue est capturée via `captureException` mais n'interrompt plus l'écriture de la mission ni l'import. Le déclenchement de l'enrichissement async est une opération secondaire : elle ne doit jamais faire échouer le flux principal.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Test unitaire ajouté : `api/src/services/__tests__/mission.test.ts` (délégation nominale + non-propagation de l'erreur en cas de queue indisponible).
- Le comportement bloquant explicite est conservé pour le re-enrichissement « force » admin (`controllers/mission.ts`), où l'erreur doit rester visible.