### PR TITLE
fix(api): mission-browse does_not_contain support

### DIFF
--- a/api/src/services/search/collections/missions/__tests__/diffusion-rules-filter.test.ts
+++ b/api/src/services/search/collections/missions/__tests__/diffusion-rules-filter.test.ts
@@ -35,10 +35,7 @@ describe("publisherDiffusionRulesToMissionFilter", () => {
   });
 
   it("traduit les règles racines publisherId is en filtre de recherche", () => {
-    const result = publisherDiffusionRulesToMissionFilter([
-      buildRule({ id: "rule-1", value: "annonceur-1" }),
-      buildRule({ id: "rule-2", value: "annonceur-2", position: 1 }),
-    ]);
+    const result = publisherDiffusionRulesToMissionFilter([buildRule({ id: "rule-1", value: "annonceur-1" }), buildRule({ id: "rule-2", value: "annonceur-2", position: 1 })]);
 
     expect(result).toEqual({
       kind: "filter",
@@ -85,8 +82,7 @@ describe("publisherDiffusionRulesToMissionFilter", () => {
 
     expect(result).toEqual({
       kind: "filter",
-      filterBy:
-        "(publisherId:=`annonceur-1` && publisherOrganizationParentOrganizations:=`Réseau 1` && publisherOrganizationParentOrganizations:!=`Réseau 2`)",
+      filterBy: "(publisherId:=`annonceur-1` && publisherOrganizationParentOrganizations:=`Réseau 1` && publisherOrganizationParentOrganizations:!=`Réseau 2`)",
       missionWhere: {
         AND: [
           { publisherId: "annonceur-1" },
@@ -94,6 +90,43 @@ describe("publisherDiffusionRulesToMissionFilter", () => {
           { NOT: { publisherOrganization: { parentOrganizations: { has: "Réseau 2" } } } },
         ],
       },
+    });
+  });
+
+  it("traduit les enfants publisherOrganization.parentOrganizations avec contains/does_not_contain comme appartenance exacte", () => {
+    const result = publisherDiffusionRulesToMissionFilter([
+      buildRule({ id: "root-1", value: "annonceur-1" }),
+      buildRule({ id: "child-1", combinedWithId: "root-1", field: "publisherOrganization.parentOrganizations", operator: "contains", value: "Réseau 1" }),
+      buildRule({ id: "child-2", combinedWithId: "root-1", field: "publisherOrganization.parentOrganizations", operator: "does_not_contain", value: "Armee de l'air" }),
+    ]);
+
+    expect(result).toEqual({
+      kind: "filter",
+      filterBy: "(publisherId:=`annonceur-1` && publisherOrganizationParentOrganizations:=`Réseau 1` && publisherOrganizationParentOrganizations:!=`Armee de l'air`)",
+      missionWhere: {
+        AND: [
+          { publisherId: "annonceur-1" },
+          { publisherOrganization: { parentOrganizations: { has: "Réseau 1" } } },
+          { NOT: { publisherOrganization: { parentOrganizations: { has: "Armee de l'air" } } } },
+        ],
+      },
+    });
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it("ne supporte pas contains/does_not_contain sur publisherOrganizationId (champ scalaire)", () => {
+    const result = publisherDiffusionRulesToMissionFilter([
+      buildRule({ id: "root-1", value: "annonceur-1" }),
+      buildRule({ id: "child-1", combinedWithId: "root-1", field: "publisherOrganizationId", operator: "does_not_contain", value: "po-1" }),
+    ]);
+
+    expect(result).toEqual({ kind: "none", missionWhere: null });
+    expect(captureException).toHaveBeenCalledWith(expect.any(Error), {
+      extra: expect.objectContaining({
+        reason: "unsupported_child_operator_or_empty_value",
+        ruleId: "child-1",
+        operator: "does_not_contain",
+      }),
     });
   });
 
@@ -177,10 +210,7 @@ describe("publisherDiffusionRulesToMissionFilter", () => {
   });
 
   it("déduplique les publisherIds supportés", () => {
-    const result = publisherDiffusionRulesToMissionFilter([
-      buildRule({ id: "rule-1", value: "annonceur-1" }),
-      buildRule({ id: "rule-2", value: "annonceur-1", position: 1 }),
-    ]);
+    const result = publisherDiffusionRulesToMissionFilter([buildRule({ id: "rule-1", value: "annonceur-1" }), buildRule({ id: "rule-2", value: "annonceur-1", position: 1 })]);
 
     expect(result).toEqual({
       kind: "filter",

--- a/api/src/services/search/collections/missions/diffusion-rules-filter.ts
+++ b/api/src/services/search/collections/missions/diffusion-rules-filter.ts
@@ -69,33 +69,19 @@ const buildChildrenByParentId = (rules: PublisherDiffusionRuleRecord[]): Map<str
   return childrenByParentId;
 };
 
-const buildParentOrganizationWhere = (rule: PublisherDiffusionRuleRecord): Prisma.MissionWhereInput | null => {
-  const value = rule.value.trim();
-  if (!value) {
-    return null;
-  }
-
-  if (rule.operator === "is") {
-    return { publisherOrganization: { parentOrganizations: { has: value } } };
-  }
-
-  if (rule.operator === "is_not") {
-    return { NOT: { publisherOrganization: { parentOrganizations: { has: value } } } };
-  }
-
-  return null;
-};
-
 const buildSupportedChildGroup = (rule: PublisherDiffusionRuleRecord): SupportedGroup | null => {
   const value = rule.value.trim();
-  if (!value || (rule.operator !== "is" && rule.operator !== "is_not")) {
+  if (!value) {
     reportUnsupportedRule(rule, "unsupported_child_operator_or_empty_value");
     return null;
   }
 
-  const isNot = rule.operator === "is_not";
-
   if (rule.field === "publisherOrganizationId") {
+    if (rule.operator !== "is" && rule.operator !== "is_not") {
+      reportUnsupportedRule(rule, "unsupported_child_operator_or_empty_value");
+      return null;
+    }
+    const isNot = rule.operator === "is_not";
     return {
       filterBy: isNot ? buildSearchNotEqualFilter("publisherOrganizationId", value) : buildSearchEqualFilter("publisherOrganizationId", value),
       missionWhere: { publisherOrganizationId: isNot ? { not: value } : value },
@@ -103,15 +89,16 @@ const buildSupportedChildGroup = (rule: PublisherDiffusionRuleRecord): Supported
   }
 
   if (rule.field === "publisherOrganization.parentOrganizations") {
-    const missionWhere = buildParentOrganizationWhere(rule);
-    if (!missionWhere) {
+    // Champ array : appartenance exacte, donc `contains` ≡ `is` et `does_not_contain` ≡ `is_not`
+    // (même sémantique que buildArraySqlCondition dans utils/publisher-diffusion-rule-query.ts).
+    const isNot = rule.operator === "is_not" || rule.operator === "does_not_contain";
+    if (!isNot && rule.operator !== "is" && rule.operator !== "contains") {
+      reportUnsupportedRule(rule, "unsupported_child_operator_or_empty_value");
       return null;
     }
     return {
-      filterBy: isNot
-        ? buildSearchNotEqualFilter("publisherOrganizationParentOrganizations", value)
-        : buildSearchEqualFilter("publisherOrganizationParentOrganizations", value),
-      missionWhere,
+      filterBy: isNot ? buildSearchNotEqualFilter("publisherOrganizationParentOrganizations", value) : buildSearchEqualFilter("publisherOrganizationParentOrganizations", value),
+      missionWhere: isNot ? { NOT: { publisherOrganization: { parentOrganizations: { has: value } } } } : { publisherOrganization: { parentOrganizations: { has: value } } },
     };
   }
 

--- a/api/src/services/search/collections/missions/diffusion-rules-filter.ts
+++ b/api/src/services/search/collections/missions/diffusion-rules-filter.ts
@@ -89,8 +89,8 @@ const buildSupportedChildGroup = (rule: PublisherDiffusionRuleRecord): Supported
   }
 
   if (rule.field === "publisherOrganization.parentOrganizations") {
-    // Champ array : appartenance exacte, donc `contains` ≡ `is` et `does_not_contain` ≡ `is_not`
-    // (même sémantique que buildArraySqlCondition dans utils/publisher-diffusion-rule-query.ts).
+    // Champ array indexé par mission-browse : appartenance exacte, donc `contains` ≡ `is`
+    // et `does_not_contain` ≡ `is_not`.
     const isNot = rule.operator === "is_not" || rule.operator === "does_not_contain";
     if (!isNot && rule.operator !== "is" && rule.operator !== "contains") {
       reportUnsupportedRule(rule, "unsupported_child_operator_or_empty_value");


### PR DESCRIPTION
## Description

Corrige l'erreur Sentry `[PublisherDiffusionRule] Règle non supportée dans le filtre de recherche des missions` (`reason: unsupported_child_operator_or_empty_value`), déclenchée par une règle de diffusion enfant `publisherOrganization.parentOrganizations does_not_contain "Armee de l'air"`.

**Cause** : le filtre de recherche Typesense (`diffusion-rules-filter.ts`) n'acceptait que les opérateurs `is`/`is_not` sur les règles enfants, alors que le chemin canonique Prisma/SQL (`buildArraySqlCondition` dans `utils/publisher-diffusion-rule-query.ts`) traite `contains`/`does_not_contain` sur un champ array comme des alias de `is`/`is_not` (appartenance exacte).

**Impact du bug** : au-delà du bruit Sentry, un enfant non supporté faisait rejeter tout le groupe de règles (racine + enfants) → **toutes les missions de l'annonceur concerné disparaissaient de la recherche mission-browse** pour le diffuseur, au lieu de simplement exclure le réseau visé.

**Changements** :
- `buildSupportedChildGroup` accepte `contains`/`does_not_contain` comme alias de `is`/`is_not`, uniquement pour le champ array `publisherOrganization.parentOrganizations` (validation d'opérateur désormais par champ)
- `publisherOrganizationId` (scalaire) reste limité à `is`/`is_not` : `contains` y signifie un match par sous-chaîne (ILIKE côté SQL), inexprimable en filtre Typesense → toujours reporté comme non supporté
- 2 tests unitaires ajoutés : le cas exact de l'erreur Sentry (sans appel à `captureException`) et le cas scalaire toujours rejeté

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/PublisherRule-incompatible-mission-browse-37d72a322d5080aeb205d5960606dbf3?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
