### PR TITLE
fix(plateform): display 5 markers

### DIFF
--- a/plateform/app/components/mission-detail/description-card.tsx
+++ b/plateform/app/components/mission-detail/description-card.tsx
@@ -11,7 +11,7 @@ export default function MissionDescriptionCard({ mission }: MissionDescriptionCa
     <section className="fr-card fr-card--no-arrow shadow-card bg-none! p-0!">
       <div className="fr-card__body">
         <div className="fr-card__content p-6! md:p-12!">
-          <h2 className="fr-h3 mb-4!">Présentation de la mission</h2>
+          <h2 className="fr-h1 mb-4!">Présentation de la mission</h2>
           {mission.descriptionHtml ? (
             <div className="mission-description prose text-title-grey max-w-none" dangerouslySetInnerHTML={{ __html: mission.descriptionHtml }} />
           ) : (

--- a/plateform/app/components/results/mission-map.tsx
+++ b/plateform/app/components/results/mission-map.tsx
@@ -1,38 +1,39 @@
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
+import type { MissionMatchItem } from "@engagement/dto";
 import { useEffect, useId, useMemo } from "react";
 import { MapContainer, Marker, Popup, TileLayer, useMap } from "react-leaflet";
 import { TILE_LAYER_PROPS, createEmojiIcon } from "~/components/ui/location-map";
-import type { MissionMatchItem } from "@engagement/dto";
+import { type GeoPosition, getNearbyPosition } from "~/utils/geo";
 
 type MapMission = {
   item: MissionMatchItem;
-  position: [number, number];
-  hasRealAddress: boolean;
+  position: GeoPosition;
+  addressLabel: string | null;
+  usesRemoteIcon: boolean;
 };
 
 const classicIcon = createEmojiIcon("📍");
 const remoteIcon = createEmojiIcon("👨‍💻");
 
-const hashString = (value: string): number => {
-  let hash = 0;
-  for (let i = 0; i < value.length; i += 1) {
-    hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
-  }
-  return hash;
-};
-
-const getNearbyPosition = (center: [number, number], seed: string, index: number): [number, number] => {
-  const hash = hashString(`${seed}-${index}`);
-  const angle = ((hash % 360) * Math.PI) / 180;
-  const radiusKm = 0.8 + ((hash >>> 8) % 25) / 10;
-  const latDelta = (Math.cos(angle) * radiusKm) / 111;
-  const lonDelta = (Math.sin(angle) * radiusKm) / (111 * Math.max(Math.cos((center[0] * Math.PI) / 180), 0.1));
-
-  return [center[0] + latDelta, center[1] + lonDelta];
-};
-
 const getAddressLabel = (item: MissionMatchItem): string | null => item.mission.location.closestAddress ?? item.mission.location.city;
+
+function spreadOverlappingPositions(missions: MapMission[]): MapMission[] {
+  const positionCounts = new Map<string, number>();
+
+  return missions.map((mission) => {
+    const key = mission.position.join(",");
+    const index = positionCounts.get(key) ?? 0;
+    positionCounts.set(key, index + 1);
+
+    if (index === 0) return mission;
+
+    return {
+      ...mission,
+      position: getNearbyPosition(mission.position, mission.item.mission.id, index),
+    };
+  });
+}
 
 function BoundsFitter({ positions }: { positions: [number, number][] }) {
   const map = useMap();
@@ -51,19 +52,24 @@ interface Props {
 
 export default function MissionMap({ items, center, onMarkerClick }: Props) {
   const missions = useMemo<MapMission[]>(
-    () =>
-      items.map((item, index) => {
-        const hasRealAddress = item.mission.remote !== "full" && item.mission.location.closestLat !== null && item.mission.location.closestLon !== null;
-        const position: [number, number] = hasRealAddress
+    () => {
+      const positionedMissions = items.map((item, index) => {
+        const hasPreciseCoordinates = item.mission.remote !== "full" && typeof item.mission.location.closestLat === "number" && typeof item.mission.location.closestLon === "number";
+        const addressLabel = item.mission.remote !== "full" ? getAddressLabel(item) : null;
+        const position: GeoPosition = hasPreciseCoordinates
           ? [item.mission.location.closestLat!, item.mission.location.closestLon!]
           : getNearbyPosition(center, item.mission.id, index);
 
         return {
           item,
-          hasRealAddress,
+          addressLabel,
           position,
+          usesRemoteIcon: item.mission.remote === "full" || (!hasPreciseCoordinates && !addressLabel),
         };
-      }),
+      });
+
+      return spreadOverlappingPositions(positionedMissions);
+    },
     [center, items],
   );
 
@@ -80,23 +86,23 @@ export default function MissionMap({ items, center, onMarkerClick }: Props) {
       <MapContainer center={center} zoom={12} className="mission-map" zoomControl={false}>
         <TileLayer {...TILE_LAYER_PROPS} />
         <BoundsFitter positions={boundsPositions} />
-        {missions.map(({ item, position, hasRealAddress }) => (
+        {missions.map(({ item, position, addressLabel, usesRemoteIcon }) => (
           <Marker
             key={item.mission.id}
             position={position}
-            icon={hasRealAddress ? classicIcon : remoteIcon}
+            icon={usesRemoteIcon ? remoteIcon : classicIcon}
             eventHandlers={onMarkerClick ? { click: () => onMarkerClick(item) } : undefined}
           >
             {!onMarkerClick && (
               <Popup>
                 <strong>{item.mission.title}</strong>
-                {hasRealAddress && getAddressLabel(item) && (
+                {addressLabel && (
                   <>
                     <br />
-                    {getAddressLabel(item)}
+                    {addressLabel}
                   </>
                 )}
-                {!hasRealAddress && (
+                {!addressLabel && (
                   <>
                     <br />
                     Mission à distance ou sans adresse précise

--- a/plateform/app/utils/__tests__/geo.test.ts
+++ b/plateform/app/utils/__tests__/geo.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { type GeoPosition, getNearbyPosition } from "../geo";
+
+describe("getNearbyPosition", () => {
+  it("retourne toujours la même position pour les mêmes entrées", () => {
+    const center: GeoPosition = [48.8566, 2.3522];
+
+    expect(getNearbyPosition(center, "mission-123", 1)).toEqual(getNearbyPosition(center, "mission-123", 1));
+  });
+
+  it("ne retourne pas exactement le centre", () => {
+    const center: GeoPosition = [48.8566, 2.3522];
+
+    expect(getNearbyPosition(center, "mission-123", 1)).not.toEqual(center);
+  });
+
+  it("retourne des positions différentes pour des indexes différents", () => {
+    const center: GeoPosition = [48.8566, 2.3522];
+
+    expect(getNearbyPosition(center, "mission-123", 1)).not.toEqual(getNearbyPosition(center, "mission-123", 2));
+  });
+});

--- a/plateform/app/utils/__tests__/string.test.ts
+++ b/plateform/app/utils/__tests__/string.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { hashString } from "../string";
+
+describe("hashString", () => {
+  it("retourne toujours le même hash pour la même chaîne", () => {
+    expect(hashString("mission-123")).toBe(hashString("mission-123"));
+  });
+
+  it("retourne des hashes distincts pour des chaînes différentes", () => {
+    expect(hashString("mission-a")).not.toBe(hashString("mission-b"));
+  });
+});

--- a/plateform/app/utils/geo.ts
+++ b/plateform/app/utils/geo.ts
@@ -1,0 +1,13 @@
+import { hashString } from "~/utils/string";
+
+export type GeoPosition = [number, number];
+
+export function getNearbyPosition(center: GeoPosition, seed: string, index: number): GeoPosition {
+  const hash = hashString(`${seed}-${index}`);
+  const angle = ((hash % 360) * Math.PI) / 180;
+  const radiusKm = 0.8 + ((hash >>> 8) % 25) / 10;
+  const latDelta = (Math.cos(angle) * radiusKm) / 111;
+  const lonDelta = (Math.sin(angle) * radiusKm) / (111 * Math.max(Math.cos((center[0] * Math.PI) / 180), 0.1));
+
+  return [center[0] + latDelta, center[1] + lonDelta];
+}

--- a/plateform/app/utils/string.ts
+++ b/plateform/app/utils/string.ts
@@ -1,0 +1,7 @@
+export function hashString(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}


### PR DESCRIPTION
## Description

Cette PR corrige l’affichage de la carte des résultats afin de rendre visibles toutes les missions épinglées, même lorsque plusieurs missions partagent la même position.

Elle apporte notamment :
- la séparation déterministe des markers superposés sur la carte ;
- l’extraction de `getNearbyPosition` dans `utils/geo.ts` ;
- l’extraction de `hashString` dans `utils/string.ts` ;
- l’ajout de tests unitaires sur les helpers de positionnement et de hash.

## Liens utiles

- 📝 Ticket Notion : Partie de https://app.notion.com/p/jeveuxaider/Retour-Q-A-plateforme-de-l-engagement-round-2-37a72a322d5080a1b6c1c94984803b64?source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire