### PR TITLE
fix(analytics): dbt-core and python version pin

### DIFF
--- a/analytics/Dockerfile.production
+++ b/analytics/Dockerfile.production
@@ -12,7 +12,8 @@ COPY . .
 RUN npm run build
 
 # Run
-FROM node:24-alpine
+# Pin Alpine 3.22 (Python 3.12) : dbt-core 1.11.x ne supporte pas Python 3.14
+FROM node:24-alpine3.22
 
 WORKDIR /app
 

--- a/analytics/dbt/analytics/requirements.txt
+++ b/analytics/dbt/analytics/requirements.txt
@@ -1,4 +1,4 @@
-dbt-core==1.10.22
+dbt-core==1.11.11
 dbt-postgres==1.10.0
 dbt-metabase==1.7.5
 sqlfluff==3.5.0


### PR DESCRIPTION
## Description

Corrige l'échec du build/run de l'image analytics dû à Python 3.14.

`node:24-alpine` suit désormais Alpine 3.24, qui fournit Python 3.14.5. Or `dbt-core` (1.10 comme 1.11) épingle `mashumaro<3.15`, alors que le support de Python 3.14 n'arrive qu'avec mashumaro 3.17 → `dbt` plante à l'import 
```
mashumaro.exceptions.UnserializableField: Field "schema" of type Optional[str] in JSONObjectSchema is not serializable
```

Deux changements :

- Pin `node:24-alpine3.22` (Python 3.12.13) sur le stage runtime — Alpine ne propose pas 3.13, le choix se fait entre 3.12 (≤ Alpine 3.23) et 3.14 (Alpine 3.24).
- Bump `dbt-core==1.11.11` (dernière 1.11.x ; `dbt-postgres==1.10.0` reste compatible car il requiert `dbt-core>=1.8`).



## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
