### PR TITLE
feat(plateform): add debug param to display debug button

### DIFF
--- a/plateform/app/components/results/other-missions.tsx
+++ b/plateform/app/components/results/other-missions.tsx
@@ -11,6 +11,7 @@ interface OtherMissionsProps {
   pageLoading: boolean;
   visiblePageNumbers: number[];
   userScoringId: string | undefined;
+  showDebug: boolean;
   gridClassName?: string;
   onPageChange: (page: number) => void;
 }
@@ -22,6 +23,7 @@ export default function OtherMissions({
   pageLoading,
   visiblePageNumbers,
   userScoringId,
+  showDebug,
   gridClassName = "grid grid-cols-1 gap-6",
   onPageChange,
 }: OtherMissionsProps) {
@@ -36,7 +38,7 @@ export default function OtherMissions({
           {items.map((item) => (
             <div key={item.mission.id} className="relative">
               <MissionCard mission={matchResultToBrowseMission(item)} link={{ type: "internal", to: buildMissionDetailHref(item, userScoringId) }} />
-              <DebugButton missionId={item.mission.id} />
+              {showDebug && <DebugButton missionId={item.mission.id} />}
             </div>
           ))}
         </div>

--- a/plateform/app/components/results/pinned-missions.tsx
+++ b/plateform/app/components/results/pinned-missions.tsx
@@ -9,9 +9,10 @@ interface PinnedMissionsProps {
   loading: boolean;
   error: string | null;
   userScoringId: string | undefined;
+  showDebug: boolean;
 }
 
-export default function PinnedMissions({ items, loading, error, userScoringId }: PinnedMissionsProps) {
+export default function PinnedMissions({ items, loading, error, userScoringId, showDebug }: PinnedMissionsProps) {
   return (
     <div className="relative w-full px-6">
       {!loading && error && (
@@ -26,7 +27,7 @@ export default function PinnedMissions({ items, loading, error, userScoringId }:
             {items.map((item) => (
               <div key={item.mission.id} className="relative w-full md:max-w-[330px]">
                 <MissionCard mission={matchResultToBrowseMission(item)} link={{ type: "internal", to: buildMissionDetailHref(item, userScoringId) }} />
-                <DebugButton missionId={item.mission.id} />
+                {showDebug && <DebugButton missionId={item.mission.id} />}
               </div>
             ))}
           </div>

--- a/plateform/app/routes/results.tsx
+++ b/plateform/app/routes/results.tsx
@@ -1,6 +1,6 @@
 import type { MissionMatchItem } from "@engagement/dto";
 import { useMemo, useRef, useState } from "react";
-import { Link, useParams } from "react-router";
+import { Link, useParams, useSearchParams } from "react-router";
 import { FooterContent } from "~/components/layout/footer";
 import Newsletter from "~/components/layout/newsletter";
 import Partners from "~/components/layout/partners";
@@ -24,6 +24,7 @@ const FRANCE_CENTER: [number, number] = [46.6, 2.3];
 
 export default function ResultsPage() {
   const { userScoringId } = useParams<{ userScoringId: string }>();
+  const [searchParams] = useSearchParams();
   const isMobile = useIsMobile();
   const answers = useQuizStore((s) => s.answers);
   const { pinnedItems, otherItems, page, setPage, hasNextPage, loading, pageLoading, error, visiblePageNumbers } = useMissionResults(userScoringId);
@@ -64,6 +65,7 @@ export default function ResultsPage() {
 
   const showMap = !loading && pinnedItems.length > 0;
   const showOther = !loading && !error && (otherItems.length > 0 || page > 1);
+  const showDebug = searchParams.get("debug") === "true";
 
   // Dernier step visible du quiz selon les réponses courantes → "Changer mes réponses" y renvoie.
   const lastQuizStep = QUIZ_FLOW.filter((s) => !s.condition || evalCondition(s.condition, answers)).at(-1);
@@ -167,7 +169,7 @@ export default function ResultsPage() {
             </div>
 
             <div ref={scrollRef} className={`flex-1 overflow-y-auto overscroll-contain ${expanded ? "" : "hidden"}`}>
-              <PinnedMissions items={pinnedItems} loading={loading} error={error} userScoringId={userScoringId} />
+              <PinnedMissions items={pinnedItems} loading={loading} error={error} userScoringId={userScoringId} showDebug={showDebug} />
 
               {showOther && (
                 <div className="px-6 pt-2 pb-8">
@@ -178,6 +180,7 @@ export default function ResultsPage() {
                     pageLoading={pageLoading}
                     visiblePageNumbers={visiblePageNumbers}
                     userScoringId={userScoringId}
+                    showDebug={showDebug}
                     onPageChange={setPage}
                   />
                 </div>
@@ -223,7 +226,7 @@ export default function ResultsPage() {
                   Changer mes réponses
                 </Link>
               </div>
-              <PinnedMissions items={pinnedItems} loading={loading} error={error} userScoringId={userScoringId} />
+              <PinnedMissions items={pinnedItems} loading={loading} error={error} userScoringId={userScoringId} showDebug={showDebug} />
             </div>
             <div className="sticky top-0 max-h-[720px] flex-1 py-12">{showMap && <LazyMissionMap items={pinnedItems} center={mapCenter} />}</div>
           </section>
@@ -239,6 +242,7 @@ export default function ResultsPage() {
               pageLoading={pageLoading}
               visiblePageNumbers={visiblePageNumbers}
               userScoringId={userScoringId}
+              showDebug={showDebug}
               gridClassName="grid gap-6 sm:grid-cols-2 lg:grid-cols-4 mx-auto"
               onPageChange={setPage}
             />


### PR DESCRIPTION
## Description

Cette PR masque les boutons de debug du matching sur la page de résultats par défaut.

Les boutons ne sont désormais affichés que lorsque l'URL contient explicitement le paramètre `?debug=true`. La modale de debug reste montée dans la page afin de conserver le fonctionnement des liens directs avec `debug_id`.

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire