### PR TITLE
fix(jobs): grimpio with diffusion service

### DIFF
--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -70,7 +70,7 @@ const buildScopeCondition = (rule: PublisherDiffusionRule, childrenByParentId: M
  * annonceur (`publisherId === X`) combiné à ses critères enfants. `publisherIds`
  * restreint optionnellement aux annonceurs demandés (param `publisher` de la route).
  */
-const buildAllowlistWhere = (rules: PublisherDiffusionRule[], publisherIds?: string[]): Prisma.MissionWhereInput => {
+const buildAllowlistFilter = (rules: PublisherDiffusionRule[], publisherIds?: string[]): { where: Prisma.MissionWhereInput; publisherIds: string[] } => {
   const { roots, childrenByParentId } = groupRulesByParent(rules);
   const scopeRoots = roots.filter((root) => root.field === "publisherId" && root.operator === "is" && (!publisherIds || publisherIds.includes(root.value)));
 
@@ -78,10 +78,12 @@ const buildAllowlistWhere = (rules: PublisherDiffusionRule[], publisherIds?: str
     .map((root) => buildScopeCondition(root, childrenByParentId))
     .filter((scope): scope is Prisma.MissionWhereInput => scope !== null && Object.keys(scope).length > 0);
 
+  const candidatePublisherIds = Array.from(new Set(scopeRoots.map((root) => root.value)));
+
   if (scopes.length === 0) {
-    return {};
+    return { where: {}, publisherIds: candidatePublisherIds };
   }
-  return scopes.length === 1 ? scopes[0] : { OR: scopes };
+  return { where: scopes.length === 1 ? scopes[0] : { OR: scopes }, publisherIds: candidatePublisherIds };
 };
 
 const findOrderedRules = (publisherId: string): Promise<PublisherDiffusionRule[]> =>
@@ -153,7 +155,13 @@ export const publisherDiffusionRuleService = {
    */
   async buildMissionDiffuseurCandidateWhere(publisherId: string, publisherIds?: string[]): Promise<Prisma.MissionWhereInput> {
     const rules = await findOrderedRules(publisherId);
-    return buildAllowlistWhere(rules, publisherIds);
+    const { where } = buildAllowlistFilter(rules, publisherIds);
+    return where;
+  },
+
+  async buildMissionDiffuseurCandidateFilter(publisherId: string, publisherIds?: string[]): Promise<{ where: Prisma.MissionWhereInput; publisherIds: string[] }> {
+    const rules = await findOrderedRules(publisherId);
+    return buildAllowlistFilter(rules, publisherIds);
   },
 
   async canPublisherAccessMission({ publisherId, missionId }: { publisherId: string; missionId: string }): Promise<boolean> {
@@ -162,7 +170,7 @@ export const publisherDiffusionRuleService = {
       return true;
     }
 
-    const diffusionRuleWhere = buildAllowlistWhere(rules);
+    const { where: diffusionRuleWhere } = buildAllowlistFilter(rules);
     if (Object.keys(diffusionRuleWhere).length === 0) {
       return false;
     }

--- a/api/tests/integration/jobs/grimpio/grimpio.handler.test.ts
+++ b/api/tests/integration/jobs/grimpio/grimpio.handler.test.ts
@@ -59,6 +59,14 @@ describe("GrimpioHandler (integration test)", () => {
     // Annonceurs configurés en DB pour grimpio : JVA + ASC (pas "otherPublisher")
     await publisherDiffusionRuleService.findOrCreateScopeRoot(GRIMPIO_ID, JVA_ID);
     await publisherDiffusionRuleService.findOrCreateScopeRoot(GRIMPIO_ID, ASC_ID);
+    await publisherDiffusionRuleService.createRule({
+      publisherId: GRIMPIO_ID,
+      field: "publisherId",
+      fieldType: "string",
+      operator: "is_not",
+      value: otherPublisher.id,
+      combinator: "or",
+    });
 
     await createTestMission({ publisherId: JVA_ID, statusCode: "ACCEPTED", endAt: FUTURE_END, clientId: "jva-mission-1", title: "Mission JVA" });
     await createTestMission({ publisherId: ASC_ID, statusCode: "ACCEPTED", endAt: FUTURE_END, clientId: "asc-mission-1", title: "Mission ASC" });


### PR DESCRIPTION
## Description

Cette PR corrige le job Grimpio après la simplification du service de diffusion rules. Celui-ci ne tournait plus et les tests étaient cassés. 

La PR centralise la construction du filtre candidat diffuseur dans `publisherDiffusionRuleService` afin de retourner en une seule analyse des rules :

- le `where` Prisma des missions diffusables ;
- la liste des annonceurs configurés via les roots positives `publisherId is <annonceurId>`.

`buildMissionDiffuseurCandidateWhere` reste disponible comme raccourci pour les appels qui ont uniquement besoin du `where`, tandis que Grimpio continue d utiliser `buildMissionDiffuseurCandidateFilter` pour générer un feed par annonceur configure.

La couverture integration Grimpio est renforcée avec une rule negative `publisherId is_not ...` pour verifier qu elle ne genere pas de feed annonceur.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire