### PR TITLE
fix(api): remove diffuseurPublisherId from iframe mission filters

### DIFF
--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -214,7 +214,6 @@ const buildMissionFilters = async (widget: WidgetRecord, query: { [key: string]:
   const filters: MissionSearchFilters = {
     directFilters: await applyWidgetRules(widget.rules || [], publisherOrganizationService.findIdsMatchingArrayValue),
     publisherIds: widget.publishers,
-    diffuseurPublisherId: widget.fromPublisherId,
     skip: pagination.skip,
     limit: pagination.limit,
   };


### PR DESCRIPTION
## Description

Supprime le filtre `diffuseurPublisherId` des filtres de missions de l'iframe widget.

Dans `buildMissionFilters` (`api/src/controllers/iframe.ts`), le champ `diffuseurPublisherId: widget.fromPublisherId` était passé à la recherche de missions, ce qui restreignait incorrectement les résultats. Ce filtre est retiré pour corriger le comportement des filtres de l'iframe.

**Changements** :
- Suppression de `diffuseurPublisherId: widget.fromPublisherId` dans `buildMissionFilters`

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Hotfix ciblé : une seule ligne supprimée, aucun changement de format d'API ni de migration DB.