### PR TITLE
fix(api): trim function only on string type

### DIFF
--- a/api/src/utils/normalize.ts
+++ b/api/src/utils/normalize.ts
@@ -4,7 +4,7 @@ export const normalizeOptionalString = (value: string | null | undefined): strin
   if (value === undefined) {
     return undefined;
   }
-  if (value === null) {
+  if (value === null || typeof value !== "string") {
     return null;
   }
   const trimmed = value.trim();


### PR DESCRIPTION
## Description

S'assurer que l'appel de la fonction `trim` soit uniquement fait sur des valeurs de type `string`

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/Erreur-de-parsing-dans-le-job-verify-publisher-organizations-37572a322d508020b7c2d71aef773f4e?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
