### PR TITLE
fix(api): case-insensitive matching on widget rule array fields

### DIFF
--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -5,6 +5,7 @@ import zod from "zod";
 import { PUBLISHER_IDS } from "@/config";
 import { INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
 import { ipRateLimiter } from "@/middlewares/rate-limit";
+import publisherOrganizationService from "@/services/publisher-organization";
 import { widgetService } from "@/services/widget";
 import { widgetMissionService } from "@/services/widget-mission";
 import { WidgetRecord } from "@/types";
@@ -114,7 +115,7 @@ router.get("/:id/search", cors({ origin: "*" }), async (req: Request, res: Respo
       return res.status(404).send({ ok: false, code: NOT_FOUND });
     }
 
-    const filters = buildMissionFilters(widget, query.data, { skip: query.data.from, limit: query.data.size });
+    const filters = await buildMissionFilters(widget, query.data, { skip: query.data.from, limit: query.data.size });
     const { data, total } = await widgetMissionService.fetchWidgetMissions(widget, filters, MISSION_FIELDS);
     const mappedData = data.map((mission) => toWidgetMission(mission, widget));
 
@@ -171,7 +172,7 @@ router.get("/:id/aggs", cors({ origin: "*" }), async (req: Request, res: Respons
       return res.status(404).send({ ok: false, code: NOT_FOUND });
     }
 
-    const filters = buildMissionFilters(widget, query.data, { skip: 0, limit: 0 });
+    const filters = await buildMissionFilters(widget, query.data, { skip: 0, limit: 0 });
     const aggs = await widgetMissionService.fetchWidgetAggregations(widget, filters, query.data.aggs);
     return res.status(200).send({ ok: true, data: aggs });
   } catch (error) {
@@ -209,9 +210,9 @@ const resolveLocationFilters = (widget: WidgetRecord, lon?: number, lat?: number
   return undefined;
 };
 
-const buildMissionFilters = (widget: WidgetRecord, query: { [key: string]: any }, pagination: { skip: number; limit: number }): MissionSearchFilters => {
+const buildMissionFilters = async (widget: WidgetRecord, query: { [key: string]: any }, pagination: { skip: number; limit: number }): Promise<MissionSearchFilters> => {
   const filters: MissionSearchFilters = {
-    directFilters: applyWidgetRules(widget.rules || []),
+    directFilters: await applyWidgetRules(widget.rules || [], publisherOrganizationService.findIdsMatchingArrayValue),
     publisherIds: widget.publishers,
     diffuseurPublisherId: widget.fromPublisherId,
     skip: pagination.skip,

--- a/api/src/controllers/mission.ts
+++ b/api/src/controllers/mission.ts
@@ -8,6 +8,7 @@ import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { missionService } from "@/services/mission";
 import { missionEnrichmentService } from "@/services/mission-enrichment";
 import { missionScoringService } from "@/services/mission-scoring";
+import publisherOrganizationService from "@/services/publisher-organization";
 import type { UserRequest } from "@/types/passport";
 import { applyWidgetRules, getDistanceKm } from "@/utils";
 import { getUserPublisherIds, hasAdminOrDirectPublisherAccess, isAdmin, readRequiredParam } from "@/utils/publisher-access";
@@ -154,7 +155,7 @@ router.post("/search", passport.authenticate("user", { session: false }), async 
     }
 
     if (body.data.rules) {
-      filters.directFilters = applyWidgetRules(body.data.rules);
+      filters.directFilters = await applyWidgetRules(body.data.rules, publisherOrganizationService.findIdsMatchingArrayValue);
     }
 
     const withAdminProcessingFlags = async (data: Awaited<ReturnType<typeof missionService.findMissions>>["data"]) => {

--- a/api/src/repositories/publisher-organization.ts
+++ b/api/src/repositories/publisher-organization.ts
@@ -1,6 +1,6 @@
 import { Prisma, PublisherOrganization } from "@/db/core";
 import { prisma } from "@/db/postgres";
-import { PublisherOrganizationWithRelations } from "@/types/publisher-organization";
+import { ORG_ARRAY_COLUMNS, OrgArrayColumn, PublisherOrganizationWithRelations } from "@/types/publisher-organization";
 
 export const publisherOrganizationRepository = {
   async findUnique(params: Prisma.PublisherOrganizationFindUniqueArgs): Promise<PublisherOrganization | null> {
@@ -45,10 +45,14 @@ export const publisherOrganizationRepository = {
    * Retourne les ids des organisations dont la colonne array `column` contient un élément
    * égal à `value`, de manière insensible à la casse.
    * Prisma ne supportant pas `mode: "insensitive"` sur les opérateurs array, on passe par du SQL brut.
-   * `column` est restreint à une union typée (pas d'interpolation libre → pas d'injection).
+   * `column` est validée contre l'allowlist `ORG_ARRAY_COLUMNS` avant d'être utilisée comme
+   * identifiant SQL (guillemets échappés) → aucune injection possible.
    */
-  async findIdsByArrayValueInsensitive(column: "parent_organizations" | "actions", value: string): Promise<string[]> {
-    const columnSql = column === "actions" ? Prisma.sql`"actions"` : Prisma.sql`"parent_organizations"`;
+  async findIdsByArrayValueInsensitive(column: OrgArrayColumn, value: string): Promise<string[]> {
+    if (!ORG_ARRAY_COLUMNS.includes(column)) {
+      throw new Error(`Unsupported array column: ${column}`);
+    }
+    const columnSql = Prisma.raw(`"${column.replaceAll('"', '""')}"`);
     const rows = await prisma.$queryRaw<{ id: string }[]>`
       SELECT "id" FROM "publisher_organization"
       WHERE EXISTS (SELECT 1 FROM unnest(${columnSql}) AS elem WHERE lower(elem) = lower(${value}))

--- a/api/src/repositories/publisher-organization.ts
+++ b/api/src/repositories/publisher-organization.ts
@@ -40,5 +40,20 @@ export const publisherOrganizationRepository = {
   async count(params: Prisma.PublisherOrganizationCountArgs = {}): Promise<number> {
     return prisma.publisherOrganization.count(params);
   },
+
+  /**
+   * Retourne les ids des organisations dont la colonne array `column` contient un élément
+   * égal à `value`, de manière insensible à la casse.
+   * Prisma ne supportant pas `mode: "insensitive"` sur les opérateurs array, on passe par du SQL brut.
+   * `column` est restreint à une union typée (pas d'interpolation libre → pas d'injection).
+   */
+  async findIdsByArrayValueInsensitive(column: "parent_organizations" | "actions", value: string): Promise<string[]> {
+    const columnSql = column === "actions" ? Prisma.sql`"actions"` : Prisma.sql`"parent_organizations"`;
+    const rows = await prisma.$queryRaw<{ id: string }[]>`
+      SELECT "id" FROM "publisher_organization"
+      WHERE EXISTS (SELECT 1 FROM unnest(${columnSql}) AS elem WHERE lower(elem) = lower(${value}))
+    `;
+    return rows.map((row) => row.id);
+  },
 };
 export default publisherOrganizationRepository;

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -1,27 +1,33 @@
 import { Prisma, PublisherDiffusionRule } from "@/db/core";
 import { missionRepository } from "@/repositories/mission";
 import { publisherDiffusionRuleRepository } from "@/repositories/publisher-diffusion-rule";
+import publisherOrganizationService from "@/services/publisher-organization";
 import type {
   PublisherDiffusionRuleCombinator,
   PublisherDiffusionRuleCreateInput,
   PublisherDiffusionRuleFindParams,
   PublisherDiffusionRuleRecord,
 } from "@/types/publisher-diffusion-rule";
+import type { OrganizationArrayIdsResolver } from "@/types/publisher-organization";
 import { buildMissionPublisherDiffusionRuleConditionFromRule, buildMissionPublisherDiffusionRuleSqlFromRules } from "@/utils/publisher-diffusion-rule-query";
 
 type PublisherDiffusionRuleWithChildren = PublisherDiffusionRule & {
   combinedRules?: PublisherDiffusionRule[];
 };
 
-const buildNodeCondition = (rule: PublisherDiffusionRule, childrenByParentId: Map<string, PublisherDiffusionRule[]>): Prisma.MissionWhereInput | null => {
-  const selfCondition = buildMissionPublisherDiffusionRuleConditionFromRule(rule);
+const buildNodeCondition = async (
+  rule: PublisherDiffusionRule,
+  childrenByParentId: Map<string, PublisherDiffusionRule[]>,
+  resolveOrganizationIds: OrganizationArrayIdsResolver
+): Promise<Prisma.MissionWhereInput | null> => {
+  const selfCondition = await buildMissionPublisherDiffusionRuleConditionFromRule(rule, resolveOrganizationIds);
   if (!selfCondition) {
     return null;
   }
 
-  const children = (childrenByParentId.get(rule.id) ?? [])
-    .map((child: PublisherDiffusionRule) => buildNodeCondition(child, childrenByParentId))
-    .filter((condition: Prisma.MissionWhereInput | null): condition is Prisma.MissionWhereInput => Boolean(condition));
+  const children = (
+    await Promise.all((childrenByParentId.get(rule.id) ?? []).map((child: PublisherDiffusionRule) => buildNodeCondition(child, childrenByParentId, resolveOrganizationIds)))
+  ).filter((condition: Prisma.MissionWhereInput | null): condition is Prisma.MissionWhereInput => Boolean(condition));
 
   if (!children.length) {
     return selfCondition;
@@ -31,7 +37,7 @@ const buildNodeCondition = (rule: PublisherDiffusionRule, childrenByParentId: Ma
   return { OR: [{ NOT: selfCondition }, childrenAnd] };
 };
 
-const buildMissionWhere = (rules: PublisherDiffusionRule[]): Prisma.MissionWhereInput => {
+const buildMissionWhere = async (rules: PublisherDiffusionRule[], resolveOrganizationIds: OrganizationArrayIdsResolver): Promise<Prisma.MissionWhereInput> => {
   const childrenByParentId = new Map<string, PublisherDiffusionRule[]>();
   const roots: PublisherDiffusionRule[] = [];
 
@@ -45,9 +51,9 @@ const buildMissionWhere = (rules: PublisherDiffusionRule[]): Prisma.MissionWhere
     }
   }
 
-  const groups = roots
-    .map((root: PublisherDiffusionRule) => buildNodeCondition(root, childrenByParentId))
-    .filter((group: Prisma.MissionWhereInput | null): group is Prisma.MissionWhereInput => Boolean(group));
+  const groups = (await Promise.all(roots.map((root: PublisherDiffusionRule) => buildNodeCondition(root, childrenByParentId, resolveOrganizationIds)))).filter(
+    (group: Prisma.MissionWhereInput | null): group is Prisma.MissionWhereInput => Boolean(group)
+  );
 
   if (!groups.length) {
     return {};
@@ -100,7 +106,7 @@ export const publisherDiffusionRuleService = {
       orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
     });
 
-    return buildMissionWhere(rules);
+    return buildMissionWhere(rules, publisherOrganizationService.findIdsMatchingArrayValue);
   },
 
   async canPublisherAccessMission({ publisherId, missionId }: { publisherId: string; missionId: string }): Promise<boolean> {
@@ -112,7 +118,7 @@ export const publisherDiffusionRuleService = {
       return true;
     }
 
-    const diffusionRuleWhere = buildMissionWhere(rules);
+    const diffusionRuleWhere = await buildMissionWhere(rules, publisherOrganizationService.findIdsMatchingArrayValue);
     if (Object.keys(diffusionRuleWhere).length === 0) {
       return false;
     }

--- a/api/src/services/publisher-organization.ts
+++ b/api/src/services/publisher-organization.ts
@@ -1,6 +1,7 @@
 import { Prisma, PublisherOrganization } from "@/db/core";
 import { publisherOrganizationRepository } from "@/repositories/publisher-organization";
 import {
+  OrgArrayColumn,
   PublisherOrganizationFindManyOptions,
   PublisherOrganizationFindParams,
   PublisherOrganizationRecord,
@@ -127,10 +128,10 @@ const publisherOrganizationService = {
     return publisherOrganizationRepository.groupBy(by, where);
   },
   /**
-   * Résout les ids des organisations matchant `value` sur une colonne array, insensiblement à la casse.
-   * Utilisé pour le filtrage des règles widget (champs array adossés à l'organisation).
+   * Returns the IDs of organizations whose names match `value` in an array column, case-insensitively.
+   * Used for filtering widget rules (array fields associated with the organization).
    */
-  findIdsMatchingArrayValue: async (column: "parent_organizations" | "actions", value: string): Promise<string[]> => {
+  findIdsMatchingArrayValue: async (column: OrgArrayColumn, value: string): Promise<string[]> => {
     return publisherOrganizationRepository.findIdsByArrayValueInsensitive(column, value);
   },
 };

--- a/api/src/services/publisher-organization.ts
+++ b/api/src/services/publisher-organization.ts
@@ -126,6 +126,13 @@ const publisherOrganizationService = {
   groupBy: async (by: (keyof PublisherOrganization)[], where: Prisma.PublisherOrganizationWhereInput) => {
     return publisherOrganizationRepository.groupBy(by, where);
   },
+  /**
+   * Résout les ids des organisations matchant `value` sur une colonne array, insensiblement à la casse.
+   * Utilisé pour le filtrage des règles widget (champs array adossés à l'organisation).
+   */
+  findIdsMatchingArrayValue: async (column: "parent_organizations" | "actions", value: string): Promise<string[]> => {
+    return publisherOrganizationRepository.findIdsByArrayValueInsensitive(column, value);
+  },
 };
 
 export default publisherOrganizationService;

--- a/api/src/types/publisher-organization.ts
+++ b/api/src/types/publisher-organization.ts
@@ -1,6 +1,15 @@
 import { Prisma } from "@/db/core";
 import { OrganizationRecord } from "@/types/organization";
 
+/**
+ * Colonnes de type tableau (`TEXT[]`) de `publisher_organization` sur lesquelles un matching
+ * insensible à la casse est requis (impossible via Prisma → résolution en SQL brut).
+ * Source de vérité unique : ajouter une colonne ici suffit, le typage guide le reste.
+ * Sert aussi d'allowlist anti-injection (aucune colonne hors de cette liste n'est interpolée).
+ */
+export const ORG_ARRAY_COLUMNS = ["parent_organizations", "actions"] as const;
+export type OrgArrayColumn = (typeof ORG_ARRAY_COLUMNS)[number];
+
 export interface PublisherOrganizationFindParams {
   id?: string;
   ids?: string[];

--- a/api/src/types/publisher-organization.ts
+++ b/api/src/types/publisher-organization.ts
@@ -10,6 +10,13 @@ import { OrganizationRecord } from "@/types/organization";
 export const ORG_ARRAY_COLUMNS = ["parent_organizations", "actions"] as const;
 export type OrgArrayColumn = (typeof ORG_ARRAY_COLUMNS)[number];
 
+/**
+ * Résout les ids d'organisations dont un élément de la colonne `column` correspond à `value`,
+ * insensiblement à la casse. Injecté dans les builders de règles (widget + diffusion) pour
+ * garder les utils agnostiques de la DB (l'implémentation vit dans le service publisher-organization).
+ */
+export type OrganizationArrayIdsResolver = (column: OrgArrayColumn, value: string) => Promise<string[]>;
+
 export interface PublisherOrganizationFindParams {
   id?: string;
   ids?: string[];

--- a/api/src/utils/__tests__/publisher-diffusion-rule-query.test.ts
+++ b/api/src/utils/__tests__/publisher-diffusion-rule-query.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { buildMissionPublisherDiffusionRuleSqlFromRules, type PublisherDiffusionRuleCondition } from "@/utils/publisher-diffusion-rule-query";
+import type { OrganizationArrayIdsResolver } from "@/types/publisher-organization";
+import {
+  buildMissionPublisherDiffusionRuleConditionFromRule,
+  buildMissionPublisherDiffusionRuleSqlFromRules,
+  type PublisherDiffusionRuleCondition,
+} from "@/utils/publisher-diffusion-rule-query";
 
 const rule = (override: Partial<PublisherDiffusionRuleCondition> = {}): PublisherDiffusionRuleCondition => ({
   field: "publisherOrganization.parentOrganizations",
@@ -26,5 +31,45 @@ describe("buildMissionPublisherDiffusionRuleSqlFromRules - array fields", () => 
 
     expect(sql.sql).toContain("NOT");
     expect(sql.sql).toContain("lower(elem) = lower(");
+  });
+});
+
+describe("buildMissionPublisherDiffusionRuleConditionFromRule - array fields (Prisma where)", () => {
+  it("resolves the org array field to a case-insensitive publisherOrganizationId filter", async () => {
+    const resolve: OrganizationArrayIdsResolver = vi.fn().mockResolvedValue(["org-1", "org-2"]);
+
+    const where = await buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "contains", value: "AFEV" }), resolve);
+
+    expect(resolve).toHaveBeenCalledWith("parent_organizations", "AFEV");
+    expect(where).toEqual({ publisherOrganizationId: { in: ["org-1", "org-2"] } });
+  });
+
+  it("wraps negative array operators in NOT", async () => {
+    const resolve: OrganizationArrayIdsResolver = vi.fn().mockResolvedValue(["org-1"]);
+
+    const where = await buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "is_not", value: "AFEV" }), resolve);
+
+    expect(where).toEqual({ NOT: { publisherOrganizationId: { in: ["org-1"] } } });
+  });
+
+  it("does not resolve and keeps generic handling for exists on an array field", async () => {
+    const resolve = vi.fn();
+
+    const where = await buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "exists", value: "" }), resolve);
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(where).toEqual({ publisherOrganization: { parentOrganizations: { isEmpty: false } } });
+  });
+
+  it("does not resolve scalar fields", async () => {
+    const resolve = vi.fn();
+
+    const where = await buildMissionPublisherDiffusionRuleConditionFromRule(
+      rule({ field: "publisherOrganization.clientId", fieldType: "string", operator: "is", value: "client-1" }),
+      resolve
+    );
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(where).toEqual({ publisherOrganization: { clientId: "client-1" } });
   });
 });

--- a/api/src/utils/__tests__/publisher-diffusion-rule-query.test.ts
+++ b/api/src/utils/__tests__/publisher-diffusion-rule-query.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMissionPublisherDiffusionRuleSqlFromRules, type PublisherDiffusionRuleCondition } from "@/utils/publisher-diffusion-rule-query";
+
+const rule = (override: Partial<PublisherDiffusionRuleCondition> = {}): PublisherDiffusionRuleCondition => ({
+  field: "publisherOrganization.parentOrganizations",
+  fieldType: "array",
+  operator: "contains",
+  value: "AFEV",
+  combinator: "or",
+  ...override,
+});
+
+describe("buildMissionPublisherDiffusionRuleSqlFromRules - array fields", () => {
+  it("matches array elements case-insensitively via unnest + lower", () => {
+    const sql = buildMissionPublisherDiffusionRuleSqlFromRules([rule({ operator: "contains" })]);
+
+    expect(sql.sql).toContain("unnest");
+    expect(sql.sql).toContain("lower(elem) = lower(");
+    expect(sql.sql).not.toContain("= ANY(");
+    expect(sql.values).toContain("AFEV");
+  });
+
+  it("negates the case-insensitive match for does_not_contain", () => {
+    const sql = buildMissionPublisherDiffusionRuleSqlFromRules([rule({ operator: "does_not_contain" })]);
+
+    expect(sql.sql).toContain("NOT");
+    expect(sql.sql).toContain("lower(elem) = lower(");
+  });
+});

--- a/api/src/utils/__tests__/widget.test.ts
+++ b/api/src/utils/__tests__/widget.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { applyWidgetRules, type OrganizationArrayIdsResolver } from "@/utils/widget";
+
+type Rule = { field: string; operator: string; value: string; combinator: "and" | "or" };
+
+const rule = (override: Partial<Rule> = {}): Rule => ({
+  field: "title",
+  operator: "contains",
+  value: "mentor",
+  combinator: "or",
+  ...override,
+});
+
+describe("applyWidgetRules", () => {
+  it("returns an empty object when there are no rules", async () => {
+    const resolve = vi.fn();
+    expect(await applyWidgetRules([], resolve)).toEqual({});
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("resolves org array fields to a case-insensitive publisherOrganizationId filter", async () => {
+    const resolve: OrganizationArrayIdsResolver = vi.fn().mockResolvedValue(["org-1", "org-2"]);
+
+    const where = await applyWidgetRules([rule({ field: "parentOrganization", operator: "contains", value: "AFEV", combinator: "or" })], resolve);
+
+    expect(resolve).toHaveBeenCalledWith("parent_organizations", "AFEV");
+    expect(where).toEqual({ OR: [{ publisherOrganizationId: { in: ["org-1", "org-2"] } }] });
+  });
+
+  it("maps organizationActions to the actions column", async () => {
+    const resolve: OrganizationArrayIdsResolver = vi.fn().mockResolvedValue(["org-3"]);
+
+    const where = await applyWidgetRules([rule({ field: "organizationActions", operator: "contains", value: "Sport", combinator: "or" })], resolve);
+
+    expect(resolve).toHaveBeenCalledWith("actions", "Sport");
+    expect(where).toEqual({ OR: [{ publisherOrganizationId: { in: ["org-3"] } }] });
+  });
+
+  it("maps legacy reseaux aliases to the parent_organizations column", async () => {
+    const resolve: OrganizationArrayIdsResolver = vi.fn().mockResolvedValue(["org-9"]);
+
+    await applyWidgetRules([rule({ field: "associationReseaux", operator: "is", value: "Afev", combinator: "or" })], resolve);
+
+    // l'opérateur legacy "is" est normalisé en "contains" pour les champs array
+    expect(resolve).toHaveBeenCalledWith("parent_organizations", "Afev");
+  });
+
+  it("wraps does_not_contain on an org array field in NOT", async () => {
+    const resolve: OrganizationArrayIdsResolver = vi.fn().mockResolvedValue(["org-1"]);
+
+    const where = await applyWidgetRules([rule({ field: "parentOrganization", operator: "does_not_contain", value: "AFEV", combinator: "or" })], resolve);
+
+    expect(where).toEqual({ OR: [{ NOT: { publisherOrganizationId: { in: ["org-1"] } } }] });
+  });
+
+  it("returns an empty in-filter when no organization matches (matches nothing)", async () => {
+    const resolve: OrganizationArrayIdsResolver = vi.fn().mockResolvedValue([]);
+
+    const where = await applyWidgetRules([rule({ field: "parentOrganization", operator: "contains", value: "UNKNOWN", combinator: "or" })], resolve);
+
+    expect(where).toEqual({ OR: [{ publisherOrganizationId: { in: [] } }] });
+  });
+
+  it("preserves AND/OR combinators across mixed text and org array rules", async () => {
+    const resolve: OrganizationArrayIdsResolver = vi.fn().mockResolvedValue(["org-1"]);
+
+    const where = await applyWidgetRules(
+      [
+        rule({ field: "title", operator: "contains", value: "mentor", combinator: "and" }),
+        rule({ field: "parentOrganization", operator: "contains", value: "AFEV", combinator: "and" }),
+      ],
+      resolve
+    );
+
+    expect(where).toEqual({
+      AND: [{ title: { contains: "mentor", mode: "insensitive" } }, { publisherOrganizationId: { in: ["org-1"] } }],
+    });
+  });
+
+  it("keeps Mission-level tags as a case-sensitive has filter (not resolved)", async () => {
+    const resolve = vi.fn();
+
+    const where = await applyWidgetRules([rule({ field: "tags", operator: "contains", value: "health", combinator: "or" })], resolve);
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(where).toEqual({ OR: [{ tags: { has: "health" } }] });
+  });
+});

--- a/api/src/utils/__tests__/widget.test.ts
+++ b/api/src/utils/__tests__/widget.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { applyWidgetRules, type OrganizationArrayIdsResolver } from "@/utils/widget";
+import type { OrganizationArrayIdsResolver } from "@/types/publisher-organization";
+import { applyWidgetRules } from "@/utils/widget";
 
 type Rule = { field: string; operator: string; value: string; combinator: "and" | "or" };
 

--- a/api/src/utils/publisher-diffusion-rule-query.ts
+++ b/api/src/utils/publisher-diffusion-rule-query.ts
@@ -76,13 +76,16 @@ const buildArraySqlCondition = (target: Prisma.Sql, rule: PublisherDiffusionRule
     return null;
   }
 
+  // Matching insensible à la casse sur un tableau (`= ANY` étant sensible à la casse).
+  const arrayContains = Prisma.sql`EXISTS (SELECT 1 FROM unnest(${target}) AS elem WHERE lower(elem) = lower(${value}))`;
+
   switch (rule.operator) {
     case "is":
     case "contains":
-      return Prisma.sql`${value} = ANY(${target})`;
+      return arrayContains;
     case "is_not":
     case "does_not_contain":
-      return Prisma.sql`NOT (${value} = ANY(${target}))`;
+      return Prisma.sql`NOT ${arrayContains}`;
     case "exists":
       return Prisma.sql`COALESCE(cardinality(${target}), 0) > 0`;
     case "does_not_exist":

--- a/api/src/utils/publisher-diffusion-rule-query.ts
+++ b/api/src/utils/publisher-diffusion-rule-query.ts
@@ -1,4 +1,5 @@
 import { Prisma, PublisherDiffusionRule } from "@/db/core";
+import { OrganizationArrayIdsResolver, OrgArrayColumn } from "@/types/publisher-organization";
 import {
   applyMissionRules,
   buildNestedMissionWhere,
@@ -10,7 +11,17 @@ import {
 
 export type PublisherDiffusionRuleCondition = Pick<PublisherDiffusionRule, "field" | "fieldType" | "operator" | "value" | "combinator">;
 
-const ARRAY_FIELD_PATHS = new Set(["publisherOrganization.parentOrganizations"]);
+/**
+ * Champs array (chemin Prisma) adossés à `PublisherOrganization` → colonne PostgreSQL.
+ * Source de vérité unique d'où l'on dérive `ARRAY_FIELD_PATHS`.
+ */
+const ARRAY_FIELD_PATH_TO_COLUMN: Record<string, OrgArrayColumn> = {
+  "publisherOrganization.parentOrganizations": "parent_organizations",
+};
+const ARRAY_FIELD_PATHS = new Set(Object.keys(ARRAY_FIELD_PATH_TO_COLUMN));
+
+// Opérateurs array pour lesquels le matching doit être insensible à la casse (cf. règles widget).
+const CASE_INSENSITIVE_ARRAY_OPERATORS = new Set(["is", "is_not", "contains", "does_not_contain"]);
 
 type SqlFieldConfig = {
   column: string;
@@ -143,8 +154,25 @@ const combineRuleSqlConditions = (rules: PublisherDiffusionRuleCondition[], miss
   return Prisma.sql`(${Prisma.join(parts, " AND ")})`;
 };
 
-export const buildMissionPublisherDiffusionRuleConditionFromRule = (rule: PublisherDiffusionRuleCondition): Prisma.MissionWhereInput | null =>
-  buildRuleCondition(rule, { arrayFields: ARRAY_FIELD_PATHS, buildFieldWhere: buildNestedMissionWhere });
+export const buildMissionPublisherDiffusionRuleConditionFromRule = async (
+  rule: PublisherDiffusionRuleCondition,
+  resolveOrganizationIds: OrganizationArrayIdsResolver
+): Promise<Prisma.MissionWhereInput | null> => {
+  // Champs array d'organisation : matching insensible à la casse via pré-résolution des ids (cf. règles widget).
+  const column = ARRAY_FIELD_PATH_TO_COLUMN[rule.field];
+  if (column && CASE_INSENSITIVE_ARRAY_OPERATORS.has(rule.operator)) {
+    const value = normalizeTypedRuleValue(rule);
+    if (shouldSkipMissionRuleValue(value)) {
+      return null;
+    }
+    const ids = await resolveOrganizationIds(column, `${value}`);
+    const base: Prisma.MissionWhereInput = { publisherOrganizationId: { in: ids } };
+    return rule.operator === "is_not" || rule.operator === "does_not_contain" ? { NOT: base } : base;
+  }
+
+  // Autres champs (scalaires, ou exists/does_not_exist sur array) : logique générique inchangée.
+  return buildRuleCondition(rule, { arrayFields: ARRAY_FIELD_PATHS, buildFieldWhere: buildNestedMissionWhere });
+};
 
 export const buildMissionPublisherDiffusionRuleWhereFromRules = (rules: PublisherDiffusionRuleCondition[]): Prisma.MissionWhereInput =>
   applyMissionRules(rules, {

--- a/api/src/utils/widget.ts
+++ b/api/src/utils/widget.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "@/db/core";
+import { OrgArrayColumn } from "@/types/publisher-organization";
 import { WidgetRuleRecord } from "@/types/widget";
 
 type WidgetRule = Pick<WidgetRuleRecord, "field" | "operator" | "value" | "combinator">;
@@ -9,12 +10,12 @@ type WidgetRule = Pick<WidgetRuleRecord, "field" | "operator" | "value" | "combi
 const ARRAY_FIELDS = new Set(["organizationActions", "parentOrganization", "tags", "associationReseaux", "organizationNetwork", "organizationReseaux"]);
 
 /**
- * Champs array adossés à `PublisherOrganization` → colonne PostgreSQL correspondante.
- * Le matching insensible à la casse sur ces colonnes (`TEXT[]`) n'étant pas possible via Prisma,
- * on pré-résout les ids d'organisations correspondantes via SQL brut (voir `OrganizationArrayIdsResolver`).
- * NB : `tags` est une colonne `Mission` (pas une organisation) → non listé ici, conserve `{ has }`.
+ * Array fields associated with `PublisherOrganization` → corresponding PostgreSQL column.
+ * Since case-insensitive matching on these columns (`TEXT[]`) is not possible via Prisma,
+ * we pre-resolve the corresponding organization IDs using raw SQL (see `OrganizationArrayIdsResolver`).
+ * Note: `tags` is a `Mission` column (not an organization) → not listed here, retains `{ has }`.
  */
-const ORG_ARRAY_FIELD_TO_COLUMN: Record<string, "parent_organizations" | "actions"> = {
+const ORG_ARRAY_FIELD_TO_COLUMN: Record<string, OrgArrayColumn> = {
   parentOrganization: "parent_organizations",
   organizationActions: "actions",
   // LEGACY FIELDS to be removed after migration
@@ -24,10 +25,10 @@ const ORG_ARRAY_FIELD_TO_COLUMN: Record<string, "parent_organizations" | "action
 };
 
 /**
- * Résout, pour une colonne array d'organisation et une valeur, les ids des organisations
- * dont un élément correspond à la valeur, insensiblement à la casse.
+ * Given an “organization” array column and a value, returns the IDs of the organizations
+ * for which an element matches the value, case-insensitively.
  */
-export type OrganizationArrayIdsResolver = (column: "parent_organizations" | "actions", value: string) => Promise<string[]>;
+export type OrganizationArrayIdsResolver = (column: OrgArrayColumn, value: string) => Promise<string[]>;
 
 /**
  * Mapping des champs virtuels (utilisés dans les règles widget) vers les chemins Prisma réels.
@@ -85,7 +86,7 @@ const buildRuleCondition = async (rule: WidgetRule, resolveOrganizationIds: Orga
     return null;
   }
 
-  // Champs array adossés à l'organisation : matching insensible à la casse via pré-résolution des ids.
+  // Organization-backed array fields: case-insensitive matching via ID pre-resolution.
   const orgArrayColumn = ORG_ARRAY_FIELD_TO_COLUMN[field];
   if (orgArrayColumn && (operator === "contains" || operator === "does_not_contain")) {
     const ids = await resolveOrganizationIds(orgArrayColumn, `${normalizedValue}`);

--- a/api/src/utils/widget.ts
+++ b/api/src/utils/widget.ts
@@ -1,5 +1,5 @@
 import { Prisma } from "@/db/core";
-import { OrgArrayColumn } from "@/types/publisher-organization";
+import { OrganizationArrayIdsResolver, OrgArrayColumn } from "@/types/publisher-organization";
 import { WidgetRuleRecord } from "@/types/widget";
 
 type WidgetRule = Pick<WidgetRuleRecord, "field" | "operator" | "value" | "combinator">;
@@ -23,12 +23,6 @@ const ORG_ARRAY_FIELD_TO_COLUMN: Record<string, OrgArrayColumn> = {
   organizationNetwork: "parent_organizations",
   organizationReseaux: "parent_organizations",
 };
-
-/**
- * Given an “organization” array column and a value, returns the IDs of the organizations
- * for which an element matches the value, case-insensitively.
- */
-export type OrganizationArrayIdsResolver = (column: OrgArrayColumn, value: string) => Promise<string[]>;
 
 /**
  * Mapping des champs virtuels (utilisés dans les règles widget) vers les chemins Prisma réels.

--- a/api/src/utils/widget.ts
+++ b/api/src/utils/widget.ts
@@ -9,6 +9,27 @@ type WidgetRule = Pick<WidgetRuleRecord, "field" | "operator" | "value" | "combi
 const ARRAY_FIELDS = new Set(["organizationActions", "parentOrganization", "tags", "associationReseaux", "organizationNetwork", "organizationReseaux"]);
 
 /**
+ * Champs array adossés à `PublisherOrganization` → colonne PostgreSQL correspondante.
+ * Le matching insensible à la casse sur ces colonnes (`TEXT[]`) n'étant pas possible via Prisma,
+ * on pré-résout les ids d'organisations correspondantes via SQL brut (voir `OrganizationArrayIdsResolver`).
+ * NB : `tags` est une colonne `Mission` (pas une organisation) → non listé ici, conserve `{ has }`.
+ */
+const ORG_ARRAY_FIELD_TO_COLUMN: Record<string, "parent_organizations" | "actions"> = {
+  parentOrganization: "parent_organizations",
+  organizationActions: "actions",
+  // LEGACY FIELDS to be removed after migration
+  associationReseaux: "parent_organizations",
+  organizationNetwork: "parent_organizations",
+  organizationReseaux: "parent_organizations",
+};
+
+/**
+ * Résout, pour une colonne array d'organisation et une valeur, les ids des organisations
+ * dont un élément correspond à la valeur, insensiblement à la casse.
+ */
+export type OrganizationArrayIdsResolver = (column: "parent_organizations" | "actions", value: string) => Promise<string[]>;
+
+/**
  * Mapping des champs virtuels (utilisés dans les règles widget) vers les chemins Prisma réels.
  * Les champs non listés ici sont utilisés directement sur le modèle Mission.
  */
@@ -52,7 +73,7 @@ const normalizeArrayOperator = (operator: string): string => {
  * Opérateurs pour les champs tableau (array) : contains, does_not_contain
  *   → l'insensibilité à la casse n'est pas possible sur ces champs
  */
-const buildRuleCondition = (rule: WidgetRule): Prisma.MissionWhereInput | null => {
+const buildRuleCondition = async (rule: WidgetRule, resolveOrganizationIds: OrganizationArrayIdsResolver): Promise<Prisma.MissionWhereInput | null> => {
   const { field, value } = rule;
   const normalizedValue = field === "openToMinors" ? normalizeBooleanValue(value) : value;
   const isArrayField = ARRAY_FIELDS.has(field);
@@ -62,6 +83,14 @@ const buildRuleCondition = (rule: WidgetRule): Prisma.MissionWhereInput | null =
 
   if (operator !== "exists" && operator !== "does_not_exist" && !normalizedValue) {
     return null;
+  }
+
+  // Champs array adossés à l'organisation : matching insensible à la casse via pré-résolution des ids.
+  const orgArrayColumn = ORG_ARRAY_FIELD_TO_COLUMN[field];
+  if (orgArrayColumn && (operator === "contains" || operator === "does_not_contain")) {
+    const ids = await resolveOrganizationIds(orgArrayColumn, `${normalizedValue}`);
+    const base: Prisma.MissionWhereInput = { publisherOrganizationId: { in: ids } };
+    return operator === "does_not_contain" ? { NOT: base } : base;
   }
 
   // Construit la condition de base selon l'opérateur
@@ -134,7 +163,7 @@ const normalizeBooleanValue = (value?: string | null) => {
  * Applique les règles du widget pour construire un objet Prisma.MissionWhereInput.
  * Les règles sont combinées avec AND ou OR selon le combinator de chaque règle.
  */
-export const applyWidgetRules = (rules: WidgetRule[]): Prisma.MissionWhereInput => {
+export const applyWidgetRules = async (rules: WidgetRule[], resolveOrganizationIds: OrganizationArrayIdsResolver): Promise<Prisma.MissionWhereInput> => {
   if (!rules.length) {
     return {};
   }
@@ -160,10 +189,10 @@ export const applyWidgetRules = (rules: WidgetRule[]): Prisma.MissionWhereInput 
     return inner as Prisma.PublisherOrganizationWhereInput;
   };
 
-  rules.forEach((rule, index) => {
-    const condition = buildRuleCondition(rule);
+  for (const [index, rule] of rules.entries()) {
+    const condition = await buildRuleCondition(rule, resolveOrganizationIds);
     if (!condition) {
-      return;
+      continue;
     }
 
     // Pour la première règle avec plusieurs règles, utiliser le combinator de la deuxième règle
@@ -179,17 +208,17 @@ export const applyWidgetRules = (rules: WidgetRule[]): Prisma.MissionWhereInput 
       } else if (combinator === "or") {
         publisherOrganizationOr.push(publisherOrganizationCondition);
       }
-      return;
+      continue;
     }
 
     if (combinator === "and") {
       andConditions.push(condition);
-      return;
+      continue;
     }
     if (combinator === "or") {
       orConditions.push(condition);
     }
-  });
+  }
 
   if (publisherOrganizationAnd.length) {
     andConditions.push({

--- a/api/tests/integration/api/endpoints/iframe/search.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/search.test.ts
@@ -392,6 +392,55 @@ describe("GET /iframe/:id/search", () => {
       expect(titles).toEqual(expect.arrayContaining(["Mission Environnement Paris", "Mission Éducation Lyon"]));
       expect(titles).not.toContain("Mission Santé Marseille");
     });
+
+    it("should match parent organization rules case-insensitively (legacy organizationReseaux alias)", async () => {
+      // mission1 stocke parent_organizations = ["Network A"] ; la règle utilise une casse différente.
+      const caseInsensitiveWidget = await createTestWidget({
+        fromPublisher: publisher,
+        publishers: [publisher.id],
+        rules: [createTestWidgetRule("organizationReseaux", "contains", "network a", { combinator: "or" })],
+      });
+
+      const response = await request(app).get(`/iframe/${caseInsensitiveWidget.id}/search`).expect(200);
+
+      expect(response.body.total).toBe(1);
+      expect(response.body.data[0].title).toBe("Mission Environnement Paris");
+    });
+
+    it("should match parentOrganization rules case-insensitively", async () => {
+      // mission2 stocke parent_organizations = ["Network B"] ; la règle utilise une casse différente.
+      const caseInsensitiveWidget = await createTestWidget({
+        fromPublisher: publisher,
+        publishers: [publisher.id],
+        rules: [createTestWidgetRule("parentOrganization", "contains", "NETWORK B", { combinator: "or" })],
+      });
+
+      const response = await request(app).get(`/iframe/${caseInsensitiveWidget.id}/search`).expect(200);
+
+      expect(response.body.total).toBe(1);
+      expect(response.body.data[0].title).toBe("Mission Éducation Lyon");
+    });
+
+    it("should match organizationActions rules case-insensitively", async () => {
+      await createTestMission({
+        publisherId: publisher.id,
+        title: "Mission Action Distribution",
+        organizationClientId: "action-org-1",
+        organizationName: "Action Org",
+        organizationActions: ["Distribution Alimentaire"],
+      });
+
+      const actionsWidget = await createTestWidget({
+        fromPublisher: publisher,
+        publishers: [publisher.id],
+        rules: [createTestWidgetRule("organizationActions", "contains", "distribution alimentaire", { combinator: "or" })],
+      });
+
+      const response = await request(app).get(`/iframe/${actionsWidget.id}/search`).expect(200);
+
+      expect(response.body.total).toBe(1);
+      expect(response.body.data[0].title).toBe("Mission Action Distribution");
+    });
   });
 
   describe("JVA moderation", () => {


### PR DESCRIPTION
## Description

Les règles de filtrage des widgets de diffusion (`widget_rule`) ciblant des colonnes tableau PostgreSQL (`parent_organizations`, `actions` sur `PublisherOrganization`) étaient traduites en filtre Prisma `{ has: "AFEV" }`, compilé en `'AFEV' = ANY(parent_organizations)` — une comparaison **strictement sensible à la casse**.

Conséquence : si la base contient `"Afev"` et que la règle vaut `"AFEV"`, aucune mission ne remonte, **silencieusement**. Le bug touche `parentOrganization` / `associationReseaux` / `organizationNetwork` / `organizationReseaux` (→ `parent_organizations`) et `organizationActions` (→ `actions`).

Prisma ne supporte pas `mode: "insensitive"` sur les opérateurs array (`has`, `hasSome`) : la correction ne peut pas se faire au niveau de l'ORM. Pour ces champs, on **pré-résout** désormais via SQL brut les `publisher_organization.id` correspondants (insensible à la casse) et on convertit la règle en filtre Prisma natif `{ publisherOrganizationId: { in: ids } }`. Le même bug est corrigé dans le chemin SQL brut des règles de diffusion éditeur (`buildArraySqlCondition`, consommé par le matching-engine).

### Détail des changements

- `repositories/publisher-organization.ts` : `findIdsByArrayValueInsensitive(column, value)` — `EXISTS (SELECT 1 FROM unnest(col) elem WHERE lower(elem) = lower(value))`, colonne restreinte à une union typée (pas d'injection).
- `services/publisher-organization.ts` : wrapper `findIdsMatchingArrayValue` (respecte controller → service → repository).
- `utils/widget.ts` : `applyWidgetRules` devient `async` et reçoit un resolver injecté (le util reste agnostique de la DB) ; les champs array adossés à l'organisation produisent `{ publisherOrganizationId: { in } }` / `{ NOT: { ... } }`.
- `controllers/iframe.ts` & `controllers/mission.ts` : `await` + passage du resolver service.
- `utils/publisher-diffusion-rule-query.ts` : `value = ANY(col)` → `unnest + lower(elem) = lower(value)`.

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/R-gles-case-insensitives-sur-les-widgets-34b72a322d508048a75ff30b68a07ad3?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
