### PR TITLE
feat(plateform): manage multi address on list

### DIFF
--- a/api/src/controllers/mission-browse.ts
+++ b/api/src/controllers/mission-browse.ts
@@ -41,6 +41,7 @@ router.get("/browse", async (req: Request, res: Response, next: NextFunction) =>
 });
 
 const missionIdSchema = zod.object({ id: zod.string() });
+const missionDetailQuerySchema = zod.object({ addressId: zod.string().optional() });
 
 router.get("/browse/:id", async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -48,7 +49,11 @@ router.get("/browse/:id", async (req: Request, res: Response, next: NextFunction
     if (!params.success) {
       return res.status(400).send({ ok: false, code: INVALID_QUERY, message: params.error });
     }
-    const result = await missionBrowseService.findById(params.data.id);
+    const query = missionDetailQuerySchema.safeParse(req.query);
+    if (!query.success) {
+      return res.status(400).send({ ok: false, code: INVALID_QUERY, message: query.error });
+    }
+    const result = await missionBrowseService.findById(params.data.id, query.data.addressId);
     if (!result) {
       return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Mission not found" });
     }

--- a/api/src/services/mission-browse/index.ts
+++ b/api/src/services/mission-browse/index.ts
@@ -99,11 +99,11 @@ export const missionBrowseService = {
     return { data, total, page: params.page, pageSize: params.pageSize, facets };
   },
 
-  async findById(id: string): Promise<MissionDetailResponse | null> {
+  async findById(id: string, addressId?: string | null): Promise<MissionDetailResponse | null> {
     const mission = await missionService.findOneMissionBy({ id, deletedAt: null, statusCode: "ACCEPTED" });
     if (!mission) {
       return null;
     }
-    return toMissionDetailPayload(mission);
+    return toMissionDetailPayload(mission, addressId);
   },
 };

--- a/api/src/services/mission-browse/transformers.ts
+++ b/api/src/services/mission-browse/transformers.ts
@@ -25,8 +25,8 @@ export const toMissionBrowse = (mission: MissionRecord): MissionBrowse => {
   };
 };
 
-export const toMissionDetailPayload = (mission: MissionRecord): MissionDetailResponse => {
-  const addr = mission.addresses[0] ?? null;
+export const toMissionDetailPayload = (mission: MissionRecord, addressId?: string | null): MissionDetailResponse => {
+  const addr = (addressId ? mission.addresses.find((a) => a.id === addressId) : null) ?? mission.addresses[0] ?? null;
   const addressParts = [addr?.street, addr?.postalCode && addr?.city ? `${addr.postalCode} ${addr.city}` : (addr?.city ?? null)].filter(Boolean);
 
   const hasCompensation = mission.compensationAmount != null || mission.compensationAmountMax != null;

--- a/api/src/services/mission-match/transformers.ts
+++ b/api/src/services/mission-match/transformers.ts
@@ -137,6 +137,7 @@ export const toMissionMatchItem = (item: MatchMissionItem, missionIndex: Record<
         closestLat: item.closestLat,
         closestLon: item.closestLon,
         closestAddress: item.closestAddress,
+        addressId: item.missionAddressId,
       },
     },
     match: {

--- a/packages/dto/src/resources/mission-match.ts
+++ b/packages/dto/src/resources/mission-match.ts
@@ -10,6 +10,7 @@ export type MissionMatchLocation = {
   closestLat: number | null;
   closestLon: number | null;
   closestAddress: string | null;
+  addressId: string | null;
 };
 
 export type MissionMatchMission = {

--- a/plateform/app/components/mission-detail/similar-missions.tsx
+++ b/plateform/app/components/mission-detail/similar-missions.tsx
@@ -4,7 +4,7 @@ import type { MissionMatchItem } from "@engagement/dto";
 import MissionCard from "~/components/missions/mission-card";
 import Highlight from "~/components/ui/highlight";
 import { fetchMatches } from "~/services/matching";
-import { matchResultToBrowseMission } from "~/utils/mission";
+import { buildMissionDetailHref, matchResultToBrowseMission } from "~/utils/mission";
 
 interface Props {
   userScoringId: string;
@@ -53,7 +53,7 @@ export default function SimilarMissions({ userScoringId, currentMissionId }: Pro
         <div ref={scrollRef} className="flex snap-x snap-mandatory gap-5 overflow-x-auto pb-2 scrollbar-none">
           {items.map((item) => (
             <div key={item.mission.id} className="w-[280px] flex-none snap-start md:w-[283px]">
-              <MissionCard mission={matchResultToBrowseMission(item)} link={{ type: "internal", to: `/results/${userScoringId}/missions/${item.mission.id}` }} />
+              <MissionCard mission={matchResultToBrowseMission(item)} link={{ type: "internal", to: buildMissionDetailHref(item, userScoringId) }} />
             </div>
           ))}
         </div>

--- a/plateform/app/components/results/other-missions.tsx
+++ b/plateform/app/components/results/other-missions.tsx
@@ -2,7 +2,7 @@ import type { MissionMatchItem } from "@engagement/dto";
 import MissionCard from "~/components/missions/mission-card";
 import { DebugButton } from "~/components/results/matching-debug-modal";
 import Pagination from "~/components/ui/pagination";
-import { matchResultToBrowseMission } from "~/utils/mission";
+import { buildMissionDetailHref, matchResultToBrowseMission } from "~/utils/mission";
 
 interface OtherMissionsProps {
   items: MissionMatchItem[];
@@ -35,10 +35,7 @@ export default function OtherMissions({
         <div className={gridClassName}>
           {items.map((item) => (
             <div key={item.mission.id} className="relative">
-              <MissionCard
-                mission={matchResultToBrowseMission(item)}
-                link={{ type: "internal", to: userScoringId ? `/results/${userScoringId}/missions/${item.mission.id}` : `/missions/${item.mission.id}` }}
-              />
+              <MissionCard mission={matchResultToBrowseMission(item)} link={{ type: "internal", to: buildMissionDetailHref(item, userScoringId) }} />
               <DebugButton missionId={item.mission.id} />
             </div>
           ))}

--- a/plateform/app/components/results/pinned-missions.tsx
+++ b/plateform/app/components/results/pinned-missions.tsx
@@ -2,7 +2,7 @@ import type { MissionMatchItem } from "@engagement/dto";
 import MissionCard from "~/components/missions/mission-card";
 import EmailMissionsModal from "~/components/results/email-missions-modal";
 import { DebugButton } from "~/components/results/matching-debug-modal";
-import { matchResultToBrowseMission } from "~/utils/mission";
+import { buildMissionDetailHref, matchResultToBrowseMission } from "~/utils/mission";
 
 interface PinnedMissionsProps {
   items: MissionMatchItem[];
@@ -25,10 +25,7 @@ export default function PinnedMissions({ items, loading, error, userScoringId }:
           <div className="grid grid-cols-1 gap-6 pb-6 md:grid-cols-2 md:px-4">
             {items.map((item) => (
               <div key={item.mission.id} className="relative w-full md:max-w-[330px]">
-                <MissionCard
-                  mission={matchResultToBrowseMission(item)}
-                  link={{ type: "internal", to: userScoringId ? `/results/${userScoringId}/missions/${item.mission.id}` : `/missions/${item.mission.id}` }}
-                />
+                <MissionCard mission={matchResultToBrowseMission(item)} link={{ type: "internal", to: buildMissionDetailHref(item, userScoringId) }} />
                 <DebugButton missionId={item.mission.id} />
               </div>
             ))}

--- a/plateform/app/routes/api.missions.browse.$id.ts
+++ b/plateform/app/routes/api.missions.browse.$id.ts
@@ -6,9 +6,10 @@ import { createApi, upstreamErrorResponse } from "~/services/api";
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const { id } = params;
   if (!id) return Response.json({ ok: false, code: "MISSING_ID" }, { status: 400 });
+  const addressId = new URL(request.url).searchParams.get("addressId");
   const api = createApi(request);
   try {
-    const data = await api.get<MissionDetailResponse>(`/missions/browse/${id}`);
+    const data = await api.get<MissionDetailResponse>(`/missions/browse/${id}${addressId ? `?addressId=${encodeURIComponent(addressId)}` : ""}`);
     return Response.json({ ok: true, data });
   } catch (error) {
     return upstreamErrorResponse(error);

--- a/plateform/app/routes/mission-detail.tsx
+++ b/plateform/app/routes/mission-detail.tsx
@@ -1,6 +1,6 @@
 import type { MissionDetailResponse } from "@engagement/dto";
 import { useEffect, useState } from "react";
-import { Link, useParams } from "react-router";
+import { Link, useParams, useSearchParams } from "react-router";
 
 import MissionCtaPanel from "~/components/mission-detail/cta-panel";
 import MissionDescriptionCard from "~/components/mission-detail/description-card";
@@ -12,6 +12,8 @@ import { fetchMissionDetail } from "~/services/mission-browse";
 
 export default function MissionDetailPage() {
   const { missionId, userScoringId } = useParams<{ missionId: string; userScoringId?: string }>();
+  const [searchParams] = useSearchParams();
+  const addressId = searchParams.get("addressId");
   const [mission, setMission] = useState<MissionDetailResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -19,11 +21,11 @@ export default function MissionDetailPage() {
   useEffect(() => {
     if (!missionId) return;
     setLoading(true);
-    fetchMissionDetail(missionId)
+    fetchMissionDetail(missionId, addressId)
       .then(setMission)
       .catch(() => setError("Impossible de charger cette mission."))
       .finally(() => setLoading(false));
-  }, [missionId]);
+  }, [missionId, addressId]);
 
   const backPath = userScoringId ? `/results/${userScoringId}` : "/";
   const backLabel = userScoringId ? "Retour aux résultats" : "Accueil";

--- a/plateform/app/routes/results.tsx
+++ b/plateform/app/routes/results.tsx
@@ -18,7 +18,7 @@ import { useIsMobile } from "~/hooks/useIsMobile";
 import { useMissionResults } from "~/hooks/useMissionResults";
 import { useQuizStore } from "~/stores/quiz";
 import { evalCondition } from "~/utils/conditions";
-import { matchResultToBrowseMission } from "~/utils/mission";
+import { buildMissionDetailHref, matchResultToBrowseMission } from "~/utils/mission";
 
 const FRANCE_CENTER: [number, number] = [46.6, 2.3];
 
@@ -111,10 +111,7 @@ export default function ResultsPage() {
               }}
             >
               <div className="relative">
-                <MissionCard
-                  mission={matchResultToBrowseMission(selectedMission)}
-                  link={{ type: "internal", to: userScoringId ? `/results/${userScoringId}/missions/${selectedMission.mission.id}` : `/missions/${selectedMission.mission.id}` }}
-                />
+                <MissionCard mission={matchResultToBrowseMission(selectedMission)} link={{ type: "internal", to: buildMissionDetailHref(selectedMission, userScoringId) }} />
                 <div className="absolute right-3 top-3 z-10 flex items-center gap-2">
                   <button
                     type="button"

--- a/plateform/app/services/mission-browse.ts
+++ b/plateform/app/services/mission-browse.ts
@@ -20,4 +20,5 @@ export async function browseMissions(filters: MissionBrowseFilters, signal?: Abo
   return client.get<MissionBrowseResponse>(`/api/missions/browse?${params.toString()}`, signal);
 }
 
-export const fetchMissionDetail = (id: string): Promise<MissionDetailResponse> => client.get<MissionDetailResponse>(`/api/missions/browse/${id}`);
+export const fetchMissionDetail = (id: string, addressId?: string | null): Promise<MissionDetailResponse> =>
+  client.get<MissionDetailResponse>(`/api/missions/browse/${id}${addressId ? `?addressId=${encodeURIComponent(addressId)}` : ""}`);

--- a/plateform/app/utils/mission.ts
+++ b/plateform/app/utils/mission.ts
@@ -59,6 +59,17 @@ export function formatDeadline(endAt: string | null): string | null {
   return `Candidatures ouvertes jusqu'au ${d.getDate()} ${MONTHS[d.getMonth()]}`;
 }
 
+/**
+ * Construit le lien vers la page détail d'une mission issue des résultats de matching.
+ * Propage l'adresse qui a permis le match (`addressId`) afin que la page détail affiche
+ * la bonne adresse quand la mission en a plusieurs.
+ */
+export function buildMissionDetailHref(item: MissionMatchItem, userScoringId?: string): string {
+  const base = userScoringId ? `/results/${userScoringId}/missions/${item.mission.id}` : `/missions/${item.mission.id}`;
+  const addressId = item.mission.location.addressId;
+  return addressId ? `${base}?addressId=${encodeURIComponent(addressId)}` : base;
+}
+
 export function matchResultToBrowseMission(item: MissionMatchItem): MissionBrowse {
   return {
     id: item.mission.id,


### PR DESCRIPTION
## Description

Quand une mission a plusieurs adresses, la carte de la page résultats affiche l'adresse **qui a permis le match** (la plus proche). Mais en cliquant sur la mission, la page détail affichait toujours la **première adresse** de la mission, qui pouvait différer de celle vue sur la carte.

Cette PR propage l'identifiant de l'adresse ayant matché (`addressId`) de bout en bout, via un paramètre de route `?addressId`, pour que la page détail affiche la bonne adresse. En l'absence de `?addressId` (accès direct, page `/missions`, adresse non géolocalisée), le comportement actuel est conservé (première adresse).

Le moteur de matching connaissait déjà cet identifiant (`missionAddressId`) ; il était simplement absent du DTO et n'était pas transmis jusqu'au détail.

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Détail des changements**

- **DTO** (`@engagement/dto`) : ajout du champ `addressId: string | null` à `MissionMatchLocation` (additif, rétrocompatible).
- **API** :
  - `mission-match` : le transformer expose `addressId` (= `missionAddressId`).
  - `mission-browse` : `toMissionDetailPayload(mission, addressId?)` sélectionne l'adresse par id, avec fallback sur la première adresse ; `findById` et le controller (`GET /missions/browse/:id`) acceptent un `addressId` optionnel validé via zod.
- **plateform** :
  - helper `buildMissionDetailHref()` centralisant la construction de l'URL (+ `?addressId` conditionnel), utilisé par les 4 points d'entrée vers le détail (résultats, missions épinglées, autres missions, missions similaires).
  - `fetchMissionDetail(id, addressId?)` + forward du paramètre dans la route SSR.
  - `mission-detail.tsx` lit `?addressId` via `useSearchParams`.

**Points d'attention reviewer**

- `missionAddressId` peut être `null` → on n'ajoute pas le paramètre, fallback naturel sur la première adresse (pas de régression sur les liens existants).
- Contrat partagé `@engagement/dto` modifié → producteurs (`api/`) et consommateurs (`plateform/`) adaptés dans la même PR.
- Pas de tests unitaires ajoutés (threading/mapping sans logique métier nouvelle) ; lint + typecheck + suite plateform (59/59) au vert.

**À vérifier en review (desktop + mobile)**

- Mission multi-adresses : l'adresse de la carte résultats correspond à celle de la page détail (lien avec `?addressId`).
- Accès direct sans `?addressId` : la première adresse s'affiche comme avant.
