### PR TITLE
fix(api): parentOrganization autocomplete

### DIFF
--- a/api/src/controllers/mission.ts
+++ b/api/src/controllers/mission.ts
@@ -201,6 +201,14 @@ router.get("/autocomplete", passport.authenticate("user", { session: false }), a
       return res.status(403).send({ ok: false, code: FORBIDDEN });
     }
 
+    // Le réseau parent n'est pas porté par la mission : on agrège directement `publisher_organization.parent_organizations`
+    // pour ne pas dépendre des missions remontées (limite, statut ACCEPTED, tri) qui masquaient des valeurs existantes.
+    if (query.data.field === "parentOrganization") {
+      const data = await publisherOrganizationService.autocompleteParentOrganizations(publisherIds, query.data.search);
+
+      return res.status(200).send({ ok: true, data });
+    }
+
     const missions = await missionService.findMissions({
       publisherIds,
       limit: 1000,

--- a/api/src/repositories/publisher-organization.ts
+++ b/api/src/repositories/publisher-organization.ts
@@ -59,5 +59,25 @@ export const publisherOrganizationRepository = {
     `;
     return rows.map((row) => row.id);
   },
+
+  async aggregateParentOrganizations(publisherIds: string[], search: string): Promise<Array<{ value: string; count: number }>> {
+    const publisherFilter = publisherIds.length ? Prisma.sql`WHERE publisher_id IN (${Prisma.join(publisherIds)})` : Prisma.empty;
+    const rows = await prisma.$queryRaw<Array<{ value: string; doc_count: bigint }>>(
+      Prisma.sql`
+        SELECT value, COUNT(*) as doc_count
+        FROM (
+          SELECT UNNEST(parent_organizations) as value
+          FROM publisher_organization
+          ${publisherFilter}
+        ) t
+        WHERE value IS NOT NULL AND value != '' AND value ILIKE ${`%${search}%`}
+        GROUP BY value
+        ORDER BY doc_count DESC
+        LIMIT 1000
+      `
+    );
+
+    return rows.map((row) => ({ value: row.value, count: Number(row.doc_count) }));
+  },
 };
 export default publisherOrganizationRepository;

--- a/api/src/services/publisher-organization.ts
+++ b/api/src/services/publisher-organization.ts
@@ -134,6 +134,11 @@ const publisherOrganizationService = {
   findIdsMatchingArrayValue: async (column: OrgArrayColumn, value: string): Promise<string[]> => {
     return publisherOrganizationRepository.findIdsByArrayValueInsensitive(column, value);
   },
+  autocompleteParentOrganizations: async (publisherIds: string[], search: string): Promise<Array<{ key: string; doc_count: number }>> => {
+    const rows = await publisherOrganizationRepository.aggregateParentOrganizations(publisherIds, search);
+
+    return rows.map((row) => ({ key: row.value, doc_count: row.count }));
+  },
 };
 
 export default publisherOrganizationService;

--- a/api/tests/fixtures/publisher-organization.ts
+++ b/api/tests/fixtures/publisher-organization.ts
@@ -4,7 +4,7 @@ import type { PublisherOrganization } from "@/db/core";
 import { prisma } from "@/db/postgres";
 
 export const createTestPublisherOrganization = async (
-  data: { publisherId: string; clientId: string; name?: string | null } & Partial<Pick<PublisherOrganization, "rna" | "siren" | "siret">>
+  data: { publisherId: string; clientId: string; name?: string | null } & Partial<Pick<PublisherOrganization, "rna" | "siren" | "siret" | "parentOrganizations">>
 ): Promise<PublisherOrganization> => {
   const publisherId = data.publisherId;
   const clientId = data.clientId ?? `org-${randomUUID().slice(0, 8)}`;
@@ -21,7 +21,8 @@ export const createTestPublisherOrganization = async (
       rna: data.rna ?? null,
       siren: data.siren ?? null,
       siret: data.siret ?? null,
+      parentOrganizations: data.parentOrganizations ?? [],
     },
-    update: { name },
+    update: { name, parentOrganizations: data.parentOrganizations ?? [] },
   });
 };

--- a/api/tests/integration/api/endpoints/mission.test.ts
+++ b/api/tests/integration/api/endpoints/mission.test.ts
@@ -2,7 +2,7 @@ import request from "supertest";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { PUBLISHER_IDS } from "@/config";
-import { createTestMission, createTestPublisher } from "../../../fixtures";
+import { createTestMission, createTestPublisher, createTestPublisherOrganization } from "../../../fixtures";
 import { createTestUser } from "../../../fixtures/user";
 import { createTestApp } from "../../../testApp";
 
@@ -56,5 +56,41 @@ describe("Dashboard mission controller", () => {
     const res = await request(app).get(`/mission/${mission.id}`).set(authHeader());
 
     expect(res.status).toBe(403);
+  });
+
+  describe("GET /mission/autocomplete?field=parentOrganization", () => {
+    it("returns a parent organization stored in publisher_organization even without a matching mission", async () => {
+      // Réseau parent présent en base mais sans mission rattachée : doit malgré tout être proposé.
+      await createTestPublisherOrganization({
+        publisherId,
+        clientId: "org-with-network",
+        parentOrganizations: ["La Ligue de l'Enseignement"],
+      });
+
+      const res = await request(app)
+        .get(`/mission/autocomplete?field=parentOrganization&search=${encodeURIComponent("ligue de l'ens")}&publishers[]=${publisherId}`)
+        .set(authHeader());
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      // La valeur remontée conserve la casse exacte stockée en base.
+      expect(res.body.data).toEqual([{ key: "La Ligue de l'Enseignement", doc_count: 1 }]);
+    });
+
+    it("does not return parent organizations from other publishers", async () => {
+      const otherPublisher = await createTestPublisher();
+      await createTestPublisherOrganization({
+        publisherId: otherPublisher.id,
+        clientId: "org-other",
+        parentOrganizations: ["Réseau Privé"],
+      });
+
+      const res = await request(app)
+        .get(`/mission/autocomplete?field=parentOrganization&search=${encodeURIComponent("Réseau")}&publishers[]=${publisherId}`)
+        .set(authHeader());
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
## Description

Corrige l'autocomplete du champ **Réseau parent de l'organisation** (écran de création
de widget `/broadcast/widget/new`), qui ne proposait pas toutes les valeurs réellement
stockées en base.

Pour `field=parentOrganization`, l'endpoint `GET /mission/autocomplete` agrégeait les
valeurs depuis les **missions** (`mission.organizationReseaux`, dérivé de
`publisher_organization.parent_organizations`) au lieu de lire directement la source de
vérité. Conséquences :

- seules les organisations rattachées à une mission présente dans les 1000 premières
  missions étaient visibles ;
- les missions étaient filtrées implicitement (`statusCode = ACCEPTED`, `deletedAt = null`) ;
- le tri `startAt desc` pouvait exclure des organisations pourtant présentes en base ;
- une valeur existante dans `publisher_organization.parent_organizations` pouvait donc
  ne jamais être proposée.

Effet de bord aggravant : si la valeur exacte n'était pas proposée, l'utilisateur la
saisissait à la main avec une casse différente (`La ligue de l'enseignement` au lieu de
`La Ligue de l'Enseignement`), créant une règle widget valide en apparence mais
inefficace en production.

Désormais, pour `field=parentOrganization`, l'endpoint lit directement
`publisher_organization.parent_organizations`, sans passer par les missions. La casse
exacte stockée en base est restituée.


## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/R-gles-case-insensitives-sur-les-widgets-34b72a322d508048a75ff30b68a07ad3?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

