### PR TITLE
feat(jobs): add on-demand job to replay dead letter queues

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -113,6 +113,41 @@ npm run worker:run -- mission.enrichment '{"missionId":"abc123"}'
 
 Les types disponibles correspondent aux clés du `taskRegistry` (`src/worker/registry.ts`). Un message d'erreur explicite est affiché si le type est inconnu ou si le payload ne correspond pas au schéma attendu.
 
+### Rejeu des Dead Letter Queues (DLQ)
+
+Chaque queue SQS dispose d'une **Dead Letter Queue** (`<queue>-dlq`) vers laquelle un message bascule après plusieurs échecs de traitement (10 tentatives). Le job **`process-dead-letter-queues`** permet de rejouer ces messages, typiquement après correction de la cause racine.
+
+Pour chaque queue traitée, le job lit (pull) sa DLQ et **republie chaque message sur la queue source**. Un message n'est **supprimé de la DLQ qu'après un rejeu réussi** ; un message illisible, de type inconnu ou dont le rejeu échoue est conservé (et remonté dans Sentry).
+
+```bash
+# Rejouer toutes les DLQ
+npm run job -- process-dead-letter-queues --env staging
+
+# Cibler une seule queue
+npm run job -- process-dead-letter-queues '{"taskType":"mission.index"}' --env staging
+
+# Inspecter sans rien modifier (lecture seule)
+npm run job -- process-dead-letter-queues '{"dryRun":true}' --env staging
+
+# Tester sur un seul message
+npm run job -- process-dead-letter-queues '{"taskType":"mission.index","max":1}' --env staging
+```
+
+Paramètres (tous optionnels) :
+
+| Paramètre  | Défaut | Description                                                                                  |
+| ---------- | ------ | ------------------------------------------------------------------------------------------- |
+| `taskType` | —      | Clé du `taskRegistry` à traiter (ex. `mission.index`). Absent → toutes les DLQ sont drainées. |
+| `max`      | `1000` | Nombre maximum de messages traités **par queue** (`1` pour tester un seul message).          |
+| `dryRun`   | `false`| Lit et compte les messages sans republier ni supprimer.                                      |
+
+Détails d'implémentation :
+
+- `src/jobs/process-dead-letter-queues/handler.ts` — orchestration (sélection des queues, boucle de lecture, agrégation des compteurs `received / replayed / skipped`).
+- `src/services/async-task/dlq-consumer.ts` — `DlqConsumer` dédié (`receive` / `delete` / `getQueueUrl`), isolé du bus qui reste *publish-only*.
+- Le nom de la DLQ est dérivé de la queue source : `SCW_QUEUE_URL_<NOM>` doit donc pointer sur la **queue source** (le job ajoute lui-même le suffixe `-dlq`), qui est aussi la cible du rejeu.
+- Côté infra, le job (`scaleway_job_definition`) tourne avec une credential dédiée `async_task_dlq_processor` (droits `receive` + `publish`).
+
 ## Mode production
 
 ### Compilation pour la production

--- a/api/src/jobs/process-dead-letter-queues/handler.ts
+++ b/api/src/jobs/process-dead-letter-queues/handler.ts
@@ -1,0 +1,143 @@
+import { captureException } from "@/error";
+import { BaseHandler } from "@/jobs/base/handler";
+import { JobResult } from "@/jobs/types";
+import { asyncTaskBus } from "@/services/async-task";
+import { DlqConsumer } from "@/services/async-task/dlq-consumer";
+import { taskRegistry, TaskType } from "@/worker/registry";
+import { taskEnvelopeSchema } from "@/worker/types";
+
+const LOG_PREFIX = "[process-dead-letter-queues-job]";
+const DEFAULT_MAX = 1000;
+const MAX_DURATION_MS = 5 * 60 * 1000;
+
+export interface ProcessDeadLetterQueuesJobPayload {
+  taskType?: string;
+  max?: number;
+  dryRun?: boolean;
+}
+
+export interface ProcessDeadLetterQueuesJobResult extends JobResult {
+  taskType: string;
+  received: number;
+  replayed: number;
+  skipped: number;
+}
+
+interface DrainResult {
+  received: number;
+  replayed: number;
+  skipped: number;
+  error?: string;
+}
+
+/**
+ * On-demand job: Clears the DLQ of a given queue by republishing each message to the source queue.
+ *
+ * Pull mode (no native acknowledgment): A message is removed from the DLQ only after a successful republish.
+ * A message that is unreadable, of an unknown type, or whose republish fails is retained (counted as `skipped`).
+ *
+ * Without `taskType`, every DLQ of the registry is drained; with `taskType`, only that queue's DLQ is.
+ */
+export class ProcessDeadLetterQueuesHandler implements BaseHandler<ProcessDeadLetterQueuesJobPayload, ProcessDeadLetterQueuesJobResult> {
+  name = "Rejeu des Dead Letter Queues";
+
+  async handle({ taskType, max = DEFAULT_MAX, dryRun = false }: ProcessDeadLetterQueuesJobPayload = {}): Promise<ProcessDeadLetterQueuesJobResult> {
+    const base = { timestamp: new Date(), taskType: taskType ?? "all", received: 0, replayed: 0, skipped: 0 };
+
+    if (taskType && !(taskType in taskRegistry)) {
+      const message = `taskType invalide: ${taskType} — attendu l'un de [${Object.keys(taskRegistry).join(", ")}]`;
+      console.error(`${LOG_PREFIX} ${message}`);
+      return { ...base, success: false, message };
+    }
+
+    const types = (taskType ? [taskType] : Object.keys(taskRegistry)) as TaskType[];
+    const consumer = new DlqConsumer();
+
+    let received = 0;
+    let replayed = 0;
+    let skipped = 0;
+    let hadError = false;
+    const parts: string[] = [];
+
+    for (const type of types) {
+      const result = await this.drainQueue(type, consumer, { max, dryRun });
+      received += result.received;
+      replayed += result.replayed;
+      skipped += result.skipped;
+      if (result.error) {
+        hadError = true;
+      }
+      parts.push(`${type}: ${result.replayed} rejoués / ${result.skipped} ignorés / ${result.received} reçus${result.error ? ` (${result.error})` : ""}`);
+    }
+
+    const message = `${parts.join(" | ")}${dryRun ? " (dry-run)" : ""}`;
+    console.log(`${LOG_PREFIX} done — ${message}`);
+
+    return { ...base, success: !hadError && skipped === 0, received, replayed, skipped, message };
+  }
+
+  private async drainQueue(type: TaskType, consumer: DlqConsumer, { max, dryRun }: { max: number; dryRun: boolean }): Promise<DrainResult> {
+    const sourceUrl = taskRegistry[type].queueUrl;
+    if (!sourceUrl) {
+      console.error(`${LOG_PREFIX} URL de la queue source non configurée pour ${type}`);
+      return { received: 0, replayed: 0, skipped: 0, error: "queue source non configurée" };
+    }
+
+    const dlqName = `${sourceUrl.split("/").pop()}-dlq`;
+
+    let dlqUrl: string;
+    try {
+      dlqUrl = await consumer.getQueueUrl(dlqName);
+    } catch (error) {
+      console.error(`${LOG_PREFIX} DLQ introuvable: ${dlqName}`, error);
+      captureException(error, { extra: { taskType: type, dlqName } });
+      return { received: 0, replayed: 0, skipped: 0, error: `DLQ introuvable: ${dlqName}` };
+    }
+
+    console.log(`${LOG_PREFIX} drain ${dlqName} → ${type} (max: ${max}, dryRun: ${dryRun})`);
+
+    let received = 0;
+    let replayed = 0;
+    let skipped = 0;
+    const start = Date.now();
+
+    while (received < max && Date.now() - start < MAX_DURATION_MS) {
+      const batch = await consumer.receive(dlqUrl, max - received);
+      if (batch.length === 0) {
+        break;
+      }
+
+      for (const message of batch) {
+        received++;
+        try {
+          const envelope = taskEnvelopeSchema.parse(JSON.parse(message.body));
+
+          if (!(envelope.type in taskRegistry)) {
+            skipped++;
+            console.warn(`${LOG_PREFIX} type inconnu, message conservé: ${envelope.type}`);
+            continue;
+          }
+
+          const targetType = envelope.type as TaskType;
+          const payload = taskRegistry[targetType].schema.parse(envelope.payload);
+
+          console.log(payload);
+
+          if (dryRun) {
+            continue;
+          }
+
+          await asyncTaskBus.publish({ type: targetType, payload });
+          await consumer.delete(dlqUrl, message.receiptHandle);
+          replayed++;
+        } catch (error) {
+          skipped++;
+          console.error(`${LOG_PREFIX} échec rejeu, message conservé`, error);
+          captureException(error, { extra: { taskType: type, dlqName } });
+        }
+      }
+    }
+
+    return { received, replayed, skipped };
+  }
+}

--- a/api/src/services/async-task/dlq-consumer.ts
+++ b/api/src/services/async-task/dlq-consumer.ts
@@ -1,0 +1,55 @@
+import { REGION, SCW_QUEUE_ACCESS_KEY, SCW_QUEUE_ENDPOINT, SCW_QUEUE_SECRET_KEY } from "@/config";
+import { DeleteMessageCommand, GetQueueUrlCommand, ReceiveMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
+
+export type ReceivedMessage = {
+  receiptHandle: string;
+  body: string;
+};
+
+/**
+ * A consumer dedicated to Dead Letter Queues (pull mode).
+ *
+ * Separate from the `QueueProvider`/`asyncTaskBus` (which remains publish-only): encapsulates an SQS client
+ * to read (`receive`) and acknowledge (`delete`) messages from a DLQ, and resolve its URL.
+ */
+export class DlqConsumer {
+  private client: SQSClient;
+
+  constructor() {
+    this.client = new SQSClient({
+      region: REGION,
+      endpoint: SCW_QUEUE_ENDPOINT,
+      credentials: {
+        accessKeyId: SCW_QUEUE_ACCESS_KEY,
+        secretAccessKey: SCW_QUEUE_SECRET_KEY,
+      },
+    });
+  }
+
+  async getQueueUrl(queueName: string): Promise<string> {
+    const response = await this.client.send(new GetQueueUrlCommand({ QueueName: queueName }));
+    if (!response.QueueUrl) {
+      throw new Error(`[dlq-consumer] queue introuvable: ${queueName}`);
+    }
+    return response.QueueUrl;
+  }
+
+  async receive(queueUrl: string, max: number): Promise<ReceivedMessage[]> {
+    const response = await this.client.send(
+      new ReceiveMessageCommand({
+        QueueUrl: queueUrl,
+        MaxNumberOfMessages: Math.min(Math.max(max, 1), 10),
+        WaitTimeSeconds: 5,
+        VisibilityTimeout: 30,
+      })
+    );
+
+    return (response.Messages ?? [])
+      .filter((message) => message.ReceiptHandle && message.Body !== undefined)
+      .map((message) => ({ receiptHandle: message.ReceiptHandle as string, body: message.Body as string }));
+  }
+
+  async delete(queueUrl: string, receiptHandle: string): Promise<void> {
+    await this.client.send(new DeleteMessageCommand({ QueueUrl: queueUrl, ReceiptHandle: receiptHandle }));
+  }
+}

--- a/terraform/jobs.tf
+++ b/terraform/jobs.tf
@@ -330,6 +330,26 @@ resource "scaleway_job_definition" "update-mission-index" {
   env = local.all_env_vars
 }
 
+# Job Definition for the 'process-dead-letter-queues' task (on-demand only, no cron)
+resource "scaleway_job_definition" "process-dead-letter-queues" {
+  count                  = var.enable_async_tasks ? 1 : 0
+  name                   = "${terraform.workspace}-process-dead-letter-queues"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["dist/jobs/run-job.js", "process-dead-letter-queues"]
+  timeout                = "30m"
+
+  # SQS credential overload: the job must be able to read from the DLQ (receive) AND republish (publish)
+  env = merge(local.all_env_vars, {
+    "SCW_QUEUE_ACCESS_KEY" = scaleway_mnq_sqs_credentials.async_task_dlq_processor[0].access_key
+    "SCW_QUEUE_SECRET_KEY" = scaleway_mnq_sqs_credentials.async_task_dlq_processor[0].secret_key
+  })
+}
+
 # Job Definition for the 'verify-publisher-organization' task
 resource "scaleway_job_definition" "verify-publisher-organization" {
   count                  = var.enable_mission_jobs ? 1 : 0

--- a/terraform/queues.tf
+++ b/terraform/queues.tf
@@ -38,6 +38,19 @@ resource "scaleway_mnq_sqs_credentials" "async_task_trigger" {
   }
 }
 
+# DLQ replay job credentials: reads the DLQ (receive) and republishes it to the source queue (publish)
+resource "scaleway_mnq_sqs_credentials" "async_task_dlq_processor" {
+  count      = var.enable_async_tasks ? 1 : 0
+  project_id = data.scaleway_mnq_sqs.main.project_id
+  name       = "${var.workspace}-async-task-dlq-processor"
+
+  permissions {
+    can_manage  = false
+    can_receive = true
+    can_publish = true
+  }
+}
+
 locals {
   async_task_queues = {
     mission_enrichment = {


### PR DESCRIPTION
## Description

Ajoute un job **on-demand** `process-dead-letter-queues` qui dépile (pull) les messages d'une DLQ Scaleway et les **republie sur la queue source**. Le `delete` du message dans la DLQ n'a lieu qu'**après un republish réussi** (mode pull, pas d'acquittement natif). Un message illisible, de type inconnu ou dont le rejeu échoue est conservé (compté `skipped`).

- Sans `taskType` → draine **toutes** les DLQ du registry (`mission.enrichment`, `mission.scoring`, `mission.index`).
- Avec `taskType` → cible une seule DLQ.
- Paramètres `max` (plafond de messages, par queue — `max:1` pour tester un seul message) et `dryRun` (lecture seule, sans republish ni delete).

La sélection de la DLQ est dérivée du nom de la queue source (`<queue>-dlq`) puis résolue via `GetQueueUrl`.

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Architecture**
- `api/src/services/async-task/dlq-consumer.ts` — nouveau `DlqConsumer` (`receive` / `delete` / `getQueueUrl`) isolé, qui laisse `asyncTaskBus` *publish-only*.
- `api/src/jobs/process-dead-letter-queues/handler.ts` — le job ; réutilise `taskRegistry`, `taskEnvelopeSchema` et `asyncTaskBus.publish` pour le rejeu.

**Terraform**
- `queues.tf` — nouvelle credential `async_task_dlq_processor` (`can_receive` + `can_publish`), nécessaire car aucune credential existante ne combine lecture + publication.
- `jobs.tf` — `scaleway_job_definition` on-demand (sans cron), avec surcharge des clés SQS par celles du DLQ processor.
