### PR TITLE
fix(api): places default values

### DIFF
--- a/api/src/v2/mission/controller.ts
+++ b/api/src/v2/mission/controller.ts
@@ -185,7 +185,7 @@ router.post("/", passport.authenticate(["apikey", "api"], { session: false }), p
       startAt: body.startAt,
       endAt: body.endAt,
       priority: body.priority,
-      places: body.places,
+      places: body.places || 1,
       compensationAmount: body.compensationAmount,
       compensationAmountMax: body.compensationAmountMax,
       compensationUnit: body.compensationUnit,

--- a/api/tests/integration/api/endpoints/v2/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v2/mission.test.ts
@@ -238,6 +238,7 @@ describe("Mission V2 Write API Integration Tests", () => {
       expect(response.status).toBe(201);
       const mission = await missionService.findMissionByClientAndPublisher("test-no-places", publisher.id);
       expect(mission?.placesStatus).toBe("ATTRIBUTED_BY_API");
+      expect(mission?.places).toBe(1);
     });
 
     it("should store addresses with geolocStatus = SHOULD_ENRICH", async () => {


### PR DESCRIPTION
## Description

Aligne le comportement du champ `places` de l'API V2 (`POST /v2/mission`) sur celui de l'import XML.

Avant ce correctif, une mission créée via l'API V2 **sans** `places` conservait `places = null` en base, alors que l'import XML attribue une valeur par défaut de `1`. Les deux sources étaient déjà cohérentes sur `placesStatus` (`ATTRIBUTED_BY_API` quand `places` n'est pas fourni), seule la valeur stockée divergeait.

| Source | `places` sans valeur fournie | `placesStatus` |
| --- | --- | --- |
| Import XML | `1` | `ATTRIBUTED_BY_API` |
| API V2 (avant) | `null` | `ATTRIBUTED_BY_API` |
| API V2 (après) | **`1`** | `ATTRIBUTED_BY_API` |

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Changement minimal : `places: body.places || 1` dans `api/src/v2/mission/controller.ts` (création uniquement). Mirroir du `parseNumber(missionXML.places) || 1` de l'import XML.
- L'endpoint `PUT /v2/mission/:clientId` (update) n'est **pas** modifié : son schéma impose `places` entier positif (`zod.number().int().positive().optional()`), donc la valeur est toujours renseignée quand la clé est présente.
- Test d'intégration renforcé (`expect(mission?.places).toBe(1)`) sur le cas « places absent ». Suite V2 complète : 43 tests passants.
- ⚠️ Comportement appliqué aux **nouvelles** missions créées après déploiement ; pas de backfill des missions V2 existantes à `places = null` (il n'y en a pas en base)
