### PR TITLE
fix(app): RGAA accessibility fixes across the back-office

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -62,6 +62,9 @@ const App = () => {
         ariaLabel="Notifications"
       />
       <BrowserRouter>
+        <a href="#main-content" className="skip-link">
+          Aller au contenu principal
+        </a>
         <Routes>
           <Route element={<AuthLayout />}>
             <Route path="/login" element={<Login />} />
@@ -121,7 +124,7 @@ const AuthLayout = () => {
   }
 
   return (
-    <div className="bg-global-background flex min-h-screen w-screen flex-col">
+    <div className="bg-global-background flex min-h-screen w-full flex-col">
       <Header />
       <main id="main-content" role="main" tabIndex={-1} className="flex flex-1">
         <div className="flex-1">
@@ -238,7 +241,7 @@ const ProtectedLayout = () => {
   }
 
   return (
-    <div className="bg-global-background flex min-h-screen w-screen flex-col">
+    <div className="bg-global-background flex min-h-screen w-full flex-col">
       {ENV === "staging" && (
         <div className="bg-error w-full p-2 text-center">
           <p className="text-sm text-white">Environnement de pré-prod</p>
@@ -316,7 +319,7 @@ const PublicLayout = () => {
   }, [location.pathname]);
 
   return (
-    <div className="bg-global-background flex min-h-screen w-screen flex-col">
+    <div className="bg-global-background flex min-h-screen w-full flex-col">
       <Header />
       {user ? <Nav /> : ""}
       <main id="main-content" role="main" tabIndex={-1} aria-labelledby={user && hasActiveTab ? activeTabId : undefined}>

--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -161,29 +161,12 @@ const PATH = [
 ];
 
 const ADMIN_PATH = ["/admin-mission", "/admin-organization", "/admin-account", "/admin-stats", "/admin-warning", "/admin-report", "/user/", "/publisher/"];
-const getActiveTabId = (pathname) => {
-  if (pathname.includes("performance")) {
-    return "tab-performance";
-  }
-  if (pathname.includes("broadcast")) {
-    return "tab-broadcast";
-  }
-  if (pathname.includes("my-missions")) {
-    return "tab-my-missions";
-  }
-  if (pathname.includes("settings")) {
-    return "tab-settings";
-  }
-  return null;
-};
 
 const ProtectedLayout = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { user, setAuth } = useStore();
   const [loading, setLoading] = useState(true);
-  const activeTabId = getActiveTabId(location.pathname);
-  const hasActiveTab = Boolean(activeTabId);
 
   // Simple page tracking with user role
   useEffect(() => {
@@ -255,13 +238,7 @@ const ProtectedLayout = () => {
       <Header />
       <Nav />
 
-      <main
-        id="main-content"
-        role="main"
-        tabIndex={-1}
-        aria-labelledby={hasActiveTab ? activeTabId : undefined}
-        className="mx-auto mb-14 w-full max-w-[1200px] flex-1 px-0 pt-14 sm:w-4/5 sm:px-4"
-      >
+      <main id="main-content" role="main" tabIndex={-1} className="mx-auto mb-14 w-full max-w-[1200px] flex-1 px-0 pt-14 sm:w-4/5 sm:px-4">
         <Outlet />
       </main>
       <Footer />
@@ -309,8 +286,6 @@ const PublisherSyncLayout = () => {
 const PublicLayout = () => {
   const { user } = useStore();
   const location = useLocation();
-  const activeTabId = getActiveTabId(location.pathname);
-  const hasActiveTab = Boolean(activeTabId);
 
   useEffect(() => {
     if (window.plausible) {
@@ -322,7 +297,7 @@ const PublicLayout = () => {
     <div className="bg-global-background flex min-h-screen w-full flex-col">
       <Header />
       {user ? <Nav /> : ""}
-      <main id="main-content" role="main" tabIndex={-1} aria-labelledby={user && hasActiveTab ? activeTabId : undefined}>
+      <main id="main-content" role="main" tabIndex={-1}>
         <Outlet />
       </main>
       <Footer />

--- a/app/src/components/AnalyticsViz.jsx
+++ b/app/src/components/AnalyticsViz.jsx
@@ -125,7 +125,7 @@ const AnalyticsViz = ({
 
   if (error) {
     return (
-      <div className={`flex h-[200px] w-full flex-col items-center justify-center border border-dashed border-gray-900 bg-[#f6f6f6] ${className}`}>
+      <div className={`flex min-h-[200px] w-full flex-col items-center justify-center border border-dashed border-gray-900 bg-[#f6f6f6] ${className}`}>
         <p className="text-sm text-[#666]">Impossible de charger les données.</p>
         <p className="text-xs text-[#666]">{error.message}</p>
       </div>
@@ -135,7 +135,7 @@ const AnalyticsViz = ({
   if (type === "table") {
     if (!tableRows.length) {
       return (
-        <div className={`flex h-[200px] w-full flex-col items-center justify-center border border-dashed border-gray-900 bg-[#f6f6f6] ${className}`}>
+        <div className={`flex min-h-[200px] w-full flex-col items-center justify-center border border-dashed border-gray-900 bg-[#f6f6f6] ${className}`}>
           <img src={EmptySVG} alt="" aria-hidden="true" className="h-16 w-16" />
           <p className="text-base text-[#666]">Aucune donnée disponible</p>
         </div>
@@ -201,7 +201,7 @@ const AnalyticsViz = ({
   if (type === "kpi") {
     if (kpiValue === null) {
       return (
-        <div className={`flex h-[120px] w-full flex-col items-center justify-center border border-dashed border-gray-900 bg-[#f6f6f6] ${className}`}>
+        <div className={`flex min-h-[120px] w-full flex-col items-center justify-center border border-dashed border-gray-900 bg-[#f6f6f6] ${className}`}>
           <img src={EmptySVG} alt="" aria-hidden="true" className="h-12 w-12" />
           <p className="text-base text-[#666]">Aucune donnée disponible</p>
         </div>
@@ -238,7 +238,7 @@ const AnalyticsViz = ({
 
   if (!data.length) {
     return (
-      <div className={`flex h-[200px] w-full flex-col items-center justify-center border border-dashed border-gray-900 bg-[#f6f6f6] ${className}`}>
+      <div className={`flex min-h-[200px] w-full flex-col items-center justify-center border border-dashed border-gray-900 bg-[#f6f6f6] ${className}`}>
         <img src={EmptySVG} alt="" aria-hidden="true" className="h-16 w-16" />
         <p className="text-base text-[#666]">Aucune donnée disponible</p>
       </div>

--- a/app/src/components/AnalyticsViz.jsx
+++ b/app/src/components/AnalyticsViz.jsx
@@ -210,13 +210,14 @@ const AnalyticsViz = ({
 
     return (
       <div className={`border border-gray-900 p-6 ${className}`}>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <p className="text-[28px] font-bold">
+        <div className="flex items-start justify-between">
+          <p className="text-base">
+            <span className="block text-[28px] font-bold">
               {kpiValue.toLocaleString("fr")}
               {kpiUnit ? ` ${kpiUnit}` : ""}
-            </p>
-          </div>
+            </span>
+            {kpiLabel}
+          </p>
           <div className="flex items-center gap-2">
             {kpiTooltip ? (
               <Tooltip
@@ -231,7 +232,6 @@ const AnalyticsViz = ({
             {kpiIcon && <div className="text-text-mention text-xl">{kpiIcon}</div>}
           </div>
         </div>
-        {kpiLabel && <p className="text-base">{kpiLabel}</p>}
       </div>
     );
   }

--- a/app/src/components/Autocomplete.jsx
+++ b/app/src/components/Autocomplete.jsx
@@ -2,7 +2,20 @@ import { useEffect, useId, useRef, useState } from "react";
 
 import Loader from "./Loader";
 
-const Autocomplete = ({ options = [], value, onChange, onSelect, loading = false, placeholder, className, id, getLabel = (o) => o, getValue = (o) => o, getCount = null }) => {
+const Autocomplete = ({
+  options = [],
+  value,
+  onChange,
+  onSelect,
+  loading = false,
+  placeholder,
+  className,
+  id,
+  ariaDescribedby,
+  getLabel = (o) => o,
+  getValue = (o) => o,
+  getCount = null,
+}) => {
   const [isOpen, setIsOpen] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const containerRef = useRef(null);
@@ -150,6 +163,7 @@ const Autocomplete = ({ options = [], value, onChange, onSelect, loading = false
           aria-controls={listboxId}
           aria-autocomplete="list"
           aria-activedescendant={focusedIndex >= 0 ? `${inputId}-option-${focusedIndex}` : undefined}
+          aria-describedby={ariaDescribedby}
           onChange={(e) => {
             setIsOpen(true);
             onChange(e.target.value);

--- a/app/src/components/ChartDetailsTable.jsx
+++ b/app/src/components/ChartDetailsTable.jsx
@@ -19,15 +19,17 @@ const ChartDetailsTable = ({
     return null;
   }
 
-  const visibilityClass = mode === "sr-only" ? "sr-only" : "";
-  const tableClassName = `${visibilityClass} ${className}`.trim();
+  const tableClassName = className.trim();
   const caption = title ? `Description détaillée du graphique : ${title}` : "Description détaillée du graphique";
   const captionText = description ? `${caption}. ${description}` : caption;
   const formatName = (value) => (nameFormatter ? nameFormatter(value) : value);
   const formatValue = (value) => (valueFormatter ? valueFormatter(value) : formatChartValue(value));
+  // sr-only doit être porté par un div englobant : appliqué directement à une <table>,
+  // width/height 1px est ignoré (taille min-content) et clip ne masque pas la <caption>
+  const wrap = (table) => (mode === "sr-only" ? <div className="sr-only">{table}</div> : table);
 
   if (type === "stacked") {
-    return (
+    return wrap(
       <table id={id} className={`mt-4 w-full table-auto text-xs ${tableClassName}`}>
         <caption className={mode === "sr-only" ? "" : "mb-2 text-left font-semibold"}>{captionText}</caption>
         <thead className="text-text-mention text-left text-[10px] uppercase">
@@ -59,11 +61,11 @@ const ChartDetailsTable = ({
             );
           })}
         </tbody>
-      </table>
+      </table>,
     );
   }
 
-  return (
+  return wrap(
     <table id={id} className={`mt-4 w-full table-auto text-xs ${tableClassName}`}>
       <caption className={mode === "sr-only" ? "" : "mb-2 text-left font-semibold"}>{captionText}</caption>
       <thead className="text-text-mention text-left text-[10px] uppercase">
@@ -82,7 +84,7 @@ const ChartDetailsTable = ({
           </tr>
         ))}
       </tbody>
-    </table>
+    </table>,
   );
 };
 

--- a/app/src/components/DateRangePicker.jsx
+++ b/app/src/components/DateRangePicker.jsx
@@ -173,7 +173,8 @@ export const DateInput = ({ value, onChange }) => {
 
   return (
     <div className="relative" ref={ref}>
-      <div className="flex items-center gap-2">
+      <fieldset className="m-0 flex items-center gap-2 border-0 p-0">
+        <legend className="sr-only">Période personnalisée</legend>
         <div className="input flex items-center gap-1 px-2 py-1">
           <label htmlFor={`${id}-from`} className="text-sm text-gray-500">
             Du
@@ -216,7 +217,7 @@ export const DateInput = ({ value, onChange }) => {
         >
           <RiCalendarLine className="text-lg" aria-hidden="true" />
         </button>
-      </div>
+      </fieldset>
 
       <div
         role="dialog"

--- a/app/src/components/DateRangePicker.jsx
+++ b/app/src/components/DateRangePicker.jsx
@@ -187,6 +187,7 @@ export const DateInput = ({ value, onChange }) => {
             onChange={handleFromTextChange}
             placeholder="JJ/MM/AAAA"
             aria-describedby={`${id}-format`}
+            aria-required="true"
             className="w-24 border-0 bg-transparent p-0 text-sm font-semibold outline-none focus:ring-0"
           />
         </div>
@@ -202,6 +203,7 @@ export const DateInput = ({ value, onChange }) => {
             onChange={handleToTextChange}
             placeholder="JJ/MM/AAAA"
             aria-describedby={`${id}-format`}
+            aria-required="true"
             className="w-24 border-0 bg-transparent p-0 text-sm font-semibold outline-none focus:ring-0"
           />
         </div>

--- a/app/src/components/DateRangePicker.jsx
+++ b/app/src/components/DateRangePicker.jsx
@@ -108,6 +108,7 @@ export const DateInput = ({ value, onChange }) => {
   const [show, setShow] = useState(false);
   const ref = useRef(null);
   const buttonRef = useRef(null);
+  const dialogRef = useRef(null);
 
   useEffect(() => {
     const handleClickOutside = (event) => {
@@ -137,6 +138,27 @@ export const DateInput = ({ value, onChange }) => {
     setFromText(formatDateFr(value.from));
     setToText(formatDateFr(value.to));
   }, [value]);
+
+  useEffect(() => {
+    if (show) {
+      dialogRef.current?.focus();
+    }
+  }, [show]);
+
+  const handleDialogKeyDown = (e) => {
+    if (e.key !== "Tab" || !dialogRef.current) return;
+    const focusables = dialogRef.current.querySelectorAll("button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])");
+    if (!focusables.length) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (e.shiftKey && (document.activeElement === first || document.activeElement === dialogRef.current)) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
 
   const handleCalendarChange = (dates) => {
     const [start, end] = dates;
@@ -173,7 +195,7 @@ export const DateInput = ({ value, onChange }) => {
 
   return (
     <div className="relative" ref={ref}>
-      <fieldset className="m-0 flex items-center gap-2 border-0 p-0">
+      <fieldset className="m-0 flex flex-wrap items-center gap-2 border-0 p-0">
         <legend className="sr-only">Période personnalisée</legend>
         <div className="input focus-within:outline-outline-blue flex items-center gap-1 px-2 py-1 focus-within:outline-2 focus-within:outline-offset-2">
           <label htmlFor={`${id}-from`} className="text-sm text-gray-500">
@@ -225,6 +247,9 @@ export const DateInput = ({ value, onChange }) => {
         role="dialog"
         aria-modal="true"
         aria-label="Sélection de période"
+        ref={dialogRef}
+        tabIndex={-1}
+        onKeyDown={handleDialogKeyDown}
         className={`border-grey-border fixed inset-0 z-50 overflow-y-auto border bg-white px-4 pt-4 pb-4 shadow-lg sm:absolute sm:inset-auto sm:right-0 sm:mt-1 sm:overflow-visible sm:px-8 sm:pt-6 ${show ? "block" : "hidden"}`}
       >
         <div className="mb-4 flex justify-end sm:hidden">

--- a/app/src/components/DateRangePicker.jsx
+++ b/app/src/components/DateRangePicker.jsx
@@ -175,7 +175,7 @@ export const DateInput = ({ value, onChange }) => {
     <div className="relative" ref={ref}>
       <fieldset className="m-0 flex items-center gap-2 border-0 p-0">
         <legend className="sr-only">Période personnalisée</legend>
-        <div className="input flex items-center gap-1 px-2 py-1">
+        <div className="input focus-within:outline-outline-blue flex items-center gap-1 px-2 py-1 focus-within:outline-2 focus-within:outline-offset-2">
           <label htmlFor={`${id}-from`} className="text-sm text-gray-500">
             Du
           </label>
@@ -190,7 +190,7 @@ export const DateInput = ({ value, onChange }) => {
             className="w-24 border-0 bg-transparent p-0 text-sm font-semibold outline-none focus:ring-0"
           />
         </div>
-        <div className="input flex items-center gap-1 px-2 py-1">
+        <div className="input focus-within:outline-outline-blue flex items-center gap-1 px-2 py-1 focus-within:outline-2 focus-within:outline-offset-2">
           <label htmlFor={`${id}-to`} className="text-sm text-gray-500">
             Au
           </label>

--- a/app/src/components/ErrorAlert.jsx
+++ b/app/src/components/ErrorAlert.jsx
@@ -6,7 +6,7 @@ const ErrorAlert = ({ children, onClose }) => {
   return (
     <div className="border-error relative flex border">
       {onClose && (
-        <button className="absolute top-0 right-0 p-2" onClick={onClose}>
+        <button className="absolute top-0 right-0 p-2" onClick={onClose} aria-label="Fermer">
           <RiCloseFill className="text-blue-france" aria-hidden="true" />
         </button>
       )}

--- a/app/src/components/Footer.jsx
+++ b/app/src/components/Footer.jsx
@@ -31,76 +31,76 @@ const Footer = () => {
               L'API vous permet de faciliter l'engagement en simplifiant la démarche de recherche d'une mission de bénévolat ou de volontariat
             </p>
 
-            <ul role="list" aria-label="Liens gouvernementaux" className="text-grey-default flex flex-wrap items-center gap-x-6 gap-y-2 text-sm font-bold">
-              <li>
-                <a href="https://www.legifrance.gouv.fr/" target="_blank" rel="noopener external" className="link-external">
-                  legifrance.gouv.fr
-                  <RiExternalLinkLine className="ml-1" aria-hidden="true" />
-                </a>
-              </li>
-              <li>
-                <a href="https://www.gouvernement.fr/" target="_blank" rel="noopener external" className="link-external">
-                  gouvernement.fr
-                  <RiExternalLinkLine className="ml-1" aria-hidden="true" />
-                </a>
-              </li>
-              <li>
-                <a href="https://www.service-public.fr/" target="_blank" rel="noopener external" className="link-external">
-                  service-public.fr
-                  <RiExternalLinkLine className="ml-1" aria-hidden="true" />
-                </a>
-              </li>
-              <li>
-                <a href="https://www.data.gouv.fr/fr/" target="_blank" rel="noopener external" className="link-external">
-                  data.gouv.fr
-                  <RiExternalLinkLine className="ml-1" aria-hidden="true" />
-                </a>
-              </li>
-            </ul>
+            <nav role="navigation" aria-label="Liens gouvernementaux">
+              <ul role="list" className="text-grey-default flex flex-wrap items-center gap-x-6 gap-y-2 text-sm font-bold">
+                <li>
+                  <a href="https://www.legifrance.gouv.fr/" target="_blank" rel="noopener external" className="link-external">
+                    legifrance.gouv.fr
+                    <RiExternalLinkLine className="ml-1" aria-hidden="true" />
+                  </a>
+                </li>
+                <li>
+                  <a href="https://www.gouvernement.fr/" target="_blank" rel="noopener external" className="link-external">
+                    gouvernement.fr
+                    <RiExternalLinkLine className="ml-1" aria-hidden="true" />
+                  </a>
+                </li>
+                <li>
+                  <a href="https://www.service-public.fr/" target="_blank" rel="noopener external" className="link-external">
+                    service-public.fr
+                    <RiExternalLinkLine className="ml-1" aria-hidden="true" />
+                  </a>
+                </li>
+                <li>
+                  <a href="https://www.data.gouv.fr/fr/" target="_blank" rel="noopener external" className="link-external">
+                    data.gouv.fr
+                    <RiExternalLinkLine className="ml-1" aria-hidden="true" />
+                  </a>
+                </li>
+              </ul>
+            </nav>
           </div>
         </div>
 
-        <ul
-          role="list"
-          aria-label="Liens de pied de page"
-          className="divide-text-mention border-grey-border text-text-mention mt-10 flex flex-wrap items-center divide-x border-t py-4 text-xs"
-        >
-          <li>
-            <a href="https://api-engagement.beta.gouv.fr/accessibilite/" className="pr-3 hover:underline">
-              Accessibilité : non conforme
-            </a>
-          </li>
-          <li>
-            <Link to="/public-stats" className="px-3 hover:underline">
-              Statistiques
-            </Link>
-          </li>
-          <li>
-            <a href="https://doc.api-engagement.beta.gouv.fr/" className="px-3 hover:underline">
-              Documentation
-            </a>
-          </li>
-          <li>
-            <a href="https://api-engagement.beta.gouv.fr/mentions-legales/" className="px-3 hover:underline">
-              Mentions légales
-            </a>
-          </li>
-          <li>
-            <a href="https://doc.api-engagement.beta.gouv.fr/get-started/rgpd" className="px-3 hover:underline">
-              Données personnelles et cookies
-            </a>
-          </li>
-          <li>
-            <a href="https://api-engagement.beta.gouv.fr/politique-de-confidentialite/" className="px-3 hover:underline">
-              Politique de confidentialité
-            </a>
-          </li>
-          <li>
-            <Link to="cgu" className="pl-3 hover:underline">
-              CGU
-            </Link>
-          </li>
-        </ul>
+        <nav role="navigation" aria-label="Liens de pied de page">
+          <ul role="list" className="divide-text-mention border-grey-border text-text-mention mt-10 flex flex-wrap items-center divide-x border-t py-4 text-xs">
+            <li>
+              <a href="https://api-engagement.beta.gouv.fr/accessibilite/" className="pr-3 hover:underline">
+                Accessibilité : non conforme
+              </a>
+            </li>
+            <li>
+              <Link to="/public-stats" className="px-3 hover:underline">
+                Statistiques
+              </Link>
+            </li>
+            <li>
+              <a href="https://doc.api-engagement.beta.gouv.fr/" className="px-3 hover:underline">
+                Documentation
+              </a>
+            </li>
+            <li>
+              <a href="https://api-engagement.beta.gouv.fr/mentions-legales/" className="px-3 hover:underline">
+                Mentions légales
+              </a>
+            </li>
+            <li>
+              <a href="https://doc.api-engagement.beta.gouv.fr/get-started/rgpd" className="px-3 hover:underline">
+                Données personnelles et cookies
+              </a>
+            </li>
+            <li>
+              <a href="https://api-engagement.beta.gouv.fr/politique-de-confidentialite/" className="px-3 hover:underline">
+                Politique de confidentialité
+              </a>
+            </li>
+            <li>
+              <Link to="cgu" className="pl-3 hover:underline">
+                CGU
+              </Link>
+            </li>
+          </ul>
+        </nav>
         <p className="text-text-mention flex flex-wrap items-center py-4 text-xs">
           Sauf mention explicite de propriété intellectuelle détenue par des tiers, les contenus de ce site sont proposés sous
           <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" target="_blank" className="ml-1 flex items-center hover:underline">

--- a/app/src/components/Header.jsx
+++ b/app/src/components/Header.jsx
@@ -38,7 +38,7 @@ const Header = () => {
           </div>
         </Link>
         <nav role="navigation" aria-label="Navigation d'en-tête" className="text-blue-france flex items-center gap-3 text-sm">
-          <a href="https://doc.api-engagement.beta.gouv.fr/" target="_blank" className="text-blue-france flex items-center">
+          <a href="https://doc.api-engagement.beta.gouv.fr/" target="_blank" className="text-blue-france flex items-center" aria-label="Documentation">
             <RiBookletLine className="mr-2" aria-hidden="true" />
             <span className="hidden sm:block">Documentation</span>
           </a>
@@ -342,7 +342,7 @@ const AccountMenu = () => {
 
   return (
     <div className="relative" ref={ref} onBlur={handleFocusOut} onKeyDown={handleKeyDown}>
-      <button ref={buttonRef} className="btn hover:bg-gray-975 focus" type="button" onClick={() => setShow(!show)}>
+      <button ref={buttonRef} className="btn hover:bg-gray-975 focus" type="button" onClick={() => setShow(!show)} aria-label="Menu du compte">
         <div className="bg-blue-france flex h-8 w-8 items-center justify-center rounded-full">
           <RiUserLine className="text-white" aria-hidden="true" />
         </div>

--- a/app/src/components/Header.jsx
+++ b/app/src/components/Header.jsx
@@ -98,7 +98,7 @@ const NotificationMenu = () => {
       <MenuItems
         transition
         anchor="bottom end"
-        className="mt-2 w-[400px] origin-top-right bg-white text-black shadow-lg transition duration-200 ease-out focus:outline-none data-closed:scale-95 data-closed:opacity-0"
+        className="mt-2 w-[calc(100vw-2rem)] origin-top-right bg-white text-black shadow-lg transition duration-200 ease-out focus:outline-none data-closed:scale-95 data-closed:opacity-0 sm:w-[400px]"
       >
         <MenuItem>
           <div className="flex items-center justify-between p-6">
@@ -221,7 +221,7 @@ const AdminNotificationMenu = () => {
       <MenuItems
         transition
         anchor="bottom end"
-        className="w-[400px] origin-top-right bg-white text-black shadow-lg transition duration-200 ease-out focus:outline-none data-closed:scale-95 data-closed:opacity-0"
+        className="w-[calc(100vw-2rem)] origin-top-right bg-white text-black shadow-lg transition duration-200 ease-out focus:outline-none data-closed:scale-95 data-closed:opacity-0 sm:w-[400px]"
       >
         <MenuItem>
           <div className="flex items-center justify-between p-6">

--- a/app/src/components/Header.jsx
+++ b/app/src/components/Header.jsx
@@ -33,7 +33,7 @@ const Header = () => {
           </div>
           <LogoSvg alt="" className="hidden w-8 sm:block" aria-hidden="true" />
           <div className="hidden sm:block">
-            <h1 className="text-xl font-bold">API Engagement</h1>
+            <p className="text-xl font-bold">API Engagement</p>
             <p className="text-sm">Plateforme de partage de missions de bénévolat et de volontariat</p>
           </div>
         </Link>
@@ -113,7 +113,7 @@ const NotificationMenu = () => {
           <MenuItem>
             <Link to={warningPath} className="border-grey-border flex items-center justify-between gap-6 border-t p-6 hover:bg-gray-950">
               <div className="flex w-6 items-center">
-                <LogoSvg alt="" />
+                <LogoSvg alt="" aria-hidden="true" />
               </div>
               <div className="flex flex-1 flex-col gap-2">
                 <p className="text-base font-bold text-black">
@@ -236,7 +236,7 @@ const AdminNotificationMenu = () => {
           <MenuItem>
             <Link to="/admin-warning" className="border-grey-border flex items-center justify-between gap-6 border-t p-6 hover:bg-gray-950">
               <div className="flex w-6 items-center">
-                <LogoSvg alt="" />
+                <LogoSvg alt="" aria-hidden="true" />
               </div>
               <div className="flex flex-1 flex-col gap-2">
                 <p className="text-base font-bold text-black">

--- a/app/src/components/Header.jsx
+++ b/app/src/components/Header.jsx
@@ -90,7 +90,7 @@ const NotificationMenu = () => {
 
   return (
     <Menu>
-      <MenuButton as="div" className="data-[focus]:bg-gray-975 hover:bg-gray-975 relative p-2 text-lg">
+      <MenuButton as="div" className="data-[focus]:bg-gray-975 hover:bg-gray-975 relative p-2 text-lg" aria-label="Ouvrir le menu des alertes">
         <RiDashboard3Line aria-hidden="true" />
         {warnings.length > 0 && <div className="bg-error absolute top-2 right-1.5 h-[9px] w-[9px] rounded-full border border-white" />}
       </MenuButton>
@@ -214,7 +214,7 @@ const AdminNotificationMenu = () => {
 
   return (
     <Menu>
-      <MenuButton className="data-[focus]:bg-gray-975 hover:bg-gray-975 relative p-2 text-lg">
+      <MenuButton className="data-[focus]:bg-gray-975 hover:bg-gray-975 relative p-2 text-lg" aria-label="Ouvrir le menu des alertes">
         <RiDashboard3Line aria-hidden="true" />
         {warnings.length > 0 && <div className="bg-error absolute top-2 right-1.5 h-[9px] w-[9px] rounded-full border border-white" />}
       </MenuButton>

--- a/app/src/components/Header.jsx
+++ b/app/src/components/Header.jsx
@@ -37,7 +37,7 @@ const Header = () => {
             <p className="text-sm">Plateforme de partage de missions de bénévolat et de volontariat</p>
           </div>
         </Link>
-        <nav role="navigation" aria-label="Navigation d'en-tête" className="text-blue-france flex items-center gap-3 text-sm">
+        <nav role="navigation" aria-label="Navigation d'en-tête" className="text-blue-france relative flex items-center gap-3 text-sm">
           <a href="https://doc.api-engagement.beta.gouv.fr/" target="_blank" className="text-blue-france flex items-center" aria-label="Documentation">
             <RiBookletLine className="mr-2" aria-hidden="true" />
             <span className="hidden sm:block">Documentation</span>
@@ -90,15 +90,14 @@ const NotificationMenu = () => {
 
   return (
     <Menu>
-      <MenuButton as="div" className="data-[focus]:bg-gray-975 hover:bg-gray-975 relative p-2 text-lg" aria-label="Ouvrir le menu des alertes">
+      <MenuButton className="data-[focus]:bg-gray-975 hover:bg-gray-975 relative p-2 text-lg" aria-label="Ouvrir le menu des alertes">
         <RiDashboard3Line aria-hidden="true" />
         {warnings.length > 0 && <div className="bg-error absolute top-2 right-1.5 h-[9px] w-[9px] rounded-full border border-white" />}
       </MenuButton>
 
       <MenuItems
         transition
-        anchor="bottom end"
-        className="mt-2 w-[calc(100vw-2rem)] origin-top-right bg-white text-black shadow-lg transition duration-200 ease-out focus:outline-none data-closed:scale-95 data-closed:opacity-0 sm:w-[400px]"
+        className="absolute top-full right-0 z-10 mt-2 w-[calc(100vw-2rem)] origin-top-right bg-white text-black shadow-lg transition duration-200 ease-out focus:outline-none data-closed:scale-95 data-closed:opacity-0 sm:w-[400px]"
       >
         <MenuItem>
           <div className="flex items-center justify-between p-6">
@@ -220,8 +219,7 @@ const AdminNotificationMenu = () => {
       </MenuButton>
       <MenuItems
         transition
-        anchor="bottom end"
-        className="w-[calc(100vw-2rem)] origin-top-right bg-white text-black shadow-lg transition duration-200 ease-out focus:outline-none data-closed:scale-95 data-closed:opacity-0 sm:w-[400px]"
+        className="absolute top-full right-0 z-10 mt-2 w-[calc(100vw-2rem)] origin-top-right bg-white text-black shadow-lg transition duration-200 ease-out focus:outline-none data-closed:scale-95 data-closed:opacity-0 sm:w-[400px]"
       >
         <MenuItem>
           <div className="flex items-center justify-between p-6">
@@ -355,7 +353,7 @@ const AccountMenu = () => {
 
       <div
         inert={!show ? true : undefined}
-        className={`border-grey-border absolute left-1/2 z-10 w-[calc(100vw-2rem)] -translate-x-1/2 border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out sm:right-0 sm:left-auto sm:w-56 ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
+        className={`border-grey-border absolute right-0 z-10 w-[calc(100vw-2rem)] border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out sm:w-56 ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
       >
         <ul className="m-0 flex list-none flex-col p-0">
           <li>

--- a/app/src/components/InfoAlert.jsx
+++ b/app/src/components/InfoAlert.jsx
@@ -4,7 +4,7 @@ const InfoAlert = ({ children, onClose }) => {
   return (
     <div className="border-info relative flex border">
       {onClose && (
-        <button className="absolute top-0 right-0 p-2" onClick={onClose}>
+        <button className="absolute top-0 right-0 p-2" onClick={onClose} aria-label="Fermer">
           <RiCloseFill className="text-blue-france" aria-hidden="true" />
         </button>
       )}

--- a/app/src/components/Loader.jsx
+++ b/app/src/components/Loader.jsx
@@ -1,6 +1,6 @@
 export const Loader = ({ className = "mr-2 h-5 w-5 text-blue-france" }) => {
   return (
-    <svg className={`-ml-1 animate-spin ${className}`} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+    <svg className={`-ml-1 animate-spin ${className}`} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
       <path className="opacity-90" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
     </svg>

--- a/app/src/components/Modal.jsx
+++ b/app/src/components/Modal.jsx
@@ -27,6 +27,7 @@ const Modal = ({ open, children, onClose, title, className = "min-w-2xl" }) => {
   return (
     <dialog
       ref={dialogRef}
+      aria-modal="true"
       aria-labelledby={titleId}
       onClick={handleBackdropClick}
       className="fixed inset-0 m-auto max-h-[90vh] max-w-[90vw] overflow-visible bg-transparent p-0 backdrop:bg-black/60"

--- a/app/src/components/Modal.jsx
+++ b/app/src/components/Modal.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useId, useRef } from "react";
 import { RiCloseFill } from "react-icons/ri";
 
-const Modal = ({ open, children, onClose, title, className = "min-w-2xl" }) => {
+const Modal = ({ open, children, onClose, title, className = "w-[90vw] max-w-2xl" }) => {
   const dialogRef = useRef(null);
   const titleId = useId();
 

--- a/app/src/components/Nav.jsx
+++ b/app/src/components/Nav.jsx
@@ -122,7 +122,7 @@ const Nav = () => {
             <ul role="list" className="m-0 flex w-full list-none flex-col items-start gap-2 p-0 lg:w-auto lg:flex-row lg:items-center lg:gap-6">
               {menuItems.map((item) => (
                 <li key={item.key}>
-                  <Link to={item.to} aria-current={item.isActive} className="nav-item" onClick={() => setMenuOpen(false)}>
+                  <Link to={item.to} aria-current={item.isActive ? "page" : undefined} className="nav-item" onClick={() => setMenuOpen(false)}>
                     {item.label}
                   </Link>
                 </li>
@@ -390,7 +390,10 @@ const PublisherMenu = ({ options, value, onChange }) => {
         inert={!show ? true : undefined}
         className={`border-grey-border absolute right-0 z-50 w-[calc(100vw-2rem)] w-full border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out focus:outline-none sm:w-80 ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
       >
-        <div role="search" className="border-grey-border focus flex items-center gap-2 border-b p-3">
+        <div
+          role="search"
+          className="border-grey-border focus-within:outline-outline-blue flex items-center gap-2 border-b p-3 focus-within:outline-2 focus-within:outline-offset-2"
+        >
           <RiSearchLine aria-hidden="true" />
           <label htmlFor="publisher-search" className="sr-only">
             Rechercher un partenaire

--- a/app/src/components/Nav.jsx
+++ b/app/src/components/Nav.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { RiArrowDownSFill, RiArrowDownSLine, RiArrowLeftRightLine, RiCheckLine, RiMenuLine, RiCloseLine, RiSearchLine } from "react-icons/ri";
+import { RiArrowDownSFill, RiArrowDownSLine, RiArrowLeftRightLine, RiCheckLine, RiCloseLine, RiMenuLine, RiSearchLine } from "react-icons/ri";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import api from "@/services/api";
@@ -112,10 +112,14 @@ const Nav = () => {
           </button>
         </div>
 
-        <ul className={`m-0 w-full list-none flex-col items-start justify-between gap-x-6 gap-y-2 p-0 pb-4 lg:flex lg:flex-row lg:items-center lg:pb-0 ${menuOpen ? "flex" : "hidden lg:flex"}`} role="list" aria-label="Menu principal">
+        <ul
+          className={`m-0 w-full list-none flex-col items-start justify-between gap-x-6 gap-y-2 p-0 pb-4 lg:flex lg:flex-row lg:items-center lg:pb-0 ${menuOpen ? "flex" : "hidden lg:flex"}`}
+          role="list"
+          aria-label="Menu principal"
+        >
           <li className="flex w-full flex-col items-start gap-4 lg:w-auto lg:flex-row lg:items-center lg:gap-6">
             {publisher.isAnnonceur && (publisher.hasApiRights || publisher.hasWidgetRights || publisher.hasCampaignRights) && <FluxMenu value={flux} onChange={handleFluxChange} />}
-            <ul className="m-0 flex w-full list-none flex-col items-start gap-2 p-0 lg:w-auto lg:flex-row lg:items-center lg:gap-6">
+            <ul role="list" className="m-0 flex w-full list-none flex-col items-start gap-2 p-0 lg:w-auto lg:flex-row lg:items-center lg:gap-6">
               {menuItems.map((item) => (
                 <li key={item.key}>
                   <Link to={item.to} aria-current={item.isActive} className="nav-item" onClick={() => setMenuOpen(false)}>
@@ -505,7 +509,7 @@ const AdminMenu = () => {
         inert={!show ? true : undefined}
         className={`border-grey-border absolute right-0 z-10 w-[calc(100vw-2rem)] w-full border bg-white shadow-lg transition-[max-height,opacity] duration-200 ease-in-out sm:w-80 ${show ? "max-h-96 opacity-100" : "pointer-events-none max-h-0 opacity-0"}`}
       >
-        <ul className="m-0 flex list-none flex-col p-0">
+        <ul role="list" className="m-0 flex list-none flex-col p-0">
           {ADMIN_MENU_ITEMS.map((item, index) => {
             const isCurrent = location.pathname.startsWith(item.href);
             return (

--- a/app/src/components/Nav.jsx
+++ b/app/src/components/Nav.jsx
@@ -404,12 +404,13 @@ const PublisherMenu = ({ options, value, onChange }) => {
             role="searchbox"
             id="publisher-search"
             name="publisher-search"
+            aria-controls="publisher-listbox"
             className="w-full pl-2 focus:outline-none"
             onChange={(e) => setSearch(e.target.value)}
             onKeyDown={handleInputKeyDown}
           />
         </div>
-        <ul className="flex max-h-80 list-none flex-col overflow-x-visible overflow-y-auto px-2" role="listbox">
+        <ul id="publisher-listbox" role="listbox" aria-label="Partenaires" className="flex max-h-80 list-none flex-col overflow-x-visible overflow-y-auto px-2">
           {filtered.map((option, index) => (
             <li
               ref={(el) => {
@@ -417,7 +418,7 @@ const PublisherMenu = ({ options, value, onChange }) => {
               }}
               key={index}
               role="option"
-              aria-selected={focusedIndex === index}
+              aria-selected={value.id === option.id}
               aria-label={option.name}
               tabIndex={focusedIndex === index ? 0 : -1}
               className={`nav-link -mx-2 cursor-pointer items-center ${index === 0 ? "shadow-none" : ""} ${focusedIndex === index || value.id === option.id ? "text-blue-france" : ""}`}

--- a/app/src/components/Table.jsx
+++ b/app/src/components/Table.jsx
@@ -14,10 +14,7 @@ const SortableHeader = ({ item, sortBy, onSort }) => {
     <th key={item.key} className="p-4" width={item.width || undefined} aria-sort={ariaSort}>
       <button className={`group flex h-full w-full items-center gap-2 ${positionClass}`} onClick={() => onSort(item.key)} type="button">
         <span className={`text-sm font-semibold ${item.position === "right" ? "text-right" : item.position === "center" ? "text-center" : "text-left"}`}>{item.title}</span>
-        <RiArrowDownSLine
-          className={`ml-2 text-lg transition-transform duration-200 ${isSorted ? "rotate-180 opacity-100" : "opacity-0 group-hover:opacity-100"}`}
-          aria-hidden="true"
-        />
+        {isSorted && <RiArrowDownSLine className={`ml-2 size-4 shrink-0 text-lg ${isAscending ? "rotate-180" : ""}`} aria-hidden="true" />}
       </button>
     </th>
   );

--- a/app/src/components/Table.jsx
+++ b/app/src/components/Table.jsx
@@ -5,8 +5,8 @@ import { RiArrowDownSLine, RiArrowLeftSLine, RiArrowRightSLine, RiSkipLeftLine, 
 import Loader from "@/components/Loader";
 
 const SortableHeader = ({ item, sortBy, onSort }) => {
-  const isSorted = sortBy === item.key;
-  const isAscending = isSorted && sortBy.startsWith?.("-");
+  const isSorted = sortBy === item.key || sortBy === `-${item.key}`;
+  const isAscending = isSorted && sortBy.startsWith("-");
   const ariaSort = isSorted ? (isAscending ? "ascending" : "descending") : undefined;
   const positionClass = item.position === "right" ? "justify-end" : item.position === "center" ? "justify-center" : "justify-start";
 
@@ -43,7 +43,7 @@ const Table = ({ header, caption, sortBy, total, onSort, loading, children, stic
 
   return (
     <>
-      <div className={`w-full overflow-x-auto overflow-y-visible ${className}`}>
+      <div className={`relative w-full overflow-x-auto overflow-y-visible ${className}`}>
         <table className="min-w-full table-fixed border-collapse">
           {caption && (
             <caption className="sr-only">
@@ -129,14 +129,14 @@ const Pagination = ({ page, setPage, end }) => {
         </li>
 
         {pages.map((p, index) => (
-          <li key={index}>
+          <li key={index} aria-hidden={p === "..." ? "true" : undefined}>
             {p === "..." ? (
               <div className="mx-2 text-sm">{p}</div>
             ) : (
               <button
                 aria-label={`Page ${p}`}
                 aria-current={parseInt(p) === page ? "page" : undefined}
-                className={`pagination-btn ${parseInt(p) === page ? "bg-blue-france text-white" : ""}`}
+                className={`pagination-btn ${parseInt(p) === page ? "bg-blue-france font-bold text-white underline underline-offset-4" : ""}`}
                 onClick={() => setPage(parseInt(p))}
               >
                 {p}

--- a/app/src/components/WarningAlert.jsx
+++ b/app/src/components/WarningAlert.jsx
@@ -4,7 +4,7 @@ const WarningAlert = ({ children, onClose }) => {
   return (
     <div className="border-warning relative flex border">
       {onClose && (
-        <button className="absolute top-0 right-0 p-2" onClick={onClose}>
+        <button className="absolute top-0 right-0 p-2" onClick={onClose} aria-label="Fermer">
           <RiCloseFill className="text-blue-france" aria-hidden="true" />
         </button>
       )}

--- a/app/src/components/combobox/DesignSystem.jsx
+++ b/app/src/components/combobox/DesignSystem.jsx
@@ -18,6 +18,7 @@ const Combobox = ({
 }) => {
   const ref = useRef(null);
   const inputRef = useRef(null);
+  const buttonRef = useRef(null);
   const [listRef, setListRef] = useState(options.map(() => undefined));
   const [show, setShow] = useState(false);
   const [selection, setSelection] = useState(values || []);
@@ -53,6 +54,17 @@ const Combobox = ({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  useEffect(() => {
+    if (show) {
+      inputRef.current?.focus();
+    }
+  }, [show]);
+
+  const closeAndReturnFocus = () => {
+    setShow(false);
+    buttonRef.current?.focus();
+  };
+
   const handleToggle = (option) => {
     let newSelection;
     if (selection.some((o) => getValue(o) === getValue(option))) {
@@ -79,8 +91,23 @@ const Combobox = ({
     }
   };
 
+  const handleSearchKeyDown = (e) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeAndReturnFocus();
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setFocusedIndex(0);
+      listRef[0]?.focus();
+    }
+  };
+
   const handleListKeyDown = (e, item) => {
     switch (e.key) {
+      case "Escape":
+        e.preventDefault();
+        closeAndReturnFocus();
+        break;
       case "Tab":
         if (e.shiftKey) {
           if (inputRef && inputRef.current) {
@@ -127,7 +154,12 @@ const Combobox = ({
       </div>
       <div className="relative w-full">
         <button
+          ref={buttonRef}
           id={id}
+          type="button"
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-controls={`${id}-list`}
           aria-label={placeholder}
           aria-expanded={show}
           className="select relative w-full truncate pr-12 text-left"
@@ -161,12 +193,7 @@ const Combobox = ({
         )}
       </div>
 
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={id}
-        className={`absolute ${position} z-50 mt-1 ${className} border-grey-border border bg-white py-4 shadow-md ${show ? "block" : "hidden"}`}
-      >
+      <div className={`absolute ${position} z-50 mt-1 ${className} border-grey-border border bg-white py-4 shadow-md ${show ? "block" : "hidden"}`}>
         <div className="relative mx-4 mb-4">
           <input
             ref={inputRef}
@@ -175,6 +202,7 @@ const Combobox = ({
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={handleSearchKeyDown}
             placeholder={placeholder}
             className="input w-full"
           />
@@ -182,7 +210,7 @@ const Combobox = ({
         </div>
 
         <p className="mx-4 mb-2 text-base">{placeholder}</p>
-        <ul id={`${id}-list`} className="max-h-60 w-full overflow-auto py-2" tabIndex={-1} role="listbox" aria-multiselectable="true">
+        <ul id={`${id}-list`} aria-label={placeholder} className="max-h-60 w-full overflow-auto py-2" tabIndex={-1} role="listbox" aria-multiselectable="true">
           {options?.length === 0 ? (
             <li className="py-2 text-center text-sm">Aucune option disponible</li>
           ) : loading ? (

--- a/app/src/components/combobox/LocationCombobox.jsx
+++ b/app/src/components/combobox/LocationCombobox.jsx
@@ -1,7 +1,7 @@
-import { captureError } from "@/services/error";
 import Combobox from "@/components/combobox/index";
+import { captureError } from "@/services/error";
 
-const LocationCombobox = ({ id, selected, onSelect, placeholder, className }) => {
+const LocationCombobox = ({ id, selected, onSelect, placeholder, className, ariaDescribedby }) => {
   const fetchLocasions = async (search) => {
     if (search.length < 4) {
       if (selected) {
@@ -29,7 +29,17 @@ const LocationCombobox = ({ id, selected, onSelect, placeholder, className }) =>
     return [];
   };
 
-  return <Combobox id={id} value={selected ? selected.value : null} onSelect={onSelect} onSearch={fetchLocasions} placeholder={placeholder} className={className} />;
+  return (
+    <Combobox
+      id={id}
+      value={selected ? selected.value : null}
+      onSelect={onSelect}
+      onSearch={fetchLocasions}
+      placeholder={placeholder}
+      className={className}
+      ariaDescribedby={ariaDescribedby}
+    />
+  );
 };
 
 export default LocationCombobox;

--- a/app/src/components/combobox/index.jsx
+++ b/app/src/components/combobox/index.jsx
@@ -11,6 +11,7 @@ const Combobox = ({
   className,
   id,
   options = null,
+  ariaDescribedby,
   debounce = 300,
   onSearch = null,
   onChange = null,
@@ -62,6 +63,7 @@ const Combobox = ({
           aria-label={placeholder}
           aria-owns={`${id}-options`}
           aria-activedescendant={selectedIndex !== -1 ? `${id}-option-${selectedIndex}` : undefined}
+          aria-describedby={ariaDescribedby}
         />
         <ComboboxButton className="absolute inset-y-2 right-0 flex items-center pr-4" aria-label="Ouvrir les options">
           {({ open }) => <RiArrowDownSLine className={`text-lg ${open ? "rotate-180 transform" : ""}`} aria-hidden="true" />}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -169,7 +169,7 @@ body {
   transform: translateY(0);
 }
 
-@custom-variant aria-current (&[aria-current="true"]);
+@custom-variant aria-current (&[aria-current="page"]);
 
 @utility focus {
   @apply focus-visible:outline-outline-blue focus-visible:shadow-none! focus-visible:outline-2 focus-visible:outline-offset-2;

--- a/app/src/scenes/account/index.jsx
+++ b/app/src/scenes/account/index.jsx
@@ -24,7 +24,7 @@ const Account = () => {
 
     const errors = {};
     if (!values.firstname) {
-      errors.firstname = "Le nom est requis";
+      errors.firstname = "Le prénom est requis";
     }
 
     setErrors(errors);
@@ -71,24 +71,37 @@ const Account = () => {
             Se deconnecter
           </button>
         </div>
+        <p className="text-text-mention mb-6 text-sm">
+          <span className="text-error" aria-hidden="true">
+            *
+          </span>{" "}
+          : champ obligatoire
+        </p>
         <div className="grid grid-cols-1 gap-x-10 gap-y-5 sm:grid-cols-2">
           <div className="flex flex-col">
             <label className="mb-2 text-sm" htmlFor="firstname">
               Prénom
+              <span className="text-error ml-1" aria-hidden="true">
+                *
+              </span>
             </label>
             <input
               id="firstname"
               className={`input mb-2 ${errors.firstname ? "border-b-error" : "border-b-black"}`}
               name="firstname"
               autoComplete="given-name"
+              required
+              aria-required="true"
+              aria-invalid={errors.firstname ? true : undefined}
+              aria-describedby={errors.firstname ? "firstname-error" : undefined}
               value={values.firstname}
               onChange={(e) => setValues({ ...values, firstname: e.target.value })}
             />
             {errors.firstname && (
-              <div className="text-error flex items-center text-sm">
-                <RiErrorWarningFill className="mr-2" aria-hidden="true" />
+              <p id="firstname-error" className="text-error flex items-center text-sm" aria-live="polite">
+                <RiErrorWarningFill className="mr-2 shrink-0" aria-hidden="true" />
                 {errors.firstname}
-              </div>
+              </p>
             )}
           </div>
 
@@ -149,13 +162,13 @@ const ResetPasswordModal = () => {
   const handleSubmit = async () => {
     const errors = {};
     if (values.newPassword.length < 12 || !/[a-zA-Z]/.test(values.newPassword) || !/[0-9]/.test(values.newPassword) || !/[!-@#$%^&*(),.?":{}|<>]/.test(values.newPassword)) {
-      errors.newPassword = "Le mot de passe ne respecte pas les critères de sécurité";
+      errors.newPassword = "Le nouveau mot de passe ne respecte pas les critères de sécurité";
     }
     if (values.newPassword === values.oldPassword) {
       errors.newPassword = "Le nouveau mot de passe ne peut pas être identique à l'ancien mot de passe";
     }
     if (values.newPassword !== values.confirmPassword) {
-      errors.confirmPassword = "Les mots de passe ne sont pas identiques";
+      errors.confirmPassword = "La confirmation du nouveau mot de passe ne correspond pas au nouveau mot de passe";
     }
 
     setErrors(errors);
@@ -167,7 +180,7 @@ const ResetPasswordModal = () => {
       const res = await api.put(`/user/change-password`, values);
       if (!res.ok) {
         if (res.code === "INVALID_PASSWORD") {
-          setErrors({ newPassword: "Le mot de passe ne respecte pas les critères de sécurité" });
+          setErrors({ newPassword: "Le nouveau mot de passe ne respecte pas les critères de sécurité" });
           return;
         }
 
@@ -199,29 +212,46 @@ const ResetPasswordModal = () => {
       </button>
 
       <Modal open={open} onClose={onClose} title="Changement du mot de passe" className="w-[90vw] max-w-3xl">
+        <p className="text-text-mention text-sm">
+          <span className="text-error" aria-hidden="true">
+            *
+          </span>{" "}
+          : champ obligatoire
+        </p>
         <div className="flex flex-col">
           <label className="mb-2 text-sm" htmlFor="old-password">
             Ancien mot de passe
+            <span className="text-error ml-1" aria-hidden="true">
+              *
+            </span>
           </label>
           <input
             id="old-password"
             className={`input mb-2 ${errors.oldPassword ? "border-b-error" : "border-b-black"}`}
             name="oldPassword"
             type="password"
+            autoComplete="current-password"
+            required
+            aria-required="true"
+            aria-invalid={errors.oldPassword ? true : undefined}
+            aria-describedby={errors.oldPassword ? "old-password-error" : undefined}
             value={values.oldPassword}
             onChange={(e) => setValues({ ...values, oldPassword: e.target.value })}
           />
           {errors.oldPassword && (
-            <div className="text-error flex items-center text-sm">
-              <RiErrorWarningFill className="mr-2" aria-hidden="true" />
+            <p id="old-password-error" className="text-error flex items-center text-sm" aria-live="polite">
+              <RiErrorWarningFill className="mr-2 shrink-0" aria-hidden="true" />
               {errors.oldPassword}
-            </div>
+            </p>
           )}
         </div>
         <div className="flex flex-col">
           <div className="flex justify-between">
             <label className="mb-2 text-sm" htmlFor="new-password">
               Nouveau mot de passe
+              <span className="text-error ml-1" aria-hidden="true">
+                *
+              </span>
             </label>
             <button
               type="button"
@@ -238,21 +268,28 @@ const ResetPasswordModal = () => {
             className={`input mb-2 ${errors.newPassword ? "border-b-error" : "border-b-black"}`}
             name="newPassword"
             type={showNewPassword ? "text" : "password"}
+            required
+            aria-required="true"
+            aria-invalid={errors.newPassword ? true : undefined}
+            aria-describedby={errors.newPassword ? "new-password-error new-password-criteria" : "new-password-criteria"}
             value={values.newPassword}
             onChange={(e) => setValues({ ...values, newPassword: e.target.value })}
             autoComplete="new-password"
           />
           {errors.newPassword && (
-            <div className="text-error flex items-center text-sm">
-              <RiErrorWarningFill className="mr-2" aria-hidden="true" />
+            <p id="new-password-error" className="text-error flex items-center text-sm" aria-live="polite">
+              <RiErrorWarningFill className="mr-2 shrink-0" aria-hidden="true" />
               {errors.newPassword}
-            </div>
+            </p>
           )}
         </div>
         <div className="flex flex-col">
           <div className="flex justify-between">
             <label className="mb-2 text-sm" htmlFor="confirm-password">
               Confirmez le nouveau mot de passe
+              <span className="text-error ml-1" aria-hidden="true">
+                *
+              </span>
             </label>
             <button
               type="button"
@@ -269,18 +306,23 @@ const ResetPasswordModal = () => {
             className={`input mb-2 ${errors.confirmPassword ? "border-b-error" : "border-b-black"}`}
             name="confirmPassword"
             type={showConfirmPassword ? "text" : "password"}
+            autoComplete="new-password"
+            required
+            aria-required="true"
+            aria-invalid={errors.confirmPassword ? true : undefined}
+            aria-describedby={errors.confirmPassword ? "confirm-password-error" : undefined}
             value={values.confirmPassword}
             onChange={(e) => setValues({ ...values, confirmPassword: e.target.value })}
           />
           {errors.confirmPassword && (
-            <div className="text-error flex items-center text-sm">
-              <RiErrorWarningFill className="mr-2" aria-hidden="true" />
+            <p id="confirm-password-error" className="text-error flex items-center text-sm" aria-live="polite">
+              <RiErrorWarningFill className="mr-2 shrink-0" aria-hidden="true" />
               {errors.confirmPassword}
-            </div>
+            </p>
           )}
         </div>
 
-        <div className="flex flex-col gap-2">
+        <div id="new-password-criteria" className="flex flex-col gap-2">
           <PasswordCriterion valid={(values.newPassword || "").length >= 12}>Au moins 12 caractères</PasswordCriterion>
           <PasswordCriterion valid={/[a-zA-Z]/.test(values.newPassword)}>Au moins une lettre</PasswordCriterion>
           <PasswordCriterion valid={/[0-9]/.test(values.newPassword)}>Au moins un chiffre</PasswordCriterion>

--- a/app/src/scenes/account/index.jsx
+++ b/app/src/scenes/account/index.jsx
@@ -198,7 +198,7 @@ const ResetPasswordModal = () => {
         Réinitialiser le mot de passe
       </button>
 
-      <Modal open={open} onClose={onClose} title="Changement du mot de passe" className="min-w-3xl">
+      <Modal open={open} onClose={onClose} title="Changement du mot de passe" className="w-[90vw] max-w-3xl">
         <div className="flex flex-col">
           <label className="mb-2 text-sm" htmlFor="old-password">
             Ancien mot de passe

--- a/app/src/scenes/admin-mission/index.jsx
+++ b/app/src/scenes/admin-mission/index.jsx
@@ -231,9 +231,9 @@ const AdminMission = () => {
             <div className="flex flex-wrap items-center gap-2">
               <p className="text-text-mention text-base">Dernière synchronisation le {lastImport ? new Date(lastImport.startedAt).toLocaleDateString("fr") : "N/A"}</p>
               {lastImport && new Date(lastImport.startedAt) > new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() - 1) ? (
-                <RiCheckboxCircleFill role="img" aria-label="OK" className="text-success text-base" />
+                <RiCheckboxCircleFill role="img" aria-label="Synchronisation à jour" className="text-success text-base" />
               ) : (
-                <ErrorIconSvg role="img" aria-label="Erreur" className="fill-error h-4 w-4" />
+                <ErrorIconSvg role="img" aria-label="Synchronisation en retard" className="fill-error h-4 w-4" />
               )}
             </div>
           </div>
@@ -286,9 +286,9 @@ const AdminMission = () => {
               <td className="px-6">
                 <div className="flex items-center gap-1">
                   {item.statusCode === "ACCEPTED" ? (
-                    <RiCheckboxCircleFill role="img" aria-label="OK" className="text-success text-2xl" />
+                    <RiCheckboxCircleFill role="img" aria-label="Acceptée par l'API" className="text-success text-2xl" />
                   ) : (
-                    <ErrorIconSvg role="img" aria-label="Erreur" className="fill-error h-6 w-6" />
+                    <ErrorIconSvg role="img" aria-label="Non acceptée par l'API" className="fill-error h-6 w-6" />
                   )}
                   {item.statusComment ? (
                     <Tooltip

--- a/app/src/scenes/admin-mission/index.jsx
+++ b/app/src/scenes/admin-mission/index.jsx
@@ -227,7 +227,7 @@ const AdminMission = () => {
       <div className="space-y-6">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="min-w-0 flex-1 space-y-2">
-            <h2 className="text-2xl font-bold">{total.toLocaleString("fr")} missions partagées</h2>
+            <h1 className="text-2xl font-bold">{total.toLocaleString("fr")} missions partagées</h1>
             <div className="flex flex-wrap items-center gap-2">
               <p className="text-text-mention text-base">Dernière synchronisation le {lastImport ? new Date(lastImport.startedAt).toLocaleDateString("fr") : "N/A"}</p>
               {lastImport && new Date(lastImport.startedAt) > new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() - 1) ? (

--- a/app/src/scenes/admin-report/index.jsx
+++ b/app/src/scenes/admin-report/index.jsx
@@ -61,7 +61,7 @@ const AdminReport = () => {
     <div className="space-y-12 bg-white p-4 shadow-lg sm:p-12">
       <title>API Engagement - Rapports d'impacts - Administration</title>
       <div className="flex items-center justify-between">
-        <h2 className="flex-1 text-2xl font-semibold">{total.toLocaleString("fr")} rapports d'impacts</h2>
+        <h1 className="flex-1 text-2xl font-semibold">{total.toLocaleString("fr")} rapports d'impacts</h1>
       </div>
 
       <div className="border-grey-border space-y-6 overflow-x-auto border p-4 sm:p-6">

--- a/app/src/scenes/admin-stats/Apercu.jsx
+++ b/app/src/scenes/admin-stats/Apercu.jsx
@@ -2,16 +2,16 @@ import { useEffect, useState } from "react";
 import { HiChevronRight } from "react-icons/hi";
 import { Link, useSearchParams } from "react-router-dom";
 
+import EmptySVG from "@/assets/svg/empty-info.svg";
+import { StackedBarchart } from "@/components/Chart";
 import ChartDetailsTable from "@/components/ChartDetailsTable";
 import DateRangePicker from "@/components/DateRangePicker";
-import { StackedBarchart } from "@/components/Chart";
 import Loader from "@/components/Loader";
+import { METABASE_CARD_ID, MISSION_TYPE_OPTIONS } from "@/constants";
 import AnalyticsCard from "@/scenes/performance/AnalyticsCard";
 import { useAnalyticsProvider } from "@/services/analytics/provider";
 import { captureError } from "@/services/error";
 import { slugify } from "@/utils/string";
-import EmptySVG from "@/assets/svg/empty-info.svg";
-import { METABASE_CARD_ID, MISSION_TYPE_OPTIONS } from "@/constants";
 
 const CHART_COLORS = ["rgba(117,165,236,1)", "rgba(251,146,107,1)", "#fdc639"];
 
@@ -249,15 +249,7 @@ const TrafficByAnnouncerChart = ({ filters, cardId, title, subtitle }) => {
             <div className="h-[420px] w-full" role="img" aria-label={title} aria-describedby={descriptionId}>
               <StackedBarchart data={histogram} dataKey={keys} />
             </div>
-            <ChartDetailsTable
-              id={descriptionId}
-              title={title}
-              description={subtitle}
-              mode="sr-only"
-              type="stacked"
-              data={histogram}
-              stackedKeys={keys}
-            />
+            <ChartDetailsTable id={descriptionId} title={title} description={subtitle} mode="sr-only" type="stacked" data={histogram} stackedKeys={keys} />
           </figure>
         )}
       </div>
@@ -268,7 +260,9 @@ const TrafficByAnnouncerChart = ({ filters, cardId, title, subtitle }) => {
 const EngagementSection = ({ filters }) => {
   return (
     <div className="space-y-6">
-      <h2 className="text-3xl font-bold">🫶 Engagement généré</h2>
+      <h2 className="text-3xl font-bold">
+        <span aria-hidden="true">🫶</span> Engagement généré
+      </h2>
       <TrafficByAnnouncerChart
         filters={filters}
         cardId={METABASE_CARD_ID.ADMIN_STATS_ENGAGEMENT_REDIRECTIONS}
@@ -288,7 +282,9 @@ const EngagementSection = ({ filters }) => {
 const MissionsSection = ({ filters }) => {
   return (
     <div className="space-y-6">
-      <h2 className="text-3xl font-bold">🚀 Missions</h2>
+      <h2 className="text-3xl font-bold">
+        <span aria-hidden="true">🚀</span> Missions
+      </h2>
       <ChartBlock
         title="Missions actives"
         subtitle="Répartition par type de mission sur la période"
@@ -318,7 +314,9 @@ const MissionsSection = ({ filters }) => {
 const PartnersSection = ({ filters }) => {
   return (
     <div className="space-y-6">
-      <h2 className="text-3xl font-bold">🤝 Partenaires</h2>
+      <h2 className="text-3xl font-bold">
+        <span aria-hidden="true">🤝</span> Partenaires
+      </h2>
       <div className="space-y-4">
         <ChartBlock
           title="Top diffuseurs"

--- a/app/src/scenes/admin-warning/index.jsx
+++ b/app/src/scenes/admin-warning/index.jsx
@@ -8,8 +8,8 @@ import { DAYS, MONTHS, WARNINGS, YEARS } from "@/constants";
 import Bots from "@/scenes/admin-warning/components/Bots";
 import api from "@/services/api";
 import { captureError } from "@/services/error";
-import { slugify } from "@/utils/string";
 import { withLegacyPublishers } from "@/utils/publisher";
+import { slugify } from "@/utils/string";
 
 const Index = () => {
   const [currentWarnings, setCurrentWarnings] = useState([]);
@@ -194,7 +194,7 @@ const Index = () => {
               ? `${Object.keys(currentWarningsByPublishers).length} partenaires rencontrent un problème`
               : `${Object.keys(currentWarningsByPublishers).length} partenaire rencontre un problème`}
           </h2>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 sm:gap-10">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-10 lg:grid-cols-4">
             {Object.values(currentWarningsByPublishers).map((p, i) => (
               <div className="border-grey-border flex h-40 flex-col items-center border" key={i}>
                 <div className="text-text-mention mt-2 text-center text-xs">{p.name}</div>
@@ -266,7 +266,11 @@ const Index = () => {
                   const label = WARNINGS[w.type] || WARNINGS.OTHER_WARNING;
                   return (
                     <div className="flex flex-col gap-4 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:gap-8 sm:p-6" key={i} id={slugify(`${w.type}-${w.publisherName}`)}>
-                      {w.publisherLogo ? <img className="h-20 w-36 shrink-0 object-contain" src={w.publisherLogo} alt="" aria-hidden="true" /> : <div className="bg-grey-200 h-20 w-36 shrink-0" />}
+                      {w.publisherLogo ? (
+                        <img className="h-20 w-36 shrink-0 object-contain" src={w.publisherLogo} alt="" aria-hidden="true" />
+                      ) : (
+                        <div className="bg-grey-200 h-20 w-36 shrink-0" />
+                      )}
                       <div className="flex flex-col justify-between">
                         <div className="mb-2">
                           <span className="bg-yellow-tournesol-950 text-yellow-tournesol-200 truncate rounded p-1 text-center text-xs font-semibold uppercase">{label.name}</span>
@@ -335,7 +339,11 @@ const Index = () => {
                   const label = WARNINGS[w.type] || WARNINGS.OTHER_WARNING;
                   return (
                     <div className="flex flex-col gap-4 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:gap-8 sm:p-6" key={i}>
-                      {w.publisherLogo ? <img className="h-20 w-36 shrink-0 object-contain" src={w.publisherLogo} alt="" aria-hidden="true" /> : <div className="bg-grey-200 h-20 w-36 shrink-0" />}
+                      {w.publisherLogo ? (
+                        <img className="h-20 w-36 shrink-0 object-contain" src={w.publisherLogo} alt="" aria-hidden="true" />
+                      ) : (
+                        <div className="bg-grey-200 h-20 w-36 shrink-0" />
+                      )}
 
                       <div className="flex flex-col justify-between">
                         <div className="mb-2">
@@ -375,7 +383,7 @@ const Badge = ({ label, value, onDelete }) => {
     <div className="bg-blue-france-975 flex items-center gap-2 rounded p-2">
       <p className="text-sm">{label}:</p>
       <p className="text-sm">{value}</p>
-      <button className="text-sm text-black" onClick={onDelete}>
+      <button className="text-sm text-black" onClick={onDelete} aria-label={`Retirer le filtre ${label}`}>
         <RiCloseFill aria-hidden="true" />
       </button>
     </div>

--- a/app/src/scenes/auth/Login.jsx
+++ b/app/src/scenes/auth/Login.jsx
@@ -74,6 +74,9 @@ const Login = () => {
           *
         </span>
       </label>
+      <p id="email-hint" className="text-text-mention mb-2 text-xs">
+        Exemple de format attendu : jane.doe@gmail.com
+      </p>
       <input
         className={`input mb-2 ${errors.email ? "border-b-error" : "border-b-black"}`}
         name="email"
@@ -83,7 +86,7 @@ const Login = () => {
         required
         aria-required="true"
         aria-invalid={errors.email ? true : undefined}
-        aria-describedby={errors.email ? "email-error" : undefined}
+        aria-describedby={errors.email ? "email-error email-hint" : "email-hint"}
       />
       {errors.email && (
         <p id="email-error" className="text-error flex items-center text-sm" aria-live="polite">
@@ -109,7 +112,7 @@ const Login = () => {
         aria-invalid={errors.password ? true : undefined}
         aria-describedby={errors.password ? "password-error" : undefined}
       />
-      
+
       {errors.password && (
         <p id="password-error" className="text-error flex items-center text-sm" aria-live="polite">
           <RiErrorWarningFill className="mr-2 shrink-0" aria-hidden="true" />

--- a/app/src/scenes/auth/ResetPassword.jsx
+++ b/app/src/scenes/auth/ResetPassword.jsx
@@ -124,10 +124,10 @@ const ResetPasswordForm = ({ user, token }) => {
           <label className="mb-2 text-sm" htmlFor="password">
             Nouveau mot de passe
           </label>
-          <div className="flex cursor-pointer items-center gap-1" onClick={() => setShow(!show)}>
+          <button type="button" className="flex cursor-pointer items-center gap-1" onClick={() => setShow(!show)}>
             {show ? <IoMdEyeOff className="text-blue-france" aria-hidden="true" /> : <IoMdEye className="text-blue-france" aria-hidden="true" />}
             <span className="text-blue-france text-xs font-bold">{show ? "CACHER" : "AFFICHER"}</span>
-          </div>
+          </button>
         </div>
 
         <input
@@ -181,10 +181,10 @@ const ResetPasswordForm = ({ user, token }) => {
           <label className="mb-2 text-sm" htmlFor="confirm-password">
             Confirmez ce mot de passe
           </label>
-          <div className="flex cursor-pointer items-center gap-1" onClick={() => setShowConfirm(!showConfirm)}>
+          <button type="button" className="flex cursor-pointer items-center gap-1" onClick={() => setShowConfirm(!showConfirm)}>
             {showConfirm ? <IoMdEyeOff className="text-blue-france" aria-hidden="true" /> : <IoMdEye className="text-blue-france" aria-hidden="true" />}
             <span className="text-blue-france text-xs font-bold">{showConfirm ? "CACHER" : "AFFICHER"}</span>
-          </div>
+          </button>
         </div>
         <input
           id="confirm-password"

--- a/app/src/scenes/auth/Signup.jsx
+++ b/app/src/scenes/auth/Signup.jsx
@@ -172,10 +172,10 @@ const SignupForm = ({ user }) => {
           <label className="mb-1" htmlFor="password">
             Mot de passe
           </label>
-          <div className="flex cursor-pointer items-center gap-1" onClick={() => setShow(!show)}>
+          <button type="button" className="flex cursor-pointer items-center gap-1" onClick={() => setShow(!show)}>
             {show ? <IoMdEyeOff className="text-blue-france" aria-hidden="true" /> : <IoMdEye className="text-blue-france" aria-hidden="true" />}
             <span className="text-blue-france text-xs font-bold">{show ? "CACHER" : "AFFICHER"}</span>
-          </div>
+          </button>
         </div>
         <input
           id="password"
@@ -224,10 +224,10 @@ const SignupForm = ({ user }) => {
           <label className="mb-1" htmlFor="confirm-password">
             Confirmation du mot de passe
           </label>
-          <div className="flex cursor-pointer items-center gap-1" onClick={() => setShowConfirm(!showConfirm)}>
+          <button type="button" className="flex cursor-pointer items-center gap-1" onClick={() => setShowConfirm(!showConfirm)}>
             {showConfirm ? <IoMdEyeOff className="text-blue-france" aria-hidden="true" /> : <IoMdEye className="text-blue-france" aria-hidden="true" />}
             <span className="text-blue-france text-xs font-bold">{showConfirm ? "CACHER" : "AFFICHER"}</span>
-          </div>
+          </button>
         </div>
         <input
           id="confirm-password"

--- a/app/src/scenes/broadcast/Api.jsx
+++ b/app/src/scenes/broadcast/Api.jsx
@@ -43,7 +43,7 @@ const Api = () => {
 
   const handleCopy = () => {
     navigator.clipboard.writeText(publisher.apikey);
-    toast.success("Lien copié");
+    toast.success("Clé copiée");
   };
 
   if (!publisher) return <p className="p-3">Chargement...</p>;

--- a/app/src/scenes/broadcast/Api.jsx
+++ b/app/src/scenes/broadcast/Api.jsx
@@ -92,12 +92,15 @@ const Api = () => {
         </div>
         <div className="flex flex-col gap-4 pt-6">
           <div className="flex items-center justify-between gap-4">
-            <p className="font-semibold sm:w-1/4">Exemple d'appel</p>
+            <p id="curl-example-label" className="font-semibold sm:w-1/4">
+              Exemple d'appel
+            </p>
           </div>
           <textarea
             className="border-blue-france-925 bg-blue-france-975 w-full rounded-none border px-4 py-2 font-mono text-sm read-only:opacity-80"
             rows={2}
             readOnly
+            aria-labelledby="curl-example-label"
             value={curl}
           />
         </div>

--- a/app/src/scenes/broadcast/moderation/components/Header.jsx
+++ b/app/src/scenes/broadcast/moderation/components/Header.jsx
@@ -39,7 +39,9 @@ const Header = ({ total, data, size, sort, selected, onSize, onSort, onSelect, o
               </button>
             </div>
           ) : (
-            <h2 className="text-xl font-semibold">{total.toLocaleString("fr")} missions diffusables</h2>
+            <h2 role="status" className="text-xl font-semibold">
+              {total.toLocaleString("fr")} missions diffusables
+            </h2>
           )}
           <div className="flex items-center gap-4">
             <span className="text-text-mention text-sm">{selected.length === 1 ? `1 sélectionnée` : `${selected.length} sélectionnées`}</span>
@@ -55,7 +57,9 @@ const Header = ({ total, data, size, sort, selected, onSize, onSort, onSelect, o
 
   return (
     <div className="mx-4 flex flex-wrap items-center justify-between gap-4 py-4 sm:mx-12">
-      <h2 className="text-xl font-semibold">{total.toLocaleString("fr")} missions diffusables</h2>
+      <h2 role="status" className="text-xl font-semibold">
+        {total.toLocaleString("fr")} missions diffusables
+      </h2>
 
       <div className="flex flex-wrap items-center gap-2">
         <label htmlFor="missions-per-page" className="text-text-mention text-xs">
@@ -117,7 +121,7 @@ const ManyUpdateModal = ({ onClose, selected, onChange }) => {
         Modérer
       </button>
 
-      <Modal open={open} onClose={() => setOpen(false)} title="Modérer les missions" className="min-w-3xl">
+      <Modal open={open} onClose={() => setOpen(false)} title="Modérer les missions" className="w-[90vw] max-w-3xl">
         <form onSubmit={handleSubmit}>
           <div className="flex items-center justify-center">
             <div className="flex w-full flex-col justify-center gap-4">

--- a/app/src/scenes/broadcast/moderation/components/MissionItem.jsx
+++ b/app/src/scenes/broadcast/moderation/components/MissionItem.jsx
@@ -74,9 +74,13 @@ const MissionItem = ({ data, history, selected, onChange, onSelect, onFilter, on
           </label>
 
           <div className="flex flex-1 flex-col justify-between py-2">
-            <div className="hover:text-blue-france my-2 line-clamp-3 flex items-center text-base font-semibold hover:cursor-pointer" onClick={handleMissionClick}>
+            <button
+              type="button"
+              className="hover:text-blue-france my-2 line-clamp-3 flex items-center text-left text-base font-semibold hover:cursor-pointer"
+              onClick={handleMissionClick}
+            >
               {data.title || data.missionTitle}
-            </div>
+            </button>
             <div className="text-text-mention mb-2 flex items-center gap-4 text-xs">
               {data.missionCity && (
                 <span className="flex items-center">

--- a/app/src/scenes/broadcast/moderation/components/MissionItem.jsx
+++ b/app/src/scenes/broadcast/moderation/components/MissionItem.jsx
@@ -1,6 +1,6 @@
 import { toast } from "@/services/toast";
 import { Menu, Transition } from "@headlessui/react";
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useEffect, useId, useState } from "react";
 import { BsDot } from "react-icons/bs";
 import { RiCalendarEventFill, RiCheckboxCircleFill, RiCloseCircleFill, RiMapPin2Fill, RiMoreFill, RiPencilFill, RiTimeLine } from "react-icons/ri";
 import { useSearchParams } from "react-router-dom";
@@ -70,7 +70,7 @@ const MissionItem = ({ data, history, selected, onChange, onSelect, onFilter, on
         <div className="flex items-center">
           <label className="flex w-14 items-center">
             <span className="sr-only">Sélectionner la mission</span>
-            <input type="checkbox" className="checkbox" name="moderation-select" onChange={handleSelectModeration} checked={selected} />
+            <input type="checkbox" className="checkbox" onChange={handleSelectModeration} checked={selected} />
           </label>
 
           <div className="flex flex-1 flex-col justify-between py-2">
@@ -130,6 +130,7 @@ const MissionItem = ({ data, history, selected, onChange, onSelect, onFilter, on
               className="select flex-1 border-b-2 pr-2"
               style={{ borderBottomColor: STATUS_COLORS[values.status] }}
               name="status"
+              aria-label="Statut de la mission"
               value={values.status}
               onChange={(e) => handleSubmit({ status: e.target.value })}
             >
@@ -142,7 +143,13 @@ const MissionItem = ({ data, history, selected, onChange, onSelect, onFilter, on
             <MissionActionsMenu data={data} onFilter={onFilter} onChange={(v) => onChange({ ...data, ...v })} />
           </div>
           {values.status === "REFUSED" && (
-            <select className="select mt-4 w-full border-b-2" name="motif" value={values.comment} onChange={(e) => handleSubmit({ status: "REFUSED", comment: e.target.value })}>
+            <select
+              className="select mt-4 w-full border-b-2"
+              name="motif"
+              aria-label="Motif de refus"
+              value={values.comment}
+              onChange={(e) => handleSubmit({ status: "REFUSED", comment: e.target.value })}
+            >
               <option value="">Motif de refus</option>
               {Object.entries(JVA_MODERATION_COMMENTS_LABELS).map(([key, value]) => (
                 <option key={key} value={key} className="whitespace-nowrap text-black">
@@ -241,6 +248,7 @@ const MissionActionsMenu = ({ data, onFilter, onChange }) => {
 
 const UpdateNoteModal = ({ open, onChange, onClose, data }) => {
   const { publisher } = useStore();
+  const noteId = useId();
   const [note, setNote] = useState(data.note || "");
 
   useEffect(() => {
@@ -268,10 +276,10 @@ const UpdateNoteModal = ({ open, onChange, onClose, data }) => {
         <div className="flex items-center justify-center">
           <div className="flex w-full flex-col justify-center gap-4">
             <div className="flex flex-col gap-1">
-              <label htmlFor="note" className="text-sm">
+              <label htmlFor={noteId} className="text-sm">
                 Note
               </label>
-              <textarea id="note" className="input" rows={4} name="note" value={note} onChange={(e) => setNote(e.target.value)} required />
+              <textarea id={noteId} className="input" rows={4} name="note" value={note} onChange={(e) => setNote(e.target.value)} required />
               <div className="mt-6 flex justify-end">
                 <button className="primary-btn w-full" type="submit">
                   Enregistrer

--- a/app/src/scenes/broadcast/moderation/components/MissionItem.jsx
+++ b/app/src/scenes/broadcast/moderation/components/MissionItem.jsx
@@ -271,7 +271,7 @@ const UpdateNoteModal = ({ open, onChange, onClose, data }) => {
   };
 
   return (
-    <Modal open={open} onClose={onClose} title="Modifier la note" className="min-w-3xl">
+    <Modal open={open} onClose={onClose} title="Modifier la note" className="w-[90vw] max-w-3xl">
       <form onSubmit={handleSubmit}>
         <div className="flex items-center justify-center">
           <div className="flex w-full flex-col justify-center gap-4">

--- a/app/src/scenes/broadcast/moderation/components/OrganizationRefusedModal.jsx
+++ b/app/src/scenes/broadcast/moderation/components/OrganizationRefusedModal.jsx
@@ -47,7 +47,7 @@ const OrganizationRefusedModal = ({ open, onClose, data, update, onChange, total
   };
 
   return (
-    <Modal open={open} onClose={onClose} className="min-w-3xl" title="Refuser les autres missions de cette organisation">
+    <Modal open={open} onClose={onClose} className="w-[90vw] max-w-3xl" title="Refuser les autres missions de cette organisation">
       <p className="text-sm text-black">
         Vous venez de refuser une mission de l’organisation <b>{data.missionOrganizationName}</b> avec le motif <b>{JVA_MODERATION_COMMENTS_LABELS[update.comment]}</b>.
       </p>

--- a/app/src/scenes/broadcast/moderation/components/SettingsModal.jsx
+++ b/app/src/scenes/broadcast/moderation/components/SettingsModal.jsx
@@ -33,8 +33,8 @@ const SettingsModal = () => {
               </select>
             </div>
             <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" defaultValue="6 mois" readOnly />
-              <input className="input" type="text" defaultValue="À modérer" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="6 mois" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="À modérer" readOnly />
             </div>
           </fieldset>
           <div className="border-grey-border my-4 border-t" />
@@ -57,8 +57,8 @@ const SettingsModal = () => {
               </select>
             </div>
             <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" defaultValue="Refusée" readOnly />
-              <input className="input" type="text" defaultValue="La mission est refusée car la date de création est trop ancienne (> 6 mois)" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="Refusée" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="La mission est refusée car la date de création est trop ancienne (> 6 mois)" readOnly />
             </div>
           </fieldset>
         </div>
@@ -88,9 +88,9 @@ const SettingsModal = () => {
               </select>
             </div>
             <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" defaultValue="7 jours" readOnly />
-              <input className="input" type="text" defaultValue="21 jours" readOnly />
-              <input className="input" type="text" defaultValue="À modérer" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="7 jours" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="21 jours" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="À modérer" readOnly />
             </div>
           </fieldset>
           <div className="border-grey-border my-4 border-t" />
@@ -113,8 +113,8 @@ const SettingsModal = () => {
               </select>
             </div>
             <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" defaultValue="Refusée" readOnly />
-              <input className="input" type="text" defaultValue="La date de la mission n’est pas compatible avec le recrutement de bénévoles" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="Refusée" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="La date de la mission n’est pas compatible avec le recrutement de bénévoles" readOnly />
             </div>
           </fieldset>
         </div>
@@ -138,8 +138,8 @@ const SettingsModal = () => {
               </select>
             </div>
             <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" defaultValue="300 caractères" readOnly />
-              <input className="input" type="text" defaultValue="À modérer" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="300 caractères" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="À modérer" readOnly />
             </div>
           </fieldset>
           <div className="border-grey-border my-4 border-t" />
@@ -162,8 +162,8 @@ const SettingsModal = () => {
               </select>
             </div>
             <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" defaultValue="Refusée" readOnly />
-              <input className="input" type="text" defaultValue="Le contenu est insuffisant / non qualitatif" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="Refusée" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="Le contenu est insuffisant / non qualitatif" readOnly />
             </div>
           </fieldset>
         </div>
@@ -188,7 +188,7 @@ const SettingsModal = () => {
             </div>
             <div className="flex flex-1 flex-col gap-2">
               <div className="h-9" />
-              <input className="input" type="text" defaultValue="À modérer" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="À modérer" readOnly />
             </div>
           </fieldset>
           <div className="border-grey-border my-4 border-t" />
@@ -212,8 +212,8 @@ const SettingsModal = () => {
             </div>
 
             <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" defaultValue="Refusée" readOnly />
-              <input className="input" type="text" defaultValue="Le contenu est insuffisant / non qualitatif" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="Refusée" readOnly />
+              <input className="input" type="text" aria-label="Valeur" defaultValue="Le contenu est insuffisant / non qualitatif" readOnly />
             </div>
           </fieldset>
         </div>

--- a/app/src/scenes/broadcast/moderation/components/SettingsModal.jsx
+++ b/app/src/scenes/broadcast/moderation/components/SettingsModal.jsx
@@ -14,21 +14,21 @@ const SettingsModal = () => {
 
       <Modal open={open} onClose={() => setOpen(false)} className="min-w-5xl" title="Paramétrages de la modération automatique">
         <div className="border-grey-border mb-10 flex flex-col border p-4">
-          <fieldset className="flex items-start gap-3">
-            <legend className="w-[20%] text-lg">Conditions</legend>
+          <div className="flex items-start gap-3">
+            <div className="w-[20%] text-lg">Conditions</div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="createdAt">
                 <option value="">createdAt</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="modération">
                 <option value="">modération</option>
               </select>
             </div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="supérieure à">
                 <option value="">supérieure à</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="égale à">
                 <option value="">égale à</option>
               </select>
             </div>
@@ -36,23 +36,23 @@ const SettingsModal = () => {
               <input className="input" type="text" aria-label="Valeur" defaultValue="6 mois" readOnly />
               <input className="input" type="text" aria-label="Valeur" defaultValue="À modérer" readOnly />
             </div>
-          </fieldset>
+          </div>
           <div className="border-grey-border my-4 border-t" />
-          <fieldset className="flex items-start gap-3">
-            <legend className="w-[20%] text-lg">Action</legend>
+          <div className="flex items-start gap-3">
+            <div className="w-[20%] text-lg">Action</div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="modération">
                 <option value="">modération</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="motif">
                 <option value="">motif</option>
               </select>
             </div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="égale à">
                 <option value="">égale à</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="égale à">
                 <option value="">égale à</option>
               </select>
             </div>
@@ -60,30 +60,30 @@ const SettingsModal = () => {
               <input className="input" type="text" aria-label="Valeur" defaultValue="Refusée" readOnly />
               <input className="input" type="text" aria-label="Valeur" defaultValue="La mission est refusée car la date de création est trop ancienne (> 6 mois)" readOnly />
             </div>
-          </fieldset>
+          </div>
         </div>
         <div className="border-grey-border flex flex-col border p-4">
-          <fieldset className="flex items-start gap-3">
-            <legend className="w-[20%] text-lg">Conditions</legend>
+          <div className="flex items-start gap-3">
+            <div className="w-[20%] text-lg">Conditions</div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="startAt">
                 <option value="">startAt</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="endAt">
                 <option value="">endAt</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="modération">
                 <option value="">modération</option>
               </select>
             </div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="inférieur à">
                 <option value="">inférieur à</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="inférieur à">
                 <option value="">inférieur à</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="égale à">
                 <option value="">égale à</option>
               </select>
             </div>
@@ -92,23 +92,23 @@ const SettingsModal = () => {
               <input className="input" type="text" aria-label="Valeur" defaultValue="21 jours" readOnly />
               <input className="input" type="text" aria-label="Valeur" defaultValue="À modérer" readOnly />
             </div>
-          </fieldset>
+          </div>
           <div className="border-grey-border my-4 border-t" />
-          <fieldset className="flex items-start gap-3">
-            <legend className="w-[20%] text-lg">Action</legend>
+          <div className="flex items-start gap-3">
+            <div className="w-[20%] text-lg">Action</div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="modération">
                 <option value="">modération</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="motif">
                 <option value="">motif</option>
               </select>
             </div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="égale à">
                 <option value="">égale à</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="égale à">
                 <option value="">égale à</option>
               </select>
             </div>
@@ -116,24 +116,24 @@ const SettingsModal = () => {
               <input className="input" type="text" aria-label="Valeur" defaultValue="Refusée" readOnly />
               <input className="input" type="text" aria-label="Valeur" defaultValue="La date de la mission n’est pas compatible avec le recrutement de bénévoles" readOnly />
             </div>
-          </fieldset>
+          </div>
         </div>
         <div className="border-grey-border flex flex-col border p-4">
-          <fieldset className="flex items-start gap-3">
-            <legend className="w-[20%] text-lg">Conditions</legend>
+          <div className="flex items-start gap-3">
+            <div className="w-[20%] text-lg">Conditions</div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="description">
                 <option value="">description</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="modération">
                 <option value="">modération</option>
               </select>
             </div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="inférieur à">
                 <option value="">inférieur à</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="égale à">
                 <option value="">égale à</option>
               </select>
             </div>
@@ -141,23 +141,23 @@ const SettingsModal = () => {
               <input className="input" type="text" aria-label="Valeur" defaultValue="300 caractères" readOnly />
               <input className="input" type="text" aria-label="Valeur" defaultValue="À modérer" readOnly />
             </div>
-          </fieldset>
+          </div>
           <div className="border-grey-border my-4 border-t" />
-          <fieldset className="flex items-start gap-3">
-            <legend className="w-[20%] text-lg">Action</legend>
+          <div className="flex items-start gap-3">
+            <div className="w-[20%] text-lg">Action</div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="modération">
                 <option value="">modération</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="motif">
                 <option value="">motif</option>
               </select>
             </div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="égale à">
                 <option value="">égale à</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="égale à">
                 <option value="">égale à</option>
               </select>
             </div>
@@ -165,24 +165,24 @@ const SettingsModal = () => {
               <input className="input" type="text" aria-label="Valeur" defaultValue="Refusée" readOnly />
               <input className="input" type="text" aria-label="Valeur" defaultValue="Le contenu est insuffisant / non qualitatif" readOnly />
             </div>
-          </fieldset>
+          </div>
         </div>
         <div className="border-grey-border flex flex-col border p-4">
-          <fieldset className="flex items-start gap-3">
-            <legend className="w-[20%] text-lg">Conditions</legend>
+          <div className="flex items-start gap-3">
+            <div className="w-[20%] text-lg">Conditions</div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="city">
                 <option value="">city</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="modération">
                 <option value="">modération</option>
               </select>
             </div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="n'hexiste pas">
                 <option value="">n'hexiste pas</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="égale à">
                 <option value="">égale à</option>
               </select>
             </div>
@@ -190,23 +190,23 @@ const SettingsModal = () => {
               <div className="h-9" />
               <input className="input" type="text" aria-label="Valeur" defaultValue="À modérer" readOnly />
             </div>
-          </fieldset>
+          </div>
           <div className="border-grey-border my-4 border-t" />
-          <fieldset className="flex items-start gap-3">
-            <legend className="w-[20%] text-lg">Action</legend>
+          <div className="flex items-start gap-3">
+            <div className="w-[20%] text-lg">Action</div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="modération">
                 <option value="">modération</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="motif">
                 <option value="">motif</option>
               </select>
             </div>
             <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="égale à">
                 <option value="">égale à</option>
               </select>
-              <select className="select" disabled defaultValue="">
+              <select className="select" disabled defaultValue="" aria-label="égale à">
                 <option value="">égale à</option>
               </select>
             </div>
@@ -215,7 +215,7 @@ const SettingsModal = () => {
               <input className="input" type="text" aria-label="Valeur" defaultValue="Refusée" readOnly />
               <input className="input" type="text" aria-label="Valeur" defaultValue="Le contenu est insuffisant / non qualitatif" readOnly />
             </div>
-          </fieldset>
+          </div>
         </div>
       </Modal>
     </>

--- a/app/src/scenes/broadcast/moderation/components/SettingsModal.jsx
+++ b/app/src/scenes/broadcast/moderation/components/SettingsModal.jsx
@@ -2,6 +2,77 @@ import Modal from "@/components/Modal";
 import { useState } from "react";
 import { RiSettings3Fill } from "react-icons/ri";
 
+const RULES = [
+  {
+    conditions: [
+      { field: "createdAt", operator: "supérieure à", value: "6 mois" },
+      { field: "modération", operator: "égale à", value: "À modérer" },
+    ],
+    action: [
+      { field: "modération", operator: "égale à", value: "Refusée" },
+      { field: "motif", operator: "égale à", value: "La mission est refusée car la date de création est trop ancienne (> 6 mois)" },
+    ],
+  },
+  {
+    conditions: [
+      { field: "startAt", operator: "inférieur à", value: "7 jours" },
+      { field: "endAt", operator: "inférieur à", value: "21 jours" },
+      { field: "modération", operator: "égale à", value: "À modérer" },
+    ],
+    action: [
+      { field: "modération", operator: "égale à", value: "Refusée" },
+      { field: "motif", operator: "égale à", value: "La date de la mission n’est pas compatible avec le recrutement de bénévoles" },
+    ],
+  },
+  {
+    conditions: [
+      { field: "description", operator: "inférieur à", value: "300 caractères" },
+      { field: "modération", operator: "égale à", value: "À modérer" },
+    ],
+    action: [
+      { field: "modération", operator: "égale à", value: "Refusée" },
+      { field: "motif", operator: "égale à", value: "Le contenu est insuffisant / non qualitatif" },
+    ],
+  },
+  {
+    conditions: [
+      { field: "city", operator: "n'hexiste pas", value: null },
+      { field: "modération", operator: "égale à", value: "À modérer" },
+    ],
+    action: [
+      { field: "modération", operator: "égale à", value: "Refusée" },
+      { field: "motif", operator: "égale à", value: "Le contenu est insuffisant / non qualitatif" },
+    ],
+  },
+];
+
+const RuleGroup = ({ title, titleId, rows }) => (
+  <div role="group" aria-labelledby={titleId} className="flex items-start gap-3">
+    <div id={titleId} className="w-[20%] text-lg">
+      {title}
+    </div>
+    <div className="flex w-[20%] flex-col gap-2">
+      {rows.map((row, i) => (
+        <select key={i} className="select" disabled defaultValue="" aria-label={row.field}>
+          <option value="">{row.field}</option>
+        </select>
+      ))}
+    </div>
+    <div className="flex w-[20%] flex-col gap-2">
+      {rows.map((row, i) => (
+        <select key={i} className="select" disabled defaultValue="" aria-label={row.operator}>
+          <option value="">{row.operator}</option>
+        </select>
+      ))}
+    </div>
+    <div className="flex flex-1 flex-col gap-2">
+      {rows.map((row, i) =>
+        row.value === null ? <div key={i} className="h-9" /> : <input key={i} className="input" type="text" aria-label="Valeur" defaultValue={row.value} readOnly />,
+      )}
+    </div>
+  </div>
+);
+
 const SettingsModal = () => {
   const [open, setOpen] = useState(false);
 
@@ -12,211 +83,14 @@ const SettingsModal = () => {
         <span>Paramétrage</span>
       </button>
 
-      <Modal open={open} onClose={() => setOpen(false)} className="min-w-5xl" title="Paramétrages de la modération automatique">
-        <div className="border-grey-border mb-10 flex flex-col border p-4">
-          <div className="flex items-start gap-3">
-            <div className="w-[20%] text-lg">Conditions</div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="createdAt">
-                <option value="">createdAt</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="modération">
-                <option value="">modération</option>
-              </select>
-            </div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="supérieure à">
-                <option value="">supérieure à</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="égale à">
-                <option value="">égale à</option>
-              </select>
-            </div>
-            <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" aria-label="Valeur" defaultValue="6 mois" readOnly />
-              <input className="input" type="text" aria-label="Valeur" defaultValue="À modérer" readOnly />
-            </div>
+      <Modal open={open} onClose={() => setOpen(false)} className="w-[90vw] max-w-5xl" title="Paramétrages de la modération automatique">
+        {RULES.map((rule, i) => (
+          <div key={i} className="border-grey-border mb-10 flex flex-col border p-4 last:mb-0">
+            <RuleGroup title="Conditions" titleId={`rule-${i}-conditions`} rows={rule.conditions} />
+            <div className="border-grey-border my-4 border-t" />
+            <RuleGroup title="Action" titleId={`rule-${i}-action`} rows={rule.action} />
           </div>
-          <div className="border-grey-border my-4 border-t" />
-          <div className="flex items-start gap-3">
-            <div className="w-[20%] text-lg">Action</div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="modération">
-                <option value="">modération</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="motif">
-                <option value="">motif</option>
-              </select>
-            </div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="égale à">
-                <option value="">égale à</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="égale à">
-                <option value="">égale à</option>
-              </select>
-            </div>
-            <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" aria-label="Valeur" defaultValue="Refusée" readOnly />
-              <input className="input" type="text" aria-label="Valeur" defaultValue="La mission est refusée car la date de création est trop ancienne (> 6 mois)" readOnly />
-            </div>
-          </div>
-        </div>
-        <div className="border-grey-border flex flex-col border p-4">
-          <div className="flex items-start gap-3">
-            <div className="w-[20%] text-lg">Conditions</div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="startAt">
-                <option value="">startAt</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="endAt">
-                <option value="">endAt</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="modération">
-                <option value="">modération</option>
-              </select>
-            </div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="inférieur à">
-                <option value="">inférieur à</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="inférieur à">
-                <option value="">inférieur à</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="égale à">
-                <option value="">égale à</option>
-              </select>
-            </div>
-            <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" aria-label="Valeur" defaultValue="7 jours" readOnly />
-              <input className="input" type="text" aria-label="Valeur" defaultValue="21 jours" readOnly />
-              <input className="input" type="text" aria-label="Valeur" defaultValue="À modérer" readOnly />
-            </div>
-          </div>
-          <div className="border-grey-border my-4 border-t" />
-          <div className="flex items-start gap-3">
-            <div className="w-[20%] text-lg">Action</div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="modération">
-                <option value="">modération</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="motif">
-                <option value="">motif</option>
-              </select>
-            </div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="égale à">
-                <option value="">égale à</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="égale à">
-                <option value="">égale à</option>
-              </select>
-            </div>
-            <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" aria-label="Valeur" defaultValue="Refusée" readOnly />
-              <input className="input" type="text" aria-label="Valeur" defaultValue="La date de la mission n’est pas compatible avec le recrutement de bénévoles" readOnly />
-            </div>
-          </div>
-        </div>
-        <div className="border-grey-border flex flex-col border p-4">
-          <div className="flex items-start gap-3">
-            <div className="w-[20%] text-lg">Conditions</div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="description">
-                <option value="">description</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="modération">
-                <option value="">modération</option>
-              </select>
-            </div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="inférieur à">
-                <option value="">inférieur à</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="égale à">
-                <option value="">égale à</option>
-              </select>
-            </div>
-            <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" aria-label="Valeur" defaultValue="300 caractères" readOnly />
-              <input className="input" type="text" aria-label="Valeur" defaultValue="À modérer" readOnly />
-            </div>
-          </div>
-          <div className="border-grey-border my-4 border-t" />
-          <div className="flex items-start gap-3">
-            <div className="w-[20%] text-lg">Action</div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="modération">
-                <option value="">modération</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="motif">
-                <option value="">motif</option>
-              </select>
-            </div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="égale à">
-                <option value="">égale à</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="égale à">
-                <option value="">égale à</option>
-              </select>
-            </div>
-            <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" aria-label="Valeur" defaultValue="Refusée" readOnly />
-              <input className="input" type="text" aria-label="Valeur" defaultValue="Le contenu est insuffisant / non qualitatif" readOnly />
-            </div>
-          </div>
-        </div>
-        <div className="border-grey-border flex flex-col border p-4">
-          <div className="flex items-start gap-3">
-            <div className="w-[20%] text-lg">Conditions</div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="city">
-                <option value="">city</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="modération">
-                <option value="">modération</option>
-              </select>
-            </div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="n'hexiste pas">
-                <option value="">n'hexiste pas</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="égale à">
-                <option value="">égale à</option>
-              </select>
-            </div>
-            <div className="flex flex-1 flex-col gap-2">
-              <div className="h-9" />
-              <input className="input" type="text" aria-label="Valeur" defaultValue="À modérer" readOnly />
-            </div>
-          </div>
-          <div className="border-grey-border my-4 border-t" />
-          <div className="flex items-start gap-3">
-            <div className="w-[20%] text-lg">Action</div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="modération">
-                <option value="">modération</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="motif">
-                <option value="">motif</option>
-              </select>
-            </div>
-            <div className="flex w-[20%] flex-col gap-2">
-              <select className="select" disabled defaultValue="" aria-label="égale à">
-                <option value="">égale à</option>
-              </select>
-              <select className="select" disabled defaultValue="" aria-label="égale à">
-                <option value="">égale à</option>
-              </select>
-            </div>
-
-            <div className="flex flex-1 flex-col gap-2">
-              <input className="input" type="text" aria-label="Valeur" defaultValue="Refusée" readOnly />
-              <input className="input" type="text" aria-label="Valeur" defaultValue="Le contenu est insuffisant / non qualitatif" readOnly />
-            </div>
-          </div>
-        </div>
+        ))}
       </Modal>
     </>
   );

--- a/app/src/scenes/broadcast/moderation/index.jsx
+++ b/app/src/scenes/broadcast/moderation/index.jsx
@@ -162,7 +162,7 @@ const Moderation = () => {
         <div className="pt-4">
           <div className="flex items-center gap-4">
             <Toggle aria-label="Activer la modération automatique" value={true} />
-            <label className="ml-2 font-semibold">Activer la modération automatique</label>
+            <span className="ml-2 font-semibold">Activer la modération automatique</span>
           </div>
           <div className="flex items-center justify-end">
             <SettingsModal />

--- a/app/src/scenes/broadcast/moderation/modal/components/Header.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/components/Header.jsx
@@ -77,6 +77,7 @@ const Header = ({ data, onChange }) => {
               className="select w-56 border-b-2 pr-2"
               style={{ borderBottomColor: STATUS_COLORS[values.status] }}
               name="status"
+              aria-label="Statut de la mission"
               value={values.status}
               onChange={(e) => handleChange({ status: e.target.value })}
             >
@@ -90,6 +91,7 @@ const Header = ({ data, onChange }) => {
               <select
                 className="select border-error w-64 border-b-2"
                 name="motif"
+                aria-label="Motif de refus"
                 value={values.comment}
                 onChange={(e) => handleChange({ status: "REFUSED", comment: e.target.value })}
               >

--- a/app/src/scenes/broadcast/moderation/modal/components/Header.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/components/Header.jsx
@@ -65,16 +65,16 @@ const Header = ({ data, onChange }) => {
   return (
     <>
       <OrganizationRefusedModal open={missionToRefuse > 0} onClose={() => setMissionToRefuse(0)} data={data} update={values} onChange={onChange} total={missionToRefuse} />
-      <div className="bg-global-background border-grey-border sticky top-0 z-50 flex items-center justify-between gap-8 border-b pt-4 pb-8">
-        <div className="max-w-[50%] space-y-2">
+      <div className="bg-global-background border-grey-border sticky top-0 z-50 flex flex-col gap-4 border-b pt-4 pb-8 md:flex-row md:items-center md:justify-between md:gap-8">
+        <div className="max-w-full space-y-2 md:max-w-[50%]">
           <h1 className="mb-1">{DOMAINS[data.missionDomain]}</h1>
           <h2 className="text-xl font-semibold">{data.title || data.missionTitle}</h2>
         </div>
 
         <div className="relative space-y-2 pt-4">
-          <div className="flex items-center justify-end gap-2">
+          <div className="flex flex-col items-stretch gap-2 md:flex-row md:flex-wrap md:items-center md:justify-end">
             <select
-              className="select w-56 border-b-2 pr-2"
+              className="select w-full border-b-2 pr-2 md:w-56"
               style={{ borderBottomColor: STATUS_COLORS[values.status] }}
               name="status"
               aria-label="Statut de la mission"
@@ -89,7 +89,7 @@ const Header = ({ data, onChange }) => {
             </select>
             {values.status === "REFUSED" && (
               <select
-                className="select border-error w-64 border-b-2"
+                className="select border-error w-full border-b-2 md:w-64"
                 name="motif"
                 aria-label="Motif de refus"
                 value={values.comment}
@@ -104,7 +104,7 @@ const Header = ({ data, onChange }) => {
               </select>
             )}
           </div>
-          <div className="absolute right-0 -bottom-6 w-screen text-right text-xs italic">
+          <div className="absolute right-0 -bottom-6 w-full text-right text-xs italic md:w-screen">
             {values.status === "REFUSED" && !values.comment ? "Veuillez renseigner un motif de refus pour sauvegarder le changement de statut" : ""}
           </div>
         </div>

--- a/app/src/scenes/broadcast/moderation/modal/components/HistoryTab.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/components/HistoryTab.jsx
@@ -2,10 +2,10 @@ import { Fragment, useEffect, useState } from "react";
 import { RiCheckboxCircleFill, RiCloseFill, RiTimeLine } from "react-icons/ri";
 
 import Loader from "@/components/Loader";
+import { JVA_MODERATION_COMMENTS_LABELS, STATUS } from "@/scenes/broadcast/moderation/components/Constants";
 import api from "@/services/api";
 import { captureError } from "@/services/error";
 import useStore from "@/services/store";
-import { JVA_MODERATION_COMMENTS_LABELS, STATUS } from "@/scenes/broadcast/moderation/components/Constants";
 
 const HistoryTab = ({ data }) => {
   const { publisher } = useStore();
@@ -40,7 +40,7 @@ const HistoryTab = ({ data }) => {
     );
 
   return (
-    <div className="p-8">
+    <div className="p-4 md:p-8">
       <h3 className="text-text-mention mb-4 text-xs font-bold uppercase">Évolution des statuts</h3>
       <div className="space-y-2">
         {status.length === 0 && modifications.length === 0 && <p className="text-text-mention text-center">Aucun événement de modération trouvé.</p>}

--- a/app/src/scenes/broadcast/moderation/modal/components/MissionTab.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/components/MissionTab.jsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
-import { RiErrorWarningFill, RiExternalLinkLine } from "react-icons/ri";
-import { Link } from "react-router-dom";
-import { toast } from "@/services/toast";
 import api from "@/services/api";
 import { captureError } from "@/services/error";
 import useStore from "@/services/store";
+import { toast } from "@/services/toast";
+import { useEffect, useState } from "react";
+import { RiErrorWarningFill, RiExternalLinkLine } from "react-icons/ri";
+import { Link } from "react-router-dom";
 
 const MissionTab = ({ data, onChange }) => {
   const { publisher } = useStore();
@@ -64,9 +64,7 @@ const MissionTab = ({ data, onChange }) => {
         </div>
         <div className="border-grey-border border-t" />
         <div className="flex flex-col space-y-2">
-          <label className="mb-2 text-sm" htmlFor="description">
-            Description
-          </label>
+          <p className="mb-2 text-sm">Description</p>
           <div
             className="text-text-mention border-grey-border overflow-hidden rounded-t border bg-gray-950 p-6 text-sm"
             dangerouslySetInnerHTML={{ __html: `<p>${data.missionDescription.replace(/\n/g, "</p><p>")}</p>` }}
@@ -74,34 +72,26 @@ const MissionTab = ({ data, onChange }) => {
         </div>
         <div className="border-grey-border border-t" />
         <div className="flex flex-col space-y-2 py-2">
-          <label className="text-sm" htmlFor="title">
-            Lieu de la mission
-          </label>
+          <p className="text-sm">Lieu de la mission</p>
           <p className="text-text-mention text-sm">
-          {data.missionDepartmentName} ({data.missionDepartmentCode})
+            {data.missionDepartmentName} ({data.missionDepartmentCode})
           </p>
         </div>
         <div className="border-grey-border border-t" />
         <div className="flex flex-col space-y-2 py-2">
-          <label className="text-sm" htmlFor="title">
-            Date de la mission
-          </label>
+          <p className="text-sm">Date de la mission</p>
           <p className="text-text-mention text-sm">À partir du {new Date(data.missionStartAt).toLocaleDateString("fr", { year: "numeric", month: "long", day: "numeric" })}</p>
         </div>
         <div className="border-grey-border border-t" />
         <div className="flex flex-col space-y-2 py-2">
-          <label className="text-sm" htmlFor="title">
-            Date de création
-          </label>
+          <p className="text-sm">Date de création</p>
           <p className="text-text-mention text-sm">
             Postée le {new Date(data.missionPostedAt).toLocaleDateString("fr")} sur {data.missionPublisherName}
           </p>
         </div>
         <div className="border-grey-border border-t" />
         <div className="flex flex-col space-y-2 py-2">
-          <label className="text-sm" htmlFor="title">
-            Lien de la mission
-          </label>
+          <p className="text-sm">Lien de la mission</p>
           <div className="flex items-center gap-2">
             <Link
               to={data.missionApplicationUrl.includes("http") ? data.missionApplicationUrl : `https://${data.missionApplicationUrl}`}
@@ -115,9 +105,7 @@ const MissionTab = ({ data, onChange }) => {
         </div>
         <div className="border-grey-border border-t" />
         <div className="flex flex-col space-y-2 py-2">
-          <label className="text-sm" htmlFor="title">
-            ID
-          </label>
+          <p className="text-sm">ID</p>
           <p className="text-text-mention text-sm">{data.missionId}</p>
         </div>
       </div>

--- a/app/src/scenes/broadcast/moderation/modal/components/MissionTab.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/components/MissionTab.jsx
@@ -45,14 +45,16 @@ const MissionTab = ({ data, onChange }) => {
             placeholder={data.missionTitle}
             value={title}
             onChange={(e) => setTitle(e.target.value)}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? "new-mission-title-error new-mission-title-hint" : "new-mission-title-hint"}
           />
           {error && (
-            <div className="text-error flex items-center text-sm">
-              <RiErrorWarningFill className="mr-2" aria-hidden="true" />
+            <p id="new-mission-title-error" className="text-error flex items-center text-sm" aria-live="polite">
+              <RiErrorWarningFill className="mr-2 shrink-0" aria-hidden="true" />
               {error}
-            </div>
+            </p>
           )}
-          <p className="text-text-mention text-xs">
+          <p id="new-mission-title-hint" className="text-text-mention text-xs">
             <span className="mr-1 font-semibold">Titre d'origine:</span>
             {data.missionTitle}
           </p>
@@ -64,7 +66,7 @@ const MissionTab = ({ data, onChange }) => {
         </div>
         <div className="border-grey-border border-t" />
         <div className="flex flex-col space-y-2">
-          <p className="mb-2 text-sm">Description</p>
+          <h3 className="mb-2 text-sm">Description</h3>
           <div
             className="text-text-mention border-grey-border overflow-hidden rounded-t border bg-gray-950 p-6 text-sm"
             dangerouslySetInnerHTML={{ __html: `<p>${data.missionDescription.replace(/\n/g, "</p><p>")}</p>` }}
@@ -72,26 +74,26 @@ const MissionTab = ({ data, onChange }) => {
         </div>
         <div className="border-grey-border border-t" />
         <div className="flex flex-col space-y-2 py-2">
-          <p className="text-sm">Lieu de la mission</p>
+          <h3 className="text-sm">Lieu de la mission</h3>
           <p className="text-text-mention text-sm">
             {data.missionDepartmentName} ({data.missionDepartmentCode})
           </p>
         </div>
         <div className="border-grey-border border-t" />
         <div className="flex flex-col space-y-2 py-2">
-          <p className="text-sm">Date de la mission</p>
+          <h3 className="text-sm">Date de la mission</h3>
           <p className="text-text-mention text-sm">À partir du {new Date(data.missionStartAt).toLocaleDateString("fr", { year: "numeric", month: "long", day: "numeric" })}</p>
         </div>
         <div className="border-grey-border border-t" />
         <div className="flex flex-col space-y-2 py-2">
-          <p className="text-sm">Date de création</p>
+          <h3 className="text-sm">Date de création</h3>
           <p className="text-text-mention text-sm">
             Postée le {new Date(data.missionPostedAt).toLocaleDateString("fr")} sur {data.missionPublisherName}
           </p>
         </div>
         <div className="border-grey-border border-t" />
         <div className="flex flex-col space-y-2 py-2">
-          <p className="text-sm">Lien de la mission</p>
+          <h3 className="text-sm">Lien de la mission</h3>
           <div className="flex items-center gap-2">
             <Link
               to={data.missionApplicationUrl.includes("http") ? data.missionApplicationUrl : `https://${data.missionApplicationUrl}`}
@@ -105,7 +107,7 @@ const MissionTab = ({ data, onChange }) => {
         </div>
         <div className="border-grey-border border-t" />
         <div className="flex flex-col space-y-2 py-2">
-          <p className="text-sm">ID</p>
+          <h3 className="text-sm">ID</h3>
           <p className="text-text-mention text-sm">{data.missionId}</p>
         </div>
       </div>

--- a/app/src/scenes/broadcast/moderation/modal/components/MissionTab.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/components/MissionTab.jsx
@@ -33,7 +33,7 @@ const MissionTab = ({ data, onChange }) => {
 
   return (
     <form className="flex divide-x pb-4" onSubmit={handleSubmit}>
-      <div className="flex w-full flex-col gap-4 p-8">
+      <div className="flex w-full flex-col gap-4 p-4 md:p-8">
         <div className="flex flex-col">
           <label className="mb-2 text-sm" htmlFor="new-mission-title">
             Nom de la mission

--- a/app/src/scenes/broadcast/moderation/modal/components/Organization.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/components/Organization.jsx
@@ -1,5 +1,5 @@
-import { RiCheckboxCircleFill, RiCloseCircleFill, RiFileCopyLine, RiPencilFill } from "react-icons/ri";
 import { toast } from "@/services/toast";
+import { RiCheckboxCircleFill, RiCloseCircleFill, RiFileCopyLine, RiPencilFill } from "react-icons/ri";
 
 const Organization = ({ data, history }) => {
   return (
@@ -9,11 +9,11 @@ const Organization = ({ data, history }) => {
         <h3 className="text-text-mention text-xs font-semibold">ORGANISATION</h3>
       </div>
       <div className="flex flex-col">
-        <span className="font-semibold">{data.organizationName}</span>
-        <span className="text-text-mention text-xs">
+        <p className="font-semibold">{data.organizationName}</p>
+        <p className="text-text-mention text-xs">
           Inscrite sur
           {/* TODO: Add association sources */}
-        </span>
+        </p>
       </div>
       <div>
         <div className="border-grey-border my-2 inline-flex flex-wrap items-center gap-1 rounded border p-2">
@@ -29,28 +29,34 @@ const Organization = ({ data, history }) => {
         <div className="flex items-center gap-6">
           <span className="text-text-mention text-xs">SIREN</span>
           <span className="text-text-mention text-xs">{data.missionOrganizationSirenVerified || "/"}</span>
-          <RiFileCopyLine
-            className="text-text-mention text-xs hover:cursor-pointer"
-            aria-hidden="true"
+          <button
+            type="button"
+            className="text-text-mention text-xs hover:cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Copier le SIREN"
+            disabled={!data.missionOrganizationSirenVerified}
             onClick={() => {
-              if (!data.missionOrganizationSirenVerified) return;
               navigator.clipboard.writeText(data.missionOrganizationSirenVerified);
               toast.success("Copié dans le presse-papier");
             }}
-          />
+          >
+            <RiFileCopyLine aria-hidden="true" />
+          </button>
         </div>
         <div className="flex items-center gap-6">
           <span className="text-text-mention text-xs">RNA</span>
           <span className="text-text-mention text-xs">{data.missionOrganizationRNAVerified || "/"}</span>
-          <RiFileCopyLine
-            className="text-text-mention text-xs hover:cursor-pointer"
-            aria-hidden="true"
+          <button
+            type="button"
+            className="text-text-mention text-xs hover:cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Copier le RNA"
+            disabled={!data.missionOrganizationRNAVerified}
             onClick={() => {
-              if (!data.missionOrganizationRNAVerified) return;
               navigator.clipboard.writeText(data.missionOrganizationRNAVerified);
               toast.success("Copié dans le presse-papier");
             }}
-          />
+          >
+            <RiFileCopyLine aria-hidden="true" />
+          </button>
         </div>
       </div>
     </div>

--- a/app/src/scenes/broadcast/moderation/modal/components/OrganizationTab.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/components/OrganizationTab.jsx
@@ -75,7 +75,7 @@ const OrganizationTab = ({ data, onChange }) => {
   return (
     <>
       <form className="flex h-full divide-x" onSubmit={handleSubmit}>
-        <div className="flex flex-1 flex-col gap-2 p-8">
+        <div className="flex flex-1 flex-col gap-2 p-4 md:p-8">
           <div className="flex flex-col gap-2">
             <label className="text-sm" htmlFor="organization-name">
               Nom de l'organisation

--- a/app/src/scenes/broadcast/moderation/modal/components/OrganizationTab.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/components/OrganizationTab.jsx
@@ -133,29 +133,21 @@ const OrganizationTab = ({ data, onChange }) => {
             </button>
           )}
           <div className="border-grey-border flex flex-col gap-2 border-t py-4">
-            <label className="text-sm" htmlFor="title">
-              Adresse
-            </label>
+            <h3 className="text-sm">Adresse</h3>
             <p className="text-text-mention text-sm">{data.missionOrganizationFullAddress ? data.missionOrganizationFullAddress : "/"}</p>
           </div>
           <div className="border-grey-border flex flex-col gap-2 border-t py-4">
-            <label className="text-sm" htmlFor="title">
-              Domaine d'action
-            </label>
+            <h3 className="text-sm">Domaine d'action</h3>
             <p className="text-text-mention text-sm">{DOMAINS[data.missionDomain]}</p>
           </div>
           <div className="border-grey-border flex flex-col gap-2 border-t py-4">
-            <label className="text-sm" htmlFor="title">
-              Organisation déjà inscrite sur
-            </label>
+            <h3 className="text-sm">Organisation déjà inscrite sur</h3>
             <p className="text-text-mention text-sm">
               {/* {data.associationSources?.length ? data.associationSources.map((s) => (s === "Je veux aider" ? "JeVeuxAider.gouv.fr" : s)).join(", ") : "/"} */}
             </p>
           </div>
           <div className="border-grey-border flex flex-col gap-2 border-t py-4">
-            <label className="text-sm" htmlFor="title">
-              Site internet
-            </label>
+            <h3 className="text-sm">Site internet</h3>
             <a href={data.missionOrganizationUrl} className="text-blue-france text-sm underline" target="_blank">
               {data.missionOrganizationUrl}
             </a>

--- a/app/src/scenes/broadcast/moderation/modal/components/OrganizationTab.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/components/OrganizationTab.jsx
@@ -99,8 +99,9 @@ const OrganizationTab = ({ data, onChange }) => {
               getLabel={(o) => o?.label || ""}
               getValue={(o) => o?.siren || null}
               placeholder="SIREN"
+              ariaDescribedby="organization-siren-hint"
             />
-            <p className="text-text-mention text-xs">
+            <p id="organization-siren-hint" className="text-text-mention text-xs">
               <span className="mr-1 font-semibold">SIREN d'origine:</span>
               {data.missionOrganizationSiren ? data.missionOrganizationSiren : "/"}
             </p>
@@ -121,8 +122,9 @@ const OrganizationTab = ({ data, onChange }) => {
               getLabel={(o) => o?.label || ""}
               getValue={(o) => o?.rna || null}
               placeholder="RNA"
+              ariaDescribedby="organization-rna-hint"
             />
-            <p className="text-text-mention text-xs">
+            <p id="organization-rna-hint" className="text-text-mention text-xs">
               <span className="mr-1 font-semibold">RNA d'origine:</span>
               {data.missionOrganizationRNA ? data.missionOrganizationRNA : "/"}
             </p>

--- a/app/src/scenes/broadcast/moderation/modal/index.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/index.jsx
@@ -82,7 +82,7 @@ const MissionModal = ({ onChange }) => {
   };
 
   return (
-    <dialog ref={dialogRef} aria-labelledby="mission-modal-title" className="fixed inset-0 m-0 h-screen max-h-none w-screen max-w-none">
+    <dialog ref={dialogRef} aria-modal="true" aria-labelledby="mission-modal-title" className="fixed inset-0 m-0 h-screen max-h-none w-screen max-w-none">
       <div className="bg-global-background relative h-full w-full overflow-scroll">
         <div className="flex justify-end px-8 pt-4">
           <button type="button" className="p-3 text-xl text-black" onClick={handleClose} aria-label="Fermer">
@@ -90,15 +90,15 @@ const MissionModal = ({ onChange }) => {
           </button>
         </div>
         <div className="mb-16 flex flex-col gap-4 px-8">
+          <p id="mission-modal-title" className="sr-only">
+            Détails de la mission
+          </p>
           {!data ? (
             <div className="flex justify-center py-10">
               <Loader />
             </div>
           ) : (
             <div className="max-h-full overflow-y-auto px-20">
-              <p id="mission-modal-title" className="sr-only">
-                Détails de la mission
-              </p>
               <Header
                 data={data}
                 onChange={(v) => {

--- a/app/src/scenes/broadcast/moderation/modal/index.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/index.jsx
@@ -84,12 +84,12 @@ const MissionModal = ({ onChange }) => {
   return (
     <dialog ref={dialogRef} aria-modal="true" aria-labelledby="mission-modal-title" className="fixed inset-0 m-0 h-screen max-h-none w-screen max-w-none">
       <div className="bg-global-background relative h-full w-full overflow-scroll">
-        <div className="flex justify-end px-8 pt-4">
+        <div className="flex justify-end px-4 pt-4 md:px-8">
           <button type="button" className="p-3 text-xl text-black" onClick={handleClose} aria-label="Fermer">
             <RiCloseFill aria-hidden="true" />
           </button>
         </div>
-        <div className="mb-16 flex flex-col gap-4 px-8">
+        <div className="mb-16 flex flex-col gap-4 px-4 md:px-8">
           <p id="mission-modal-title" className="sr-only">
             Détails de la mission
           </p>
@@ -98,7 +98,7 @@ const MissionModal = ({ onChange }) => {
               <Loader />
             </div>
           ) : (
-            <div className="max-h-full overflow-y-auto px-20">
+            <div className="max-h-full overflow-y-auto px-0 lg:px-20">
               <Header
                 data={data}
                 onChange={(v) => {
@@ -112,13 +112,13 @@ const MissionModal = ({ onChange }) => {
               />
 
               <div className="mt-8 flex w-full flex-1 flex-col">
-                <div role="tablist" aria-label="Onglets de modération" className="flex items-center space-x-2 pl-4 font-semibold text-black">
+                <div role="tablist" aria-label="Onglets de modération" className="flex items-center space-x-2 pl-0 font-semibold text-black md:pl-4">
                   <Tab name="mission" title="Mission" tab={tab} setTab={setTab} />
                   <Tab name="organization" title="Organisation" tab={tab} setTab={setTab} />
                   <Tab name="history" title="Historique" tab={tab} setTab={setTab} />
                 </div>
-                <div className="mb-12 grid w-full grid-cols-3 gap-6">
-                  <div className="border-grey-border col-span-2 border bg-white">
+                <div className="mb-12 grid w-full grid-cols-1 gap-6 lg:grid-cols-3">
+                  <div className="border-grey-border border bg-white lg:col-span-2">
                     {
                       {
                         mission: (

--- a/app/src/scenes/broadcast/moderation/modal/index.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/index.jsx
@@ -3,6 +3,7 @@ import { RiCloseFill } from "react-icons/ri";
 import { useSearchParams } from "react-router-dom";
 
 import Loader from "@/components/Loader";
+import Tabs from "@/components/Tabs";
 import Header from "@/scenes/broadcast/moderation/modal/components/Header";
 import HistoryTab from "@/scenes/broadcast/moderation/modal/components/HistoryTab";
 import MissionTab from "@/scenes/broadcast/moderation/modal/components/MissionTab";
@@ -81,6 +82,13 @@ const MissionModal = ({ onChange }) => {
     setSearchParams(newSearchParams);
   };
 
+  const tabs = [
+    { key: "mission", label: "Mission" },
+    { key: "organization", label: "Organisation" },
+    { key: "history", label: "Historique" },
+  ].map((t) => ({ ...t, id: `mission-modal-tab-${t.key}`, isActive: tab === t.key, onSelect: () => setTab(t.key) }));
+  const activeTabId = `mission-modal-tab-${tab}`;
+
   return (
     <dialog ref={dialogRef} aria-modal="true" aria-labelledby="mission-modal-title" className="fixed inset-0 m-0 h-screen max-h-none w-screen max-w-none">
       <div className="bg-global-background relative h-full w-full overflow-scroll">
@@ -112,13 +120,15 @@ const MissionModal = ({ onChange }) => {
               />
 
               <div className="mt-8 flex w-full flex-1 flex-col">
-                <div role="tablist" aria-label="Onglets de modération" className="flex items-center space-x-2 pl-0 font-semibold text-black md:pl-4">
-                  <Tab name="mission" title="Mission" tab={tab} setTab={setTab} />
-                  <Tab name="organization" title="Organisation" tab={tab} setTab={setTab} />
-                  <Tab name="history" title="Historique" tab={tab} setTab={setTab} />
-                </div>
+                <Tabs
+                  tabs={tabs}
+                  ariaLabel="Onglets de modération"
+                  panelId="mission-modal-panel"
+                  className="flex items-center gap-2 pl-0 font-semibold text-black md:pl-4"
+                  variant="primary"
+                />
                 <div className="mb-12 grid w-full grid-cols-1 gap-6 lg:grid-cols-3">
-                  <div className="border-grey-border border bg-white lg:col-span-2">
+                  <div id="mission-modal-panel" role="tabpanel" aria-labelledby={activeTabId} tabIndex={0} className="border-grey-border border bg-white lg:col-span-2">
                     {
                       {
                         mission: (
@@ -161,34 +171,6 @@ const MissionModal = ({ onChange }) => {
         </div>
       </div>
     </dialog>
-  );
-};
-
-const Tab = ({ name, title, tab, setTab, actives }) => {
-  const [active, setActive] = useState(false);
-
-  useEffect(() => {
-    if (actives && actives.includes(tab)) {
-      setActive(true);
-    } else if (tab === name) {
-      setActive(true);
-    } else {
-      setActive(false);
-    }
-  }, [tab]);
-
-  return (
-    <button
-      type="button"
-      role="tab"
-      aria-selected={active}
-      onClick={() => setTab(name)}
-      className={`${
-        active ? "border-blue-france text-blue-france hover:bg-gray-975 border-t-2 bg-white" : "bg-blue-france-925 hover:bg-blue-france-925-hover border-0"
-      } border-x-grey-border flex translate-y-px cursor-pointer items-center border-x px-4 py-2`}
-    >
-      {title}
-    </button>
   );
 };
 

--- a/app/src/scenes/campaign/Create.jsx
+++ b/app/src/scenes/campaign/Create.jsx
@@ -123,7 +123,7 @@ const CopyModal = ({ open, campaignId, onClose }) => {
         onClose();
         navigate(`/broadcast/campaign/${campaignId}`);
       }}
-      className="min-w-3xl"
+      className="w-[90vw] max-w-3xl"
       title="Votre campagne est créée !"
     >
       <p className="text-base">Pour commencer à diffuser des missions et suivre les statistiques, insérez ce lien dans le contenu de votre campagne.</p>

--- a/app/src/scenes/campaign/Edit.jsx
+++ b/app/src/scenes/campaign/Edit.jsx
@@ -226,7 +226,7 @@ const CampaignMenu = ({ setIsReassignModalOpen, handleDelete }) => {
   return (
     <Dropdown
       renderTrigger={({ onClick }) => (
-        <button className="tertiary-btn flex items-center" onClick={onClick}>
+        <button className="tertiary-btn flex items-center" onClick={onClick} aria-label="Plus d'actions">
           <RiMoreLine className="text-xl" aria-hidden="true" />
         </button>
       )}

--- a/app/src/scenes/mission/View.jsx
+++ b/app/src/scenes/mission/View.jsx
@@ -27,8 +27,7 @@ const formatDateTime = (date) => (date ? new Date(date).toLocaleString("fr").rep
 
 const formatScore = (value) => (typeof value === "number" ? value.toLocaleString("fr", { maximumFractionDigits: 2 }) : "N/A");
 
-const formatConfidence = (value) =>
-  typeof value === "number" ? `${(value * 100).toLocaleString("fr", { maximumFractionDigits: 0 })} %` : "N/A";
+const formatConfidence = (value) => (typeof value === "number" ? `${(value * 100).toLocaleString("fr", { maximumFractionDigits: 0 })} %` : "N/A");
 
 const AdminDataTable = ({ caption, emptyMessage, headers, rows, renderRow }) => {
   if (!rows?.length) {
@@ -117,11 +116,32 @@ const View = () => {
   const technicalTabs = [
     ...(isAdmin
       ? [
-          { key: "enrichment", label: "🧠 Enrichissement" },
-          { key: "scoring", label: "🎯 Scoring" },
+          {
+            key: "enrichment",
+            label: (
+              <>
+                <span aria-hidden="true">🧠</span> Enrichissement
+              </>
+            ),
+          },
+          {
+            key: "scoring",
+            label: (
+              <>
+                <span aria-hidden="true">🎯</span> Scoring
+              </>
+            ),
+          },
         ]
       : []),
-    { key: "raw", label: "🧾 Données brutes" },
+    {
+      key: "raw",
+      label: (
+        <>
+          <span aria-hidden="true">🧾</span> Données brutes
+        </>
+      ),
+    },
   ].map((tab) => ({
     ...tab,
     id: `mission-technical-tab-${tab.key}`,
@@ -272,7 +292,7 @@ const View = () => {
                     )}
                   </div>
                   <button className="secondary-btn shrink-0" type="button" disabled={triggeringTask !== null} onClick={() => handleTriggerTask("enrichment")}>
-                    🧠 Relancer l&apos;enrichment
+                    <span aria-hidden="true">🧠</span> Relancer l&apos;enrichment
                   </button>
                 </div>
                 {mission.adminEnrichment && (
@@ -325,7 +345,7 @@ const View = () => {
                     )}
                   </div>
                   <button className="secondary-btn shrink-0" type="button" disabled={triggeringTask !== null} onClick={() => handleTriggerTask("scoring")}>
-                    🎯 Relancer le scoring
+                    <span aria-hidden="true">🎯</span> Relancer le scoring
                   </button>
                 </div>
                 {mission.adminScoring && (

--- a/app/src/scenes/my-missions/Flux.jsx
+++ b/app/src/scenes/my-missions/Flux.jsx
@@ -199,9 +199,9 @@ const Flux = ({ moderated }) => {
             <div className="flex flex-wrap items-center gap-2">
               <p className="text-text-mention text-base">Dernière synchronisation le {lastImport ? new Date(lastImport.startedAt).toLocaleDateString("fr") : "N/A"}</p>
               {lastImport && new Date(lastImport.startedAt) > new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() - 1) ? (
-                <RiCheckboxCircleFill role="img" aria-label="OK" className="text-success shrink-0 text-base" />
+                <RiCheckboxCircleFill role="img" aria-label="Synchronisation à jour" className="text-success shrink-0 text-base" />
               ) : (
-                <ErrorIconSvg role="img" aria-label="Erreur" className="fill-error h-4 w-4 shrink-0" />
+                <ErrorIconSvg role="img" aria-label="Synchronisation en retard" className="fill-error h-4 w-4 shrink-0" />
               )}
               <Link to="/settings" className="link whitespace-nowrap">
                 Paraméter mon flux de missions
@@ -242,9 +242,9 @@ const Flux = ({ moderated }) => {
               <td className="px-6">
                 <div className="flex items-center gap-1">
                   {item.statusCode === "ACCEPTED" ? (
-                    <RiCheckboxCircleFill role="img" aria-label="OK" className="text-success text-2xl" />
+                    <RiCheckboxCircleFill role="img" aria-label="Acceptée par l'API" className="text-success text-2xl" />
                   ) : (
-                    <ErrorIconSvg role="img" aria-label="Erreur" className="fill-error h-6 w-6" />
+                    <ErrorIconSvg role="img" aria-label="Non acceptée par l'API" className="fill-error h-6 w-6" />
                   )}
                   {item.statusComment ? (
                     <Tooltip

--- a/app/src/scenes/my-missions/Moderation.jsx
+++ b/app/src/scenes/my-missions/Moderation.jsx
@@ -4,6 +4,7 @@ import { RiCloseFill, RiInformationLine } from "react-icons/ri";
 import { Link } from "react-router-dom";
 
 import JvaLogoPng from "@/assets/img/jva-logo.png";
+import ChartDetailsTable from "@/components/ChartDetailsTable";
 import Loader from "@/components/Loader";
 import Pie, { colors } from "@/components/Pie";
 import SearchInput from "@/components/SearchInput";
@@ -232,9 +233,12 @@ const Moderation = () => {
           <div className="flex items-start">
             <h3 className="flex-1 text-lg font-bold">Répartition des missions par statut</h3>
           </div>
-          <div className="p-4">
-            <Pie data={stats.status} backgroundColor={colors} legendPosition="bottom" />
-          </div>
+          <figure className="m-0 p-4">
+            <div role="img" aria-label="Diagramme de la répartition des missions par statut - description détaillée ci-dessous" aria-describedby="status-pie-table">
+              <Pie data={stats.status} backgroundColor={colors} legendPosition="bottom" />
+            </div>
+            <ChartDetailsTable id="status-pie-table" title="Répartition des missions par statut" mode="sr-only" type="pie" data={stats.status} nameKey="key" dataKey="doc_count" />
+          </figure>
         </div>
         <div className="border-grey-border col-span-2 border p-4">
           <div className="flex items-start">

--- a/app/src/scenes/my-missions/index.jsx
+++ b/app/src/scenes/my-missions/index.jsx
@@ -2,11 +2,11 @@ import { useEffect, useState } from "react";
 import { Route, Routes, useLocation } from "react-router-dom";
 
 import Tabs from "@/components/Tabs";
+import Flux from "@/scenes/my-missions/Flux";
+import Moderation from "@/scenes/my-missions/Moderation";
 import api from "@/services/api";
 import { captureError } from "@/services/error";
 import useStore from "@/services/store";
-import Flux from "@/scenes/my-missions/Flux";
-import Moderation from "@/scenes/my-missions/Moderation";
 
 const MyMissions = () => {
   const { publisher } = useStore();
@@ -50,6 +50,8 @@ const MyMissions = () => {
     ...tab,
     id: `my-missions-tab-${tab.key}`,
   }));
+  const activeTab = tabs.find((tab) => tab.isActive) || tabs[0];
+  const activeTabId = activeTab ? activeTab.id : null;
 
   return (
     <div className="space-y-12">
@@ -57,7 +59,7 @@ const MyMissions = () => {
 
       <div>
         <Tabs tabs={tabs} ariaLabel="Vos missions" panelId="my-missions-panel" className="flex items-center gap-4 pl-4 font-semibold text-black" variant="primary" />
-        <section id="my-missions-panel" className="bg-white shadow-lg">
+        <section id="my-missions-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} tabIndex={0} className="bg-white shadow-lg">
           <Routes>
             <Route path="/" element={<Flux moderated={moderated} />} />
             <Route path="/moderated-mission" element={<Moderation />} />

--- a/app/src/scenes/performance/AnalyticsCard.jsx
+++ b/app/src/scenes/performance/AnalyticsCard.jsx
@@ -66,7 +66,7 @@ const AnalyticsCard = ({
   }
 
   return (
-    <div className="overflow-x-auto">
+    <div className="relative overflow-x-auto">
       <div className="min-w-[600px] space-y-4 p-0 sm:p-6">{content}</div>
     </div>
   );

--- a/app/src/scenes/performance/GlobalAnnounce.jsx
+++ b/app/src/scenes/performance/GlobalAnnounce.jsx
@@ -287,7 +287,7 @@ const Evolution = ({ filters }) => {
         <h2 className="text-3xl font-bold">Evolution</h2>
         <p className="text-text-mention text-base">Trafic reçu grâce à vos partenaires diffuseurs</p>
       </div>
-      <div className="border-grey-border overflow-x-auto border p-4">
+      <div className="border-grey-border relative overflow-x-auto border p-4">
         <Tabs tabs={tabs} ariaLabel="Trafic reçu grâce à vos partenaires diffuseurs" panelId="announce-evolution-panel" className="mb-6 gap-8 pb-2 text-sm" variant="underline" />
         <div id="announce-evolution-panel" role="tabpanel" tabIndex={0} aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
           {loading ? (
@@ -438,7 +438,7 @@ const Announcers = ({ filters }) => {
           <Loader />
         </div>
       ) : (
-        <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
+        <div className="border-grey-border relative space-y-4 overflow-x-auto border p-6">
           <Tabs tabs={tabs} ariaLabel="Top partenaires diffuseurs" panelId="announce-traffic-panel" className="mb-6 gap-8 pb-2 text-sm" variant="underline" />
           <div id="announce-traffic-panel" role="tabpanel" tabIndex={0} aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
             {!data.length ? (

--- a/app/src/scenes/performance/GlobalAnnounce.jsx
+++ b/app/src/scenes/performance/GlobalAnnounce.jsx
@@ -1,6 +1,6 @@
 import EmptySVG from "@/assets/svg/empty-info.svg";
-import ChartDetailsTable from "@/components/ChartDetailsTable";
 import { Pie, StackedBarchart } from "@/components/Chart";
+import ChartDetailsTable from "@/components/ChartDetailsTable";
 import DateRangePicker from "@/components/DateRangePicker";
 import Loader from "@/components/Loader";
 import Tabs from "@/components/Tabs";
@@ -289,7 +289,7 @@ const Evolution = ({ filters }) => {
       </div>
       <div className="border-grey-border overflow-x-auto border p-4">
         <Tabs tabs={tabs} ariaLabel="Trafic reçu grâce à vos partenaires diffuseurs" panelId="announce-evolution-panel" className="mb-6 gap-8 pb-2 text-sm" variant="underline" />
-        <div id="announce-evolution-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
+        <div id="announce-evolution-panel" role="tabpanel" tabIndex={0} aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
           {loading ? (
             <div className="flex h-[248px] items-center justify-center">
               <Loader />
@@ -440,7 +440,7 @@ const Announcers = ({ filters }) => {
       ) : (
         <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
           <Tabs tabs={tabs} ariaLabel="Top partenaires diffuseurs" panelId="announce-traffic-panel" className="mb-6 gap-8 pb-2 text-sm" variant="underline" />
-          <div id="announce-traffic-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
+          <div id="announce-traffic-panel" role="tabpanel" tabIndex={0} aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
             {!data.length ? (
               <div className="border-grey-border bg-background-grey-hover flex h-[248px] w-full flex-col items-center justify-center border border-dashed">
                 <img src={EmptySVG} alt="" aria-hidden="true" className="h-16 w-16" />

--- a/app/src/scenes/performance/GlobalAnnounce.jsx
+++ b/app/src/scenes/performance/GlobalAnnounce.jsx
@@ -295,7 +295,7 @@ const Evolution = ({ filters }) => {
               <Loader />
             </div>
           ) : !histogram.length ? (
-            <div className="border-grey-border bg-background-grey-hover flex h-[248px] w-full flex-col items-center justify-center border border-dashed">
+            <div className="border-grey-border bg-background-grey-hover flex min-h-[248px] w-full flex-col items-center justify-center border border-dashed">
               <img src={EmptySVG} alt="" aria-hidden="true" className="h-16 w-16" />
               <p className="text-color-gray-425 text-base">Aucune donnée disponible pour la période</p>
             </div>
@@ -442,7 +442,7 @@ const Announcers = ({ filters }) => {
           <Tabs tabs={tabs} ariaLabel="Top partenaires diffuseurs" panelId="announce-traffic-panel" className="mb-6 gap-8 pb-2 text-sm" variant="underline" />
           <div id="announce-traffic-panel" role="tabpanel" tabIndex={0} aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
             {!data.length ? (
-              <div className="border-grey-border bg-background-grey-hover flex h-[248px] w-full flex-col items-center justify-center border border-dashed">
+              <div className="border-grey-border bg-background-grey-hover flex min-h-[248px] w-full flex-col items-center justify-center border border-dashed">
                 <img src={EmptySVG} alt="" aria-hidden="true" className="h-16 w-16" />
                 <p className="text-color-gray-425 text-base">Aucune donnée disponible pour la période</p>
               </div>

--- a/app/src/scenes/performance/GlobalBroadcast.jsx
+++ b/app/src/scenes/performance/GlobalBroadcast.jsx
@@ -42,7 +42,6 @@ const GlobalDiffuseur = ({ filters, onFiltersChange }) => {
 
   return (
     <div className="space-y-12 p-12">
-      <title>API Engagement - Au global - Performance</title>
       <div className="space-y-2">
         <p className="text-text-mention text-sm font-semibold uppercase">Période</p>
         <DateRangePicker value={filters} onChange={(value) => onFiltersChange({ ...filters, ...value })} />

--- a/app/src/scenes/performance/GlobalBroadcast.jsx
+++ b/app/src/scenes/performance/GlobalBroadcast.jsx
@@ -199,7 +199,7 @@ const DistributionMean = ({ filters }) => {
   return (
     <div className="space-y-6">
       <h2 className="text-3xl font-bold">Répartition par moyen de diffusion</h2>
-      <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
+      <div className="border-grey-border relative space-y-4 overflow-x-auto border p-6">
         <Tabs tabs={tabs} ariaLabel="Répartition par moyen de diffusion" panelId="distribution-panel" className="mb-6 gap-8 pb-2 text-sm" variant="underline" />
         <div id="distribution-panel" role="tabpanel" tabIndex={0} aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
           {loading ? (
@@ -416,7 +416,7 @@ const Evolution = ({ filters }) => {
         <h2 className="text-3xl font-bold">Evolution</h2>
         <p className="text-text-mention text-base">Trafic que vous avez généré pour vos partenaires annonceurs</p>
       </div>
-      <div className="border-grey-border overflow-x-auto border p-4">
+      <div className="border-grey-border relative overflow-x-auto border p-4">
         <Tabs tabs={tabs} ariaLabel="Evolution" panelId="evolution-panel" className="mb-6 gap-8 pb-2 text-sm" variant="underline" />
         <div id="evolution-panel" role="tabpanel" tabIndex={0} aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
           {loading ? (
@@ -465,7 +465,7 @@ const Announcers = ({ filters }) => {
   const [announcerData, setAnnouncerData] = useState([]);
   const [missionData, setMissionData] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [tableSettings, setTableSettings] = useState({ page: 1, sortBy: "publisherId" });
+  const [tableSettings, setTableSettings] = useState({ page: 1, sortBy: "-publisherId" });
 
   useEffect(() => {
     if (!analyticsProvider?.query) {
@@ -599,7 +599,7 @@ const Announcers = ({ filters }) => {
         </div>
       ) : (
         <>
-          <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
+          <div className="border-grey-border relative space-y-4 overflow-x-auto border p-6">
             <div className="flex min-w-[600px] flex-col gap-4">
               <h3 className="text-2xl font-semibold">Performance des annonceurs</h3>
               <Table
@@ -611,10 +611,10 @@ const Announcers = ({ filters }) => {
                 onPageChange={(page) => setTableSettings({ ...tableSettings, page })}
                 total={announcerData.length}
                 sortBy={tableSettings.sortBy}
-                onSort={(sortBy) => setTableSettings({ ...tableSettings, sortBy })}
+                onSort={(key) => setTableSettings({ ...tableSettings, sortBy: key === "publisherId" ? "-publisherId" : key })}
               >
                 {announcerData
-                  .sort((a, b) => (tableSettings.sortBy === "publisherId" ? a.publisherId.localeCompare(b.publisherId) : b[tableSettings.sortBy] - a[tableSettings.sortBy]))
+                  .sort((a, b) => (tableSettings.sortBy === "-publisherId" ? a.publisherId.localeCompare(b.publisherId) : b[tableSettings.sortBy] - a[tableSettings.sortBy]))
                   .slice((tableSettings.page - 1) * 5, tableSettings.page * 5)
                   .map((item, i) => (
                     <tr key={i} className={`${i % 2 === 0 ? "bg-table-even" : "bg-table-odd"} table-row`}>
@@ -629,7 +629,7 @@ const Announcers = ({ filters }) => {
               </Table>
             </div>
           </div>
-          <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
+          <div className="border-grey-border relative space-y-4 overflow-x-auto border p-6">
             <div className="min-w-[600px]">
               <h3 className="text-2xl font-semibold">Répartition des missions par annonceur</h3>
               {!missionData.length ? (

--- a/app/src/scenes/performance/GlobalBroadcast.jsx
+++ b/app/src/scenes/performance/GlobalBroadcast.jsx
@@ -207,7 +207,7 @@ const DistributionMean = ({ filters }) => {
               <Loader />
             </div>
           ) : !data.length ? (
-            <div className="border-grey-border bg-background-grey-hover flex h-[248px] w-full flex-col items-center justify-center border border-dashed">
+            <div className="border-grey-border bg-background-grey-hover flex min-h-[248px] w-full flex-col items-center justify-center border border-dashed">
               <img src={EmptySVG} alt="" aria-hidden="true" className="h-16 w-16" />
               <p className="text-color-gray-425 text-base">Aucune donnée disponible pour la période</p>
             </div>
@@ -424,7 +424,7 @@ const Evolution = ({ filters }) => {
               <Loader />
             </div>
           ) : !histogram.length ? (
-            <div className="border-grey-border bg-background-grey-hover flex h-[248px] w-full flex-col items-center justify-center border border-dashed">
+            <div className="border-grey-border bg-background-grey-hover flex min-h-[248px] w-full flex-col items-center justify-center border border-dashed">
               <img src={EmptySVG} alt="" aria-hidden="true" className="h-16 w-16" />
               <p className="text-color-gray-425 text-base">Aucune donnée disponible pour la période</p>
             </div>
@@ -633,7 +633,7 @@ const Announcers = ({ filters }) => {
             <div className="min-w-[600px]">
               <h3 className="text-2xl font-semibold">Répartition des missions par annonceur</h3>
               {!missionData.length ? (
-                <div className="border-grey-border bg-background-grey-hover mt-4 flex h-[248px] w-full flex-col items-center justify-center border border-dashed">
+                <div className="border-grey-border bg-background-grey-hover mt-4 flex min-h-[248px] w-full flex-col items-center justify-center border border-dashed">
                   <img src={EmptySVG} alt="" aria-hidden="true" className="h-16 w-16" />
                   <p className="text-color-gray-425 text-base">Aucune donnée disponible pour la période</p>
                 </div>

--- a/app/src/scenes/performance/GlobalBroadcast.jsx
+++ b/app/src/scenes/performance/GlobalBroadcast.jsx
@@ -201,7 +201,7 @@ const DistributionMean = ({ filters }) => {
       <h2 className="text-3xl font-bold">Répartition par moyen de diffusion</h2>
       <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
         <Tabs tabs={tabs} ariaLabel="Répartition par moyen de diffusion" panelId="distribution-panel" className="mb-6 gap-8 pb-2 text-sm" variant="underline" />
-        <div id="distribution-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
+        <div id="distribution-panel" role="tabpanel" tabIndex={0} aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
           {loading ? (
             <div className="flex h-64 items-center justify-center">
               <Loader />
@@ -418,7 +418,7 @@ const Evolution = ({ filters }) => {
       </div>
       <div className="border-grey-border overflow-x-auto border p-4">
         <Tabs tabs={tabs} ariaLabel="Evolution" panelId="evolution-panel" className="mb-6 gap-8 pb-2 text-sm" variant="underline" />
-        <div id="evolution-panel" role="tabpanel" aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
+        <div id="evolution-panel" role="tabpanel" tabIndex={0} aria-labelledby={activeTabId || undefined} className="min-w-[600px]">
           {loading ? (
             <div className="flex h-[420px] items-center justify-center">
               <Loader />

--- a/app/src/scenes/performance/Mean.jsx
+++ b/app/src/scenes/performance/Mean.jsx
@@ -239,13 +239,13 @@ const Mean = ({ filters, onFiltersChange }) => {
           ) : (
             <>
               <div className="h-full w-full max-w-[220px] p-4">
-                <h3 className="text-4xl font-bold">
+                <p className="text-4xl font-bold">
                   {graph.conversionRate
                     ? graph.conversionRate.toLocaleString("fr-FR", { style: "percent", maximumFractionDigits: 2 })
                     : graph.clickCount
                       ? (graph.applyCount / graph.clickCount).toLocaleString("fr-FR", { style: "percent", maximumFractionDigits: 2 })
                       : "-"}
-                </h3>
+                </p>
                 <p className="mt-2 text-base">taux de conversion de l'API</p>
                 <p className="text-text-mention mt-4 text-sm">
                   entre le nombre de <span className="font-semibold text-black">redirections</span> et le nombre de <span className="font-semibold text-black">candidatures</span>
@@ -255,14 +255,14 @@ const Mean = ({ filters, onFiltersChange }) => {
                 <div className="group flex h-full flex-1 flex-col justify-end gap-4 px-4">
                   <Bar value={100} height={BAR_HEIGHT} />
                   <div className="h-24">
-                    <h3 className="text-3xl font-semibold text-gray-700 group-hover:text-black">{graph.clickCount.toLocaleString("fr")}</h3>
+                    <p className="text-3xl font-semibold text-gray-700 group-hover:text-black">{graph.clickCount.toLocaleString("fr")}</p>
                     <p className="text-base text-gray-700 group-hover:text-black">redirections vers une mission</p>
                   </div>
                 </div>
                 <div className="group flex h-full flex-1 flex-col justify-end gap-4 px-4">
                   <Bar value={graph.clickCount ? (graph.applyCount * 100) / graph.clickCount : 0} height={BAR_HEIGHT} />
                   <div className="h-24">
-                    <h3 className="text-3xl font-semibold text-gray-700 group-hover:text-black">{graph.applyCount.toLocaleString("fr")}</h3>
+                    <p className="text-3xl font-semibold text-gray-700 group-hover:text-black">{graph.applyCount.toLocaleString("fr")}</p>
                     <p className="text-base text-gray-700 group-hover:text-black">candidatures</p>
                   </div>
                 </div>
@@ -369,29 +369,29 @@ const SourcePerformance = ({ data, source }) => {
   return (
     <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
       <div className="min-w-[600px]">
-      <h3 className="text-2xl font-semibold">Performance par {source === "widget" ? "widget" : "campagne"}</h3>
-      <Table
-        caption={`Performance par ${source === "widget" ? "widget" : "campagne"}`}
-        header={TABLE_HEADER(source)}
-        total={data.length}
-        sortBy={sortBy}
-        onSort={setSortBy}
-        page={page}
-        onPageChange={setPage}
-        pageSize={pageSize}
-        auto
-      >
-        {paginated.map((item, i) => (
-          <tr key={`${item.name || "source"}-${(page - 1) * pageSize + i}`} className={`${i % 2 === 0 ? "bg-table-even" : "bg-table-odd"} table-row`}>
-            <td className="px-4">{item.name}</td>
-            <td className="px-4 text-right">{(item.printCount || 0).toLocaleString("fr")}</td>
-            <td className="px-4 text-right">{(item.clickCount || 0).toLocaleString("fr")}</td>
-            <td className="px-4 text-right">{(item.accountCount || 0).toLocaleString("fr")}</td>
-            <td className="px-4 text-right">{(item.applyCount || 0).toLocaleString("fr")}</td>
-            <td className="px-4 text-right">{(item.rate || 0).toLocaleString("fr", { style: "percent", minimumFractionDigits: 2 })}</td>
-          </tr>
-        ))}
-      </Table>
+        <h3 className="text-2xl font-semibold">Performance par {source === "widget" ? "widget" : "campagne"}</h3>
+        <Table
+          caption={`Performance par ${source === "widget" ? "widget" : "campagne"}`}
+          header={TABLE_HEADER(source)}
+          total={data.length}
+          sortBy={sortBy}
+          onSort={setSortBy}
+          page={page}
+          onPageChange={setPage}
+          pageSize={pageSize}
+          auto
+        >
+          {paginated.map((item, i) => (
+            <tr key={`${item.name || "source"}-${(page - 1) * pageSize + i}`} className={`${i % 2 === 0 ? "bg-table-even" : "bg-table-odd"} table-row`}>
+              <td className="px-4">{item.name}</td>
+              <td className="px-4 text-right">{(item.printCount || 0).toLocaleString("fr")}</td>
+              <td className="px-4 text-right">{(item.clickCount || 0).toLocaleString("fr")}</td>
+              <td className="px-4 text-right">{(item.accountCount || 0).toLocaleString("fr")}</td>
+              <td className="px-4 text-right">{(item.applyCount || 0).toLocaleString("fr")}</td>
+              <td className="px-4 text-right">{(item.rate || 0).toLocaleString("fr", { style: "percent", minimumFractionDigits: 2 })}</td>
+            </tr>
+          ))}
+        </Table>
       </div>
     </div>
   );

--- a/app/src/scenes/performance/Mean.jsx
+++ b/app/src/scenes/performance/Mean.jsx
@@ -238,14 +238,16 @@ const Mean = ({ filters, onFiltersChange }) => {
           ) : (
             <>
               <div className="h-full w-full max-w-[220px] p-4">
-                <p className="text-4xl font-bold">
-                  {graph.conversionRate
-                    ? graph.conversionRate.toLocaleString("fr-FR", { style: "percent", maximumFractionDigits: 2 })
-                    : graph.clickCount
-                      ? (graph.applyCount / graph.clickCount).toLocaleString("fr-FR", { style: "percent", maximumFractionDigits: 2 })
-                      : "-"}
+                <p className="text-base">
+                  <span className="block text-4xl font-bold">
+                    {graph.conversionRate
+                      ? graph.conversionRate.toLocaleString("fr-FR", { style: "percent", maximumFractionDigits: 2 })
+                      : graph.clickCount
+                        ? (graph.applyCount / graph.clickCount).toLocaleString("fr-FR", { style: "percent", maximumFractionDigits: 2 })
+                        : "-"}
+                  </span>
+                  <span className="mt-2 block">taux de conversion de l'API</span>
                 </p>
-                <p className="mt-2 text-base">taux de conversion de l'API</p>
                 <p className="text-text-mention mt-4 text-sm">
                   entre le nombre de <span className="font-semibold text-black">redirections</span> et le nombre de <span className="font-semibold text-black">candidatures</span>
                 </p>
@@ -253,17 +255,17 @@ const Mean = ({ filters, onFiltersChange }) => {
               <div className="flex h-full flex-1 flex-col gap-8 md:flex-row md:items-end">
                 <div className="group flex h-full flex-1 flex-col justify-end gap-4 px-4">
                   <Bar value={100} height={BAR_HEIGHT} />
-                  <div className="min-h-24">
-                    <p className="text-3xl font-semibold text-gray-700 group-hover:text-black">{graph.clickCount.toLocaleString("fr")}</p>
-                    <p className="text-base text-gray-700 group-hover:text-black">redirections vers une mission</p>
-                  </div>
+                  <p className="min-h-24 text-gray-700 group-hover:text-black">
+                    <span className="block text-3xl font-semibold">{graph.clickCount.toLocaleString("fr")}</span>
+                    <span className="block text-base">redirections vers une mission</span>
+                  </p>
                 </div>
                 <div className="group flex h-full flex-1 flex-col justify-end gap-4 px-4">
                   <Bar value={graph.clickCount ? (graph.applyCount * 100) / graph.clickCount : 0} height={BAR_HEIGHT} />
-                  <div className="min-h-24">
-                    <p className="text-3xl font-semibold text-gray-700 group-hover:text-black">{graph.applyCount.toLocaleString("fr")}</p>
-                    <p className="text-base text-gray-700 group-hover:text-black">candidatures</p>
-                  </div>
+                  <p className="min-h-24 text-gray-700 group-hover:text-black">
+                    <span className="block text-3xl font-semibold">{graph.applyCount.toLocaleString("fr")}</span>
+                    <span className="block text-base">candidatures</span>
+                  </p>
                 </div>
               </div>
             </>
@@ -296,7 +298,7 @@ const Mean = ({ filters, onFiltersChange }) => {
         </div>
         <div className="space-y-8">
           <div className="space-y-2">
-            <h3 className="text-2xl font-semibold">Jessica et Nassim vous accompagnent</h3>
+            <h2 className="text-2xl font-semibold">Jessica et Nassim vous accompagnent</h2>
             <p className="text-[18px]">Nous sommes là pour vous aider à optimiser votre parcours utilisateur et votre taux de conversion.</p>
           </div>
 
@@ -342,9 +344,9 @@ const Bar = ({ value, height = BAR_HEIGHT }) => {
         className="group-hover:bg-blue-france-main-525 bg-blue-france-925-active absolute bottom-0 w-full rounded transition-all duration-300 ease-in-out"
         style={{ height: `${safeValue}%` }}
       />
-      <div className="absolute left-1/2 -translate-x-1/2 rounded border bg-white px-2 py-1 text-sm shadow-lg" style={{ bottom: getLabelPosition(safeValue) }}>
+      <p className="absolute left-1/2 -translate-x-1/2 rounded border bg-white px-2 py-1 text-sm shadow-lg" style={{ bottom: getLabelPosition(safeValue) }}>
         {safeValue.toFixed(0)}%
-      </div>
+      </p>
     </div>
   );
 };
@@ -362,19 +364,19 @@ const SourcePerformance = ({ data, source }) => {
   const [sortBy, setSortBy] = useState("applyCount");
   const [page, setPage] = useState(1);
   const pageSize = 10;
-  const sorted = [...data].sort((a, b) => (sortBy === "name" ? (a.name || "").localeCompare(b.name || "") : (b[sortBy] || 0) - (a[sortBy] || 0)));
+  const sorted = [...data].sort((a, b) => (sortBy === "-name" ? (a.name || "").localeCompare(b.name || "") : (b[sortBy] || 0) - (a[sortBy] || 0)));
   const paginated = sorted.slice((page - 1) * pageSize, page * pageSize);
 
   return (
-    <div className="border-grey-border space-y-4 overflow-x-auto border p-6">
+    <div className="border-grey-border relative space-y-4 overflow-x-auto border p-6">
       <div className="min-w-[600px]">
-        <h3 className="text-2xl font-semibold">Performance par {source === "widget" ? "widget" : "campagne"}</h3>
+        <h2 className="text-2xl font-semibold">Performance par {source === "widget" ? "widget" : "campagne"}</h2>
         <Table
           caption={`Performance par ${source === "widget" ? "widget" : "campagne"}`}
           header={TABLE_HEADER(source)}
           total={data.length}
           sortBy={sortBy}
-          onSort={setSortBy}
+          onSort={(key) => setSortBy(key === "name" ? "-name" : key)}
           page={page}
           onPageChange={setPage}
           pageSize={pageSize}

--- a/app/src/scenes/performance/Mean.jsx
+++ b/app/src/scenes/performance/Mean.jsx
@@ -190,7 +190,7 @@ const Mean = ({ filters, onFiltersChange }) => {
       <title>API Engagement - Moyens de diffusion - Performance</title>
       <div className="flex flex-wrap items-center gap-6">
         <div className="space-y-2">
-          <label className="text-text-mention text-sm font-semibold uppercase">Période</label>
+          <p className="text-text-mention text-sm font-semibold uppercase">Période</p>
           <DateRangePicker value={filters} onChange={(value) => onFiltersChange({ ...filters, ...value })} />
         </div>
         {options.length > 1 && (

--- a/app/src/scenes/performance/Mean.jsx
+++ b/app/src/scenes/performance/Mean.jsx
@@ -187,7 +187,6 @@ const Mean = ({ filters, onFiltersChange }) => {
 
   return (
     <div className="space-y-12 p-12">
-      <title>API Engagement - Moyens de diffusion - Performance</title>
       <div className="flex flex-wrap items-center gap-6">
         <div className="space-y-2">
           <p className="text-text-mention text-sm font-semibold uppercase">Période</p>

--- a/app/src/scenes/performance/Mean.jsx
+++ b/app/src/scenes/performance/Mean.jsx
@@ -253,14 +253,14 @@ const Mean = ({ filters, onFiltersChange }) => {
               <div className="flex h-full flex-1 flex-col gap-8 md:flex-row md:items-end">
                 <div className="group flex h-full flex-1 flex-col justify-end gap-4 px-4">
                   <Bar value={100} height={BAR_HEIGHT} />
-                  <div className="h-24">
+                  <div className="min-h-24">
                     <p className="text-3xl font-semibold text-gray-700 group-hover:text-black">{graph.clickCount.toLocaleString("fr")}</p>
                     <p className="text-base text-gray-700 group-hover:text-black">redirections vers une mission</p>
                   </div>
                 </div>
                 <div className="group flex h-full flex-1 flex-col justify-end gap-4 px-4">
                   <Bar value={graph.clickCount ? (graph.applyCount * 100) / graph.clickCount : 0} height={BAR_HEIGHT} />
-                  <div className="h-24">
+                  <div className="min-h-24">
                     <p className="text-3xl font-semibold text-gray-700 group-hover:text-black">{graph.applyCount.toLocaleString("fr")}</p>
                     <p className="text-base text-gray-700 group-hover:text-black">candidatures</p>
                   </div>

--- a/app/src/scenes/performance/index.jsx
+++ b/app/src/scenes/performance/index.jsx
@@ -63,7 +63,13 @@ const Performance = () => {
         </>
       )}
 
-      <section id="performance-panel" role={isTabbed ? "tabpanel" : undefined} aria-labelledby={isTabbed && activeTabId ? activeTabId : undefined} className="bg-white shadow-lg">
+      <section
+        id="performance-panel"
+        role={isTabbed ? "tabpanel" : undefined}
+        tabIndex={isTabbed ? 0 : undefined}
+        aria-labelledby={isTabbed && activeTabId ? activeTabId : undefined}
+        className="bg-white shadow-lg"
+      >
         <Routes>
           <Route
             path="/"

--- a/app/src/scenes/performance/index.jsx
+++ b/app/src/scenes/performance/index.jsx
@@ -54,7 +54,7 @@ const Performance = () => {
 
   return (
     <>
-      <title>API Engagement - Au global - Performance</title>
+      <title>{`API Engagement - ${activeTab.title} - Performance`}</title>
       <h1 className="mb-12 text-4xl font-bold">Votre activité {flux === "from" ? "de diffuseur" : "d'annonceur"}</h1>
 
       {flux === "from" && (

--- a/app/src/scenes/public-stats/components/Distribution.jsx
+++ b/app/src/scenes/public-stats/components/Distribution.jsx
@@ -54,10 +54,15 @@ const Distribution = ({ filters, onFiltersChange }) => {
 
         <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <label htmlFor="year" className="sr-only">
+            <label htmlFor="distribution-year" className="sr-only">
               Année
             </label>
-            <select id="year" className="input w-full sm:w-48" value={filters.year} onChange={(e) => onFiltersChange({ ...filters, year: parseInt(e.target.value, 10) })}>
+            <select
+              id="distribution-year"
+              className="input w-full sm:w-48"
+              value={filters.year}
+              onChange={(e) => onFiltersChange({ ...filters, year: parseInt(e.target.value, 10) })}
+            >
               <option value={2020}>2020</option>
               <option value={2021}>2021</option>
               <option value={2022}>2022</option>
@@ -66,10 +71,15 @@ const Distribution = ({ filters, onFiltersChange }) => {
               <option value={2025}>2025</option>
               <option value={2026}>2026</option>
             </select>
-            <label htmlFor="department" className="sr-only">
+            <label htmlFor="distribution-department" className="sr-only">
               Département
             </label>
-            <select id="department" className="input w-full sm:w-48" value={departmentCode} onChange={(e) => onFiltersChange({ ...filters, department: e.target.value })}>
+            <select
+              id="distribution-department"
+              className="input w-full sm:w-48"
+              value={departmentCode}
+              onChange={(e) => onFiltersChange({ ...filters, department: e.target.value })}
+            >
               <option value="">Départements</option>
               {Object.entries(DEPARTMENT_NAMES)
                 .sort((a, b) => a[0].localeCompare(b[0], "fr", { numeric: true }))
@@ -79,10 +89,10 @@ const Distribution = ({ filters, onFiltersChange }) => {
                   </option>
                 ))}
             </select>
-            <label htmlFor="mission-type" className="sr-only">
+            <label htmlFor="distribution-mission-type" className="sr-only">
               Type de mission
             </label>
-            <select id="mission-type" className="input w-48" value={filters.type} onChange={(e) => onFiltersChange({ ...filters, type: e.target.value })}>
+            <select id="distribution-mission-type" className="input w-48" value={filters.type} onChange={(e) => onFiltersChange({ ...filters, type: e.target.value })}>
               <option value="">Type de mission</option>
               <option value="benevolat">Bénévolat</option>
               <option value="volontariat">Volontariat</option>

--- a/app/src/scenes/public-stats/components/SomeNumbers.jsx
+++ b/app/src/scenes/public-stats/components/SomeNumbers.jsx
@@ -111,10 +111,10 @@ const SomeNumbers = ({ filters, onFiltersChange }) => {
 
         <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <label htmlFor="year" className="sr-only">
+            <label htmlFor="numbers-year" className="sr-only">
               Année
             </label>
-            <select id="year" className="input w-full sm:w-48" value={filters.year} onChange={(e) => onFiltersChange({ ...filters, year: parseInt(e.target.value, 10) })}>
+            <select id="numbers-year" className="input w-full sm:w-48" value={filters.year} onChange={(e) => onFiltersChange({ ...filters, year: parseInt(e.target.value, 10) })}>
               <option value={2020}>2020</option>
               <option value={2021}>2021</option>
               <option value={2022}>2022</option>
@@ -123,10 +123,15 @@ const SomeNumbers = ({ filters, onFiltersChange }) => {
               <option value={2025}>2025</option>
               <option value={2026}>2026</option>
             </select>
-            <label htmlFor="department" className="sr-only">
+            <label htmlFor="numbers-department" className="sr-only">
               Département
             </label>
-            <select id="department" className="input w-full sm:w-48" value={filters.department} onChange={(e) => onFiltersChange({ ...filters, department: e.target.value })}>
+            <select
+              id="numbers-department"
+              className="input w-full sm:w-48"
+              value={filters.department}
+              onChange={(e) => onFiltersChange({ ...filters, department: e.target.value })}
+            >
               <option value="">Départements</option>
               {Object.entries(DEPARTMENT_NAMES)
                 .sort((a, b) => a[0].localeCompare(b[0], "fr", { numeric: true }))
@@ -136,10 +141,10 @@ const SomeNumbers = ({ filters, onFiltersChange }) => {
                   </option>
                 ))}
             </select>
-            <label htmlFor="mission-type" className="sr-only">
+            <label htmlFor="numbers-mission-type" className="sr-only">
               Type de mission
             </label>
-            <select id="mission-type" className="input w-full sm:w-48" value={filters.type} onChange={(e) => onFiltersChange({ ...filters, type: e.target.value })}>
+            <select id="numbers-mission-type" className="input w-full sm:w-48" value={filters.type} onChange={(e) => onFiltersChange({ ...filters, type: e.target.value })}>
               <option value="">Type de mission</option>
               <option value="benevolat">Bénévolat</option>
               <option value="volontariat">Volontariat</option>

--- a/app/src/scenes/public-stats/index.jsx
+++ b/app/src/scenes/public-stats/index.jsx
@@ -62,19 +62,21 @@ const PublicStats = () => {
           <h3 className="text-3xl font-bold">En quelques mots</h3>
           <div className="flex-start flex flex-col gap-6 sm:flex-row">
             <div className="text-text-mention mt-8 flex-1 text-lg leading-loose">
-              <strong className="text-black">
-                L'API Engagement est un service public numérique qui permet aux plateformes d'engagement associatives, publiques et privées de mettre en commun leurs missions.
-              </strong>
-              <div>
+              <p>
+                <strong className="text-black">
+                  L'API Engagement est un service public numérique qui permet aux plateformes d'engagement associatives, publiques et privées de mettre en commun leurs missions.
+                </strong>
+              </p>
+              <p>
                 Elle permet au plus grand nombre d'accéder aux opportunités d'engagement en renforçant / démultipliant la visibilité des annonces, et augmente ainsi le nombre de
                 personnes qui candidatent aux actions.
-              </div>
+              </p>
             </div>
-            <div className="text-text-mention mt-8 flex-1 text-lg leading-loose">
+            <p className="text-text-mention mt-8 flex-1 text-lg leading-loose">
               L'API Engagement permet de faciliter l'engagement en simplifiant l'accès à une pluralité d'annonces actualisées. Avec cette technologie, les points de rencontres sont
               multipliés : les annonces sont accessible aux bons endroits, c'est-à-dire là où les personnes qui souhaitent s'engager se trouvent : site de mairie, applications,
               plateformes d'engagement, etc.
-            </div>
+            </p>
           </div>
         </div>
 

--- a/app/src/scenes/settings/ApiAnnonceur.jsx
+++ b/app/src/scenes/settings/ApiAnnonceur.jsx
@@ -43,7 +43,7 @@ const ApiAnnonceur = () => {
 
   const handleCopy = () => {
     navigator.clipboard.writeText(publisher.apikey);
-    toast.success("Lien copié");
+    toast.success("Clé copiée");
   };
 
   if (!publisher) return <p className="p-3">Chargement...</p>;

--- a/app/src/scenes/settings/ApiAnnonceur.jsx
+++ b/app/src/scenes/settings/ApiAnnonceur.jsx
@@ -90,6 +90,7 @@ const ApiAnnonceur = () => {
           <textarea
             className="border-blue-france-925 bg-blue-france-975 w-full rounded-none border px-4 py-2 font-mono text-sm read-only:opacity-80"
             rows={2}
+            aria-label="Exemple d'appel"
             readOnly
             value={curl}
           />

--- a/app/src/scenes/settings/Flux.jsx
+++ b/app/src/scenes/settings/Flux.jsx
@@ -97,13 +97,13 @@ const Flux = () => {
             {imports.length > 0 && lastSync < new Date(Date.now() - 24 * 60 * 60 * 1000) ? (
               <div className="items-center">
                 <p className="inline align-middle">{new Date(lastSync).toLocaleString("fr").replace(" ", " à ")}</p>
-                <RiCloseCircleFill aria-label="Erreur" role="img" className="text-error ml-2 inline h-5 w-5 align-middle" />
+                <RiCloseCircleFill aria-label="Synchronisation en retard" role="img" className="text-error ml-2 inline h-5 w-5 align-middle" />
                 <p className="text-xs">Dernière synchronisation il y a plus de 24h.</p>
               </div>
             ) : (
               <div className="flex items-center gap-2">
                 <p>{imports.length > 0 && new Date(lastSync).toLocaleString("fr").replace(" ", " à ")}</p>
-                <RiCheckboxCircleFill aria-label="OK" role="img" className="text-success mr-1 h-5 w-5" />
+                <RiCheckboxCircleFill aria-label="Synchronisation à jour" role="img" className="text-success mr-1 h-5 w-5" />
               </div>
             )}
           </div>

--- a/app/src/scenes/settings/Flux.jsx
+++ b/app/src/scenes/settings/Flux.jsx
@@ -82,9 +82,11 @@ const Flux = () => {
         <h2 className="text-3xl font-bold">Configurer votre flux de missions</h2>
 
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
-          <label className="font-semibold sm:w-[35%] sm:flex-none">Lien du fichier XML à synchroniser</label>
+          <label htmlFor="publisher-feed" className="font-semibold sm:w-[35%] sm:flex-none">
+            Lien du fichier XML à synchroniser
+          </label>
           <div className="flex min-w-0 flex-1 gap-2">
-            <input className="input border-blue-france-925 bg-blue-france-975 min-w-0 flex-1 border read-only:opacity-80" value={publisher.feed} readOnly />
+            <input id="publisher-feed" className="input border-blue-france-925 bg-blue-france-975 min-w-0 flex-1 border read-only:opacity-80" value={publisher.feed} readOnly />
             {user.role === "admin" && <ModifyModal />}
           </div>
         </div>
@@ -176,8 +178,8 @@ const ModifyModal = () => {
       </button>
       <Modal open={open} onClose={() => setOpen(false)} title="Modifier votre flux de missions" className="w-[90vw] max-w-3xl">
         <div className="flex flex-col items-start justify-between gap-4">
-          <div>Lien du fichier XML à synchroniser</div>
-          <input className="input focus w-full" value={feed} onChange={(e) => setFeed(e.target.value)} />
+          <label htmlFor="feed-url">Lien du fichier XML à synchroniser</label>
+          <input id="feed-url" className="input focus w-full" value={feed} onChange={(e) => setFeed(e.target.value)} />
         </div>
         <div className="flex justify-end gap-6">
           <button type="button" className="tertiary-btn" onClick={() => setOpen(false)}>

--- a/app/src/scenes/settings/Flux.jsx
+++ b/app/src/scenes/settings/Flux.jsx
@@ -174,7 +174,7 @@ const ModifyModal = () => {
       <button className="primary-btn" onClick={() => setOpen(!open)}>
         Modifier
       </button>
-      <Modal open={open} onClose={() => setOpen(false)} title="Modifier votre flux de missions" className="min-w-3xl">
+      <Modal open={open} onClose={() => setOpen(false)} title="Modifier votre flux de missions" className="w-[90vw] max-w-3xl">
         <div className="flex flex-col items-start justify-between gap-4">
           <div>Lien du fichier XML à synchroniser</div>
           <input className="input focus w-full" value={feed} onChange={(e) => setFeed(e.target.value)} />

--- a/app/src/scenes/settings/TrackingAnnounce.jsx
+++ b/app/src/scenes/settings/TrackingAnnounce.jsx
@@ -32,13 +32,13 @@ const TrackingAnnounce = () => {
         <div className="space-y-4 border-b border-b-gray-900 pb-6">
           <div>
             <h3 className="text-base font-semibold">Commande de comptage d'une candidature</h3>
-            <p className="text-text-mention text-xs">
-              Lorsque vous enregistrez une candidature, effectuez cette commande chez vous nous permet de compter cette candidature.
-            </p>
+            <p className="text-text-mention text-xs">Lorsque vous enregistrez une candidature, effectuez cette commande chez vous nous permet de compter cette candidature.</p>
           </div>
           <div className="space-y-2">
             <div className="border-blue-france-925 bg-blue-france-975 overflow-x-auto rounded-none border px-4 py-2 text-sm">
-              <code className="whitespace-nowrap">window.apieng && window.apieng("trackApplication", <span className="text-warning">clientId</span>)</code>
+              <code className="whitespace-nowrap">
+                window.apieng && window.apieng("trackApplication", <span className="text-warning">clientId</span>)
+              </code>
             </div>
             <button className="secondary-btn" onClick={() => handleCopyCommand(`window.apieng && window.apieng("trackApplication", "clientId")`)}>
               Copier
@@ -55,7 +55,9 @@ const TrackingAnnounce = () => {
             </div>
             <div className="space-y-2">
               <div className="border-blue-france-925 bg-blue-france-975 overflow-x-auto rounded-none border px-4 py-2 text-sm">
-                <code className="whitespace-nowrap">window.apieng && window.apieng("trackAccount", <span className="text-warning">clientId</span>)</code>
+                <code className="whitespace-nowrap">
+                  window.apieng && window.apieng("trackAccount", <span className="text-warning">clientId</span>)
+                </code>
               </div>
               <button className="secondary-btn" onClick={() => handleCopyCommand(`window.apieng && window.apieng("trackAccount", "clientId")`)}>
                 Copier
@@ -86,6 +88,7 @@ const TrackingAnnounce = () => {
         <textarea
           className="border-blue-france-925 bg-blue-france-975 w-full rounded-none border px-4 py-2 text-base read-only:opacity-80"
           rows={8}
+          aria-label="Script à intégrer sur votre site"
           value={script.replace("{{publisherId}}", publisher.id)}
           readOnly
         />

--- a/app/src/scenes/settings/TrackingBroadcast.jsx
+++ b/app/src/scenes/settings/TrackingBroadcast.jsx
@@ -44,6 +44,7 @@ const TrackingBroadcast = () => {
       <textarea
         className="border-blue-france-925 bg-blue-france-975 w-full rounded-none border px-4 py-2 text-base read-only:opacity-80"
         rows={8}
+        aria-label="Script à intégrer sur votre site"
         value={script.replace("{{publisherId}}", publisher.id)}
         readOnly
       />

--- a/app/src/scenes/user/Edit.jsx
+++ b/app/src/scenes/user/Edit.jsx
@@ -278,7 +278,7 @@ const ResetPasswordModal = ({ user }) => {
         Réinitialiser le mot de passe
       </button>
       <Modal
-        className="min-w-2xl"
+        className="w-[90vw] max-w-2xl"
         open={open}
         onClose={() => setOpen(false)}
         title={!newPassword ? `Réinitialisation du mot de passe de ${user.firstname}` : "Voici le mot de passe temporaire"}

--- a/app/src/scenes/warnings/index.jsx
+++ b/app/src/scenes/warnings/index.jsx
@@ -143,7 +143,9 @@ const List = () => {
               </div>
               <div className="flex flex-col gap-4">
                 <div className="text-lg">
-                  <p><b>Il semble y avoir un problème de paramétrages de votre côté.</b></p>
+                  <p>
+                    <b>Il semble y avoir un problème de paramétrages de votre côté.</b>
+                  </p>
                   <p>Consultez les alertes ci-dessous pour identifier le problème.</p>
                 </div>
               </div>
@@ -181,7 +183,12 @@ const List = () => {
               {currentWarningsByDays[d].map((w, i) => {
                 const label = WARNINGS[w.type] || WARNINGS.OTHER_WARNING;
                 return (
-                  <Link to={LINKS[w.type]} className="flex flex-col gap-4 bg-white p-4 shadow-sm sm:flex-row sm:items-end sm:gap-8 sm:p-6" key={i} id={slugify(`${w.type}-${w.publisherName}`)}>
+                  <Link
+                    to={LINKS[w.type]}
+                    className="flex flex-col gap-4 bg-white p-4 shadow-sm sm:flex-row sm:items-end sm:gap-8 sm:p-6"
+                    key={i}
+                    id={slugify(`${w.type}-${w.publisherName}`)}
+                  >
                     <div className="flex items-center justify-center gap-8">
                       <div className="flex items-center justify-center">{label.emoji}</div>
                       <div className="flex flex-1 flex-col justify-between">
@@ -285,7 +292,7 @@ const Badge = ({ label, value, onDelete }) => {
     <div className="bg-blue-france-975 flex items-center gap-2 rounded p-2">
       <p className="text-sm">{label}:</p>
       <p className="text-sm">{value}</p>
-      <button className="text-sm text-black" onClick={onDelete}>
+      <button className="text-sm text-black" onClick={onDelete} aria-label={`Retirer le filtre ${label}`}>
         <RiCloseFill aria-hidden="true" />
       </button>
     </div>

--- a/app/src/scenes/widget/Edit.jsx
+++ b/app/src/scenes/widget/Edit.jsx
@@ -266,6 +266,7 @@ const Code = ({ widget }) => {
         <textarea
           className="border-blue-france-925 bg-blue-france-975 w-full rounded-none border px-4 py-2 text-base read-only:opacity-80"
           rows={widget.type === "benevolat" ? 11 : 4}
+          aria-label="Code du widget à intégrer"
           readOnly
           value={`${IFRAMES[getIframeKey(widget.type)][widget.style].replace("{{widgetId}}", widget.id)}${widget.type === "benevolat" ? `\n\n${JVA_LOGO}` : ""}`}
         />

--- a/app/src/scenes/widget/Edit.jsx
+++ b/app/src/scenes/widget/Edit.jsx
@@ -240,7 +240,7 @@ const IFRAMES = {
 };
 
 const JVA_LOGO = `<div style="padding:10px; display:flex; justify-content:center; align-items:center;">
-  <img src="https://apicivique.s3.eu-west-3.amazonaws.com/jvalogo.svg" alt="JeVeuxAider.gouv.fr"/>
+  <img src="https://api-engagement-bucket.s3.fr-par.scw.cloud/img/jva-logo-100x100.png" alt="JeVeuxAider.gouv.fr"/>
   <div style="color:#666666; font-style:normal; font-size:13px; padding:8px;">Proposé par la plateforme publique du bénévolat
     <a href="https://www.jeveuxaider.gouv.fr/" target="_blank">JeVeuxAider.gouv.fr</a>
   </div>
@@ -282,7 +282,9 @@ const StickyBar = ({ onEdit, visible, widget, handleActivate, canSubmit }) => {
   return (
     <div className="fixed top-0 left-0 z-50 w-full items-center bg-white px-4 py-4 shadow-lg">
       <div className="m-auto flex w-full items-center justify-between sm:w-[90%]">
-        <p className="hidden text-2xl font-bold sm:block" aria-hidden="true">Modifier un widget</p>
+        <p className="hidden text-2xl font-bold sm:block" aria-hidden="true">
+          Modifier un widget
+        </p>
         <div className="flex items-center gap-6">
           <div className="flex flex-col items-end">
             <Toggle aria-label={widget.active ? "Désactiver le widget" : "Activer le widget"} value={widget.active} onChange={(value) => handleActivate(value)} />

--- a/app/src/scenes/widget/components/QueryBuilder.jsx
+++ b/app/src/scenes/widget/components/QueryBuilder.jsx
@@ -39,7 +39,7 @@ const QueryBuilder = ({ values, onChange }) => {
   return (
     <div className="flex flex-col overflow-x-auto">
       {values.rules.map((r, i) => (
-        <div key={i} className="my-3 flex min-w-[600px] items-center gap-4">
+        <div key={i} className="my-3 flex flex-col gap-4 sm:min-w-[600px] sm:flex-row sm:items-center">
           <Rule index={i} fields={FIELDS} rule={r} onChange={(r) => handleRuleChange(r, i)} filters={values.publishers.map((p) => `publishers[]=${p}`).join("&")} />
           <button
             type="button"
@@ -109,17 +109,17 @@ const Rule = ({ fields, rule, onChange, index, filters }) => {
   };
 
   return (
-    <div className="flex w-full items-center gap-4">
+    <div className="flex w-full flex-col gap-4 sm:flex-row sm:items-center">
       {index > 0 ? (
-        <select className="select w-[6%] px-2" value={rule.combinator} onChange={(e) => onChange({ ...rule, combinator: e.target.value })}>
+        <select className="select w-full sm:w-[6%] sm:px-2" value={rule.combinator} onChange={(e) => onChange({ ...rule, combinator: e.target.value })}>
           <option value="and">Et</option>
           <option value="or">Ou</option>
         </select>
       ) : (
-        <div className="w-[6%]" />
+        <div className="hidden sm:block sm:w-[6%]" />
       )}
-      <div className="flex w-full items-center gap-4">
-        <select className={`select w-[35%]`} value={rule.field} onChange={handleSelectField}>
+      <div className="flex w-full flex-col gap-4 sm:flex-row sm:items-center">
+        <select className="select w-full sm:w-[35%]" value={rule.field} onChange={handleSelectField}>
           {fields.map((f) => (
             <option key={f.value} value={f.value}>
               {f.label}
@@ -128,7 +128,7 @@ const Rule = ({ fields, rule, onChange, index, filters }) => {
         </select>
         {rule.fieldType === "boolean" ? (
           <>
-            <select className="select w-[15%]" defaultValue={rule.operator} disabled>
+            <select className="select w-full sm:w-[15%]" defaultValue={rule.operator} disabled>
               <option value="is">égal à</option>
             </select>
             <select className="select flex-1" value={rule.value} onChange={(e) => onChange({ ...rule, value: e.target.value })}>
@@ -138,7 +138,7 @@ const Rule = ({ fields, rule, onChange, index, filters }) => {
           </>
         ) : rule.fieldType === "array" ? (
           <>
-            <select className="select w-[15%]" value={rule.operator} onChange={(e) => onChange({ ...rule, operator: e.target.value })}>
+            <select className="select w-full sm:w-[15%]" value={rule.operator} onChange={(e) => onChange({ ...rule, operator: e.target.value })}>
               <option value="contains">contient</option>
               <option value="does_not_contain">ne contient pas</option>
             </select>
@@ -159,7 +159,7 @@ const Rule = ({ fields, rule, onChange, index, filters }) => {
           </>
         ) : (
           <>
-            <select className="select w-[15%]" value={rule.operator} onChange={(e) => onChange({ ...rule, operator: e.target.value })}>
+            <select className="select w-full sm:w-[15%]" value={rule.operator} onChange={(e) => onChange({ ...rule, operator: e.target.value })}>
               <option value="is">égal à</option>
               <option value="is_not">différent de</option>
               <option value="contains">contient</option>

--- a/app/src/scenes/widget/components/Settings.jsx
+++ b/app/src/scenes/widget/components/Settings.jsx
@@ -152,13 +152,16 @@ const Settings = ({ widget, values, onChange, loading }) => {
             </label>
             <LocationCombobox
               id="location"
+              ariaDescribedby="location-hint"
               selected={values.location ? { label: values.location.label, value: `${values.location.lat}-${values.location.lon}` } : null}
               onSelect={(v) => onChange({ ...values, location: v ? { label: v.label, lat: parseFloat(v.value.split("-")[0]), lon: parseFloat(v.value.split("-")[1]) } : null })}
               placeholder="Localisation"
             />
             <div className="text-info mt-4 flex items-center gap-2">
               <BiSolidInfoSquare className="text-sm" aria-hidden="true" />
-              <p className="text-xs">Laisser vide pour afficher les missions de toute la France</p>
+              <p id="location-hint" className="text-xs">
+                Laisser vide pour afficher les missions de toute la France
+              </p>
             </div>
           </div>
 

--- a/app/src/scenes/widget/components/Settings.jsx
+++ b/app/src/scenes/widget/components/Settings.jsx
@@ -91,6 +91,13 @@ const Settings = ({ widget, values, onChange, loading }) => {
 
   return (
     <div className="space-y-12 bg-white p-4 shadow-lg sm:p-12">
+      <p className="text-text-mention text-sm">
+        Les champs suivis d'un astérisque{" "}
+        <span className="text-error" aria-hidden="true">
+          *
+        </span>{" "}
+        sont obligatoires.
+      </p>
       <div className="space-y-10">
         <h2 className="text-2xl font-bold">Informations générales</h2>
 
@@ -151,7 +158,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
             />
             <div className="text-info mt-4 flex items-center gap-2">
               <BiSolidInfoSquare className="text-sm" aria-hidden="true" />
-              <span className="text-xs">Laisser vide pour afficher les missions de toute la France</span>
+              <p className="text-xs">Laisser vide pour afficher les missions de toute la France</p>
             </div>
           </div>
 
@@ -276,7 +283,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
 
         <div className="space-y-4">
           <div className="space-y-2">
-            <label className="text-base">Filtrer les missions à afficher</label>
+            <h3 className="text-base">Filtrer les missions à afficher</h3>
             <p className="text-text-mention">
               {values.rules.length === 0 && "Aucun filtre appliqué - "}
               {total.toLocaleString("fr")} missions affichées
@@ -307,7 +314,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
                   checked={values.style === "page"}
                   onChange={(e) => onChange({ ...values, style: e.target.value })}
                 />
-                <span className="text-text-mention text-xs">Grille de 6 missions par page</span>
+                <p className="text-text-mention text-xs">Grille de 6 missions par page</p>
               </div>
 
               <div>
@@ -319,7 +326,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
                   checked={values.style === "carousel"}
                   onChange={(e) => onChange({ ...values, style: e.target.value })}
                 />
-                <span className="text-text-mention text-xs">Fait défiler les missions 3 par 3</span>
+                <p className="text-text-mention text-xs">Fait défiler les missions 3 par 3</p>
               </div>
             </div>
           </fieldset>
@@ -330,11 +337,20 @@ const Settings = ({ widget, values, onChange, loading }) => {
             </label>
             <div className="flex items-center gap-4">
               <div className="h-9 w-9 rounded" style={{ backgroundColor: values.color }} />
-              <input id="color" className="input flex-1" name="color" value={values.color} onChange={(e) => onChange({ ...values, color: e.target.value })} />
+              <input
+                id="color"
+                className="input flex-1"
+                name="color"
+                value={values.color}
+                onChange={(e) => onChange({ ...values, color: e.target.value })}
+                aria-describedby="color-hint"
+              />
             </div>
             <div className="text-info flex items-center gap-2">
               <BiSolidInfoSquare className="text-sm" aria-hidden="true" />
-              <span className="text-xs">Exemple: #000091</span>
+              <p id="color-hint" className="text-xs">
+                Exemple: #000091
+              </p>
             </div>
           </div>
         </div>

--- a/app/src/services/config.js
+++ b/app/src/services/config.js
@@ -1,5 +1,5 @@
 export const ENV = import.meta.env.VITE_ENV || "development";
-export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:4000";
+export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3002";
 export const BENEVOLAT_URL = import.meta.env.VITE_BENEVOLAT_URL || "http://localhost:3001";
 export const VOLONTARIAT_URL = import.meta.env.VITE_VOLONTARIAT_URL || "http://localhost:3001";
 export const SENTRY_DSN = import.meta.env.VITE_SENTRY_DSN || "";

--- a/app/tests/e2e/dashboard/fixtures.ts
+++ b/app/tests/e2e/dashboard/fixtures.ts
@@ -25,7 +25,7 @@ export const MOCK_PUBLISHER = {
 
 const MOCK_TOKEN = "mock-token-refreshed";
 
-const API_URL = "http://localhost:4000";
+const API_URL = "http://localhost:3002";
 
 type Route = { method: string; path: string; response: object; status?: number };
 


### PR DESCRIPTION
## Description

Lot de corrections d'accessibilité (RGAA) sur le back-office `app/`, suite à la revue d'audit. Vérification critère par critère, avec des correctifs ciblés et sans changement fonctionnel.

**Changements (par thème)** :
- **Structure & repères** : skiplink, landmarks (`main`/`nav`/`footer`), titres de page pertinents, hiérarchie de titres, SVG décoratifs masqués (`aria-hidden`).
- **Navigation** : `aria-current` sur la nav, sélecteur de partenaire relié à sa liste (`role="listbox"` + `aria-controls`), focus visible (sélecteur de période, recherche).
- **Listes** : `role="list"` restauré là où `list-none`/`flex` supprimait la sémantique.
- **Formulaires** : labels correctement associés (selects des statistiques publiques, champs script/flux des réglages), champs de dates `aria-required`, regroupements `fieldset`/`legend`.
- **Tableaux** : tri accessible (en-têtes en `<button>` + `aria-sort`), indicateur de tri toujours visible, `id`/`aria-current` de pagination.
- **Graphiques** : `role="img"` + alternative textuelle (tableaux de données) pour histogrammes et camemberts.
- **Modales** : dialogues accessibles + largeur responsive à 320px (`w-[90vw] max-w-*`).
- **Divers** : textes d'état (`aria-live`), intitulés de boutons/liens en icône seule, hauteurs minimales pour le zoom texte 200%.

## Liens utiles

- 📝 Ticket Notion : _à compléter_

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug (accessibilité)
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Points d'attention** :
- Deux commits hors périmètre a11y sont inclus : `fix(app): update JVA logo URL in widget embed snippet` et `chore(app): update local api default url to port 3002` (fallback de dev local → à confirmer si souhaité dans cette PR).
- Les modales de **modération** sont volontairement laissées en `min-w-*` (non responsive 320px) à ce stade.
- Vérification manuelle recommandée au clavier + lecteur d'écran (notamment le sélecteur de partenaire de la nav et les tableaux triables).