### PR TITLE
feat(analytics): mission enrichment daily mart

### DIFF
--- a/analytics/dbt/analytics/models/marts/mission/__models.yml
+++ b/analytics/dbt/analytics/models/marts/mission/__models.yml
@@ -256,6 +256,44 @@ models:
         description: Dernière date de mise à jour observée dans l'agrégat.
         tests:
           - not_null
+  - name: mission_enrichment_daily
+    description: >
+      Agrégat quotidien des enrichissements IA de mission au grain jour + publisher +
+      statut, alimenté depuis `mission_enrichment`. Le `publisher_id` est récupéré via
+      `mission` et le `publisher_name` dénormalisé via `dim_publisher`. Permet le suivi
+      du volume d'enrichissements et du coût en tokens (entrée/sortie) dans Metabase.
+    columns:
+      - name: event_date
+        description: Jour d'agrégation basé sur `mission_enrichment.created_at`.
+        tests:
+          - not_null
+      - name: publisher_id
+        description: Identifiant du partenaire propriétaire de la mission (nullable si mission introuvable).
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_publisher')
+                field: id
+      - name: publisher_name
+        description: Nom du partenaire dénormalisé pour les analyses Metabase (nullable).
+      - name: status
+        description: Statut de l'enrichissement (`pending`, `processing`, `completed`, `failed`).
+        tests:
+          - not_null
+      - name: enrichment_count
+        description: Nombre d'enrichissements dans le grain (jour + publisher + statut).
+        tests:
+          - not_null
+      - name: input_tokens
+        description: Somme des tokens d'entrée consommés (NULL/0 hors statut `completed`).
+      - name: output_tokens
+        description: Somme des tokens de sortie produits (NULL/0 hors statut `completed`).
+      - name: total_tokens
+        description: Somme des tokens totaux consommés (NULL/0 hors statut `completed`).
+      - name: max_updated_at
+        description: Dernière date de mise à jour observée dans l'agrégat (curseur incrémental).
+        tests:
+          - not_null
   - name: mission_time_to_event_weekly
     description: >
       Mart hebdomadaire des délais (time-to-click/apply) et volumes, agrégé à partir

--- a/analytics/dbt/analytics/models/marts/mission/__models.yml
+++ b/analytics/dbt/analytics/models/marts/mission/__models.yml
@@ -262,6 +262,8 @@ models:
       statut, alimenté depuis `mission_enrichment`. Le `publisher_id` est récupéré via
       `mission` et le `publisher_name` dénormalisé via `dim_publisher`. Permet le suivi
       du volume d'enrichissements et du coût en tokens (entrée/sortie) dans Metabase.
+      Le modèle incrémental supprime/réinsère les lignes au grain jour + publisher afin
+      de rafraîchir tous les statuts affectés quand une mission change de statut.
     columns:
       - name: event_date
         description: Jour d'agrégation basé sur `mission_enrichment.created_at`.

--- a/analytics/dbt/analytics/models/marts/mission/__models.yml
+++ b/analytics/dbt/analytics/models/marts/mission/__models.yml
@@ -259,11 +259,11 @@ models:
   - name: mission_enrichment_daily
     description: >
       Agrégat quotidien des enrichissements IA de mission au grain jour + publisher +
-      statut, alimenté depuis `mission_enrichment`. Le `publisher_id` est récupéré via
-      `mission` et le `publisher_name` dénormalisé via `dim_publisher`. Permet le suivi
-      du volume d'enrichissements et du coût en tokens (entrée/sortie) dans Metabase.
-      Le modèle incrémental supprime/réinsère les lignes au grain jour + publisher afin
-      de rafraîchir tous les statuts affectés quand une mission change de statut.
+      statut + version de prompt, alimenté depuis `mission_enrichment`. Le `publisher_id`
+      est récupéré via `mission` et le `publisher_name` dénormalisé via `dim_publisher`.
+      Permet le suivi du volume d'enrichissements et du coût en tokens (entrée/sortie)
+      dans Metabase. Le modèle incrémental supprime/réinsère les lignes des journées
+      affectées pour rafraîchir l'ensemble du grain quand une mission est mise à jour.
     columns:
       - name: event_date
         description: Jour d'agrégation basé sur `mission_enrichment.created_at`.
@@ -274,12 +274,16 @@ models:
         tests:
           - relationships:
               arguments:
-                to: ref('dim_publisher')
+                to: ref('publisher')
                 field: id
       - name: publisher_name
         description: Nom du partenaire dénormalisé pour les analyses Metabase (nullable).
       - name: status
         description: Statut de l'enrichissement (`pending`, `processing`, `completed`, `failed`).
+        tests:
+          - not_null
+      - name: prompt_version
+        description: Version du prompt utilisée pour produire l'enrichissement.
         tests:
           - not_null
       - name: enrichment_count

--- a/analytics/dbt/analytics/models/marts/mission/mission_enrichment_daily.sql
+++ b/analytics/dbt/analytics/models/marts/mission/mission_enrichment_daily.sql
@@ -1,0 +1,67 @@
+{{ config(
+  materialized = 'incremental',
+  unique_key = ['event_date', 'publisher_id', 'status'],
+  incremental_strategy = 'delete+insert',
+  on_schema_change = 'sync_all_columns'
+) }}
+
+with last_run as (
+  {% if is_incremental() %}
+    select
+      coalesce(max(max_updated_at), '1900-01-01'::timestamp)
+        as last_updated_at
+    from {{ this }}
+  {% else %}
+    select '1900-01-01'::timestamp as last_updated_at
+  {% endif %}
+),
+
+affected_dates as (
+  select distinct date(me.created_at) as event_date
+  from {{ ref('mission_enrichment') }} as me
+  cross join last_run
+  {% if is_incremental() %}
+    where
+      coalesce(me.updated_at, me.created_at)
+      >= last_run.last_updated_at
+  {% endif %}
+),
+
+base as (
+  select
+    m.publisher_id,
+    p.name as publisher_name,
+    me.status,
+    me.input_tokens,
+    me.output_tokens,
+    me.total_tokens,
+    date(me.created_at) as event_date,
+    coalesce(me.updated_at, me.created_at) as updated_at
+  from {{ ref('mission_enrichment') }} as me
+  left join {{ ref('mission') }} as m on me.mission_id = m.id
+  left join {{ ref('dim_publisher') }} as p on m.publisher_id = p.id
+  {% if is_incremental() %}
+    where date(me.created_at) in (
+      select ad.event_date
+      from affected_dates as ad
+    )
+  {% endif %}
+),
+
+aggregated as (
+  select
+    event_date,
+    publisher_id,
+    publisher_name,
+    status,
+    count(*) as enrichment_count,
+    sum(input_tokens) as input_tokens,
+    sum(output_tokens) as output_tokens,
+    sum(total_tokens) as total_tokens,
+    max(updated_at) as max_updated_at
+  from base
+  group by event_date, publisher_id, publisher_name, status
+)
+
+select *
+from aggregated

--- a/analytics/dbt/analytics/models/marts/mission/mission_enrichment_daily.sql
+++ b/analytics/dbt/analytics/models/marts/mission/mission_enrichment_daily.sql
@@ -1,6 +1,6 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = ['event_date', 'publisher_id'],
+  unique_key = ['event_date', 'publisher_id', 'prompt_version'],
   incremental_strategy = 'delete+insert',
   on_schema_change = 'sync_all_columns'
 ) }}
@@ -32,6 +32,7 @@ base as (
     m.publisher_id,
     p.name as publisher_name,
     me.status,
+    me.prompt_version,
     me.input_tokens,
     me.output_tokens,
     me.total_tokens,
@@ -54,13 +55,14 @@ aggregated as (
     publisher_id,
     publisher_name,
     status,
+    prompt_version,
     count(*) as enrichment_count,
     sum(input_tokens) as input_tokens,
     sum(output_tokens) as output_tokens,
     sum(total_tokens) as total_tokens,
     max(updated_at) as max_updated_at
   from base
-  group by event_date, publisher_id, publisher_name, status
+  group by event_date, publisher_id, publisher_name, status, prompt_version
 )
 
 select *

--- a/analytics/dbt/analytics/models/marts/mission/mission_enrichment_daily.sql
+++ b/analytics/dbt/analytics/models/marts/mission/mission_enrichment_daily.sql
@@ -1,6 +1,6 @@
 {{ config(
   materialized = 'incremental',
-  unique_key = ['event_date', 'publisher_id', 'status'],
+  unique_key = ['event_date', 'publisher_id'],
   incremental_strategy = 'delete+insert',
   on_schema_change = 'sync_all_columns'
 ) }}


### PR DESCRIPTION
## Description

Ajoute un mart dbt agrégé **`mission_enrichment_daily`** pour suivre l'activité d'enrichissement IA des missions dans Metabase :

- **nombre d'enrichissements par jour**,
- **coût en tokens** (entrée / sortie / total),
- **analyse par `publisher`**.

Le pipeline `mission_enrichment` existant est une vue détaillée (une ligne par tentative) qui ne porte pas le `publisher_id` — inexploitable directement pour une analyse quotidienne par partenaire. Ce nouveau mart pré-agrège au grain **`event_date` × `publisher_id` × `status`**.

### Détails techniques

- Matérialisation **`incremental`** (`delete+insert`), même pattern que `mission_jobboard_daily` / `global_events_daily` (CTE `last_run` / `affected_dates` avec curseur `max_updated_at`).
- Axe temporel basé sur `created_at` (compte tous les enrichissements lancés, quel que soit le statut).
- Segmentation par `status` : isole le coût réel (`completed`, seul porteur de tokens) des `failed`/`pending`.
- Jointures : `mission_enrichment.mission_id → mission.id` (pour `publisher_id`) puis `mission.publisher_id → dim_publisher.id` (pour `publisher_name` dénormalisé, pratique côté Metabase).
- Métriques : `enrichment_count`, `sum(input_tokens)`, `sum(output_tokens)`, `sum(total_tokens)`.
- Documentation FR + tests dbt ajoutés dans `__models.yml` (`not_null`, `relationships` vers `dim_publisher`). Les descriptions de colonnes sont remontées automatiquement vers Metabase via `dbt-metabase`.

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/R-ductions-des-co-ts-d-enrichissement-37972a322d5080e89410cdb82f35e3f6?source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] Code testé localement (`dbt parse` + SQLFluff OK ; `dbt run`/`test` à valider en CI faute de DB locale)
- [ ] Tests unitaires ajoutés/modifiés si nécessaire (tests dbt `not_null`/`relationships` ajoutés)
- [x] Respect des standards de code (SQLFluff)
- [ ] Migration de données nécessaire
