### PR TITLE
refactor(api): publisher access middleware

### DIFF
--- a/api/src/constants/metabase.ts
+++ b/api/src/constants/metabase.ts
@@ -1,0 +1,37 @@
+// Niveau d'accès requis par carte Metabase :
+// - "public" : accessible sans authentification (page /public-stats)
+// - "user"   : utilisateur authentifié ; les données sont scopées par variables.publisher_id
+// - "admin"  : réservé au rôle admin (cartes globales tous tenants)
+// Toute carte absente de cette liste est refusée (empêche l'interrogation de cartes arbitraires).
+export type MetabaseCardAccess = "public" | "user" | "admin";
+
+export const METABASE_CARD_ACCESS: Record<string, MetabaseCardAccess> = {
+  // Cartes publiques
+  "5525": "public", // PUBLIC_STATS_GLOBAL
+  "5538": "public", // PUBLIC_STATS_GLOBAL_MONTHLY
+  "5528": "public", // PUBLIC_STATS_ACTIVE_MISSIONS
+  "5535": "public", // PUBLIC_STATS_ACTIVE_MISSIONS_DEPARTMENT
+  "5531": "public", // PUBLIC_STATS_ACTIVE_ORGANIZATIONS
+  "5537": "public", // PUBLIC_STATS_MISSIONS_DEPARTMENT
+  "5536": "public", // PUBLIC_STATS_MISSIONS_DOMAIN
+  // Cartes diffuseur / annonceur (scopées par publisher_id)
+  "5497": "user", // EVOLUTION_STAT_EVENT
+  "5494": "user", // DIFFUSEUR_TOTAL_MISSIONS
+  "5495": "user", // DIFFUSEUR_TOTAL_EVENTS
+  "5496": "user", // DIFFUSEUR_REPARITION_PAR_MOYEN_DIFFUSION
+  "5487": "user", // DIFFUSEUR_PERFORMANCE_ANNONCEURS
+  "5488": "user", // DIFFUSEUR_REPARITION_PAR_ANNONCEURS
+  "5518": "user", // DIFFUSEUR_MEAN_PUBLISHER_KPI
+  "5519": "user", // DIFFUSEUR_PERFORMANCE_PER_SOURCE
+  "5490": "user", // ANNONCEUR_TOTAL_EVENTS
+  "5498": "user", // ANNONCEUR_TOTAL_MISSIONS
+  "5489": "user", // ANNONCEUR_TOP_DIFFUSEURS
+  // Cartes admin globales
+  "5726": "admin", // ADMIN_STATS_ENGAGEMENT_REDIRECTIONS
+  "5727": "admin", // ADMIN_STATS_ENGAGEMENT_CANDIDATURES
+  "5728": "admin", // ADMIN_STATS_MISSIONS_ACTIVES
+  "5729": "admin", // ADMIN_STATS_MISSIONS_CREEES
+  "5730": "admin", // ADMIN_STATS_TOP_DIFFUSEURS
+  "5731": "admin", // ADMIN_STATS_TOP_ANNONCEURS
+  "5742": "admin", // ADMIN_STATS_PARTNERS_TABLE
+};

--- a/api/src/controllers/metabase.ts
+++ b/api/src/controllers/metabase.ts
@@ -3,8 +3,9 @@ import passport from "passport";
 import zod from "zod";
 
 import { INVALID_BODY } from "@/error";
-import { metabaseService } from "@/services/metabase";
+import { requirePublisherAccessFrom } from "@/middlewares/authorization";
 import { ipRateLimiter } from "@/middlewares/rate-limit";
+import { metabaseService } from "@/services/metabase";
 import { UserRequest } from "@/types/passport";
 
 const router = Router();
@@ -29,53 +30,58 @@ const optionalUserAuthentication: RequestHandler = (req, res, next) =>
     next();
   })(req, res, next);
 
-router.post("/card/:cardId/query", optionalUserAuthentication, async (req: UserRequest, res: Response, next: NextFunction) => {
-  try {
-    const params = zod
-      .object({
-        cardId: zod.union([zod.string(), zod.number()]).transform((v) => v.toString()),
-      })
-      .safeParse(req.params);
-    if (!params.success) {
-      return res.status(400).send({ ok: false, code: INVALID_BODY, error: params.error });
-    }
-
-    const body = zod
-      .object({
-        variables: zod.record(zod.string(), zod.union([zod.string(), zod.number(), zod.boolean(), zod.array(zod.union([zod.string(), zod.number()]))])).optional(),
-        parameters: zod.array(zod.unknown()).optional(),
-        body: zod.record(zod.string(), zod.unknown()).optional(),
-      })
-      .safeParse(req.body);
-    if (!body.success) {
-      return res.status(400).send({ ok: false, code: INVALID_BODY, error: body.error });
-    }
-
-    // Endpoint should be public for /public-stats path but restrict the read of metabase card
-    if (!req.user && !PUBLIC_METABASE_CARD.includes(params.data.cardId)) {
-      return res.status(401).send();
-    }
-
+router.post(
+  "/card/:cardId/query",
+  optionalUserAuthentication,
+  requirePublisherAccessFrom({ source: "body", key: "variables.publisher_id", onMissing: "skip" }),
+  async (req: UserRequest, res: Response, next: NextFunction) => {
     try {
-      const metabaseResponse = await metabaseService.queryCard(params.data.cardId, {
-        variables: body.data.variables,
-        parameters: body.data.parameters,
-        body: body.data.body,
-      });
+      const params = zod
+        .object({
+          cardId: zod.union([zod.string(), zod.number()]).transform((v) => v.toString()),
+        })
+        .safeParse(req.params);
+      if (!params.success) {
+        return res.status(400).send({ ok: false, code: INVALID_BODY, error: params.error });
+      }
 
-      return res.status(metabaseResponse.status ?? 200).send({
-        ok: metabaseResponse.ok,
-        data: metabaseResponse.data,
-      });
-    } catch (err: any) {
-      const message = err?.message || "Erreur Metabase";
-      const status = message.toLowerCase().includes("metabase") ? 400 : 502;
+      const body = zod
+        .object({
+          variables: zod.record(zod.string(), zod.union([zod.string(), zod.number(), zod.boolean(), zod.array(zod.union([zod.string(), zod.number()]))])).optional(),
+          parameters: zod.array(zod.unknown()).optional(),
+          body: zod.record(zod.string(), zod.unknown()).optional(),
+        })
+        .safeParse(req.body);
+      if (!body.success) {
+        return res.status(400).send({ ok: false, code: INVALID_BODY, error: body.error });
+      }
 
-      return res.status(status).send({ ok: false, error: message });
+      // Endpoint should be public for /public-stats path but restrict the read of metabase card
+      if (!req.user && !PUBLIC_METABASE_CARD.includes(params.data.cardId)) {
+        return res.status(401).send();
+      }
+
+      try {
+        const metabaseResponse = await metabaseService.queryCard(params.data.cardId, {
+          variables: body.data.variables,
+          parameters: body.data.parameters,
+          body: body.data.body,
+        });
+
+        return res.status(metabaseResponse.status ?? 200).send({
+          ok: metabaseResponse.ok,
+          data: metabaseResponse.data,
+        });
+      } catch (err: any) {
+        const message = err?.message || "Erreur Metabase";
+        const status = message.toLowerCase().includes("metabase") ? 400 : 502;
+
+        return res.status(status).send({ ok: false, error: message });
+      }
+    } catch (error) {
+      next(error);
     }
-  } catch (error) {
-    next(error);
   }
-});
+);
 
 export default router;

--- a/api/src/controllers/metabase.ts
+++ b/api/src/controllers/metabase.ts
@@ -2,7 +2,8 @@ import { NextFunction, RequestHandler, Response, Router } from "express";
 import passport from "passport";
 import zod from "zod";
 
-import { INVALID_BODY } from "@/error";
+import { METABASE_CARD_ACCESS } from "@/constants/metabase";
+import { FORBIDDEN, INVALID_BODY } from "@/error";
 import { requirePublisherAccessFrom } from "@/middlewares/authorization";
 import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { metabaseService } from "@/services/metabase";
@@ -10,16 +11,6 @@ import { UserRequest } from "@/types/passport";
 
 const router = Router();
 router.use(ipRateLimiter);
-
-const PUBLIC_METABASE_CARD = [
-  "5525", // PUBLIC_STATS_GLOBAL
-  "5538", // PUBLIC_STATS_GLOBAL_MONTHLY
-  "5528", // PUBLIC_STATS_ACTIVE_MISSIONS
-  "5535", // PUBLIC_STATS_ACTIVE_MISSIONS_DEPARTMENT
-  "5531", // PUBLIC_STATS_ACTIVE_ORGANIZATIONS
-  "5537", // PUBLIC_STATS_MISSIONS_DEPARTMENT
-  "5536", // PUBLIC_STATS_MISSIONS_DOMAIN
-];
 
 const optionalUserAuthentication: RequestHandler = (req, res, next) =>
   passport.authenticate("user", { session: false }, (error: unknown, user?: UserRequest["user"]) => {
@@ -30,10 +21,33 @@ const optionalUserAuthentication: RequestHandler = (req, res, next) =>
     next();
   })(req, res, next);
 
+// Autorise la carte selon la liste blanche cardId -> rôle (carte inconnue => refus).
+const authorizeMetabaseCard: RequestHandler = (req: UserRequest, res: Response, next: NextFunction) => {
+  const access = METABASE_CARD_ACCESS[String(req.params.cardId)];
+
+  if (!access) {
+    return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Card not allowed" });
+  }
+  if (access === "public") {
+    return next();
+  }
+  if (!req.user) {
+    return res.status(401).send();
+  }
+  if (access === "admin" && req.user.role !== "admin") {
+    return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Not allowed" });
+  }
+
+  next();
+};
+
 router.post(
   "/card/:cardId/query",
   optionalUserAuthentication,
-  requirePublisherAccessFrom({ source: "body", key: "variables.publisher_id", onMissing: "skip" }),
+  // Autorise la carte selon son niveau d'accès (public / user / admin).
+  authorizeMetabaseCard,
+  // Scope les cartes "user" au tenant de l'appelant via variables.publisher_id (absent => laisse passer).
+  requirePublisherAccessFrom({ source: "body", key: "variables.publisher_id" }),
   async (req: UserRequest, res: Response, next: NextFunction) => {
     try {
       const params = zod
@@ -54,11 +68,6 @@ router.post(
         .safeParse(req.body);
       if (!body.success) {
         return res.status(400).send({ ok: false, code: INVALID_BODY, error: body.error });
-      }
-
-      // Endpoint should be public for /public-stats path but restrict the read of metabase card
-      if (!req.user && !PUBLIC_METABASE_CARD.includes(params.data.cardId)) {
-        return res.status(401).send();
       }
 
       try {

--- a/api/src/controllers/metabase.ts
+++ b/api/src/controllers/metabase.ts
@@ -37,6 +37,10 @@ const authorizeMetabaseCard: RequestHandler = (req: UserRequest, res: Response, 
   if (access === "admin" && req.user.role !== "admin") {
     return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Not allowed" });
   }
+  // Carte "user" : le publisher_id est obligatoire, sinon Metabase pourrait renvoyer les données de tous les tenants.
+  if (access === "user" && !req.body?.variables?.publisher_id) {
+    return res.status(400).send({ ok: false, code: INVALID_BODY, message: "Missing variables.publisher_id" });
+  }
 
   next();
 };

--- a/api/src/middlewares/authorization.ts
+++ b/api/src/middlewares/authorization.ts
@@ -1,9 +1,21 @@
 import { NextFunction, Response } from "express";
 
-import { FORBIDDEN, INVALID_BODY, NOT_FOUND } from "@/error";
+import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, NOT_FOUND } from "@/error";
 import { publisherService } from "@/services/publisher";
 import { UserRequest } from "@/types/passport";
-import { hasAdminOrDirectPublisherAccess, hasAllPublisherAccess, hasPublisherRelationAccess, normalizePublisherId, readRequiredParam } from "@/utils/publisher-access";
+import { hasAdminOrDirectPublisherAccess, hasAllPublisherAccess, hasPublisherRelationAccess, isAdmin, normalizePublisherId, readRequiredParam } from "@/utils/publisher-access";
+
+/** Emplacements d'où extraire un identifiant de publisher dans la requête. */
+type RequestSource = "body" | "query" | "params";
+
+/** Comportement quand l'identifiant est absent de la requête. */
+type OnMissingPublisherId = "reject" | "adminOnly" | "skip";
+
+/** Lit une valeur via un chemin pointé (ex. "variables.publisher_id"). */
+const readPath = (root: unknown, path: string): unknown =>
+  path.split(".").reduce<unknown>((acc, segment) => (acc && typeof acc === "object" ? (acc as Record<string, unknown>)[segment] : undefined), root);
+
+const readPublisherIdFrom = (req: UserRequest, source: RequestSource, key: string): string | null => normalizePublisherId(readPath(req[source], key));
 
 type PublisherAccessResolution = {
   publisherIds: string[];
@@ -107,3 +119,42 @@ export const authorizeStatsSearch = () => (req: UserRequest, res: Response, next
 
   next();
 };
+
+/**
+ * Vérifie qu'un identifiant de publisher fourni dans la requête appartient bien
+ * au périmètre de l'utilisateur authentifié (ou qu'il est admin).
+ *
+ * `key` accepte un chemin pointé pour les identifiants imbriqués
+ * (ex. `variables.publisher_id` dans un payload Metabase).
+ *
+ * Corrige les IDOR du type "n'importe quel utilisateur connecté peut passer le
+ * publisherId d'un autre tenant" (ex. `GET /stats-mean?publisherId=...`,
+ * `POST /metabase/card/:cardId/query`).
+ *
+ * `onMissing` règle le cas où l'identifiant est absent :
+ * - `"reject"` (défaut) : 400 (l'identifiant est obligatoire).
+ * - `"adminOnly"` : seul un admin passe (évite l'exposition des agrégats globaux).
+ * - `"skip"` : on laisse passer (ex. cartes Metabase publiques sans publisher_id) ;
+ *   le contrôle d'accès reste assuré dès qu'un identifiant est présent.
+ */
+export const requirePublisherAccessFrom =
+  ({ source, key, onMissing = "reject" }: { source: RequestSource; key: string; onMissing?: OnMissingPublisherId }) =>
+  (req: UserRequest, res: Response, next: NextFunction) => {
+    const publisherId = readPublisherIdFrom(req, source, key);
+
+    if (!publisherId) {
+      if (onMissing === "reject") {
+        return res.status(400).send({ ok: false, code: source === "params" ? INVALID_PARAMS : INVALID_BODY, message: `Missing ${key}` });
+      }
+      if (onMissing === "adminOnly" && !isAdmin(req.user)) {
+        return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Not allowed" });
+      }
+      return next();
+    }
+
+    if (!hasAdminOrDirectPublisherAccess(req.user, publisherId)) {
+      return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Not allowed" });
+    }
+
+    next();
+  };

--- a/api/src/middlewares/authorization.ts
+++ b/api/src/middlewares/authorization.ts
@@ -1,15 +1,12 @@
 import { NextFunction, Response } from "express";
 
-import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, NOT_FOUND } from "@/error";
+import { FORBIDDEN, INVALID_BODY, NOT_FOUND } from "@/error";
 import { publisherService } from "@/services/publisher";
 import { UserRequest } from "@/types/passport";
-import { hasAdminOrDirectPublisherAccess, hasAllPublisherAccess, hasPublisherRelationAccess, isAdmin, normalizePublisherId, readRequiredParam } from "@/utils/publisher-access";
+import { hasAdminOrDirectPublisherAccess, hasAllPublisherAccess, hasPublisherRelationAccess, normalizePublisherId, readRequiredParam } from "@/utils/publisher-access";
 
 /** Emplacements d'où extraire un identifiant de publisher dans la requête. */
 type RequestSource = "body" | "query" | "params";
-
-/** Comportement quand l'identifiant est absent de la requête. */
-type OnMissingPublisherId = "reject" | "adminOnly" | "skip";
 
 /** Lit une valeur via un chemin pointé (ex. "variables.publisher_id"). */
 const readPath = (root: unknown, path: string): unknown =>
@@ -127,32 +124,16 @@ export const authorizeStatsSearch = () => (req: UserRequest, res: Response, next
  * `key` accepte un chemin pointé pour les identifiants imbriqués
  * (ex. `variables.publisher_id` dans un payload Metabase).
  *
- * Corrige les IDOR du type "n'importe quel utilisateur connecté peut passer le
- * publisherId d'un autre tenant" (ex. `GET /stats-mean?publisherId=...`,
- * `POST /metabase/card/:cardId/query`).
- *
- * `onMissing` règle le cas où l'identifiant est absent :
- * - `"reject"` (défaut) : 400 (l'identifiant est obligatoire).
- * - `"adminOnly"` : seul un admin passe (évite l'exposition des agrégats globaux).
- * - `"skip"` : on laisse passer (ex. cartes Metabase publiques sans publisher_id) ;
- *   le contrôle d'accès reste assuré dès qu'un identifiant est présent.
+ * Si l'identifiant est absent, on laisse passer : le contrôle ne s'applique que
+ * lorsqu'un publisher_id est effectivement fourni (les routes qui rendent
+ * l'identifiant obligatoire doivent le valider en amont).
  */
 export const requirePublisherAccessFrom =
-  ({ source, key, onMissing = "reject" }: { source: RequestSource; key: string; onMissing?: OnMissingPublisherId }) =>
+  ({ source, key }: { source: RequestSource; key: string }) =>
   (req: UserRequest, res: Response, next: NextFunction) => {
     const publisherId = readPublisherIdFrom(req, source, key);
 
-    if (!publisherId) {
-      if (onMissing === "reject") {
-        return res.status(400).send({ ok: false, code: source === "params" ? INVALID_PARAMS : INVALID_BODY, message: `Missing ${key}` });
-      }
-      if (onMissing === "adminOnly" && !isAdmin(req.user)) {
-        return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Not allowed" });
-      }
-      return next();
-    }
-
-    if (!hasAdminOrDirectPublisherAccess(req.user, publisherId)) {
+    if (publisherId && !hasAdminOrDirectPublisherAccess(req.user, publisherId)) {
       return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Not allowed" });
     }
 


### PR DESCRIPTION
## Description

Renforce le contrôle d'accès par *publisher* sur `POST /metabase/card/:cardId/query` pour corriger une faille de type **IDOR / broken access control** : tout utilisateur authentifié pouvait interroger **n'importe quelle carte Metabase** (y compris des cartes admin) et lire les stats d'**un autre tenant** en changeant le `publisher_id` du payload.

Le correctif combine une **liste blanche `cardId → rôle`** et un **middleware de scope par tenant** réutilisable.

### Changements

- **Liste blanche `METABASE_CARD_ACCESS`** (`api/src/constants/metabase.ts`) : chaque carte connue est classée `public` / `user` / `admin`. Toute carte **absente de la liste est refusée** (fail-closed, empêche l'interrogation de cartes arbitraires).
- **Middleware `authorizeMetabaseCard`** (`api/src/controllers/metabase.ts`), appliqué après l'authentification optionnelle :
  - carte inconnue → `403`
  - `public` → accès anonyme autorisé
  - `user` → utilisateur authentifié requis
  - `admin` → rôle `admin` requis
- **Middleware réutilisable `requirePublisherAccessFrom`** (`api/src/middlewares/authorization.ts`) : vérifie qu'un `publisherId` présent dans la requête appartient au périmètre de l'appelant (`hasAdminOrDirectPublisherAccess`, admin inclus). Supporte les **chemins imbriqués** (`variables.publisher_id`). Si l'identifiant est absent, laisse passer ; le contrôle ne s'applique que lorsqu'un `publisher_id` est effectivement fourni.
- **Nettoyage** : suppression de l'ancien tableau `PUBLIC_METABASE_CARD` et du check inline, désormais couverts par le middleware.


Les deux contrôles sont complémentaires : `authorizeMetabaseCard` borne **quelles cartes** sont accessibles selon le rôle ; `requirePublisherAccessFrom` garantit qu'une carte `user` ne sert que les données **du tenant de l'appelant**.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
