### PR TITLE
fix(api): endpoint v0/mission with multiple publishers

### DIFF
--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -214,6 +214,7 @@ const buildMissionFilters = async (widget: WidgetRecord, query: { [key: string]:
   const filters: MissionSearchFilters = {
     directFilters: await applyWidgetRules(widget.rules || [], publisherOrganizationService.findIdsMatchingArrayValue),
     publisherIds: widget.publishers,
+    diffuseurPublisherId: widget.fromPublisherId,
     skip: pagination.skip,
     limit: pagination.limit,
   };

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -208,12 +208,20 @@ export const buildWhere = async (filters: MissionSearchFilters): Promise<Prisma.
 
   const orConditions: Prisma.MissionWhereInput[] = [];
 
+  // Restriction par publisher : les diffusion rules du diffuseur (allowlist `OR` de scopes
+  // `publisherId === annonceur AND <critères>`) font autorité. À défaut de rules, on retombe
+  // sur la simple liste d'annonceurs.
+  let publisherRestrictionApplied = false;
   if (filters.diffuseurPublisherId) {
-    const diffusionWhere = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere(filters.diffuseurPublisherId);
+    const diffusionWhere = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere(filters.diffuseurPublisherId, filters.publisherIds);
     if (Object.keys(diffusionWhere).length > 0) {
       const existingAnd = Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : [];
       where.AND = [...existingAnd, diffusionWhere];
+      publisherRestrictionApplied = true;
     }
+  }
+  if (!publisherRestrictionApplied && filters.publisherIds?.length) {
+    where.publisherId = { in: filters.publisherIds };
   }
 
   where.statusCode = filters.statusCode ?? "ACCEPTED";
@@ -229,10 +237,6 @@ export const buildWhere = async (filters: MissionSearchFilters): Promise<Prisma.
     if (deletedAtFilter) {
       orConditions.push({ deletedAt: null }, { deletedAt: deletedAtFilter });
     }
-  }
-
-  if (filters.publisherIds?.length) {
-    where.publisherId = { in: filters.publisherIds };
   }
 
   if (filters.activity?.length) {
@@ -648,6 +652,8 @@ export const missionService = {
 
   async findMissions(filters: MissionSearchFilters, select: MissionSelect | null = null): Promise<{ data: MissionRecord[]; total: number }> {
     const where = await buildWhere(filters);
+
+    console.log("where", JSON.stringify(where, null, 2));
 
     const [missions, total] = await Promise.all([
       missionRepository.findMany({

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -209,7 +209,7 @@ export const buildWhere = async (filters: MissionSearchFilters): Promise<Prisma.
   const orConditions: Prisma.MissionWhereInput[] = [];
 
   if (filters.diffuseurPublisherId) {
-    const diffusionWhere = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere(filters.diffuseurPublisherId);
+    const diffusionWhere = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere(filters.diffuseurPublisherId);
     if (Object.keys(diffusionWhere).length > 0) {
       const existingAnd = Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : [];
       where.AND = [...existingAnd, diffusionWhere];

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -653,8 +653,6 @@ export const missionService = {
   async findMissions(filters: MissionSearchFilters, select: MissionSelect | null = null): Promise<{ data: MissionRecord[]; total: number }> {
     const where = await buildWhere(filters);
 
-    console.log("where", JSON.stringify(where, null, 2));
-
     const [missions, total] = await Promise.all([
       missionRepository.findMany({
         where,

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -105,6 +105,23 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
   });
 });
 
+describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", () => {
+  beforeEach(() => {
+    prismaMock.publisherDiffusionRule.findMany.mockReset();
+  });
+
+  it("combine plusieurs annonceurs en allowlist", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "root-1", value: "annonceur-1" }),
+      buildRule({ id: "root-2", value: "annonceur-2", position: 1 }),
+    ]);
+
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1");
+
+    expect(where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }] });
+  });
+});
+
 describe("publisherDiffusionRuleService.canPublisherAccessMission", () => {
   beforeEach(() => {
     prismaMock.publisherDiffusionRule.findMany.mockReset();

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -27,16 +27,15 @@ const buildRule = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere", () => {
+describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", () => {
   beforeEach(() => {
     prismaMock.publisherDiffusionRule.findMany.mockReset();
-    prismaMock.mission.count.mockReset();
   });
 
   it("charge toutes les rules du publisher triées par position", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([]);
 
-    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1");
 
     expect(where).toEqual({});
     expect(prismaMock.publisherDiffusionRule.findMany).toHaveBeenCalledWith({
@@ -45,72 +44,29 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     });
   });
 
-  it("encode l'implication scope → enfant (NOT scope OR enfant)", async () => {
-    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
-      buildRule({ id: "root-1", value: "annonceur-1" }),
-      buildRule({ id: "child-1", combinedWithId: "root-1", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
-    ]);
+  it("réduit un annonceur sans enfant à son simple publisherId", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ id: "root-1", value: "annonceur-1" })]);
 
-    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1");
 
-    expect(where).toEqual({
-      OR: [{ NOT: { publisherId: "annonceur-1" } }, { publisherOrganizationId: { not: "po-1" } }],
-    });
+    expect(where).toEqual({ publisherId: "annonceur-1" });
   });
 
-  it("AND les enfants entre eux quand il y en a plusieurs sous le même scope", async () => {
+  it("combine l'annonceur avec ses critères enfants (publisherId AND <critère>)", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
       buildRule({ id: "root-1", value: "annonceur-1" }),
       buildRule({ id: "child-1", combinedWithId: "root-1", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
       buildRule({ id: "child-2", combinedWithId: "root-1", field: "publisherOrganizationId", operator: "is_not", value: "po-2", position: 1 }),
     ]);
 
-    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1");
 
     expect(where).toEqual({
-      OR: [{ NOT: { publisherId: "annonceur-1" } }, { AND: [{ publisherOrganizationId: { not: "po-1" } }, { publisherOrganizationId: { not: "po-2" } }] }],
+      AND: [{ publisherId: "annonceur-1" }, { publisherOrganizationId: { not: "po-1" } }, { publisherOrganizationId: { not: "po-2" } }],
     });
   });
 
-  it("descend récursivement quand un enfant a lui-même des enfants", async () => {
-    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
-      buildRule({ id: "root-1", value: "annonceur-1" }),
-      buildRule({ id: "child-1", combinedWithId: "root-1", field: "type", operator: "is", value: "benevolat" }),
-      buildRule({ id: "grandchild-1", combinedWithId: "child-1", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
-    ]);
-
-    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
-
-    expect(where).toEqual({
-      OR: [{ NOT: { publisherId: "annonceur-1" } }, { OR: [{ NOT: { type: "benevolat" } }, { publisherOrganizationId: { not: "po-1" } }] }],
-    });
-  });
-
-  it("AND plusieurs racines indépendantes au top-level", async () => {
-    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
-      buildRule({ id: "root-1", value: "annonceur-1" }),
-      buildRule({ id: "child-1", combinedWithId: "root-1", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
-      buildRule({ id: "root-2", value: "annonceur-2", position: 1 }),
-      buildRule({ id: "child-2", combinedWithId: "root-2", field: "publisherOrganizationId", operator: "is_not", value: "po-2" }),
-    ]);
-
-    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
-
-    expect(where).toEqual({
-      AND: [
-        { OR: [{ NOT: { publisherId: "annonceur-1" } }, { publisherOrganizationId: { not: "po-1" } }] },
-        { OR: [{ NOT: { publisherId: "annonceur-2" } }, { publisherOrganizationId: { not: "po-2" } }] },
-      ],
-    });
-  });
-});
-
-describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", () => {
-  beforeEach(() => {
-    prismaMock.publisherDiffusionRule.findMany.mockReset();
-  });
-
-  it("combine plusieurs annonceurs en allowlist", async () => {
+  it("combine plusieurs annonceurs en allowlist (OR)", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
       buildRule({ id: "root-1", value: "annonceur-1" }),
       buildRule({ id: "root-2", value: "annonceur-2", position: 1 }),
@@ -119,6 +75,17 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
     const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1");
 
     expect(where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }] });
+  });
+
+  it("restreint les scopes aux annonceurs demandés", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "root-1", value: "annonceur-1" }),
+      buildRule({ id: "root-2", value: "annonceur-2", position: 1 }),
+    ]);
+
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1", ["annonceur-2"]);
+
+    expect(where).toEqual({ publisherId: "annonceur-2" });
   });
 });
 

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -1,4 +1,5 @@
 import { Prisma, PublisherDiffusionRule } from "@/db/core";
+import { RESSOURCE_ALREADY_EXIST } from "@/error";
 import { missionRepository } from "@/repositories/mission";
 import { publisherDiffusionRuleRepository } from "@/repositories/publisher-diffusion-rule";
 import publisherOrganizationService from "@/services/publisher-organization";
@@ -9,10 +10,15 @@ import type {
   PublisherDiffusionRuleRecord,
 } from "@/types/publisher-diffusion-rule";
 import type { OrganizationArrayIdsResolver } from "@/types/publisher-organization";
-import { buildMissionPublisherDiffusionRuleConditionFromRule, buildMissionPublisherDiffusionRuleSqlFromRules } from "@/utils/publisher-diffusion-rule-query";
+import {
+  buildMissionPublisherDiffusionRuleConditionFromRule,
+  buildMissionPublisherDiffusionRuleSqlFromRules,
+  isPublisherDiffusionRuleArrayField,
+} from "@/utils/publisher-diffusion-rule-query";
 
 type PublisherDiffusionRuleWithChildren = PublisherDiffusionRule & {
   combinedRules?: PublisherDiffusionRule[];
+  combinedWith?: PublisherDiffusionRule | null;
 };
 
 const buildNodeCondition = async (
@@ -37,7 +43,12 @@ const buildNodeCondition = async (
   return { OR: [{ NOT: selfCondition }, childrenAnd] };
 };
 
-const buildMissionWhere = async (rules: PublisherDiffusionRule[], resolveOrganizationIds: OrganizationArrayIdsResolver): Promise<Prisma.MissionWhereInput> => {
+/**
+ * Indexe une liste plate de rules par parent : racines (`combinedWithId === null`)
+ * d'un côté, enfants regroupés par `combinedWithId` de l'autre. Partagé par les
+ * constructeurs de `where` (implication et allowlist).
+ */
+const groupRulesByParent = (rules: PublisherDiffusionRule[]): { roots: PublisherDiffusionRule[]; childrenByParentId: Map<string, PublisherDiffusionRule[]> } => {
   const childrenByParentId = new Map<string, PublisherDiffusionRule[]>();
   const roots: PublisherDiffusionRule[] = [];
 
@@ -50,6 +61,42 @@ const buildMissionWhere = async (rules: PublisherDiffusionRule[], resolveOrganiz
       childrenByParentId.set(rule.combinedWithId, siblings);
     }
   }
+
+  return { roots, childrenByParentId };
+};
+
+/**
+ * Forme allowlist d'un nœud : `selfCondition AND (enfants)`. Miroir positif de
+ * `buildNodeCondition` (qui encode l'implication `NOT self OR enfants`) : même
+ * parcours d'arbre via `combinedWithId`, enfants combinés en `AND` (le champ
+ * `combinator` n'est pas pris en compte, cohérent avec la forme implication).
+ */
+const buildAllowlistNodeCondition = async (
+  rule: PublisherDiffusionRule,
+  childrenByParentId: Map<string, PublisherDiffusionRule[]>,
+  resolveOrganizationIds: OrganizationArrayIdsResolver
+): Promise<Prisma.MissionWhereInput | null> => {
+  const selfCondition = await buildMissionPublisherDiffusionRuleConditionFromRule(rule, resolveOrganizationIds);
+
+  const children = (
+    await Promise.all(
+      (childrenByParentId.get(rule.id) ?? []).map((child: PublisherDiffusionRule) => buildAllowlistNodeCondition(child, childrenByParentId, resolveOrganizationIds))
+    )
+  ).filter((condition: Prisma.MissionWhereInput | null): condition is Prisma.MissionWhereInput => Boolean(condition));
+
+  if (!children.length) {
+    return selfCondition;
+  }
+
+  const childrenAnd = children.length === 1 ? children[0] : { AND: children };
+  if (!selfCondition) {
+    return childrenAnd;
+  }
+  return { AND: [selfCondition, childrenAnd] };
+};
+
+const buildMissionWhere = async (rules: PublisherDiffusionRule[], resolveOrganizationIds: OrganizationArrayIdsResolver): Promise<Prisma.MissionWhereInput> => {
+  const { roots, childrenByParentId } = groupRulesByParent(rules);
 
   const groups = (await Promise.all(roots.map((root: PublisherDiffusionRule) => buildNodeCondition(root, childrenByParentId, resolveOrganizationIds)))).filter(
     (group: Prisma.MissionWhereInput | null): group is Prisma.MissionWhereInput => Boolean(group)
@@ -64,6 +111,30 @@ const buildMissionWhere = async (rules: PublisherDiffusionRule[], resolveOrganiz
   return { AND: groups };
 };
 
+const buildDiffuseurCandidateFilterFromRules = async (
+  rules: PublisherDiffusionRule[]
+): Promise<{ where: Prisma.MissionWhereInput; publisherIds: string[] }> => {
+  const { roots, childrenByParentId } = groupRulesByParent(rules);
+  const scopeRoots = roots.filter((root) => root.field === "publisherId" && root.operator === "is");
+
+  const scopes = (
+    await Promise.all(scopeRoots.map((root) => buildAllowlistNodeCondition(root, childrenByParentId, publisherOrganizationService.findIdsMatchingArrayValue)))
+  ).filter((scope): scope is Prisma.MissionWhereInput => scope !== null && Object.keys(scope).length > 0);
+
+  const publisherIds = Array.from(new Set(scopeRoots.map((root) => root.value)));
+
+  if (scopes.length === 0) {
+    return { where: {}, publisherIds };
+  }
+  return { where: scopes.length === 1 ? scopes[0] : { OR: scopes }, publisherIds };
+};
+
+const findOrderedRules = (publisherId: string): Promise<PublisherDiffusionRule[]> =>
+  publisherDiffusionRuleRepository.findMany({
+    where: { publisherId },
+    orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
+  });
+
 const toRecord = (rule: PublisherDiffusionRuleWithChildren): PublisherDiffusionRuleRecord => ({
   id: rule.id,
   publisherId: rule.publisherId,
@@ -77,7 +148,26 @@ const toRecord = (rule: PublisherDiffusionRuleWithChildren): PublisherDiffusionR
   createdAt: rule.createdAt,
   updatedAt: rule.updatedAt,
   combinedRules: rule.combinedRules?.map(toRecord),
+  combinedWith: rule.combinedWith ? toRecord(rule.combinedWith) : null,
 });
+
+const EXCLUSION_OPERATORS = new Set(["is_not", "does_not_contain", "does_not_exist"]);
+
+const ruleExcludesValue = (rule: PublisherDiffusionRuleRecord, value: string): boolean => {
+  const ruleValue = (rule.value ?? "").toLowerCase();
+  const candidate = value.toLowerCase();
+  switch (rule.operator) {
+    case "is_not":
+      return candidate === ruleValue;
+    case "does_not_contain":
+      // Champs array (ex. parentOrganizations) : appartenance exacte comme le filtrage réel ; champs scalaires : sous-chaîne (ILIKE %...%).
+      return isPublisherDiffusionRuleArrayField(rule.field) ? candidate === ruleValue : candidate.includes(ruleValue);
+    case "does_not_exist":
+      return candidate.length > 0;
+    default:
+      return false;
+  }
+};
 
 const buildFindWhere = (params: PublisherDiffusionRuleFindParams): Prisma.PublisherDiffusionRuleWhereInput => {
   const where: Prisma.PublisherDiffusionRuleWhereInput = {};
@@ -101,19 +191,31 @@ const buildFindWhere = (params: PublisherDiffusionRuleFindParams): Prisma.Publis
 
 export const publisherDiffusionRuleService = {
   async buildMissionPublisherDiffusionRuleWhere(publisherId: string): Promise<Prisma.MissionWhereInput> {
-    const rules = await publisherDiffusionRuleRepository.findMany({
-      where: { publisherId },
-      orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
-    });
-
+    const rules = await findOrderedRules(publisherId);
     return buildMissionWhere(rules, publisherOrganizationService.findIdsMatchingArrayValue);
   },
 
+  /**
+   * Construit le where des missions qu'un diffuseur peut diffuser, sous forme
+   * d'allowlist : `OR` des scopes, chaque scope = `publisherId` de l'annonceur
+   * (root) `AND` ses critères/exclusions enfants. Contrairement à
+   * `buildMissionPublisherDiffusionRuleWhere` (forme implication, pensée pour
+   * contraindre un ensemble déjà restreint), cette forme exclut nativement les
+   * publishers hors annonceurs et reste valide avec plusieurs scopes.
+   */
+  async buildMissionDiffuseurCandidateWhere(publisherId: string): Promise<Prisma.MissionWhereInput> {
+    const rules = await findOrderedRules(publisherId);
+    const { where } = await buildDiffuseurCandidateFilterFromRules(rules);
+    return where;
+  },
+
+  async buildMissionDiffuseurCandidateFilter(publisherId: string): Promise<{ where: Prisma.MissionWhereInput; publisherIds: string[] }> {
+    const rules = await findOrderedRules(publisherId);
+    return buildDiffuseurCandidateFilterFromRules(rules);
+  },
+
   async canPublisherAccessMission({ publisherId, missionId }: { publisherId: string; missionId: string }): Promise<boolean> {
-    const rules = await publisherDiffusionRuleRepository.findMany({
-      where: { publisherId },
-      orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
-    });
+    const rules = await findOrderedRules(publisherId);
     if (rules.length === 0) {
       return true;
     }
@@ -137,6 +239,10 @@ export const publisherDiffusionRuleService = {
     return buildMissionPublisherDiffusionRuleSqlFromRules(rules, options);
   },
 
+  isValueDiffused({ rules, field, value }: { rules: PublisherDiffusionRuleRecord[]; field: string; value: string }): boolean {
+    return !rules.some((rule) => rule.field === field && EXCLUSION_OPERATORS.has(rule.operator) && ruleExcludesValue(rule, value));
+  },
+
   async findRules(params: PublisherDiffusionRuleFindParams = {}): Promise<PublisherDiffusionRuleRecord[]> {
     const rules = (await publisherDiffusionRuleRepository.findMany({
       where: buildFindWhere(params),
@@ -150,7 +256,7 @@ export const publisherDiffusionRuleService = {
   async findRuleById(id: string): Promise<PublisherDiffusionRuleRecord | null> {
     const rule = (await publisherDiffusionRuleRepository.findUnique({
       where: { id },
-      include: { combinedRules: true },
+      include: { combinedRules: true, combinedWith: true },
     })) as PublisherDiffusionRuleWithChildren | null;
 
     return rule ? toRecord(rule) : null;
@@ -175,28 +281,38 @@ export const publisherDiffusionRuleService = {
   },
 
   async findOrCreateScopeRoot(diffuseurPublisherId: string, annonceurPublisherId: string): Promise<PublisherDiffusionRuleRecord> {
-    const existing = await publisherDiffusionRuleRepository.findFirst({
-      where: { publisherId: diffuseurPublisherId, combinedWithId: null, field: "publisherId", value: annonceurPublisherId },
-      include: { combinedRules: true },
-    });
+    const rootWhere = { publisherId: diffuseurPublisherId, combinedWithId: null, field: "publisherId", value: annonceurPublisherId };
+
+    const existing = await publisherDiffusionRuleRepository.findFirst({ where: rootWhere, include: { combinedRules: true } });
     if (existing) {
       return toRecord(existing as PublisherDiffusionRuleWithChildren);
     }
 
-    const created = (await publisherDiffusionRuleRepository.create({
-      data: {
-        publisher: { connect: { id: diffuseurPublisherId } },
-        field: "publisherId",
-        fieldType: "string",
-        operator: "is",
-        value: annonceurPublisherId,
-        combinator: "or",
-        position: 0,
-      },
-      include: { combinedRules: true },
-    })) as PublisherDiffusionRuleWithChildren;
+    try {
+      const created = (await publisherDiffusionRuleRepository.create({
+        data: {
+          publisher: { connect: { id: diffuseurPublisherId } },
+          field: "publisherId",
+          fieldType: "string",
+          operator: "is",
+          value: annonceurPublisherId,
+          combinator: "or",
+          position: 0,
+        },
+        include: { combinedRules: true },
+      })) as PublisherDiffusionRuleWithChildren;
 
-    return toRecord(created);
+      return toRecord(created);
+    } catch (error) {
+      // Course concurrente : un autre process a créé le root entre-temps (rejeté par l'index unique partiel sur les roots).
+      if ((error as { code?: string }).code === "P2002") {
+        const root = await publisherDiffusionRuleRepository.findFirst({ where: rootWhere, include: { combinedRules: true } });
+        if (root) {
+          return toRecord(root as PublisherDiffusionRuleWithChildren);
+        }
+      }
+      throw error;
+    }
   },
 
   async createScopedRule(input: {
@@ -208,6 +324,26 @@ export const publisherDiffusionRuleService = {
     value: string;
   }): Promise<PublisherDiffusionRuleRecord> {
     const root = await this.findOrCreateScopeRoot(input.diffuseurPublisherId, input.annonceurPublisherId);
+
+    const existing = await publisherDiffusionRuleRepository.findFirst({
+      where: { publisherId: input.diffuseurPublisherId, combinedWithId: root.id, field: input.field, value: input.value },
+      include: { combinedRules: true },
+    });
+    if (existing) {
+      // Idempotent uniquement si la règle est réellement identique. Sinon on refuse explicitement au lieu de
+      // renvoyer silencieusement une règle qui ne correspond pas à la demande (clé unique sur field + value).
+      const isSameRule = existing.operator === input.operator && (existing.fieldType ?? null) === (input.fieldType ?? null);
+      if (isSameRule) {
+        return toRecord(existing as PublisherDiffusionRuleWithChildren);
+      }
+      const conflict = new Error(`A diffusion rule already exists for field "${input.field}" and value "${input.value}" with a different operator`) as Error & {
+        code: string;
+        status: number;
+      };
+      conflict.code = RESSOURCE_ALREADY_EXIST;
+      conflict.status = 409;
+      throw conflict;
+    }
 
     const created = (await publisherDiffusionRuleRepository.create({
       data: {

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -2,14 +2,12 @@ import { Prisma, PublisherDiffusionRule } from "@/db/core";
 import { RESSOURCE_ALREADY_EXIST } from "@/error";
 import { missionRepository } from "@/repositories/mission";
 import { publisherDiffusionRuleRepository } from "@/repositories/publisher-diffusion-rule";
-import publisherOrganizationService from "@/services/publisher-organization";
 import type {
   PublisherDiffusionRuleCombinator,
   PublisherDiffusionRuleCreateInput,
   PublisherDiffusionRuleFindParams,
   PublisherDiffusionRuleRecord,
 } from "@/types/publisher-diffusion-rule";
-import type { OrganizationArrayIdsResolver } from "@/types/publisher-organization";
 import {
   buildMissionPublisherDiffusionRuleConditionFromRule,
   buildMissionPublisherDiffusionRuleSqlFromRules,
@@ -21,32 +19,9 @@ type PublisherDiffusionRuleWithChildren = PublisherDiffusionRule & {
   combinedWith?: PublisherDiffusionRule | null;
 };
 
-const buildNodeCondition = async (
-  rule: PublisherDiffusionRule,
-  childrenByParentId: Map<string, PublisherDiffusionRule[]>,
-  resolveOrganizationIds: OrganizationArrayIdsResolver
-): Promise<Prisma.MissionWhereInput | null> => {
-  const selfCondition = await buildMissionPublisherDiffusionRuleConditionFromRule(rule, resolveOrganizationIds);
-  if (!selfCondition) {
-    return null;
-  }
-
-  const children = (
-    await Promise.all((childrenByParentId.get(rule.id) ?? []).map((child: PublisherDiffusionRule) => buildNodeCondition(child, childrenByParentId, resolveOrganizationIds)))
-  ).filter((condition: Prisma.MissionWhereInput | null): condition is Prisma.MissionWhereInput => Boolean(condition));
-
-  if (!children.length) {
-    return selfCondition;
-  }
-
-  const childrenAnd = children.length === 1 ? children[0] : { AND: children };
-  return { OR: [{ NOT: selfCondition }, childrenAnd] };
-};
-
 /**
- * Indexe une liste plate de rules par parent : racines (`combinedWithId === null`)
- * d'un côté, enfants regroupés par `combinedWithId` de l'autre. Partagé par les
- * constructeurs de `where` (implication et allowlist).
+ * Indexe une liste plate de rules par parent : racines (`combinedWithId === null`,
+ * une par annonceur) d'un côté, enfants regroupés par `combinedWithId` de l'autre.
  */
 const groupRulesByParent = (rules: PublisherDiffusionRule[]): { roots: PublisherDiffusionRule[]; childrenByParentId: Map<string, PublisherDiffusionRule[]> } => {
   const childrenByParentId = new Map<string, PublisherDiffusionRule[]>();
@@ -66,67 +41,47 @@ const groupRulesByParent = (rules: PublisherDiffusionRule[]): { roots: Publisher
 };
 
 /**
- * Forme allowlist d'un nœud : `selfCondition AND (enfants)`. Miroir positif de
- * `buildNodeCondition` (qui encode l'implication `NOT self OR enfants`) : même
- * parcours d'arbre via `combinedWithId`, enfants combinés en `AND` (le champ
- * `combinator` n'est pas pris en compte, cohérent avec la forme implication).
+ * Condition d'un scope : la condition de la rule combinée en `AND` avec celles de
+ * ses enfants (critères/exclusions). Ex. `publisherId === X AND <field op value>`.
  */
-const buildAllowlistNodeCondition = async (
-  rule: PublisherDiffusionRule,
-  childrenByParentId: Map<string, PublisherDiffusionRule[]>,
-  resolveOrganizationIds: OrganizationArrayIdsResolver
-): Promise<Prisma.MissionWhereInput | null> => {
-  const selfCondition = await buildMissionPublisherDiffusionRuleConditionFromRule(rule, resolveOrganizationIds);
+const buildScopeCondition = (rule: PublisherDiffusionRule, childrenByParentId: Map<string, PublisherDiffusionRule[]>): Prisma.MissionWhereInput | null => {
+  const conditions: Prisma.MissionWhereInput[] = [];
 
-  const children = (
-    await Promise.all(
-      (childrenByParentId.get(rule.id) ?? []).map((child: PublisherDiffusionRule) => buildAllowlistNodeCondition(child, childrenByParentId, resolveOrganizationIds))
-    )
-  ).filter((condition: Prisma.MissionWhereInput | null): condition is Prisma.MissionWhereInput => Boolean(condition));
-
-  if (!children.length) {
-    return selfCondition;
+  const selfCondition = buildMissionPublisherDiffusionRuleConditionFromRule(rule);
+  if (selfCondition) {
+    conditions.push(selfCondition);
   }
 
-  const childrenAnd = children.length === 1 ? children[0] : { AND: children };
-  if (!selfCondition) {
-    return childrenAnd;
+  for (const child of childrenByParentId.get(rule.id) ?? []) {
+    const childCondition = buildScopeCondition(child, childrenByParentId);
+    if (childCondition) {
+      conditions.push(childCondition);
+    }
   }
-  return { AND: [selfCondition, childrenAnd] };
+
+  if (conditions.length === 0) {
+    return null;
+  }
+  return conditions.length === 1 ? conditions[0] : { AND: conditions };
 };
 
-const buildMissionWhere = async (rules: PublisherDiffusionRule[], resolveOrganizationIds: OrganizationArrayIdsResolver): Promise<Prisma.MissionWhereInput> => {
+/**
+ * Allowlist des missions diffusables : `OR` des scopes, chaque scope étant un
+ * annonceur (`publisherId === X`) combiné à ses critères enfants. `publisherIds`
+ * restreint optionnellement aux annonceurs demandés (param `publisher` de la route).
+ */
+const buildAllowlistWhere = (rules: PublisherDiffusionRule[], publisherIds?: string[]): Prisma.MissionWhereInput => {
   const { roots, childrenByParentId } = groupRulesByParent(rules);
+  const scopeRoots = roots.filter((root) => root.field === "publisherId" && root.operator === "is" && (!publisherIds || publisherIds.includes(root.value)));
 
-  const groups = (await Promise.all(roots.map((root: PublisherDiffusionRule) => buildNodeCondition(root, childrenByParentId, resolveOrganizationIds)))).filter(
-    (group: Prisma.MissionWhereInput | null): group is Prisma.MissionWhereInput => Boolean(group)
-  );
-
-  if (!groups.length) {
-    return {};
-  }
-  if (groups.length === 1) {
-    return groups[0];
-  }
-  return { AND: groups };
-};
-
-const buildDiffuseurCandidateFilterFromRules = async (
-  rules: PublisherDiffusionRule[]
-): Promise<{ where: Prisma.MissionWhereInput; publisherIds: string[] }> => {
-  const { roots, childrenByParentId } = groupRulesByParent(rules);
-  const scopeRoots = roots.filter((root) => root.field === "publisherId" && root.operator === "is");
-
-  const scopes = (
-    await Promise.all(scopeRoots.map((root) => buildAllowlistNodeCondition(root, childrenByParentId, publisherOrganizationService.findIdsMatchingArrayValue)))
-  ).filter((scope): scope is Prisma.MissionWhereInput => scope !== null && Object.keys(scope).length > 0);
-
-  const publisherIds = Array.from(new Set(scopeRoots.map((root) => root.value)));
+  const scopes = scopeRoots
+    .map((root) => buildScopeCondition(root, childrenByParentId))
+    .filter((scope): scope is Prisma.MissionWhereInput => scope !== null && Object.keys(scope).length > 0);
 
   if (scopes.length === 0) {
-    return { where: {}, publisherIds };
+    return {};
   }
-  return { where: scopes.length === 1 ? scopes[0] : { OR: scopes }, publisherIds };
+  return scopes.length === 1 ? scopes[0] : { OR: scopes };
 };
 
 const findOrderedRules = (publisherId: string): Promise<PublisherDiffusionRule[]> =>
@@ -190,28 +145,15 @@ const buildFindWhere = (params: PublisherDiffusionRuleFindParams): Prisma.Publis
 };
 
 export const publisherDiffusionRuleService = {
-  async buildMissionPublisherDiffusionRuleWhere(publisherId: string): Promise<Prisma.MissionWhereInput> {
-    const rules = await findOrderedRules(publisherId);
-    return buildMissionWhere(rules, publisherOrganizationService.findIdsMatchingArrayValue);
-  },
-
   /**
    * Construit le where des missions qu'un diffuseur peut diffuser, sous forme
    * d'allowlist : `OR` des scopes, chaque scope = `publisherId` de l'annonceur
-   * (root) `AND` ses critères/exclusions enfants. Contrairement à
-   * `buildMissionPublisherDiffusionRuleWhere` (forme implication, pensée pour
-   * contraindre un ensemble déjà restreint), cette forme exclut nativement les
-   * publishers hors annonceurs et reste valide avec plusieurs scopes.
+   * `AND` ses critères/exclusions enfants. `publisherIds` restreint optionnellement
+   * aux annonceurs demandés (param `publisher` de la route).
    */
-  async buildMissionDiffuseurCandidateWhere(publisherId: string): Promise<Prisma.MissionWhereInput> {
+  async buildMissionDiffuseurCandidateWhere(publisherId: string, publisherIds?: string[]): Promise<Prisma.MissionWhereInput> {
     const rules = await findOrderedRules(publisherId);
-    const { where } = await buildDiffuseurCandidateFilterFromRules(rules);
-    return where;
-  },
-
-  async buildMissionDiffuseurCandidateFilter(publisherId: string): Promise<{ where: Prisma.MissionWhereInput; publisherIds: string[] }> {
-    const rules = await findOrderedRules(publisherId);
-    return buildDiffuseurCandidateFilterFromRules(rules);
+    return buildAllowlistWhere(rules, publisherIds);
   },
 
   async canPublisherAccessMission({ publisherId, missionId }: { publisherId: string; missionId: string }): Promise<boolean> {
@@ -220,7 +162,7 @@ export const publisherDiffusionRuleService = {
       return true;
     }
 
-    const diffusionRuleWhere = await buildMissionWhere(rules, publisherOrganizationService.findIdsMatchingArrayValue);
+    const diffusionRuleWhere = buildAllowlistWhere(rules);
     if (Object.keys(diffusionRuleWhere).length === 0) {
       return false;
     }

--- a/api/src/types/publisher-diffusion-rule.ts
+++ b/api/src/types/publisher-diffusion-rule.ts
@@ -13,6 +13,7 @@ export interface PublisherDiffusionRuleRecord {
   createdAt: Date;
   updatedAt: Date;
   combinedRules?: PublisherDiffusionRuleRecord[];
+  combinedWith?: PublisherDiffusionRuleRecord | null;
 }
 
 export interface PublisherDiffusionRuleFindParams {

--- a/api/src/utils/__tests__/publisher-diffusion-rule-query.test.ts
+++ b/api/src/utils/__tests__/publisher-diffusion-rule-query.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import type { OrganizationArrayIdsResolver } from "@/types/publisher-organization";
 import {
   buildMissionPublisherDiffusionRuleConditionFromRule,
   buildMissionPublisherDiffusionRuleSqlFromRules,
@@ -35,41 +34,33 @@ describe("buildMissionPublisherDiffusionRuleSqlFromRules - array fields", () => 
 });
 
 describe("buildMissionPublisherDiffusionRuleConditionFromRule - array fields (Prisma where)", () => {
-  it("resolves the org array field to a case-insensitive publisherOrganizationId filter", async () => {
-    const resolve: OrganizationArrayIdsResolver = vi.fn().mockResolvedValue(["org-1", "org-2"]);
+  it("filters the org array field directly on the relation (contains -> has)", () => {
+    const where = buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "contains", value: "AFEV" }));
 
-    const where = await buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "contains", value: "AFEV" }), resolve);
-
-    expect(resolve).toHaveBeenCalledWith("parent_organizations", "AFEV");
-    expect(where).toEqual({ publisherOrganizationId: { in: ["org-1", "org-2"] } });
+    expect(where).toEqual({ publisherOrganization: { parentOrganizations: { has: "AFEV" } } });
   });
 
-  it("wraps negative array operators in NOT", async () => {
-    const resolve: OrganizationArrayIdsResolver = vi.fn().mockResolvedValue(["org-1"]);
+  it("wraps negative array operators in NOT (does_not_contain)", () => {
+    const where = buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "does_not_contain", value: "Armee de l'air" }));
 
-    const where = await buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "is_not", value: "AFEV" }), resolve);
-
-    expect(where).toEqual({ NOT: { publisherOrganizationId: { in: ["org-1"] } } });
+    expect(where).toEqual({ NOT: { publisherOrganization: { parentOrganizations: { has: "Armee de l'air" } } } });
   });
 
-  it("does not resolve and keeps generic handling for exists on an array field", async () => {
-    const resolve = vi.fn();
+  it("wraps negative array operators in NOT (is_not)", () => {
+    const where = buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "is_not", value: "AFEV" }));
 
-    const where = await buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "exists", value: "" }), resolve);
+    expect(where).toEqual({ NOT: { publisherOrganization: { parentOrganizations: { has: "AFEV" } } } });
+  });
 
-    expect(resolve).not.toHaveBeenCalled();
+  it("keeps generic handling for exists on an array field", () => {
+    const where = buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "exists", value: "" }));
+
     expect(where).toEqual({ publisherOrganization: { parentOrganizations: { isEmpty: false } } });
   });
 
-  it("does not resolve scalar fields", async () => {
-    const resolve = vi.fn();
+  it("handles scalar fields", () => {
+    const where = buildMissionPublisherDiffusionRuleConditionFromRule(rule({ field: "publisherOrganization.clientId", fieldType: "string", operator: "is", value: "client-1" }));
 
-    const where = await buildMissionPublisherDiffusionRuleConditionFromRule(
-      rule({ field: "publisherOrganization.clientId", fieldType: "string", operator: "is", value: "client-1" }),
-      resolve
-    );
-
-    expect(resolve).not.toHaveBeenCalled();
     expect(where).toEqual({ publisherOrganization: { clientId: "client-1" } });
   });
 });

--- a/api/src/utils/publisher-diffusion-rule-query.ts
+++ b/api/src/utils/publisher-diffusion-rule-query.ts
@@ -20,6 +20,9 @@ const ARRAY_FIELD_PATH_TO_COLUMN: Record<string, OrgArrayColumn> = {
 };
 const ARRAY_FIELD_PATHS = new Set(Object.keys(ARRAY_FIELD_PATH_TO_COLUMN));
 
+// Vrai si le champ est adossé à un tableau Postgres : l'appartenance est exacte (et non par sous-chaîne).
+export const isPublisherDiffusionRuleArrayField = (field: string): boolean => ARRAY_FIELD_PATHS.has(field);
+
 // Opérateurs array pour lesquels le matching doit être insensible à la casse (cf. règles widget).
 const CASE_INSENSITIVE_ARRAY_OPERATORS = new Set(["is", "is_not", "contains", "does_not_contain"]);
 

--- a/api/src/utils/publisher-diffusion-rule-query.ts
+++ b/api/src/utils/publisher-diffusion-rule-query.ts
@@ -1,5 +1,5 @@
 import { Prisma, PublisherDiffusionRule } from "@/db/core";
-import { OrganizationArrayIdsResolver, OrgArrayColumn } from "@/types/publisher-organization";
+import { OrgArrayColumn } from "@/types/publisher-organization";
 import {
   applyMissionRules,
   buildNestedMissionWhere,
@@ -22,9 +22,6 @@ const ARRAY_FIELD_PATHS = new Set(Object.keys(ARRAY_FIELD_PATH_TO_COLUMN));
 
 // Vrai si le champ est adossé à un tableau Postgres : l'appartenance est exacte (et non par sous-chaîne).
 export const isPublisherDiffusionRuleArrayField = (field: string): boolean => ARRAY_FIELD_PATHS.has(field);
-
-// Opérateurs array pour lesquels le matching doit être insensible à la casse (cf. règles widget).
-const CASE_INSENSITIVE_ARRAY_OPERATORS = new Set(["is", "is_not", "contains", "does_not_contain"]);
 
 type SqlFieldConfig = {
   column: string;
@@ -157,25 +154,11 @@ const combineRuleSqlConditions = (rules: PublisherDiffusionRuleCondition[], miss
   return Prisma.sql`(${Prisma.join(parts, " AND ")})`;
 };
 
-export const buildMissionPublisherDiffusionRuleConditionFromRule = async (
-  rule: PublisherDiffusionRuleCondition,
-  resolveOrganizationIds: OrganizationArrayIdsResolver
-): Promise<Prisma.MissionWhereInput | null> => {
-  // Champs array d'organisation : matching insensible à la casse via pré-résolution des ids (cf. règles widget).
-  const column = ARRAY_FIELD_PATH_TO_COLUMN[rule.field];
-  if (column && CASE_INSENSITIVE_ARRAY_OPERATORS.has(rule.operator)) {
-    const value = normalizeTypedRuleValue(rule);
-    if (shouldSkipMissionRuleValue(value)) {
-      return null;
-    }
-    const ids = await resolveOrganizationIds(column, `${value}`);
-    const base: Prisma.MissionWhereInput = { publisherOrganizationId: { in: ids } };
-    return rule.operator === "is_not" || rule.operator === "does_not_contain" ? { NOT: base } : base;
-  }
-
-  // Autres champs (scalaires, ou exists/does_not_exist sur array) : logique générique inchangée.
-  return buildRuleCondition(rule, { arrayFields: ARRAY_FIELD_PATHS, buildFieldWhere: buildNestedMissionWhere });
-};
+// Condition Prisma d'une diffusion rule. Les champs array d'organisation (ex. réseau) sont filtrés
+// directement sur la relation à la requête : `does_not_contain "X"` → `{ NOT: { publisherOrganization:
+// { parentOrganizations: { has: "X" } } } }`. Matching exact (sensible casse/accents), sans pré-résolution.
+export const buildMissionPublisherDiffusionRuleConditionFromRule = (rule: PublisherDiffusionRuleCondition): Prisma.MissionWhereInput | null =>
+  buildRuleCondition(rule, { arrayFields: ARRAY_FIELD_PATHS, buildFieldWhere: buildNestedMissionWhere });
 
 export const buildMissionPublisherDiffusionRuleWhereFromRules = (rules: PublisherDiffusionRuleCondition[]): Prisma.MissionWhereInput =>
   applyMissionRules(rules, {

--- a/api/tests/integration/api/endpoints/iframe/search.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/search.test.ts
@@ -1,6 +1,7 @@
 import type { MissionRecord } from "@/types/mission";
 import type { PublisherRecord } from "@/types/publisher";
 import type { WidgetRecord } from "@/types/widget";
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import request from "supertest";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createTestMission, createTestPublisher, createTestWidget, createTestWidgetRule } from "../../../../fixtures";
@@ -372,6 +373,24 @@ describe("GET /iframe/:id/search", () => {
 
       expect(response.body.total).toBe(1);
       expect(response.body.data[0].domain).toBe("Environnement");
+    });
+
+    it("should apply fromPublisher diffusion rules in addition to widget publishers", async () => {
+      await publisherDiffusionRuleService.createScopedRule({
+        diffuseurPublisherId: publisher.id,
+        annonceurPublisherId: publisher.id,
+        field: "publisherOrganization.parentOrganizations",
+        fieldType: "array",
+        operator: "is_not",
+        value: "Network B",
+      });
+
+      const response = await request(app).get(`/iframe/${widget.id}/search`).expect(200);
+
+      expect(response.body.total).toBe(2);
+      const titles = response.body.data.map((mission: MissionRecord) => mission.title);
+      expect(titles).toEqual(expect.arrayContaining(["Mission Environnement Paris", "Mission Santé Marseille"]));
+      expect(titles).not.toContain("Mission Éducation Lyon");
     });
 
     it("should apply multiple organization rules with OR combinator", async () => {

--- a/api/tests/integration/api/endpoints/v0/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v0/mission.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import request from "supertest";
 
 import { missionModerationStatusService } from "@/services/mission-moderation-status";
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import type { MissionRecord, PublisherRecord } from "@/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestMission, createTestPublisher } from "../../../../fixtures";
@@ -140,6 +141,56 @@ describe("Mission API Integration Tests", () => {
       expect(response.body.skip).toBe(0);
 
       validateMissionStructure(response.body.data[0]);
+    });
+
+    it("should return missions from multiple PublisherDiffusion partners when diffusion rules define multiple publisher scopes", async () => {
+      const annonceurA = await createTestPublisher({ name: "Scoped Publisher A" });
+      const annonceurB = await createTestPublisher({ name: "Scoped Publisher B" });
+      const diffuseur = await createTestPublisher({
+        name: "Scoped Diffuseur",
+        publishers: [
+          { publisherId: annonceurA.id, publisherName: annonceurA.name },
+          { publisherId: annonceurB.id, publisherName: annonceurB.name },
+        ],
+      });
+
+      const scopedMissionA = await createTestMission({
+        publisherId: annonceurA.id,
+        title: "Scoped mission A",
+        clientId: `scoped-${randomUUID()}`,
+      });
+      const scopedMissionB = await createTestMission({
+        publisherId: annonceurB.id,
+        title: "Scoped mission B",
+        clientId: `scoped-${randomUUID()}`,
+      });
+
+      await publisherDiffusionRuleService.createRule({
+        publisherId: diffuseur.id,
+        field: "publisherId",
+        fieldType: "string",
+        operator: "is",
+        value: annonceurA.id,
+        combinator: "or",
+        position: 0,
+      });
+      await publisherDiffusionRuleService.createRule({
+        publisherId: diffuseur.id,
+        field: "publisherId",
+        fieldType: "string",
+        operator: "is",
+        value: annonceurB.id,
+        combinator: "or",
+        position: 1,
+      });
+
+      const response = await request(app).get("/v0/mission").set("x-api-key", diffuseur.apikey!);
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.total).toBe(2);
+      const ids = response.body.data.map((mission: any) => mission._id);
+      expect(ids).toEqual(expect.arrayContaining([scopedMissionA.id, scopedMissionB.id]));
     });
 
     it("should expose compensation fields on missions", async () => {


### PR DESCRIPTION
## Description

Cette PR corrige le filtrage des missions quand un diffuseur a plusieurs annonceurs configurés.

Le problème venait de l’application des `publisher_diffusion_rule` dans `missionService` : plusieurs règles racines `publisherId is ...` étaient combinées comme une implication globale, ce qui pouvait produire un filtre impossible du type `publisherId = A AND publisherId = B`.

La correction fait utiliser la forme “allowlist” des règles de diffusion pour les recherches de missions (`buildMissionDiffuseurCandidateWhere`), tout en conservant `PublisherDiffusion` comme source de vérité des partenaires exposés par `v0/mission`.

Point important : le service `publisher-diffusion-rule/index.ts` a été repris tel quel depuis `staging`, avec ses petits prérequis de type/utilitaire, afin de limiter les divergences et d’éviter les conflits lors du backport ou de la remise en cohérence avec `staging`.

La PR couvre aussi le cas iframe où les règles de diffusion du `fromPublisher` doivent s’appliquer en plus du périmètre `widget.publishers`, traité dans le commit 2462782 

## Liens utiles

- 📝 Ticket Notion : N/A

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement avec TypeScript
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Tests d’intégration ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire