### PR TITLE
feat(analytics): cast candidate_age as an int instead of a string

### DIFF
--- a/analytics/dbt/analytics/models/marts/stat_event/apply_jva_attrs.sql
+++ b/analytics/dbt/analytics/models/marts/stat_event/apply_jva_attrs.sql
@@ -31,10 +31,10 @@ select
   s.stat_event_id as apply_id,
   s.created_at,
   s.updated_at,
+  (s.attrs ->> 'candidateAge')::int as candidate_age,
   s.attrs ->> 'candidateJob' as candidate_job,
   s.attrs ->> 'userIdentifiant' as user_identifiant,
   s.attrs ->> 'candidatePostalCode' as candidate_postal_code,
-  (s.attrs ->> 'candidateAge')::int as candidate_age,
   coalesce((s.attrs ->> 'newUser')::boolean, true) as is_new_user
 from src as s
 inner join jva as sc on s.to_publisher_id = sc.id

--- a/analytics/dbt/analytics/models/marts/stat_event/apply_jva_attrs.sql
+++ b/analytics/dbt/analytics/models/marts/stat_event/apply_jva_attrs.sql
@@ -31,12 +31,11 @@ select
   s.stat_event_id as apply_id,
   s.created_at,
   s.updated_at,
-  coalesce((s.attrs ->> 'newUser')::boolean, true)
-    as is_new_user,
-  (s.attrs ->> 'candidateAge')::int as candidate_age,
   s.attrs ->> 'candidateJob' as candidate_job,
   s.attrs ->> 'userIdentifiant' as user_identifiant,
-  s.attrs ->> 'candidatePostalCode' as candidate_postal_code
+  s.attrs ->> 'candidatePostalCode' as candidate_postal_code,
+  (s.attrs ->> 'candidateAge')::int as candidate_age,
+  coalesce((s.attrs ->> 'newUser')::boolean, true) as is_new_user
 from src as s
 inner join jva as sc on s.to_publisher_id = sc.id
 where

--- a/analytics/dbt/analytics/models/marts/stat_event/apply_jva_attrs.sql
+++ b/analytics/dbt/analytics/models/marts/stat_event/apply_jva_attrs.sql
@@ -33,7 +33,7 @@ select
   s.updated_at,
   coalesce((s.attrs ->> 'newUser')::boolean, true)
     as is_new_user,
-  s.attrs ->> 'candidateAge' as candidate_age,
+  (s.attrs ->> 'candidateAge')::int as candidate_age,
   s.attrs ->> 'candidateJob' as candidate_job,
   s.attrs ->> 'userIdentifiant' as user_identifiant,
   s.attrs ->> 'candidatePostalCode' as candidate_postal_code


### PR DESCRIPTION
## Description

Cast du champ `candidate_age` en int dans le modèle `apply_jva_attrs`. Le champ était jusqu'ici stocké en texte, ce qui empêchait toute analyse numérique (moyenne, tranche d'âge, etc.) dans Metabase.

**Changements**
`apply_jva_attrs.sql : (s.attrs ->> 'candidateAge')::int`
**Tests**
`dbt run --select apply_jva_attrs --full-refresh` exécuté sur staging ✅
Type de la colonne vérifié dans les métadonnées Metabase ✅

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
