### PR TITLE
fix(api): add GIN index to fix v0/mission diffusion timeouts

### DIFF
--- a/api/prisma/migrations/20260610120000_add_publisher_organization_parent_organizations_gin_index/migration.sql
+++ b/api/prisma/migrations/20260610120000_add_publisher_organization_parent_organizations_gin_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "publisher_organization_parent_organizations_idx" ON "public"."publisher_organization" USING GIN ("parent_organizations");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -688,6 +688,8 @@ model PublisherOrganization {
   @@unique([publisherId, clientId], map: "publisher_organization_publisher_id_client_id_key")
   @@index([publisherId], map: "publisher_organization_publisher_id_idx")
   @@index([name], map: "publisher_organization_name_idx")
+  // Supporte le filtrage des diffusion rules sur `parentOrganizations` (`has` → `@>`) côté v0/mission.
+  @@index([parentOrganizations], type: Gin, map: "publisher_organization_parent_organizations_idx")
   @@map("publisher_organization")
 }
 


### PR DESCRIPTION
## Description

Corrige les **timeouts de l'endpoint `v0/mission`** introduits par #1130, **sans reverter** le fix fonctionnel (gestion multi-publishers / règles sur champs array d'organisation).

#1130 filtre les champs array d'organisation (`parentOrganizations`) via l'opérateur `has` → `@>` en sous-requête sur `publisher_organization` :

```
publisher_id = X
AND mission.publisher_organization_id IN (
  SELECT id FROM publisher_organization WHERE parent_organizations @> ARRAY['Y']
)
```

La partie `publisher_id = X` est déjà indexée et sélective, mais la sous-requête interne **seq-scan toute la table `publisher_organization`** car il n'existe **aucun index GIN sur `parent_organizations`**. Pour un diffuseur avec plusieurs scopes array, c'est un seq-scan par scope → timeout.

**Changement** : ajout d'un index GIN sur `publisher_organization.parent_organizations`, qui sert directement l'opérateur `@>` (même pattern que les index existants `stats_event_tags_idx` / `email_to_emails_idx`). Aucune modification du comportement de #1130.

> 🔁 **Cette PR remplace la PR de revert #1131** (fix-forward). Fermer #1131 si celle-ci est retenue.

## Liens utiles

- 🐛 Corrige les timeouts de #1130
- 🔁 Remplace #1131 (revert)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [x] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement *(`prisma validate` OK ; migration non appliquée localement faute de DB — couverte par la CI testcontainers)*
- [ ] Tests unitaires ajoutés/modifiés si nécessaire *(comportement inchangé ; les tests de #1130 couvrent la correction fonctionnelle)*
- [ ] Respect des standards de code (ESLint) *(aucun code TS modifié — uniquement schéma Prisma + migration SQL)*
- [x] Migration de données nécessaire

## Notes complémentaires

**Migration DB** :
- `20260610120000_add_publisher_organization_parent_organizations_gin_index`
  ```sql
  CREATE INDEX "publisher_organization_parent_organizations_idx"
  ON "public"."publisher_organization" USING GIN ("parent_organizations");
  ```
- Déclaré aussi dans `schema.prisma` (`@@index([parentOrganizations], type: Gin, …)`) pour rester en phase (pas de drift).

**Points d'attention** :
- Index unique nécessaire pour le seul champ array de diffusion rule (`ARRAY_FIELD_PATH_TO_COLUMN` ne mappe que `parent_organizations`).
- Construction de l'index en plain `CREATE INDEX` (format généré par Prisma, comme les autres index GIN du dépôt). Si la table `publisher_organization` est volumineuse en prod, l'envisager en `CREATE INDEX CONCURRENTLY` lors de l'application (cf. `add_mission_publisher_organization_index`).
- Pour `does_not_contain` (négation), le GIN n'accélère pas l'anti-match, mais ces règles restent bornées par le scope `publisher_id` sélectif.
