### PR TITLE
refactor(api): mission publisher diffusion rules resolution

### DIFF
--- a/api/src/jobs/process-dead-letter-queues/handler.ts
+++ b/api/src/jobs/process-dead-letter-queues/handler.ts
@@ -121,8 +121,6 @@ export class ProcessDeadLetterQueuesHandler implements BaseHandler<ProcessDeadLe
           const targetType = envelope.type as TaskType;
           const payload = taskRegistry[targetType].schema.parse(envelope.payload);
 
-          console.log(payload);
-
           if (dryRun) {
             continue;
           }

--- a/api/src/services/__tests__/mission.test.ts
+++ b/api/src/services/__tests__/mission.test.ts
@@ -14,7 +14,13 @@ vi.mock("@/error", () => ({
   captureException: captureExceptionMock,
 }));
 
+import { prisma } from "@/db/postgres";
 import { missionService } from "@/services/mission";
+
+const prismaMock = prisma as unknown as {
+  mission: { findMany: ReturnType<typeof vi.fn>; count: ReturnType<typeof vi.fn> };
+  publisherDiffusionRule: { findMany: ReturnType<typeof vi.fn> };
+};
 
 describe("missionService.enqueueMissionProcessing", () => {
   beforeEach(() => {
@@ -40,5 +46,113 @@ describe("missionService.enqueueMissionProcessing", () => {
     expect(captureExceptionMock).toHaveBeenCalledWith(error, {
       extra: { context: "enqueueMissionProcessing", missionId: "mission-1" },
     });
+  });
+});
+
+describe("missionService.findMissions (diffusion multi-scopes)", () => {
+  const buildRule = (overrides: Record<string, unknown> = {}) => ({
+    id: "rule-1",
+    publisherId: "diffuseur-1",
+    combinedWithId: null,
+    field: "publisherId",
+    fieldType: "string",
+    operator: "is",
+    value: "annonceur-1",
+    combinator: "or",
+    position: 0,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  });
+
+  const buildMission = (id: string, publisherId: string, startAt: string | null) => ({
+    id,
+    clientId: `client-${id}`,
+    publisherId,
+    title: id,
+    startAt: startAt ? new Date(startAt) : null,
+    addresses: [],
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  });
+
+  const filters = { diffuseurPublisherId: "diffuseur-1", limit: 3, skip: 0 } as Parameters<typeof missionService.findMissions>[0];
+
+  it("exécute une requête par scope et fusionne les résultats triés par startAt desc (NULLS FIRST)", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "root-1", value: "annonceur-1" }),
+      buildRule({ id: "root-2", value: "annonceur-2", position: 1 }),
+      buildRule({ id: "child-1", combinedWithId: "root-2", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
+    ]);
+
+    // Scope avec critères (annonceur-2) interrogé en premier, scope nu (annonceur-1) ensuite.
+    prismaMock.mission.findMany.mockImplementation(({ where }: { where: unknown }) =>
+      Promise.resolve(
+        JSON.stringify(where).includes("annonceur-2")
+          ? [buildMission("m2", "annonceur-2", "2026-04-01"), buildMission("m4", "annonceur-2", null)]
+          : [buildMission("m1", "annonceur-1", "2026-05-01"), buildMission("m3", "annonceur-1", "2026-03-01")],
+      ),
+    );
+    prismaMock.mission.count.mockImplementation(({ where }: { where: unknown }) => Promise.resolve(JSON.stringify(where).includes("annonceur-2") ? 2 : 5));
+
+    const { data, total } = await missionService.findMissions(filters);
+
+    expect(prismaMock.mission.findMany).toHaveBeenCalledTimes(2);
+    for (const call of prismaMock.mission.findMany.mock.calls) {
+      expect(call[0]).toMatchObject({ take: 3, orderBy: { startAt: "desc" } });
+      expect(call[0].skip).toBeUndefined();
+    }
+
+    // NULLS FIRST en DESC : m4 (startAt null) d'abord, puis tri décroissant, coupé à limit=3.
+    expect(data.map((mission) => mission.id)).toEqual(["m4", "m1", "m2"]);
+    expect(total).toBe(7);
+  });
+
+  it("applique skip/limit après fusion (take = skip + limit par scope)", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "root-1", value: "annonceur-1" }),
+      buildRule({ id: "root-2", value: "annonceur-2", position: 1 }),
+      buildRule({ id: "child-1", combinedWithId: "root-2", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
+    ]);
+    prismaMock.mission.findMany.mockImplementation(({ where }: { where: unknown }) =>
+      Promise.resolve(
+        JSON.stringify(where).includes("annonceur-2")
+          ? [buildMission("m2", "annonceur-2", "2026-04-01")]
+          : [buildMission("m1", "annonceur-1", "2026-05-01"), buildMission("m3", "annonceur-1", "2026-03-01")],
+      ),
+    );
+    prismaMock.mission.count.mockResolvedValue(0);
+
+    const { data } = await missionService.findMissions({ ...filters, skip: 1, limit: 2 });
+
+    for (const call of prismaMock.mission.findMany.mock.calls) {
+      expect(call[0]).toMatchObject({ take: 3 });
+    }
+    expect(data.map((mission) => mission.id)).toEqual(["m2", "m3"]);
+  });
+
+  it("retombe sur le chemin standard avec un seul scope", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ id: "root-1", value: "annonceur-1" })]);
+    prismaMock.mission.findMany.mockResolvedValue([]);
+    prismaMock.mission.count.mockResolvedValue(0);
+
+    await missionService.findMissions(filters);
+
+    expect(prismaMock.mission.findMany).toHaveBeenCalledTimes(1);
+    expect(prismaMock.mission.findMany.mock.calls[0][0]).toMatchObject({ skip: 0, take: 3 });
+  });
+
+  it("retombe sur le chemin standard quand un annonceur apparaît dans plusieurs scopes", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "root-1", value: "annonceur-1" }),
+      buildRule({ id: "root-2", value: "annonceur-1", position: 1 }),
+      buildRule({ id: "child-1", combinedWithId: "root-2", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
+    ]);
+    prismaMock.mission.findMany.mockResolvedValue([]);
+    prismaMock.mission.count.mockResolvedValue(0);
+
+    await missionService.findMissions(filters);
+
+    expect(prismaMock.mission.findMany).toHaveBeenCalledTimes(1);
   });
 });

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -205,16 +205,21 @@ const buildDateFilter = (range?: { gt?: Date; lt?: Date }) => {
   return Object.keys(filter).length ? filter : undefined;
 };
 
-export const buildWhere = async (filters: MissionSearchFilters): Promise<Prisma.MissionWhereInput> => {
+export const buildWhere = async (filters: MissionSearchFilters, diffusionScope?: Prisma.MissionWhereInput): Promise<Prisma.MissionWhereInput> => {
   const where: Prisma.MissionWhereInput = filters.directFilters ?? {};
 
   const orConditions: Prisma.MissionWhereInput[] = [];
 
   // Restriction par publisher : les diffusion rules du diffuseur (allowlist `OR` de scopes
   // `publisherId === annonceur AND <critères>`) font autorité. À défaut de rules, on retombe
-  // sur la simple liste d'annonceurs.
+  // sur la simple liste d'annonceurs. `diffusionScope` court-circuite la résolution des rules
+  // pour appliquer un scope unique (chemin de recherche multi-scopes).
   let publisherRestrictionApplied = false;
-  if (filters.diffuseurPublisherId) {
+  if (diffusionScope) {
+    const existingAnd = Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : [];
+    where.AND = [...existingAnd, diffusionScope];
+    publisherRestrictionApplied = true;
+  } else if (filters.diffuseurPublisherId) {
     const diffusionWhere = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere(filters.diffuseurPublisherId, filters.publisherIds);
     if (Object.keys(diffusionWhere).length > 0) {
       const existingAnd = Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : [];
@@ -570,6 +575,69 @@ const baseInclude: MissionInclude = {
   jobBoards: true,
 };
 
+// Réplique l'ordre SQL `ORDER BY start_at DESC` (NULLS FIRST, défaut Postgres en DESC).
+const compareStartAtDesc = (a: { startAt: Date | null }, b: { startAt: Date | null }): number => {
+  if (!a.startAt) {
+    return b.startAt ? -1 : 0;
+  }
+  if (!b.startAt) {
+    return 1;
+  }
+  return b.startAt.getTime() - a.startAt.getTime();
+};
+
+/**
+ * Recherche en branches de diffusion (cf. `buildMissionDiffuseurCandidateWheres`) :
+ * une requête par branche (mono-publisher, donc résoluble par l'index
+ * `mission_publisher_status_deleted_start_at_idx`) au lieu d'un `OR` inter-branches
+ * que le planner Postgres exécute en hash join + tri complet. Chaque branche ramène
+ * son top `skip + limit` trié par `start_at DESC` ; les résultats sont fusionnés puis
+ * découpés. Les branches étant disjointes, le total est la somme des counts.
+ */
+const searchMissionsByDiffusionBranches = async (
+  filters: MissionSearchFilters,
+  branches: Prisma.MissionWhereInput[],
+  select: MissionSelect | null
+): Promise<{ missions: Mission[]; total: number }> => {
+  const results = await Promise.all(
+    branches.map(async (branch) => {
+      const where = await buildWhere(filters, branch);
+      const [missions, count] = await Promise.all([
+        missionRepository.findMany({
+          where,
+          // `id` et `startAt` sont requis par la fusion ci-dessous.
+          select: select ? { ...select, id: true, startAt: true } : undefined,
+          include: select ? undefined : baseInclude,
+          orderBy: { startAt: Prisma.SortOrder.desc },
+          take: filters.skip + filters.limit,
+        }),
+        missionRepository.count(where),
+      ]);
+      return { missions, count };
+    })
+  );
+
+  const missions = results
+    .flatMap((result) => result.missions)
+    .sort(compareStartAtDesc)
+    .slice(filters.skip, filters.skip + filters.limit);
+
+  const total = results.reduce((sum, result) => sum + result.count, 0);
+
+  return { missions, total };
+};
+
+/**
+ * Branches de diffusion pour la recherche d'un diffuseur ; `null` si le chemin
+ * standard (where unique construit par `buildWhere`) doit s'appliquer.
+ */
+const resolveDiffusionBranches = async (filters: MissionSearchFilters): Promise<Prisma.MissionWhereInput[] | null> => {
+  if (!filters.diffuseurPublisherId) {
+    return null;
+  }
+  return publisherDiffusionRuleService.buildMissionDiffuseurCandidateWheres(filters.diffuseurPublisherId, filters.publisherIds);
+};
+
 export const missionService = {
   async enqueueMissionProcessing(missionId: string): Promise<void> {
     try {
@@ -653,6 +721,12 @@ export const missionService = {
   },
 
   async findMissions(filters: MissionSearchFilters, select: MissionSelect | null = null): Promise<{ data: MissionRecord[]; total: number }> {
+    const diffusionBranches = await resolveDiffusionBranches(filters);
+    if (diffusionBranches) {
+      const { missions, total } = await searchMissionsByDiffusionBranches(filters, diffusionBranches, select);
+      return { data: missions.map((mission) => toMissionRecord(mission as MissionWithRelations, filters.moderationAcceptedFor)), total };
+    }
+
     const where = await buildWhere(filters);
 
     const [missions, total] = await Promise.all([
@@ -671,6 +745,13 @@ export const missionService = {
   },
 
   async findMissionsWithFacets(filters: MissionSearchFilters): Promise<{ data: MissionRecord[]; total: number; facets: MissionFacets }> {
+    const diffusionBranches = await resolveDiffusionBranches(filters);
+    if (diffusionBranches) {
+      const { missions, total } = await searchMissionsByDiffusionBranches(filters, diffusionBranches, null);
+      const records = missions.map((mission) => toMissionRecord(mission as MissionWithRelations, filters.moderationAcceptedFor));
+      return { data: records, total, facets: computeFacetsFromRecords(records) };
+    }
+
     const where = await buildWhere(filters);
 
     const [missions, total] = await Promise.all([

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -218,3 +218,84 @@ describe("publisherDiffusionRuleService.canPublisherAccessMission", () => {
     expect(canAccess).toBe(false);
   });
 });
+
+describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWheres", () => {
+  beforeEach(() => {
+    prismaMock.publisherDiffusionRule.findMany.mockReset();
+  });
+
+  it("renvoie null quand le diffuseur n'a aucune rule (fallback chemin standard)", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([]);
+
+    const branches = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWheres("diffuseur-1");
+
+    expect(branches).toBeNull();
+  });
+
+  it("décompose l'allowlist en branches : une par annonceur à critères, les annonceurs nus regroupés", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "root-1", value: "annonceur-1" }),
+      buildRule({ id: "root-2", value: "annonceur-2", position: 1 }),
+      buildRule({ id: "root-3", value: "annonceur-3", position: 2 }),
+      buildRule({ id: "child-1", combinedWithId: "root-2", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
+      buildRule({ id: "child-2", combinedWithId: "root-2", field: "publisherOrganizationId", operator: "is_not", value: "po-2", position: 1 }),
+    ]);
+
+    const branches = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWheres("diffuseur-1");
+
+    expect(branches).toEqual([
+      { AND: [{ publisherId: "annonceur-2" }, { publisherOrganizationId: { not: "po-1" } }, { publisherOrganizationId: { not: "po-2" } }] },
+      { publisherId: { in: ["annonceur-1", "annonceur-3"] } },
+    ]);
+  });
+
+  it("restreint les branches aux annonceurs demandés", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "root-1", value: "annonceur-1" }),
+      buildRule({ id: "root-2", value: "annonceur-2", position: 1 }),
+      buildRule({ id: "child-1", combinedWithId: "root-2", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
+    ]);
+
+    const branches = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWheres("diffuseur-1", ["annonceur-1"]);
+
+    // Une seule branche restante → décomposition inutile, chemin standard.
+    expect(branches).toBeNull();
+  });
+
+  it("renvoie null quand la décomposition n'apporte rien (moins de 2 branches)", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "root-1", value: "annonceur-1" }),
+      buildRule({ id: "root-2", value: "annonceur-2", position: 1 }),
+    ]);
+
+    const branches = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWheres("diffuseur-1");
+
+    // Deux annonceurs nus → fusionnés en un seul `IN` → 1 branche → null.
+    expect(branches).toBeNull();
+  });
+
+  it("renvoie null quand un annonceur apparaît dans plusieurs scopes (branches non disjointes)", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "root-1", value: "annonceur-1" }),
+      buildRule({ id: "root-2", value: "annonceur-1", position: 1 }),
+      buildRule({ id: "child-1", combinedWithId: "root-2", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
+    ]);
+
+    const branches = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWheres("diffuseur-1");
+
+    expect(branches).toBeNull();
+  });
+
+  it("renvoie null quand un scope n'a pas de restriction publisher exploitable", async () => {
+    // `value` vide → condition publisherId ignorée par le builder : la décomposition serait incorrecte.
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "root-1", value: "" }),
+      buildRule({ id: "root-2", value: "annonceur-2", position: 1 }),
+      buildRule({ id: "child-1", combinedWithId: "root-2", field: "publisherOrganizationId", operator: "is_not", value: "po-1" }),
+    ]);
+
+    const branches = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWheres("diffuseur-1");
+
+    expect(branches).toBeNull();
+  });
+});

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -66,6 +66,59 @@ const buildScopeCondition = (rule: PublisherDiffusionRule, childrenByParentId: M
   return conditions.length === 1 ? conditions[0] : { AND: conditions };
 };
 
+const filterScopeRoots = (roots: PublisherDiffusionRule[], publisherIds?: string[]): PublisherDiffusionRule[] =>
+  roots.filter((root) => root.field === "publisherId" && root.operator === "is" && (!publisherIds || publisherIds.includes(root.value)));
+
+/**
+ * Variante décomposée de l'allowlist : une condition par requête exécutable séparément,
+ * dont l'union équivaut au `OR` de `buildAllowlistFilter`. Un `OR` de scopes dans une
+ * seule requête SQL empêche Postgres d'utiliser l'index par publisher dès que des
+ * critères d'organisation s'y mêlent (hash join + tri complet) ; en requêtes séparées,
+ * chaque branche est résoluble par l'index `(publisher_id, status_code, deleted_at, start_at)`.
+ *
+ * Les annonceurs sans critères sont regroupés en une seule branche `publisherId IN (...)`.
+ * Renvoie `null` quand la décomposition est inutile (moins de 2 branches) ou ne
+ * préserverait pas la sémantique : annonceur en doublon (les branches ne seraient plus
+ * disjointes, donc le total par somme serait faux) ou scope sans restriction publisher.
+ */
+const buildAllowlistBranches = (rules: PublisherDiffusionRule[], publisherIds?: string[]): Prisma.MissionWhereInput[] | null => {
+  const { roots, childrenByParentId } = groupRulesByParent(rules);
+  const scopeRoots = filterScopeRoots(roots, publisherIds);
+
+  const rootValues = scopeRoots.map((root) => root.value);
+  if (new Set(rootValues).size !== rootValues.length) {
+    return null;
+  }
+
+  const barePublisherIds: string[] = [];
+  const branches: Prisma.MissionWhereInput[] = [];
+
+  for (const root of scopeRoots) {
+    const selfCondition = buildMissionPublisherDiffusionRuleConditionFromRule(root);
+    if (!selfCondition || Object.keys(selfCondition).length === 0) {
+      return null;
+    }
+
+    const childConditions = (childrenByParentId.get(root.id) ?? [])
+      .map((child) => buildScopeCondition(child, childrenByParentId))
+      .filter((condition): condition is Prisma.MissionWhereInput => condition !== null && Object.keys(condition).length > 0);
+
+    if (childConditions.length === 0) {
+      barePublisherIds.push(root.value);
+    } else {
+      branches.push(optimizeMissionDiffusionRuleWhere({ AND: [selfCondition, ...childConditions] }));
+    }
+  }
+
+  if (barePublisherIds.length === 1) {
+    branches.push({ publisherId: barePublisherIds[0] });
+  } else if (barePublisherIds.length > 1) {
+    branches.push({ publisherId: { in: barePublisherIds } });
+  }
+
+  return branches.length >= 2 ? branches : null;
+};
+
 /**
  * Allowlist des missions diffusables : `OR` des scopes, chaque scope étant un
  * annonceur (`publisherId === X`) combiné à ses critères enfants. `publisherIds`
@@ -73,7 +126,7 @@ const buildScopeCondition = (rule: PublisherDiffusionRule, childrenByParentId: M
  */
 const buildAllowlistFilter = (rules: PublisherDiffusionRule[], publisherIds?: string[]): { where: Prisma.MissionWhereInput; publisherIds: string[] } => {
   const { roots, childrenByParentId } = groupRulesByParent(rules);
-  const scopeRoots = roots.filter((root) => root.field === "publisherId" && root.operator === "is" && (!publisherIds || publisherIds.includes(root.value)));
+  const scopeRoots = filterScopeRoots(roots, publisherIds);
 
   const scopes = scopeRoots
     .map((root) => buildScopeCondition(root, childrenByParentId))
@@ -85,6 +138,7 @@ const buildAllowlistFilter = (rules: PublisherDiffusionRule[], publisherIds?: st
     return { where: {}, publisherIds: candidatePublisherIds };
   }
   const where = optimizeMissionDiffusionRuleWhere(scopes.length === 1 ? scopes[0] : { OR: scopes });
+
   return { where, publisherIds: candidatePublisherIds };
 };
 
@@ -164,6 +218,19 @@ export const publisherDiffusionRuleService = {
   async buildMissionDiffuseurCandidateFilter(publisherId: string, publisherIds?: string[]): Promise<{ where: Prisma.MissionWhereInput; publisherIds: string[] }> {
     const rules = await findOrderedRules(publisherId);
     return buildAllowlistFilter(rules, publisherIds);
+  },
+
+  /**
+   * Allowlist du diffuseur décomposée en conditions exécutables en requêtes séparées
+   * (cf. `buildAllowlistBranches`). `null` si pas de rules ou décomposition impossible :
+   * le chemin standard (where unique de `buildMissionDiffuseurCandidateWhere`) s'applique.
+   */
+  async buildMissionDiffuseurCandidateWheres(publisherId: string, publisherIds?: string[]): Promise<Prisma.MissionWhereInput[] | null> {
+    const rules = await findOrderedRules(publisherId);
+    if (rules.length === 0) {
+      return null;
+    }
+    return buildAllowlistBranches(rules, publisherIds);
   },
 
   async canPublisherAccessMission({ publisherId, missionId }: { publisherId: string; missionId: string }): Promise<boolean> {

--- a/api/tests/integration/api/endpoints/v0/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v0/mission.test.ts
@@ -193,6 +193,83 @@ describe("Mission API Integration Tests", () => {
       expect(ids).toEqual(expect.arrayContaining([scopedMissionA.id, scopedMissionB.id]));
     });
 
+    it("should combine a bare publisher scope with a scope carrying organization exclusions (multi-scope search path)", async () => {
+      const annonceurA = await createTestPublisher({ name: "Multi Scope Publisher A" });
+      const annonceurB = await createTestPublisher({ name: "Multi Scope Publisher B" });
+      const diffuseur = await createTestPublisher({
+        name: "Multi Scope Diffuseur",
+        publishers: [
+          { publisherId: annonceurA.id, publisherName: annonceurA.name },
+          { publisherId: annonceurB.id, publisherName: annonceurB.name },
+        ],
+      });
+
+      const missionA = await createTestMission({
+        publisherId: annonceurA.id,
+        title: "Multi scope mission A",
+        clientId: `multi-${randomUUID()}`,
+        startAt: new Date("2026-06-01T00:00:00.000Z"),
+      });
+      const missionBKept = await createTestMission({
+        publisherId: annonceurB.id,
+        title: "Multi scope mission B kept",
+        clientId: `multi-${randomUUID()}`,
+        organizationClientId: "org-allowed",
+        startAt: new Date("2026-05-01T00:00:00.000Z"),
+      });
+      const missionBExcluded = await createTestMission({
+        publisherId: annonceurB.id,
+        title: "Multi scope mission B excluded",
+        clientId: `multi-${randomUUID()}`,
+        organizationClientId: "org-excluded",
+        startAt: new Date("2026-04-01T00:00:00.000Z"),
+      });
+
+      await publisherDiffusionRuleService.createRule({
+        publisherId: diffuseur.id,
+        field: "publisherId",
+        fieldType: "string",
+        operator: "is",
+        value: annonceurA.id,
+        combinator: "or",
+        position: 0,
+      });
+      const scopeB = await publisherDiffusionRuleService.createRule({
+        publisherId: diffuseur.id,
+        field: "publisherId",
+        fieldType: "string",
+        operator: "is",
+        value: annonceurB.id,
+        combinator: "or",
+        position: 1,
+      });
+      await publisherDiffusionRuleService.createRule({
+        publisherId: diffuseur.id,
+        combinedWithId: scopeB.id,
+        field: "publisherOrganization.clientId",
+        fieldType: "string",
+        operator: "is_not",
+        value: "org-excluded",
+        combinator: "and",
+        position: 0,
+      });
+
+      const response = await request(app).get("/v0/mission").set("x-api-key", diffuseur.apikey!);
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.total).toBe(2);
+      const ids = response.body.data.map((mission: any) => mission._id);
+      expect(ids).toEqual([missionA.id, missionBKept.id]);
+      expect(ids).not.toContain(missionBExcluded.id);
+
+      // Pagination après fusion des scopes : page 2 de taille 1 → mission B (2e par startAt desc).
+      const paginated = await request(app).get("/v0/mission?limit=1&skip=1").set("x-api-key", diffuseur.apikey!);
+      expect(paginated.status).toBe(200);
+      expect(paginated.body.total).toBe(2);
+      expect(paginated.body.data.map((mission: any) => mission._id)).toEqual([missionBKept.id]);
+    });
+
     it("should expose compensation fields on missions", async () => {
       const response = await request(app).get("/v0/mission").set("x-api-key", apiKey);
       expect(response.status).toBe(200);


### PR DESCRIPTION
## Description

Corrige une slow query qui saturait le CPU de la base Postgres (~160 ms / ~59 000 buffers par appel, soit ~465 Mo lus pour retourner 25 lignes).

**Origine** : sur `GET /v0/mission` et `GET /v0/mission/search`, les diffusion rules d'un diffuseur ayant plusieurs annonceurs sont traduites en un `OR` de scopes dans une seule requête SQL (`publisher_id = A OR (publisher_id = B AND <exclusions d'organisations>)`). Quand un scope porte des critères d'organisation, le `OR` enjambe la jointure `publisher_organization` : le planner Postgres ne peut plus utiliser l'index par publisher et exécute un hash join complet (~31 000 missions + ~27 000 organisations) suivi d'un tri de ~23 000 lignes, quel que soit le `LIMIT`.

**Fix** : décomposer l'allowlist en branches disjointes et exécuter une requête par branche, puis fusionner côté applicatif.

- `publisherDiffusionRuleService.buildMissionDiffuseurCandidateWheres()` : nouvelle méthode qui décompose les rules en conditions exécutables séparément — une branche par annonceur avec critères, les annonceurs sans critères regroupés en un seul `publisherId IN (...)`. Renvoie `null` quand la décomposition est inutile (< 2 branches) ou non sûre (annonceur en doublon, scope sans restriction publisher) → le chemin existant s'applique alors, inchangé.
- `missionService.findMissions()` / `findMissionsWithFacets()` : si des branches existent, une requête par branche (`take = skip + limit`, tri `start_at DESC`), fusion en répliquant l'ordre SQL (NULLS FIRST en DESC), découpe `skip/limit` ; `total` = somme des counts (branches disjointes garanties).
- `buildWhere(filters, diffusionScope?)` : paramètre optionnel pour injecter une branche en réutilisant toute la logique de filtres existante (géo, keywords, modération…), sans duplication.

Chaque requête par branche est résoluble par l'index existant `mission_publisher_status_deleted_start_at_idx` : plan validé par `EXPLAIN ANALYZE` en réel — **160 ms / 59 459 buffers → 0,85 ms / 447 buffers** (~190×).

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [x] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

