### PR TITLE
fix(api): v2/mission endpoint html support

### DIFF
--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -172,7 +172,9 @@ components:
         description:
           type: string
           description: |
-            Description complète de la mission. Texte brut ou HTML acceptés, stockés tels quels.
+            Description complète de la mission. Texte brut ou HTML acceptés.
+
+            Si du HTML est fourni, il est conservé pour le rendu riche et converti en texte brut pour les usages internes, la recherche et la modération.
 
             **Recommandations** :
             - Utiliser le format HTML pour une meilleure lisibilité lors de la diffusion (sauts de ligne, gras, listes)
@@ -912,7 +914,9 @@ paths:
                 description:
                   type: string
                   description: |
-                    Description complète de la mission. Texte brut ou HTML acceptés, stockés tels quels.
+                    Description complète de la mission. Texte brut ou HTML acceptés.
+
+                    Si du HTML est fourni, il est conservé pour le rendu riche et converti en texte brut pour les usages internes, la recherche et la modération.
 
                     **Recommandations** :
                     - Utiliser le format HTML pour une meilleure lisibilité lors de la diffusion (sauts de ligne, gras, listes)
@@ -1182,7 +1186,9 @@ paths:
                 description:
                   type: string
                   description: |
-                    Description complète de la mission. Texte brut ou HTML acceptés, stockés tels quels.
+                    Description complète de la mission. Texte brut ou HTML acceptés.
+
+                    Si du HTML est fourni, il est conservé pour le rendu riche et converti en texte brut pour les usages internes, la recherche et la modération.
 
                     **Recommandations** :
                     - Utiliser le format HTML pour une meilleure lisibilité lors de la diffusion (sauts de ligne, gras, listes)

--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -174,7 +174,7 @@ components:
           description: |
             Description complète de la mission. Texte brut ou HTML acceptés.
 
-            Si du HTML est fourni, il est conservé pour le rendu riche et converti en texte brut pour les usages internes, la recherche et la modération.
+            La valeur fournie est conservée pour le rendu riche. Si du HTML est fourni, elle est aussi convertie en texte brut pour les usages internes, la recherche et la modération.
 
             **Recommandations** :
             - Utiliser le format HTML pour une meilleure lisibilité lors de la diffusion (sauts de ligne, gras, listes)
@@ -916,7 +916,7 @@ paths:
                   description: |
                     Description complète de la mission. Texte brut ou HTML acceptés.
 
-                    Si du HTML est fourni, il est conservé pour le rendu riche et converti en texte brut pour les usages internes, la recherche et la modération.
+                    La valeur fournie est conservée pour le rendu riche. Si du HTML est fourni, elle est aussi convertie en texte brut pour les usages internes, la recherche et la modération.
 
                     **Recommandations** :
                     - Utiliser le format HTML pour une meilleure lisibilité lors de la diffusion (sauts de ligne, gras, listes)
@@ -1188,7 +1188,7 @@ paths:
                   description: |
                     Description complète de la mission. Texte brut ou HTML acceptés.
 
-                    Si du HTML est fourni, il est conservé pour le rendu riche et converti en texte brut pour les usages internes, la recherche et la modération.
+                    La valeur fournie est conservée pour le rendu riche. Si du HTML est fourni, elle est aussi convertie en texte brut pour les usages internes, la recherche et la modération.
 
                     **Recommandations** :
                     - Utiliser le format HTML pour une meilleure lisibilité lors de la diffusion (sauts de ligne, gras, listes)

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -827,7 +827,7 @@ export const missionService = {
       data.description = patch.description ?? undefined;
     }
     if ("descriptionHtml" in patch) {
-      data.descriptionHtml = patch.descriptionHtml ?? undefined;
+      data.descriptionHtml = patch.descriptionHtml === undefined ? undefined : patch.descriptionHtml;
     }
     if ("tags" in patch) {
       data.tags = patch.tags ?? [];

--- a/api/src/v2/mission/controller.ts
+++ b/api/src/v2/mission/controller.ts
@@ -122,7 +122,7 @@ const normalizeMissionDescriptionInput = (description?: string): Pick<MissionCre
   }
 
   if (!HTML_TAG_REGEX.test(description)) {
-    return { description };
+    return { description, descriptionHtml: description };
   }
 
   return {

--- a/api/src/v2/mission/controller.ts
+++ b/api/src/v2/mission/controller.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Response, Router } from "express";
+import { convert } from "html-to-text";
 import passport from "passport";
 import zod from "zod";
 
@@ -113,6 +114,26 @@ const missionClientIdParamSchema = zod.object({
   clientId: zod.string(),
 });
 
+const HTML_TAG_REGEX = /<\/?[a-z][\s\S]*>/i;
+
+const normalizeMissionDescriptionInput = (description?: string): Pick<MissionCreateInput, "description" | "descriptionHtml"> => {
+  if (description === undefined) {
+    return {};
+  }
+
+  if (!HTML_TAG_REGEX.test(description)) {
+    return { description };
+  }
+
+  return {
+    description: convert(description, {
+      preserveNewlines: true,
+      selectors: [{ selector: "ul", options: { itemPrefix: " • " } }],
+    }),
+    descriptionHtml: description,
+  };
+};
+
 // ──────────────────────────────────────────────────────────────────────────────
 // POST /v2/mission — Create
 // ──────────────────────────────────────────────────────────────────────────────
@@ -146,7 +167,7 @@ router.post("/", passport.authenticate(["apikey", "api"], { session: false }), p
       lastSyncAt: new Date(),
       placesStatus: body.places ? "GIVEN_BY_PARTNER" : "ATTRIBUTED_BY_API",
       addresses: buildAddresses(body.addresses),
-      description: body.description,
+      ...normalizeMissionDescriptionInput(body.description),
       applicationUrl: body.applicationUrl,
       domainLogo: body.image,
       metadata: body.metadata,
@@ -241,6 +262,10 @@ router.put("/:clientId", passport.authenticate(["apikey", "api"], { session: fal
       ...body,
       lastSyncAt: new Date(),
     };
+
+    if ("description" in body) {
+      Object.assign(patch, normalizeMissionDescriptionInput(body.description));
+    }
 
     if (publisherOrganizationId !== undefined) {
       patch.publisherOrganizationId = publisherOrganizationId;

--- a/api/src/v2/mission/helpers.ts
+++ b/api/src/v2/mission/helpers.ts
@@ -150,7 +150,7 @@ export const buildData = (mission: MissionRecord) => ({
   updatedAt: mission.updatedAt,
   deletedAt: mission.deletedAt,
   title: mission.title,
-  description: mission.description,
+  description: mission.descriptionHtml ?? mission.description,
   applicationUrl: mission.applicationUrl,
   image: mission.domainLogo,
   metadata: mission.metadata,

--- a/api/tests/integration/api/endpoints/v2/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v2/mission.test.ts
@@ -321,7 +321,7 @@ describe("Mission V2 Write API Integration Tests", () => {
     });
 
     it("should update only the provided fields (PATCH semantics)", async () => {
-      const mission = await createTestMission({ publisherId: publisher.id, title: "Original Title", description: "Original Description" });
+      const mission = await createTestMission({ publisherId: publisher.id, title: "Original Title", description: "Original Description", descriptionHtml: "Original Description" });
       const response = await request(app).put(`/v2/mission/${mission.clientId}`).set("x-api-key", apiKey).send({ title: "Updated Title" });
 
       expect(response.status).toBe(200);

--- a/api/tests/integration/api/endpoints/v2/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v2/mission.test.ts
@@ -75,6 +75,37 @@ describe("Mission V2 Write API Integration Tests", () => {
       });
     });
 
+    it("should store HTML descriptions as rich HTML and plain text", async () => {
+      const htmlDescription = "<h2>Presentation</h2><p>Une <strong>mission</strong> utile.</p><ul><li>Accueillir</li><li>Orienter</li></ul>";
+
+      const response = await request(app)
+        .post("/v2/mission")
+        .set("x-api-key", apiKey)
+        .send({ clientId: "test-html-description", title: "Mission HTML", description: htmlDescription, applicationUrl: "https://example.com/apply" });
+
+      expect(response.status).toBe(201);
+      const mission = await missionService.findMissionByClientAndPublisher("test-html-description", publisher.id);
+      expect(mission?.descriptionHtml).toBe(htmlDescription);
+      expect(mission?.description).toContain("Presentation");
+      expect(mission?.description).toContain("Une mission utile.");
+      expect(mission?.description).toContain(" • Accueillir");
+      expect(mission?.description).not.toContain("<h2>");
+    });
+
+    it("should store plain text descriptions without HTML content", async () => {
+      const description = "Une description texte simple.";
+
+      const response = await request(app)
+        .post("/v2/mission")
+        .set("x-api-key", apiKey)
+        .send({ clientId: "test-text-description", title: "Mission texte", description, applicationUrl: "https://example.com/apply" });
+
+      expect(response.status).toBe(201);
+      const mission = await missionService.findMissionByClientAndPublisher("test-text-description", publisher.id);
+      expect(mission?.description).toBe(description);
+      expect(mission?.descriptionHtml).toBeNull();
+    });
+
     it("should return 201 with all optional fields", async () => {
       const payload = {
         clientId: "test-full",
@@ -299,6 +330,27 @@ describe("Mission V2 Write API Integration Tests", () => {
         type: "mission.enrichment",
         payload: { missionId: expect.any(String) },
       });
+    });
+
+    it("should update HTML descriptions as rich HTML and plain text", async () => {
+      const mission = await createTestMission({
+        publisherId: publisher.id,
+        title: "Mission valide",
+        description: "Description existante",
+        applicationUrl: "https://example.com/apply",
+        domain: "sport",
+        statusCode: "ACCEPTED",
+      });
+      const htmlDescription = "<p>Nouvelle <strong>description</strong></p><ul><li>Former</li><li>Accompagner</li></ul>";
+
+      const response = await request(app).put(`/v2/mission/${mission.clientId}`).set("x-api-key", apiKey).send({ description: htmlDescription });
+
+      expect(response.status).toBe(200);
+      const updated = await missionService.findMissionByClientAndPublisher(mission.clientId, publisher.id);
+      expect(updated?.descriptionHtml).toBe(htmlDescription);
+      expect(updated?.description).toContain("Nouvelle description");
+      expect(updated?.description).toContain(" • Former");
+      expect(updated?.description).not.toContain("<strong>");
     });
 
     it("should update PublisherOrganization when org fields are in body", async () => {

--- a/api/tests/integration/api/endpoints/v2/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v2/mission.test.ts
@@ -92,7 +92,7 @@ describe("Mission V2 Write API Integration Tests", () => {
       expect(mission?.description).not.toContain("<h2>");
     });
 
-    it("should store plain text descriptions without HTML content", async () => {
+    it("should store plain text descriptions as rich content fallback", async () => {
       const description = "Une description texte simple.";
 
       const response = await request(app)
@@ -103,7 +103,7 @@ describe("Mission V2 Write API Integration Tests", () => {
       expect(response.status).toBe(201);
       const mission = await missionService.findMissionByClientAndPublisher("test-text-description", publisher.id);
       expect(mission?.description).toBe(description);
-      expect(mission?.descriptionHtml).toBeNull();
+      expect(mission?.descriptionHtml).toBe(description);
     });
 
     it("should return 201 with all optional fields", async () => {
@@ -353,6 +353,26 @@ describe("Mission V2 Write API Integration Tests", () => {
       expect(updated?.description).not.toContain("<strong>");
     });
 
+    it("should replace rich HTML when an HTML description is replaced by plain text", async () => {
+      const mission = await createTestMission({
+        publisherId: publisher.id,
+        title: "Mission valide",
+        description: "Ancienne description",
+        descriptionHtml: "<p>Ancienne <strong>description</strong></p>",
+        applicationUrl: "https://example.com/apply",
+        domain: "sport",
+        statusCode: "ACCEPTED",
+      });
+      const description = "Nouvelle description texte";
+
+      const response = await request(app).put(`/v2/mission/${mission.clientId}`).set("x-api-key", apiKey).send({ description });
+
+      expect(response.status).toBe(200);
+      const updated = await missionService.findMissionByClientAndPublisher(mission.clientId, publisher.id);
+      expect(updated?.description).toBe(description);
+      expect(updated?.descriptionHtml).toBe(description);
+    });
+
     it("should update PublisherOrganization when org fields are in body", async () => {
       const mission = await createTestMission({ publisherId: publisher.id });
       const response = await request(app).put(`/v2/mission/${mission.clientId}`).set("x-api-key", apiKey).send({ organizationName: "Updated Org", organizationRNA: "W999999999" });
@@ -418,6 +438,7 @@ describe("Mission V2 Write API Integration Tests", () => {
         publisherId: publisher.id,
         title: "Mission valide",
         description: "Description existante",
+        descriptionHtml: "<p>Description existante</p>",
         applicationUrl: "https://example.com/apply",
         domain: "sport", // valid domain to avoid masking the expected refusal reason
         statusCode: "ACCEPTED",
@@ -428,6 +449,8 @@ describe("Mission V2 Write API Integration Tests", () => {
       expect(response.status).toBe(200);
       expect(response.body.data.statusCode).toBe("REFUSED");
       expect(response.body.data.statusComment).toBe("Description manquante");
+      const updated = await missionService.findMissionByClientAndPublisher(mission.clientId, publisher.id);
+      expect(updated?.descriptionHtml).toBe("");
     });
 
     it("should not duplicate PublisherOrganization when org data is unchanged", async () => {

--- a/api/tests/integration/api/endpoints/v2/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v2/mission.test.ts
@@ -84,6 +84,7 @@ describe("Mission V2 Write API Integration Tests", () => {
         .send({ clientId: "test-html-description", title: "Mission HTML", description: htmlDescription, applicationUrl: "https://example.com/apply" });
 
       expect(response.status).toBe(201);
+      expect(response.body.data.description).toBe(htmlDescription);
       const mission = await missionService.findMissionByClientAndPublisher("test-html-description", publisher.id);
       expect(mission?.descriptionHtml).toBe(htmlDescription);
       expect(mission?.description).toContain("PRESENTATION");
@@ -101,6 +102,7 @@ describe("Mission V2 Write API Integration Tests", () => {
         .send({ clientId: "test-text-description", title: "Mission texte", description, applicationUrl: "https://example.com/apply" });
 
       expect(response.status).toBe(201);
+      expect(response.body.data.description).toBe(description);
       const mission = await missionService.findMissionByClientAndPublisher("test-text-description", publisher.id);
       expect(mission?.description).toBe(description);
       expect(mission?.descriptionHtml).toBe(description);
@@ -346,6 +348,7 @@ describe("Mission V2 Write API Integration Tests", () => {
       const response = await request(app).put(`/v2/mission/${mission.clientId}`).set("x-api-key", apiKey).send({ description: htmlDescription });
 
       expect(response.status).toBe(200);
+      expect(response.body.data.description).toBe(htmlDescription);
       const updated = await missionService.findMissionByClientAndPublisher(mission.clientId, publisher.id);
       expect(updated?.descriptionHtml).toBe(htmlDescription);
       expect(updated?.description).toContain("Nouvelle description");
@@ -368,6 +371,7 @@ describe("Mission V2 Write API Integration Tests", () => {
       const response = await request(app).put(`/v2/mission/${mission.clientId}`).set("x-api-key", apiKey).send({ description });
 
       expect(response.status).toBe(200);
+      expect(response.body.data.description).toBe(description);
       const updated = await missionService.findMissionByClientAndPublisher(mission.clientId, publisher.id);
       expect(updated?.description).toBe(description);
       expect(updated?.descriptionHtml).toBe(description);

--- a/api/tests/integration/api/endpoints/v2/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v2/mission.test.ts
@@ -86,7 +86,7 @@ describe("Mission V2 Write API Integration Tests", () => {
       expect(response.status).toBe(201);
       const mission = await missionService.findMissionByClientAndPublisher("test-html-description", publisher.id);
       expect(mission?.descriptionHtml).toBe(htmlDescription);
-      expect(mission?.description).toContain("Presentation");
+      expect(mission?.description).toContain("PRESENTATION");
       expect(mission?.description).toContain("Une mission utile.");
       expect(mission?.description).toContain(" • Accueillir");
       expect(mission?.description).not.toContain("<h2>");


### PR DESCRIPTION
## Description

Cette PR rend le champ public `description` de `/v2/mission` compatible avec du contenu HTML tout en conservant un seul champ dans le payload partenaire.

Concrètement :
- si `description` contient du HTML, l'API conserve la valeur brute dans `descriptionHtml` pour le rendu riche ;
- l'API convertit aussi cette valeur en texte brut dans `description` pour les usages internes, la recherche et la modération ;
- si `description` contient déjà du texte brut, le comportement reste inchangé.

La documentation OpenAPI est mise à jour pour préciser ce comportement sur le schéma mission, la création et la mise à jour de mission.

## Liens utiles

Problème initialement détecté ici pour les missions SPV -- crées via l'endpoint API : 

https://app.notion.com/p/jeveuxaider/Retour-Q-A-plateforme-de-l-engagement-round-2-37a72a322d5080a1b6c1c94984803b64?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Script de génération des missions SPV à relancer après déploiement. 