### PR TITLE
fix(api): merge publisher org relation filters in diffusion rule where

### DIFF
--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -12,6 +12,7 @@ import {
   buildMissionPublisherDiffusionRuleConditionFromRule,
   buildMissionPublisherDiffusionRuleSqlFromRules,
   isPublisherDiffusionRuleArrayField,
+  optimizeMissionDiffusionRuleWhere,
 } from "@/utils/publisher-diffusion-rule-query";
 
 type PublisherDiffusionRuleWithChildren = PublisherDiffusionRule & {
@@ -83,7 +84,8 @@ const buildAllowlistFilter = (rules: PublisherDiffusionRule[], publisherIds?: st
   if (scopes.length === 0) {
     return { where: {}, publisherIds: candidatePublisherIds };
   }
-  return { where: scopes.length === 1 ? scopes[0] : { OR: scopes }, publisherIds: candidatePublisherIds };
+  const where = optimizeMissionDiffusionRuleWhere(scopes.length === 1 ? scopes[0] : { OR: scopes });
+  return { where, publisherIds: candidatePublisherIds };
 };
 
 const findOrderedRules = (publisherId: string): Promise<PublisherDiffusionRule[]> =>

--- a/api/src/utils/__tests__/publisher-diffusion-rule-query.test.ts
+++ b/api/src/utils/__tests__/publisher-diffusion-rule-query.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildMissionPublisherDiffusionRuleConditionFromRule,
   buildMissionPublisherDiffusionRuleSqlFromRules,
+  optimizeMissionDiffusionRuleWhere,
   type PublisherDiffusionRuleCondition,
 } from "@/utils/publisher-diffusion-rule-query";
 
@@ -62,5 +63,71 @@ describe("buildMissionPublisherDiffusionRuleConditionFromRule - array fields (Pr
     const where = buildMissionPublisherDiffusionRuleConditionFromRule(rule({ field: "publisherOrganization.clientId", fieldType: "string", operator: "is", value: "client-1" }));
 
     expect(where).toEqual({ publisherOrganization: { clientId: "client-1" } });
+  });
+});
+
+describe("optimizeMissionDiffusionRuleWhere", () => {
+  it("fusionne les filtres frères d'organisation d'un AND en un seul filtre de relation", () => {
+    const where = {
+      AND: [
+        { publisherId: "annonceur-1" },
+        { publisherOrganization: { clientId: { not: "671" } } },
+        { publisherOrganization: { clientId: { not: "30575" } } },
+        { publisherOrganization: { rna: "W662005098" } },
+      ],
+    };
+
+    expect(optimizeMissionDiffusionRuleWhere(where)).toEqual({
+      AND: [{ publisherId: "annonceur-1" }, { publisherOrganization: { is: { AND: [{ clientId: { not: "671" } }, { clientId: { not: "30575" } }, { rna: "W662005098" }] } } }],
+    });
+  });
+
+  it("est générique : fusionne n'importe quel champ d'organisation, pas seulement clientId", () => {
+    const where = {
+      AND: [{ publisherOrganization: { name: { contains: "croix", mode: "insensitive" as const } } }, { publisherOrganization: { rna: "W123" } }],
+    };
+
+    expect(optimizeMissionDiffusionRuleWhere(where)).toEqual({
+      AND: [{ publisherOrganization: { is: { AND: [{ name: { contains: "croix", mode: "insensitive" } }, { rna: "W123" }] } } }],
+    });
+  });
+
+  it("ne fusionne pas un filtre d'organisation unique", () => {
+    const where = { AND: [{ publisherId: "annonceur-1" }, { publisherOrganization: { clientId: { not: "671" } } }] };
+
+    expect(optimizeMissionDiffusionRuleWhere(where)).toEqual(where);
+  });
+
+  it("laisse intactes les conditions négatives (NOT) non fusionnables", () => {
+    const where = {
+      AND: [
+        { publisherOrganization: { clientId: { not: "671" } } },
+        { NOT: { publisherOrganization: { parentOrganizations: { has: "AFEV" } } } },
+        { publisherOrganization: { clientId: { not: "915" } } },
+      ],
+    };
+
+    expect(optimizeMissionDiffusionRuleWhere(where)).toEqual({
+      AND: [
+        { NOT: { publisherOrganization: { parentOrganizations: { has: "AFEV" } } } },
+        { publisherOrganization: { is: { AND: [{ clientId: { not: "671" } }, { clientId: { not: "915" } }] } } },
+      ],
+    });
+  });
+
+  it("récurse dans les scopes d'un OR (allowlist multi-annonceurs)", () => {
+    const where = {
+      OR: [{ AND: [{ publisherId: "a-1" }, { publisherOrganization: { clientId: { not: "1" } } }, { publisherOrganization: { clientId: { not: "2" } } }] }, { publisherId: "a-2" }],
+    };
+
+    expect(optimizeMissionDiffusionRuleWhere(where)).toEqual({
+      OR: [{ AND: [{ publisherId: "a-1" }, { publisherOrganization: { is: { AND: [{ clientId: { not: "1" } }, { clientId: { not: "2" } }] } } }] }, { publisherId: "a-2" }],
+    });
+  });
+
+  it("ne touche pas un where sans AND d'organisation", () => {
+    const where = { publisherId: "annonceur-1" };
+
+    expect(optimizeMissionDiffusionRuleWhere(where)).toEqual(where);
   });
 });

--- a/api/src/utils/publisher-diffusion-rule-query.ts
+++ b/api/src/utils/publisher-diffusion-rule-query.ts
@@ -166,6 +166,92 @@ export const buildMissionPublisherDiffusionRuleWhereFromRules = (rules: Publishe
     buildFieldWhere: buildNestedMissionWhere,
   });
 
+const PUBLISHER_ORG_RELATION_KEY = "publisherOrganization";
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Extrait le `PublisherOrganizationWhereInput` d'une condition mission qui ne porte QUE sur la
+ * relation `publisherOrganization`, et seulement si elle est fusionnable (forme positive). Renvoie
+ * `null` sinon : condition sur un autre champ, négative (`isNot`), ou structure non reconnue.
+ *
+ * Formes reconnues :
+ *  - raccourcie : `{ publisherOrganization: { clientId: { not: "x" } } }`
+ *  - explicite  : `{ publisherOrganization: { is: { clientId: { not: "x" } } } }`
+ */
+const extractMergeableOrgFilter = (where: Prisma.MissionWhereInput): Prisma.PublisherOrganizationWhereInput | null => {
+  if (!isPlainObject(where) || Object.keys(where).length !== 1) {
+    return null;
+  }
+  const relationFilter = where[PUBLISHER_ORG_RELATION_KEY];
+  if (!isPlainObject(relationFilter)) {
+    return null;
+  }
+  if ("is" in relationFilter || "isNot" in relationFilter) {
+    // Seul un `is` seul est fusionnable : `isNot` (ou un mélange) change la sémantique.
+    if ("isNot" in relationFilter || Object.keys(relationFilter).length !== 1) {
+      return null;
+    }
+    return isPlainObject(relationFilter.is) ? (relationFilter.is as Prisma.PublisherOrganizationWhereInput) : null;
+  }
+  return relationFilter as Prisma.PublisherOrganizationWhereInput;
+};
+
+/**
+ * Fusionne, au sein d'un même `AND`, tous les filtres frères portant sur la relation
+ * `publisherOrganization` (relation to-one) en un unique `{ publisherOrganization: { is: { AND: [...] } } }`.
+ * Évite que Prisma n'émette une jointure par condition (une par règle d'exclusion → N jointures
+ * redondantes sur la même ligne). Inopérant s'il y a moins de deux filtres d'organisation.
+ */
+const mergeOrgRelationSiblings = (conditions: Prisma.MissionWhereInput[]): Prisma.MissionWhereInput[] => {
+  const orgFilters: Prisma.PublisherOrganizationWhereInput[] = [];
+  const others: Prisma.MissionWhereInput[] = [];
+
+  for (const condition of conditions) {
+    const orgFilter = extractMergeableOrgFilter(condition);
+    if (orgFilter) {
+      orgFilters.push(orgFilter);
+    } else {
+      others.push(condition);
+    }
+  }
+
+  if (orgFilters.length < 2) {
+    return conditions;
+  }
+
+  return [...others, { [PUBLISHER_ORG_RELATION_KEY]: { is: { AND: orgFilters } } }];
+};
+
+/**
+ * Parcourt récursivement un `where` mission et fusionne les filtres frères sur la relation
+ * `publisherOrganization` dans chaque `AND` (cf. `mergeOrgRelationSiblings`). Générique : vaut pour
+ * n'importe quel champ d'organisation, pas seulement `clientId`.
+ */
+export const optimizeMissionDiffusionRuleWhere = (where: Prisma.MissionWhereInput): Prisma.MissionWhereInput => {
+  if (!isPlainObject(where)) {
+    return where;
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(where)) {
+    if (key === "AND" && Array.isArray(value)) {
+      result.AND = mergeOrgRelationSiblings((value as Prisma.MissionWhereInput[]).map(optimizeMissionDiffusionRuleWhere));
+    } else if (key === "OR" && Array.isArray(value)) {
+      result.OR = (value as Prisma.MissionWhereInput[]).map(optimizeMissionDiffusionRuleWhere);
+    } else if (key === "NOT") {
+      result.NOT = Array.isArray(value)
+        ? (value as Prisma.MissionWhereInput[]).map(optimizeMissionDiffusionRuleWhere)
+        : optimizeMissionDiffusionRuleWhere(value as Prisma.MissionWhereInput);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result as Prisma.MissionWhereInput;
+};
+
 export const buildMissionPublisherDiffusionRuleSqlFromRules = (rules: PublisherDiffusionRuleCondition[], options: { missionAlias?: string } = {}): Prisma.Sql => {
   if (rules.length === 0) {
     return Prisma.empty;


### PR DESCRIPTION
## Description

Les règles de diffusion (`publisher_diffusion_rule`) construisaient le `where` Prisma des missions diffusables en empilant **une condition de relation `publisherOrganization` par règle**. Prisma génère alors **un `LEFT JOIN` par condition** sur la même table `publisher_organization` — toutes sur la même clé primaire, donc redondantes.

Pour un diffuseur réel (≈ 20 règles d'exclusion `clientId` + 1 filtre `rna`), cela produisait **21 jointures identiques**, avec un `COUNT(*)` mesuré à **~9,5 s** en production.

Cette PR ajoute un optimiseur de `where` qui **fusionne, dans chaque `AND`, tous les filtres frères portant sur la relation `publisherOrganization`** en un unique `{ publisherOrganization: { is: { AND: [...] } } }` → **une seule jointure**, quel que soit le nombre de règles.

```sql
-- Avant : 21 LEFT JOIN sur publisher_organization (j0..j20)
... LEFT JOIN publisher_organization j0 ON j0.id = mission.publisher_organization_id
    LEFT JOIN publisher_organization j1 ON j1.id = mission.publisher_organization_id
    ... (×21)
WHERE j0.client_id <> '671' AND j1.client_id <> '30575' AND ... AND j20.rna IN ('W662005098')

-- Après : 1 seul LEFT JOIN
... LEFT JOIN publisher_organization j ON j.id = mission.publisher_organization_id
WHERE j.client_id <> '671' AND j.client_id <> '30575' AND ... AND j.rna = 'W662005098'
```

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [x] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
