### PR TITLE
fix(api): v0/mission multiple publishers without diffusion timeout

### DIFF
--- a/api/prisma/migrations/20260610120000_add_publisher_organization_parent_organizations_gin_index/migration.sql
+++ b/api/prisma/migrations/20260610120000_add_publisher_organization_parent_organizations_gin_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "publisher_organization_parent_organizations_idx" ON "public"."publisher_organization" USING GIN ("parent_organizations");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -688,6 +688,8 @@ model PublisherOrganization {
   @@unique([publisherId, clientId], map: "publisher_organization_publisher_id_client_id_key")
   @@index([publisherId], map: "publisher_organization_publisher_id_idx")
   @@index([name], map: "publisher_organization_name_idx")
+  // Supporte le filtrage des diffusion rules sur `parentOrganizations` (`has` → `@>`) côté v0/mission.
+  @@index([parentOrganizations], type: Gin, map: "publisher_organization_parent_organizations_idx")
   @@map("publisher_organization")
 }
 

--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -214,7 +214,6 @@ const buildMissionFilters = async (widget: WidgetRecord, query: { [key: string]:
   const filters: MissionSearchFilters = {
     directFilters: await applyWidgetRules(widget.rules || [], publisherOrganizationService.findIdsMatchingArrayValue),
     publisherIds: widget.publishers,
-    diffuseurPublisherId: widget.fromPublisherId,
     skip: pagination.skip,
     limit: pagination.limit,
   };

--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -214,6 +214,7 @@ const buildMissionFilters = async (widget: WidgetRecord, query: { [key: string]:
   const filters: MissionSearchFilters = {
     directFilters: await applyWidgetRules(widget.rules || [], publisherOrganizationService.findIdsMatchingArrayValue),
     publisherIds: widget.publishers,
+    diffuseurPublisherId: widget.fromPublisherId,
     skip: pagination.skip,
     limit: pagination.limit,
   };

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -208,12 +208,20 @@ export const buildWhere = async (filters: MissionSearchFilters): Promise<Prisma.
 
   const orConditions: Prisma.MissionWhereInput[] = [];
 
+  // Restriction par publisher : les diffusion rules du diffuseur (allowlist `OR` de scopes
+  // `publisherId === annonceur AND <critères>`) font autorité. À défaut de rules, on retombe
+  // sur la simple liste d'annonceurs.
+  let publisherRestrictionApplied = false;
   if (filters.diffuseurPublisherId) {
-    const diffusionWhere = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere(filters.diffuseurPublisherId);
+    const diffusionWhere = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere(filters.diffuseurPublisherId, filters.publisherIds);
     if (Object.keys(diffusionWhere).length > 0) {
       const existingAnd = Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : [];
       where.AND = [...existingAnd, diffusionWhere];
+      publisherRestrictionApplied = true;
     }
+  }
+  if (!publisherRestrictionApplied && filters.publisherIds?.length) {
+    where.publisherId = { in: filters.publisherIds };
   }
 
   where.statusCode = filters.statusCode ?? "ACCEPTED";
@@ -229,10 +237,6 @@ export const buildWhere = async (filters: MissionSearchFilters): Promise<Prisma.
     if (deletedAtFilter) {
       orConditions.push({ deletedAt: null }, { deletedAt: deletedAtFilter });
     }
-  }
-
-  if (filters.publisherIds?.length) {
-    where.publisherId = { in: filters.publisherIds };
   }
 
   if (filters.activity?.length) {

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -27,16 +27,15 @@ const buildRule = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere", () => {
+describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", () => {
   beforeEach(() => {
     prismaMock.publisherDiffusionRule.findMany.mockReset();
-    prismaMock.mission.count.mockReset();
   });
 
   it("charge toutes les rules du publisher triées par position", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([]);
 
-    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1");
 
     expect(where).toEqual({});
     expect(prismaMock.publisherDiffusionRule.findMany).toHaveBeenCalledWith({
@@ -45,63 +44,48 @@ describe("publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere"
     });
   });
 
-  it("encode l'implication scope → enfant (NOT scope OR enfant)", async () => {
-    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
-      buildRule({ id: "root-1", value: "annonceur-1" }),
-      buildRule({ id: "child-1", combinedWithId: "root-1", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
-    ]);
+  it("réduit un annonceur sans enfant à son simple publisherId", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ id: "root-1", value: "annonceur-1" })]);
 
-    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1");
 
-    expect(where).toEqual({
-      OR: [{ NOT: { publisherId: "annonceur-1" } }, { publisherOrganizationId: { not: "po-1" } }],
-    });
+    expect(where).toEqual({ publisherId: "annonceur-1" });
   });
 
-  it("AND les enfants entre eux quand il y en a plusieurs sous le même scope", async () => {
+  it("combine l'annonceur avec ses critères enfants (publisherId AND <critère>)", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
       buildRule({ id: "root-1", value: "annonceur-1" }),
       buildRule({ id: "child-1", combinedWithId: "root-1", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
       buildRule({ id: "child-2", combinedWithId: "root-1", field: "publisherOrganizationId", operator: "is_not", value: "po-2", position: 1 }),
     ]);
 
-    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1");
 
     expect(where).toEqual({
-      OR: [{ NOT: { publisherId: "annonceur-1" } }, { AND: [{ publisherOrganizationId: { not: "po-1" } }, { publisherOrganizationId: { not: "po-2" } }] }],
+      AND: [{ publisherId: "annonceur-1" }, { publisherOrganizationId: { not: "po-1" } }, { publisherOrganizationId: { not: "po-2" } }],
     });
   });
 
-  it("descend récursivement quand un enfant a lui-même des enfants", async () => {
+  it("combine plusieurs annonceurs en allowlist (OR)", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
       buildRule({ id: "root-1", value: "annonceur-1" }),
-      buildRule({ id: "child-1", combinedWithId: "root-1", field: "type", operator: "is", value: "benevolat" }),
-      buildRule({ id: "grandchild-1", combinedWithId: "child-1", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
-    ]);
-
-    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
-
-    expect(where).toEqual({
-      OR: [{ NOT: { publisherId: "annonceur-1" } }, { OR: [{ NOT: { type: "benevolat" } }, { publisherOrganizationId: { not: "po-1" } }] }],
-    });
-  });
-
-  it("AND plusieurs racines indépendantes au top-level", async () => {
-    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
-      buildRule({ id: "root-1", value: "annonceur-1" }),
-      buildRule({ id: "child-1", combinedWithId: "root-1", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
       buildRule({ id: "root-2", value: "annonceur-2", position: 1 }),
-      buildRule({ id: "child-2", combinedWithId: "root-2", field: "publisherOrganizationId", operator: "is_not", value: "po-2" }),
     ]);
 
-    const where = await publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleWhere("publisher-1");
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1");
 
-    expect(where).toEqual({
-      AND: [
-        { OR: [{ NOT: { publisherId: "annonceur-1" } }, { publisherOrganizationId: { not: "po-1" } }] },
-        { OR: [{ NOT: { publisherId: "annonceur-2" } }, { publisherOrganizationId: { not: "po-2" } }] },
-      ],
-    });
+    expect(where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }] });
+  });
+
+  it("restreint les scopes aux annonceurs demandés", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "root-1", value: "annonceur-1" }),
+      buildRule({ id: "root-2", value: "annonceur-2", position: 1 }),
+    ]);
+
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1", ["annonceur-2"]);
+
+    expect(where).toEqual({ publisherId: "annonceur-2" });
   });
 });
 

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -1,43 +1,29 @@
 import { Prisma, PublisherDiffusionRule } from "@/db/core";
+import { RESSOURCE_ALREADY_EXIST } from "@/error";
 import { missionRepository } from "@/repositories/mission";
 import { publisherDiffusionRuleRepository } from "@/repositories/publisher-diffusion-rule";
-import publisherOrganizationService from "@/services/publisher-organization";
 import type {
   PublisherDiffusionRuleCombinator,
   PublisherDiffusionRuleCreateInput,
   PublisherDiffusionRuleFindParams,
   PublisherDiffusionRuleRecord,
 } from "@/types/publisher-diffusion-rule";
-import type { OrganizationArrayIdsResolver } from "@/types/publisher-organization";
-import { buildMissionPublisherDiffusionRuleConditionFromRule, buildMissionPublisherDiffusionRuleSqlFromRules } from "@/utils/publisher-diffusion-rule-query";
+import {
+  buildMissionPublisherDiffusionRuleConditionFromRule,
+  buildMissionPublisherDiffusionRuleSqlFromRules,
+  isPublisherDiffusionRuleArrayField,
+} from "@/utils/publisher-diffusion-rule-query";
 
 type PublisherDiffusionRuleWithChildren = PublisherDiffusionRule & {
   combinedRules?: PublisherDiffusionRule[];
+  combinedWith?: PublisherDiffusionRule | null;
 };
 
-const buildNodeCondition = async (
-  rule: PublisherDiffusionRule,
-  childrenByParentId: Map<string, PublisherDiffusionRule[]>,
-  resolveOrganizationIds: OrganizationArrayIdsResolver
-): Promise<Prisma.MissionWhereInput | null> => {
-  const selfCondition = await buildMissionPublisherDiffusionRuleConditionFromRule(rule, resolveOrganizationIds);
-  if (!selfCondition) {
-    return null;
-  }
-
-  const children = (
-    await Promise.all((childrenByParentId.get(rule.id) ?? []).map((child: PublisherDiffusionRule) => buildNodeCondition(child, childrenByParentId, resolveOrganizationIds)))
-  ).filter((condition: Prisma.MissionWhereInput | null): condition is Prisma.MissionWhereInput => Boolean(condition));
-
-  if (!children.length) {
-    return selfCondition;
-  }
-
-  const childrenAnd = children.length === 1 ? children[0] : { AND: children };
-  return { OR: [{ NOT: selfCondition }, childrenAnd] };
-};
-
-const buildMissionWhere = async (rules: PublisherDiffusionRule[], resolveOrganizationIds: OrganizationArrayIdsResolver): Promise<Prisma.MissionWhereInput> => {
+/**
+ * Indexe une liste plate de rules par parent : racines (`combinedWithId === null`,
+ * une par annonceur) d'un côté, enfants regroupés par `combinedWithId` de l'autre.
+ */
+const groupRulesByParent = (rules: PublisherDiffusionRule[]): { roots: PublisherDiffusionRule[]; childrenByParentId: Map<string, PublisherDiffusionRule[]> } => {
   const childrenByParentId = new Map<string, PublisherDiffusionRule[]>();
   const roots: PublisherDiffusionRule[] = [];
 
@@ -51,18 +37,58 @@ const buildMissionWhere = async (rules: PublisherDiffusionRule[], resolveOrganiz
     }
   }
 
-  const groups = (await Promise.all(roots.map((root: PublisherDiffusionRule) => buildNodeCondition(root, childrenByParentId, resolveOrganizationIds)))).filter(
-    (group: Prisma.MissionWhereInput | null): group is Prisma.MissionWhereInput => Boolean(group)
-  );
+  return { roots, childrenByParentId };
+};
 
-  if (!groups.length) {
+/**
+ * Condition d'un scope : la condition de la rule combinée en `AND` avec celles de
+ * ses enfants (critères/exclusions). Ex. `publisherId === X AND <field op value>`.
+ */
+const buildScopeCondition = (rule: PublisherDiffusionRule, childrenByParentId: Map<string, PublisherDiffusionRule[]>): Prisma.MissionWhereInput | null => {
+  const conditions: Prisma.MissionWhereInput[] = [];
+
+  const selfCondition = buildMissionPublisherDiffusionRuleConditionFromRule(rule);
+  if (selfCondition) {
+    conditions.push(selfCondition);
+  }
+
+  for (const child of childrenByParentId.get(rule.id) ?? []) {
+    const childCondition = buildScopeCondition(child, childrenByParentId);
+    if (childCondition) {
+      conditions.push(childCondition);
+    }
+  }
+
+  if (conditions.length === 0) {
+    return null;
+  }
+  return conditions.length === 1 ? conditions[0] : { AND: conditions };
+};
+
+/**
+ * Allowlist des missions diffusables : `OR` des scopes, chaque scope étant un
+ * annonceur (`publisherId === X`) combiné à ses critères enfants. `publisherIds`
+ * restreint optionnellement aux annonceurs demandés (param `publisher` de la route).
+ */
+const buildAllowlistWhere = (rules: PublisherDiffusionRule[], publisherIds?: string[]): Prisma.MissionWhereInput => {
+  const { roots, childrenByParentId } = groupRulesByParent(rules);
+  const scopeRoots = roots.filter((root) => root.field === "publisherId" && root.operator === "is" && (!publisherIds || publisherIds.includes(root.value)));
+
+  const scopes = scopeRoots
+    .map((root) => buildScopeCondition(root, childrenByParentId))
+    .filter((scope): scope is Prisma.MissionWhereInput => scope !== null && Object.keys(scope).length > 0);
+
+  if (scopes.length === 0) {
     return {};
   }
-  if (groups.length === 1) {
-    return groups[0];
-  }
-  return { AND: groups };
+  return scopes.length === 1 ? scopes[0] : { OR: scopes };
 };
+
+const findOrderedRules = (publisherId: string): Promise<PublisherDiffusionRule[]> =>
+  publisherDiffusionRuleRepository.findMany({
+    where: { publisherId },
+    orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
+  });
 
 const toRecord = (rule: PublisherDiffusionRuleWithChildren): PublisherDiffusionRuleRecord => ({
   id: rule.id,
@@ -77,7 +103,26 @@ const toRecord = (rule: PublisherDiffusionRuleWithChildren): PublisherDiffusionR
   createdAt: rule.createdAt,
   updatedAt: rule.updatedAt,
   combinedRules: rule.combinedRules?.map(toRecord),
+  combinedWith: rule.combinedWith ? toRecord(rule.combinedWith) : null,
 });
+
+const EXCLUSION_OPERATORS = new Set(["is_not", "does_not_contain", "does_not_exist"]);
+
+const ruleExcludesValue = (rule: PublisherDiffusionRuleRecord, value: string): boolean => {
+  const ruleValue = (rule.value ?? "").toLowerCase();
+  const candidate = value.toLowerCase();
+  switch (rule.operator) {
+    case "is_not":
+      return candidate === ruleValue;
+    case "does_not_contain":
+      // Champs array (ex. parentOrganizations) : appartenance exacte comme le filtrage réel ; champs scalaires : sous-chaîne (ILIKE %...%).
+      return isPublisherDiffusionRuleArrayField(rule.field) ? candidate === ruleValue : candidate.includes(ruleValue);
+    case "does_not_exist":
+      return candidate.length > 0;
+    default:
+      return false;
+  }
+};
 
 const buildFindWhere = (params: PublisherDiffusionRuleFindParams): Prisma.PublisherDiffusionRuleWhereInput => {
   const where: Prisma.PublisherDiffusionRuleWhereInput = {};
@@ -100,25 +145,24 @@ const buildFindWhere = (params: PublisherDiffusionRuleFindParams): Prisma.Publis
 };
 
 export const publisherDiffusionRuleService = {
-  async buildMissionPublisherDiffusionRuleWhere(publisherId: string): Promise<Prisma.MissionWhereInput> {
-    const rules = await publisherDiffusionRuleRepository.findMany({
-      where: { publisherId },
-      orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
-    });
-
-    return buildMissionWhere(rules, publisherOrganizationService.findIdsMatchingArrayValue);
+  /**
+   * Construit le where des missions qu'un diffuseur peut diffuser, sous forme
+   * d'allowlist : `OR` des scopes, chaque scope = `publisherId` de l'annonceur
+   * `AND` ses critères/exclusions enfants. `publisherIds` restreint optionnellement
+   * aux annonceurs demandés (param `publisher` de la route).
+   */
+  async buildMissionDiffuseurCandidateWhere(publisherId: string, publisherIds?: string[]): Promise<Prisma.MissionWhereInput> {
+    const rules = await findOrderedRules(publisherId);
+    return buildAllowlistWhere(rules, publisherIds);
   },
 
   async canPublisherAccessMission({ publisherId, missionId }: { publisherId: string; missionId: string }): Promise<boolean> {
-    const rules = await publisherDiffusionRuleRepository.findMany({
-      where: { publisherId },
-      orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
-    });
+    const rules = await findOrderedRules(publisherId);
     if (rules.length === 0) {
       return true;
     }
 
-    const diffusionRuleWhere = await buildMissionWhere(rules, publisherOrganizationService.findIdsMatchingArrayValue);
+    const diffusionRuleWhere = buildAllowlistWhere(rules);
     if (Object.keys(diffusionRuleWhere).length === 0) {
       return false;
     }
@@ -137,6 +181,10 @@ export const publisherDiffusionRuleService = {
     return buildMissionPublisherDiffusionRuleSqlFromRules(rules, options);
   },
 
+  isValueDiffused({ rules, field, value }: { rules: PublisherDiffusionRuleRecord[]; field: string; value: string }): boolean {
+    return !rules.some((rule) => rule.field === field && EXCLUSION_OPERATORS.has(rule.operator) && ruleExcludesValue(rule, value));
+  },
+
   async findRules(params: PublisherDiffusionRuleFindParams = {}): Promise<PublisherDiffusionRuleRecord[]> {
     const rules = (await publisherDiffusionRuleRepository.findMany({
       where: buildFindWhere(params),
@@ -150,7 +198,7 @@ export const publisherDiffusionRuleService = {
   async findRuleById(id: string): Promise<PublisherDiffusionRuleRecord | null> {
     const rule = (await publisherDiffusionRuleRepository.findUnique({
       where: { id },
-      include: { combinedRules: true },
+      include: { combinedRules: true, combinedWith: true },
     })) as PublisherDiffusionRuleWithChildren | null;
 
     return rule ? toRecord(rule) : null;
@@ -175,28 +223,38 @@ export const publisherDiffusionRuleService = {
   },
 
   async findOrCreateScopeRoot(diffuseurPublisherId: string, annonceurPublisherId: string): Promise<PublisherDiffusionRuleRecord> {
-    const existing = await publisherDiffusionRuleRepository.findFirst({
-      where: { publisherId: diffuseurPublisherId, combinedWithId: null, field: "publisherId", value: annonceurPublisherId },
-      include: { combinedRules: true },
-    });
+    const rootWhere = { publisherId: diffuseurPublisherId, combinedWithId: null, field: "publisherId", value: annonceurPublisherId };
+
+    const existing = await publisherDiffusionRuleRepository.findFirst({ where: rootWhere, include: { combinedRules: true } });
     if (existing) {
       return toRecord(existing as PublisherDiffusionRuleWithChildren);
     }
 
-    const created = (await publisherDiffusionRuleRepository.create({
-      data: {
-        publisher: { connect: { id: diffuseurPublisherId } },
-        field: "publisherId",
-        fieldType: "string",
-        operator: "is",
-        value: annonceurPublisherId,
-        combinator: "or",
-        position: 0,
-      },
-      include: { combinedRules: true },
-    })) as PublisherDiffusionRuleWithChildren;
+    try {
+      const created = (await publisherDiffusionRuleRepository.create({
+        data: {
+          publisher: { connect: { id: diffuseurPublisherId } },
+          field: "publisherId",
+          fieldType: "string",
+          operator: "is",
+          value: annonceurPublisherId,
+          combinator: "or",
+          position: 0,
+        },
+        include: { combinedRules: true },
+      })) as PublisherDiffusionRuleWithChildren;
 
-    return toRecord(created);
+      return toRecord(created);
+    } catch (error) {
+      // Course concurrente : un autre process a créé le root entre-temps (rejeté par l'index unique partiel sur les roots).
+      if ((error as { code?: string }).code === "P2002") {
+        const root = await publisherDiffusionRuleRepository.findFirst({ where: rootWhere, include: { combinedRules: true } });
+        if (root) {
+          return toRecord(root as PublisherDiffusionRuleWithChildren);
+        }
+      }
+      throw error;
+    }
   },
 
   async createScopedRule(input: {
@@ -208,6 +266,26 @@ export const publisherDiffusionRuleService = {
     value: string;
   }): Promise<PublisherDiffusionRuleRecord> {
     const root = await this.findOrCreateScopeRoot(input.diffuseurPublisherId, input.annonceurPublisherId);
+
+    const existing = await publisherDiffusionRuleRepository.findFirst({
+      where: { publisherId: input.diffuseurPublisherId, combinedWithId: root.id, field: input.field, value: input.value },
+      include: { combinedRules: true },
+    });
+    if (existing) {
+      // Idempotent uniquement si la règle est réellement identique. Sinon on refuse explicitement au lieu de
+      // renvoyer silencieusement une règle qui ne correspond pas à la demande (clé unique sur field + value).
+      const isSameRule = existing.operator === input.operator && (existing.fieldType ?? null) === (input.fieldType ?? null);
+      if (isSameRule) {
+        return toRecord(existing as PublisherDiffusionRuleWithChildren);
+      }
+      const conflict = new Error(`A diffusion rule already exists for field "${input.field}" and value "${input.value}" with a different operator`) as Error & {
+        code: string;
+        status: number;
+      };
+      conflict.code = RESSOURCE_ALREADY_EXIST;
+      conflict.status = 409;
+      throw conflict;
+    }
 
     const created = (await publisherDiffusionRuleRepository.create({
       data: {

--- a/api/src/types/publisher-diffusion-rule.ts
+++ b/api/src/types/publisher-diffusion-rule.ts
@@ -13,6 +13,7 @@ export interface PublisherDiffusionRuleRecord {
   createdAt: Date;
   updatedAt: Date;
   combinedRules?: PublisherDiffusionRuleRecord[];
+  combinedWith?: PublisherDiffusionRuleRecord | null;
 }
 
 export interface PublisherDiffusionRuleFindParams {

--- a/api/src/utils/__tests__/publisher-diffusion-rule-query.test.ts
+++ b/api/src/utils/__tests__/publisher-diffusion-rule-query.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import type { OrganizationArrayIdsResolver } from "@/types/publisher-organization";
 import {
   buildMissionPublisherDiffusionRuleConditionFromRule,
   buildMissionPublisherDiffusionRuleSqlFromRules,
@@ -35,41 +34,33 @@ describe("buildMissionPublisherDiffusionRuleSqlFromRules - array fields", () => 
 });
 
 describe("buildMissionPublisherDiffusionRuleConditionFromRule - array fields (Prisma where)", () => {
-  it("resolves the org array field to a case-insensitive publisherOrganizationId filter", async () => {
-    const resolve: OrganizationArrayIdsResolver = vi.fn().mockResolvedValue(["org-1", "org-2"]);
+  it("filters the org array field directly on the relation (contains -> has)", () => {
+    const where = buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "contains", value: "AFEV" }));
 
-    const where = await buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "contains", value: "AFEV" }), resolve);
-
-    expect(resolve).toHaveBeenCalledWith("parent_organizations", "AFEV");
-    expect(where).toEqual({ publisherOrganizationId: { in: ["org-1", "org-2"] } });
+    expect(where).toEqual({ publisherOrganization: { parentOrganizations: { has: "AFEV" } } });
   });
 
-  it("wraps negative array operators in NOT", async () => {
-    const resolve: OrganizationArrayIdsResolver = vi.fn().mockResolvedValue(["org-1"]);
+  it("wraps negative array operators in NOT (does_not_contain)", () => {
+    const where = buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "does_not_contain", value: "Armee de l'air" }));
 
-    const where = await buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "is_not", value: "AFEV" }), resolve);
-
-    expect(where).toEqual({ NOT: { publisherOrganizationId: { in: ["org-1"] } } });
+    expect(where).toEqual({ NOT: { publisherOrganization: { parentOrganizations: { has: "Armee de l'air" } } } });
   });
 
-  it("does not resolve and keeps generic handling for exists on an array field", async () => {
-    const resolve = vi.fn();
+  it("wraps negative array operators in NOT (is_not)", () => {
+    const where = buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "is_not", value: "AFEV" }));
 
-    const where = await buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "exists", value: "" }), resolve);
+    expect(where).toEqual({ NOT: { publisherOrganization: { parentOrganizations: { has: "AFEV" } } } });
+  });
 
-    expect(resolve).not.toHaveBeenCalled();
+  it("keeps generic handling for exists on an array field", () => {
+    const where = buildMissionPublisherDiffusionRuleConditionFromRule(rule({ operator: "exists", value: "" }));
+
     expect(where).toEqual({ publisherOrganization: { parentOrganizations: { isEmpty: false } } });
   });
 
-  it("does not resolve scalar fields", async () => {
-    const resolve = vi.fn();
+  it("handles scalar fields", () => {
+    const where = buildMissionPublisherDiffusionRuleConditionFromRule(rule({ field: "publisherOrganization.clientId", fieldType: "string", operator: "is", value: "client-1" }));
 
-    const where = await buildMissionPublisherDiffusionRuleConditionFromRule(
-      rule({ field: "publisherOrganization.clientId", fieldType: "string", operator: "is", value: "client-1" }),
-      resolve
-    );
-
-    expect(resolve).not.toHaveBeenCalled();
     expect(where).toEqual({ publisherOrganization: { clientId: "client-1" } });
   });
 });

--- a/api/src/utils/publisher-diffusion-rule-query.ts
+++ b/api/src/utils/publisher-diffusion-rule-query.ts
@@ -1,5 +1,5 @@
 import { Prisma, PublisherDiffusionRule } from "@/db/core";
-import { OrganizationArrayIdsResolver, OrgArrayColumn } from "@/types/publisher-organization";
+import { OrgArrayColumn } from "@/types/publisher-organization";
 import {
   applyMissionRules,
   buildNestedMissionWhere,
@@ -20,8 +20,8 @@ const ARRAY_FIELD_PATH_TO_COLUMN: Record<string, OrgArrayColumn> = {
 };
 const ARRAY_FIELD_PATHS = new Set(Object.keys(ARRAY_FIELD_PATH_TO_COLUMN));
 
-// Opérateurs array pour lesquels le matching doit être insensible à la casse (cf. règles widget).
-const CASE_INSENSITIVE_ARRAY_OPERATORS = new Set(["is", "is_not", "contains", "does_not_contain"]);
+// Vrai si le champ est adossé à un tableau Postgres : l'appartenance est exacte (et non par sous-chaîne).
+export const isPublisherDiffusionRuleArrayField = (field: string): boolean => ARRAY_FIELD_PATHS.has(field);
 
 type SqlFieldConfig = {
   column: string;
@@ -154,25 +154,11 @@ const combineRuleSqlConditions = (rules: PublisherDiffusionRuleCondition[], miss
   return Prisma.sql`(${Prisma.join(parts, " AND ")})`;
 };
 
-export const buildMissionPublisherDiffusionRuleConditionFromRule = async (
-  rule: PublisherDiffusionRuleCondition,
-  resolveOrganizationIds: OrganizationArrayIdsResolver
-): Promise<Prisma.MissionWhereInput | null> => {
-  // Champs array d'organisation : matching insensible à la casse via pré-résolution des ids (cf. règles widget).
-  const column = ARRAY_FIELD_PATH_TO_COLUMN[rule.field];
-  if (column && CASE_INSENSITIVE_ARRAY_OPERATORS.has(rule.operator)) {
-    const value = normalizeTypedRuleValue(rule);
-    if (shouldSkipMissionRuleValue(value)) {
-      return null;
-    }
-    const ids = await resolveOrganizationIds(column, `${value}`);
-    const base: Prisma.MissionWhereInput = { publisherOrganizationId: { in: ids } };
-    return rule.operator === "is_not" || rule.operator === "does_not_contain" ? { NOT: base } : base;
-  }
-
-  // Autres champs (scalaires, ou exists/does_not_exist sur array) : logique générique inchangée.
-  return buildRuleCondition(rule, { arrayFields: ARRAY_FIELD_PATHS, buildFieldWhere: buildNestedMissionWhere });
-};
+// Condition Prisma d'une diffusion rule. Les champs array d'organisation (ex. réseau) sont filtrés
+// directement sur la relation à la requête : `does_not_contain "X"` → `{ NOT: { publisherOrganization:
+// { parentOrganizations: { has: "X" } } } }`. Matching exact (sensible casse/accents), sans pré-résolution.
+export const buildMissionPublisherDiffusionRuleConditionFromRule = (rule: PublisherDiffusionRuleCondition): Prisma.MissionWhereInput | null =>
+  buildRuleCondition(rule, { arrayFields: ARRAY_FIELD_PATHS, buildFieldWhere: buildNestedMissionWhere });
 
 export const buildMissionPublisherDiffusionRuleWhereFromRules = (rules: PublisherDiffusionRuleCondition[]): Prisma.MissionWhereInput =>
   applyMissionRules(rules, {

--- a/api/tests/integration/api/endpoints/iframe/search.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/search.test.ts
@@ -1,6 +1,7 @@
 import type { MissionRecord } from "@/types/mission";
 import type { PublisherRecord } from "@/types/publisher";
 import type { WidgetRecord } from "@/types/widget";
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import request from "supertest";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createTestMission, createTestPublisher, createTestWidget, createTestWidgetRule } from "../../../../fixtures";
@@ -372,6 +373,24 @@ describe("GET /iframe/:id/search", () => {
 
       expect(response.body.total).toBe(1);
       expect(response.body.data[0].domain).toBe("Environnement");
+    });
+
+    it("should apply fromPublisher diffusion rules in addition to widget publishers", async () => {
+      await publisherDiffusionRuleService.createScopedRule({
+        diffuseurPublisherId: publisher.id,
+        annonceurPublisherId: publisher.id,
+        field: "publisherOrganization.parentOrganizations",
+        fieldType: "array",
+        operator: "is_not",
+        value: "Network B",
+      });
+
+      const response = await request(app).get(`/iframe/${widget.id}/search`).expect(200);
+
+      expect(response.body.total).toBe(2);
+      const titles = response.body.data.map((mission: MissionRecord) => mission.title);
+      expect(titles).toEqual(expect.arrayContaining(["Mission Environnement Paris", "Mission Santé Marseille"]));
+      expect(titles).not.toContain("Mission Éducation Lyon");
     });
 
     it("should apply multiple organization rules with OR combinator", async () => {

--- a/api/tests/integration/api/endpoints/v0/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v0/mission.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import request from "supertest";
 
 import { missionModerationStatusService } from "@/services/mission-moderation-status";
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import type { MissionRecord, PublisherRecord } from "@/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestMission, createTestPublisher } from "../../../../fixtures";
@@ -140,6 +141,56 @@ describe("Mission API Integration Tests", () => {
       expect(response.body.skip).toBe(0);
 
       validateMissionStructure(response.body.data[0]);
+    });
+
+    it("should return missions from multiple PublisherDiffusion partners when diffusion rules define multiple publisher scopes", async () => {
+      const annonceurA = await createTestPublisher({ name: "Scoped Publisher A" });
+      const annonceurB = await createTestPublisher({ name: "Scoped Publisher B" });
+      const diffuseur = await createTestPublisher({
+        name: "Scoped Diffuseur",
+        publishers: [
+          { publisherId: annonceurA.id, publisherName: annonceurA.name },
+          { publisherId: annonceurB.id, publisherName: annonceurB.name },
+        ],
+      });
+
+      const scopedMissionA = await createTestMission({
+        publisherId: annonceurA.id,
+        title: "Scoped mission A",
+        clientId: `scoped-${randomUUID()}`,
+      });
+      const scopedMissionB = await createTestMission({
+        publisherId: annonceurB.id,
+        title: "Scoped mission B",
+        clientId: `scoped-${randomUUID()}`,
+      });
+
+      await publisherDiffusionRuleService.createRule({
+        publisherId: diffuseur.id,
+        field: "publisherId",
+        fieldType: "string",
+        operator: "is",
+        value: annonceurA.id,
+        combinator: "or",
+        position: 0,
+      });
+      await publisherDiffusionRuleService.createRule({
+        publisherId: diffuseur.id,
+        field: "publisherId",
+        fieldType: "string",
+        operator: "is",
+        value: annonceurB.id,
+        combinator: "or",
+        position: 1,
+      });
+
+      const response = await request(app).get("/v0/mission").set("x-api-key", diffuseur.apikey!);
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.total).toBe(2);
+      const ids = response.body.data.map((mission: any) => mission._id);
+      expect(ids).toEqual(expect.arrayContaining([scopedMissionA.id, scopedMissionB.id]));
     });
 
     it("should expose compensation fields on missions", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api-engagement",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "api-engagement",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "workspaces": [
         "packages/dto",
         "packages/taxonomy",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-engagement",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "workspaces": [
     "packages/dto",
     "packages/taxonomy",


### PR DESCRIPTION
## Description

Réintroduction **propre** du fix multi-publishers `v0/mission` (#1130) **sans le timeout** qu'il avait causé. Branche partant de **v1.9.1** (dernière release saine), contenant :

1. **#1130** rejoué — endpoint `v0/mission` avec plusieurs publishers / règles sur champs array d'organisation (allowlist `OR` de scopes par annonceur).
2. **Index GIN** sur `publisher_organization.parent_organizations` — supprime le timeout : le filtre `has` (→ `@>`) de #1130 s'appuyait sur une sous-requête qui seq-scannait `publisher_organization` faute d'index GIN.

### Séquencement prévu
1. Merger le **revert #1131** sur `main` → retour à l'état v1.9.1 sain (stoppe les timeouts immédiatement).
2. Merger **cette PR** → réintroduit #1130 correctement + l'index, donc multi-publishers OK et sans timeout.

> 🔁 **Remplace #1132** (qui n'apportait que l'index, par-dessus le #1130 resté sur `main`).

## Liens utiles

- 🔁 Réintroduit #1130 (sans timeout) — remplace #1132
- ⏪ À merger après le revert #1131

## Type de changement

- [x] Nouvelle fonctionnalité *(réintroduit le support multi-publishers de #1130)*
- [x] Correction de bug
- [x] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement *(#1130 rejoué à l'identique depuis son parent v1.9.1 — cherry-pick sans conflit ; `prisma validate` OK ; migration non appliquée localement faute de DB — couverte par la CI testcontainers)*
- [x] Tests unitaires ajoutés/modifiés si nécessaire *(les tests de #1130 sont inclus : `v0/mission.test.ts`, `iframe/search.test.ts`, `publisher-diffusion-rule` unit tests)*
- [ ] Respect des standards de code (ESLint) *(aucun nouveau code hors #1130 ; ajout = schéma Prisma + migration SQL ; lint vérifié par la CI)*
- [x] Migration de données nécessaire

## Notes complémentaires

**Migration DB** :
- `20260610120000_add_publisher_organization_parent_organizations_gin_index`
  ```sql
  CREATE INDEX "publisher_organization_parent_organizations_idx"
  ON "public"."publisher_organization" USING GIN ("parent_organizations");
  ```
- Déclaré aussi dans `schema.prisma` (`@@index([parentOrganizations], type: Gin, …)`) — pas de drift.

**Points d'attention** :
- Le diff GitHub affiche #1130 + l'index (base de comparaison = v1.9.1). Une fois le revert #1131 mergé sur `main`, ce merge réintroduit proprement #1130.
- Si `publisher_organization` est volumineuse en prod, construire l'index en `CREATE INDEX CONCURRENTLY` lors de l'application (cf. `add_mission_publisher_organization_index`).
