### PR TITLE
feat(api): add a dead letter queue

### DIFF
--- a/terraform/modules/mnq-sqs-queue/main.tf
+++ b/terraform/modules/mnq-sqs-queue/main.tf
@@ -6,9 +6,23 @@ terraform {
   }
 }
 
+resource "scaleway_mnq_sqs_queue" "dlq" {
+  project_id      = var.project_id
+  name            = "${var.name}-dlq"
+  access_key      = var.access_key
+  secret_key      = var.secret_key
+  message_max_age = 1209600
+}
+
+
 resource "scaleway_mnq_sqs_queue" "this" {
-  project_id = var.project_id
-  name       = var.name
-  access_key = var.access_key
-  secret_key = var.secret_key
+  project_id                 = var.project_id
+  name                       = var.name
+  access_key                 = var.access_key
+  secret_key                 = var.secret_key
+  visibility_timeout_seconds = 65
+  dead_letter_queue {
+    id                = scaleway_mnq_sqs_queue.dlq.id
+    max_receive_count = 10
+  }
 }

--- a/terraform/modules/typesense/templates/cloud-init.yaml.tftpl
+++ b/terraform/modules/typesense/templates/cloud-init.yaml.tftpl
@@ -1,9 +1,4 @@
 #cloud-config
-package_update: true
-packages:
-  - ca-certificates
-  - curl
-  - docker.io
 
 write_files:
   - path: /etc/typesense/nodes
@@ -84,6 +79,9 @@ write_files:
       WantedBy=multi-user.target
 
 runcmd:
+  - until ping -c1 -W2 1.1.1.1 >/dev/null 2>&1; do echo "Waiting for network..."; sleep 5; done
+  - apt-get update
+  - apt-get install -y ca-certificates curl docker.io
   - systemctl enable --now docker
   - systemctl daemon-reload
   - systemctl enable --now typesense


### PR DESCRIPTION
## Description

- Ajout d'une Dead Letter Queue en cas d'erreur non géré pour pouvoir les consulter et éventuellement les traiter plus tard
- Augmentation du `visibility_timeout_seconds` pour gérer le rate limit de 1 minute de mistral
- Correction diverse sur l'initialisation du cluster typesense qui au premier démarrage voulait installer des paquets sans avoir de réseau vers l'extérieur

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
