### PR TITLE
fix(api): restore diffusion rule changes lost in merge

### DIFF
--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -214,6 +214,7 @@ const buildMissionFilters = async (widget: WidgetRecord, query: { [key: string]:
   const filters: MissionSearchFilters = {
     directFilters: await applyWidgetRules(widget.rules || [], publisherOrganizationService.findIdsMatchingArrayValue),
     publisherIds: widget.publishers,
+    diffuseurPublisherId: widget.fromPublisherId,
     skip: pagination.skip,
     limit: pagination.limit,
   };

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -70,7 +70,7 @@ const buildScopeCondition = (rule: PublisherDiffusionRule, childrenByParentId: M
  * annonceur (`publisherId === X`) combiné à ses critères enfants. `publisherIds`
  * restreint optionnellement aux annonceurs demandés (param `publisher` de la route).
  */
-const buildAllowlistWhere = (rules: PublisherDiffusionRule[], publisherIds?: string[]): Prisma.MissionWhereInput => {
+const buildAllowlistFilter = (rules: PublisherDiffusionRule[], publisherIds?: string[]): { where: Prisma.MissionWhereInput; publisherIds: string[] } => {
   const { roots, childrenByParentId } = groupRulesByParent(rules);
   const scopeRoots = roots.filter((root) => root.field === "publisherId" && root.operator === "is" && (!publisherIds || publisherIds.includes(root.value)));
 
@@ -78,10 +78,12 @@ const buildAllowlistWhere = (rules: PublisherDiffusionRule[], publisherIds?: str
     .map((root) => buildScopeCondition(root, childrenByParentId))
     .filter((scope): scope is Prisma.MissionWhereInput => scope !== null && Object.keys(scope).length > 0);
 
+  const candidatePublisherIds = Array.from(new Set(scopeRoots.map((root) => root.value)));
+
   if (scopes.length === 0) {
-    return {};
+    return { where: {}, publisherIds: candidatePublisherIds };
   }
-  return scopes.length === 1 ? scopes[0] : { OR: scopes };
+  return { where: scopes.length === 1 ? scopes[0] : { OR: scopes }, publisherIds: candidatePublisherIds };
 };
 
 const findOrderedRules = (publisherId: string): Promise<PublisherDiffusionRule[]> =>
@@ -153,7 +155,13 @@ export const publisherDiffusionRuleService = {
    */
   async buildMissionDiffuseurCandidateWhere(publisherId: string, publisherIds?: string[]): Promise<Prisma.MissionWhereInput> {
     const rules = await findOrderedRules(publisherId);
-    return buildAllowlistWhere(rules, publisherIds);
+    const { where } = buildAllowlistFilter(rules, publisherIds);
+    return where;
+  },
+
+  async buildMissionDiffuseurCandidateFilter(publisherId: string, publisherIds?: string[]): Promise<{ where: Prisma.MissionWhereInput; publisherIds: string[] }> {
+    const rules = await findOrderedRules(publisherId);
+    return buildAllowlistFilter(rules, publisherIds);
   },
 
   async canPublisherAccessMission({ publisherId, missionId }: { publisherId: string; missionId: string }): Promise<boolean> {
@@ -162,7 +170,7 @@ export const publisherDiffusionRuleService = {
       return true;
     }
 
-    const diffusionRuleWhere = buildAllowlistWhere(rules);
+    const { where: diffusionRuleWhere } = buildAllowlistFilter(rules);
     if (Object.keys(diffusionRuleWhere).length === 0) {
       return false;
     }


### PR DESCRIPTION
## Description

Le merge de #1133 a écrasé deux changements qui étaient déjà sur `staging`, ce qui cassait la compilation et un test d'intégration.

**Changements** :
- `api/src/services/publisher-diffusion-rule/index.ts` : réapplique le patch de #1137 — restaure `buildMissionDiffuseurCandidateFilter` (utilisée par `src/jobs/grimpio/handler.ts` et le test unitaire du service), perdue lors du merge. Sans elle, `staging` ne compilait plus.
- `api/src/controllers/iframe.ts` : restaure `diffuseurPublisherId: widget.fromPublisherId` dans `buildMissionFilters` — ajouté par #1130, retiré par le revert #1131, jamais réappliqué par #1133 alors que le test d'intégration `iframe/search.test.ts` qui en dépend avait été réintroduit.

## Liens utiles

- PRs concernées : #1130, #1131, #1133, #1137

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Aucun nouveau test : les deux fichiers restaurés sont déjà couverts par des tests existants qui échouaient à cause de la régression.

**Vérifications locales** :
- `tsc --noEmit` : plus aucune erreur sur `mission.ts`, `v0/diffusion-rule`, grimpio et le service
- 554 tests unitaires passent
- 504 tests d'intégration passent (dont `iframe/search.test.ts` qui échouait avant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)