### PR TITLE
fix(ci): dependabot workspace configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/api"
+    directory: "/"
     schedule:
       interval: "monthly"
     cooldown:
@@ -10,100 +10,18 @@ updates:
     versioning-strategy: "auto"
     labels:
       - "dependencies"
-      - "api"
+      - "npm"
     commit-message:
       prefix: "chore"
       include: "scope"
     groups:
       dev-dependencies:
-        patterns:
-          - "*eslint*"
-          - "*prettier*"
-          - "*test*"
-          - "*types*"
+        dependency-type: "development"
         update-types:
           - "minor"
           - "patch"
       production-dependencies:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "*eslint*"
-          - "*prettier*"
-          - "*test*"
-          - "*types*"
-        update-types:
-          - "minor"
-          - "patch"
-
-  - package-ecosystem: "npm"
-    directory: "/app"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 10
-    versioning-strategy: "auto"
-    labels:
-      - "dependencies"
-      - "app"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    groups:
-      dev-dependencies:
-        patterns:
-          - "*eslint*"
-          - "*prettier*"
-          - "*test*"
-          - "*types*"
-        update-types:
-          - "minor"
-          - "patch"
-      production-dependencies:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "*eslint*"
-          - "*prettier*"
-          - "*test*"
-          - "*types*"
-        update-types:
-          - "minor"
-          - "patch"
-
-  - package-ecosystem: "npm"
-    directory: "/widget"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 10
-    versioning-strategy: "auto"
-    labels:
-      - "dependencies"
-      - "widget"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    groups:
-      dev-dependencies:
-        patterns:
-          - "*eslint*"
-          - "*prettier*"
-          - "*test*"
-          - "*types*"
-        update-types:
-          - "minor"
-          - "patch"
-      production-dependencies:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "*eslint*"
-          - "*prettier*"
-          - "*test*"
-          - "*types*"
+        dependency-type: "production"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Description

Cette PR corrige la configuration Dependabot pour l'adapter au fonctionnement actuel du monorepo en npm workspaces.

Avant ce changement, Dependabot ouvrait des PR npm séparées pour `/api`, `/app` et `/widget`. Depuis le passage aux workspaces, le lockfile de référence est `package-lock.json` à la racine. Certaines PR Dependabot mettaient donc à jour uniquement le `package.json` d'un workspace sans mettre à jour le lockfile racine, ce qui faisait échouer la CI sur `npm ci` avec une erreur de désynchronisation entre `package.json` et `package-lock.json`.

La configuration npm Dependabot est maintenant centralisée sur `directory: "/"`, avec des groupes basés sur le type de dépendance (`development` / `production`). L'entrée `github-actions` reste inchangée.

## Liens utiles

- PR exemple en échec : #1093

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Validation locale : parsing YAML de `.github/dependabot.yml` OK.

Après merge, les PR Dependabot déjà ouvertes devront être recréées ou rebasées via `@dependabot recreate` afin qu'elles soient générées avec le `package-lock.json` racine.