### PR TITLE
feat(plateform): compensation badges

### DIFF
--- a/api/src/services/mission-browse/transformers.ts
+++ b/api/src/services/mission-browse/transformers.ts
@@ -5,6 +5,8 @@ import type { MissionRecord } from "@/types/mission";
 import { getMissionTrackedApplicationUrl } from "@/utils/mission";
 
 export const toMissionBrowse = (mission: MissionRecord): MissionBrowse => {
+  const hasCompensation = mission.compensationAmount != null || mission.compensationAmountMax != null;
+
   return {
     id: mission.id,
     title: mission.title,
@@ -22,6 +24,14 @@ export const toMissionBrowse = (mission: MissionRecord): MissionBrowse => {
     publisherLogo: mission.publisherLogo ?? null,
     applicationUrl: mission.applicationUrl ?? null,
     schedule: mission.schedule ?? null,
+    compensation: hasCompensation
+      ? {
+          amount: mission.compensationAmount ?? null,
+          amountMax: mission.compensationAmountMax ?? null,
+          unit: mission.compensationUnit ?? null,
+          type: mission.compensationType ?? null,
+        }
+      : null,
   };
 };
 

--- a/api/src/services/mission-match/transformers.ts
+++ b/api/src/services/mission-match/transformers.ts
@@ -11,6 +11,10 @@ export const missionMatchMissionSelect = {
   schedule: true,
   domainOriginal: true,
   domainLogo: true,
+  compensationAmount: true,
+  compensationAmountMax: true,
+  compensationUnit: true,
+  compensationType: true,
   domain: { select: { name: true } },
   publisher: { select: { name: true, logo: true, defaultMissionLogo: true } },
   publisherOrganization: { select: { name: true, logo: true } },
@@ -51,6 +55,10 @@ type MissionIndexEntry = {
   publisherDefaultMissionLogo: string | null;
   organizationName: string | null;
   organizationLogo: string | null;
+  compensationAmount: number | null;
+  compensationAmountMax: number | null;
+  compensationUnit: MissionMatchDbRow["compensationUnit"];
+  compensationType: MissionMatchDbRow["compensationType"];
 };
 
 const getTaxonomyValueLabel = (taxonomyKey: string, valueKey: string): string | null => {
@@ -77,6 +85,10 @@ export const buildMissionIndex = (missionRows: MissionMatchDbRow[]): Record<stri
       publisherDefaultMissionLogo: m.publisher?.defaultMissionLogo ?? null,
       organizationName: m.publisherOrganization?.name ?? null,
       organizationLogo: m.publisherOrganization?.logo ?? null,
+      compensationAmount: m.compensationAmount ?? null,
+      compensationAmountMax: m.compensationAmountMax ?? null,
+      compensationUnit: m.compensationUnit ?? null,
+      compensationType: m.compensationType ?? null,
     };
   }
   return index;
@@ -115,6 +127,7 @@ const toTaxonomyScoresDto = (taxonomyScores: MatchMissionItem["taxonomyScores"])
 export const toMissionMatchItem = (item: MatchMissionItem, missionIndex: Record<string, MissionIndexEntry>, valuesIndex: Record<string, MissionMatchValue[]>): MissionMatchItem => {
   const mission = missionIndex[item.missionId];
   const photo = mission?.domainLogo ?? mission?.organizationLogo ?? mission?.publisherDefaultMissionLogo ?? mission?.publisherLogo ?? null;
+  const hasCompensation = mission?.compensationAmount != null || mission?.compensationAmountMax != null;
 
   return {
     mission: {
@@ -139,6 +152,14 @@ export const toMissionMatchItem = (item: MatchMissionItem, missionIndex: Record<
         closestAddress: item.closestAddress,
         addressId: item.missionAddressId,
       },
+      compensation: hasCompensation
+        ? {
+            amount: mission?.compensationAmount ?? null,
+            amountMax: mission?.compensationAmountMax ?? null,
+            unit: mission?.compensationUnit ?? null,
+            type: mission?.compensationType ?? null,
+          }
+        : null,
     },
     match: {
       missionScoringId: item.missionScoringId,

--- a/packages/dto/src/resources/mission-browse.ts
+++ b/packages/dto/src/resources/mission-browse.ts
@@ -31,6 +31,7 @@ export type MissionBrowse = {
   publisherLogo: string | null;
   applicationUrl: string | null;
   schedule: string | null;
+  compensation: MissionDetailCompensation | null;
 };
 
 export type MissionBrowseResponse = {

--- a/packages/dto/src/resources/mission-match.ts
+++ b/packages/dto/src/resources/mission-match.ts
@@ -1,3 +1,5 @@
+import type { MissionDetailCompensation } from "./mission-browse";
+
 export type MissionMatchMedia = {
   photo: string | null;
   domainLogo: string | null;
@@ -24,6 +26,7 @@ export type MissionMatchMission = {
   publisherName: string | null;
   media: MissionMatchMedia;
   location: MissionMatchLocation;
+  compensation: MissionDetailCompensation | null;
 };
 
 export type MissionMatchValue = {

--- a/plateform/app/components/mission-detail/cta-panel.tsx
+++ b/plateform/app/components/mission-detail/cta-panel.tsx
@@ -20,7 +20,7 @@ function InfoRow({ icon, children }: { icon: string; children: ReactNode }) {
 
 export default function MissionCtaPanel({ mission, userScoringId, className = "" }: MissionCtaPanelProps) {
   const durationLabel = formatStartDate(mission.startAt, mission.duration);
-  const compensationLabel = mission.compensation ? formatCompensation(mission.compensation) : null;
+  const compensationLabel = mission.compensation ? formatCompensation(mission.compensation, { withType: true }) : null;
   const deadlineLabel = formatDeadline(mission.endAt);
 
   return (

--- a/plateform/app/components/missions/mission-card.tsx
+++ b/plateform/app/components/missions/mission-card.tsx
@@ -2,6 +2,8 @@ import type { MissionBrowse } from "@engagement/dto";
 import { getDomainLabel } from "@engagement/dto";
 import { Link } from "react-router";
 
+import { formatCompensation } from "~/utils/mission";
+
 type MissionCardLink = { type: "internal"; to: string } | { type: "external"; href: string };
 
 interface MissionCardProps {
@@ -12,6 +14,7 @@ interface MissionCardProps {
 export default function MissionCard({ mission, link }: MissionCardProps) {
   const domainLabel = getDomainLabel(mission.domain);
   const cardImage = mission.photo ?? mission.organizationLogo ?? mission.domainLogo;
+  const compensationLabel = mission.compensation ? formatCompensation(mission.compensation) : null;
 
   const clampStyle = { display: "-webkit-box", WebkitBoxOrient: "vertical" as const, WebkitLineClamp: 3, overflow: "hidden" };
 
@@ -32,6 +35,8 @@ export default function MissionCard({ mission, link }: MissionCardProps) {
 
   return (
     <div className="mission-card fr-card fr-card--no-icon fr-enlarge-link relative h-full w-full md:max-w-[330px]">
+      {compensationLabel && <p className="fr-badge fr-badge--sm fr-badge--purple-glycine absolute top-3 left-3 z-1 m-0!">{compensationLabel}</p>}
+
       <div className="fr-card__body px-6! py-4!">
         <div className="fr-card__content m-0! p-0!">
           {domainLabel && (

--- a/plateform/app/utils/__tests__/mission.test.ts
+++ b/plateform/app/utils/__tests__/mission.test.ts
@@ -29,12 +29,17 @@ describe("formatCompensation", () => {
   });
 
   it("formate une plage de montants", () => {
-    expect(formatCompensation({ amount: 1000, amountMax: 1500, unit: null, type: null })).toBe("1000 – 1500€");
+    expect(formatCompensation({ amount: 1000, amountMax: 1500, unit: null, type: null })).toBe("Entre 1000 et 1500€");
+    expect(formatCompensation({ amount: 600, amountMax: 800, unit: "month", type: null })).toBe("Entre 600 et 800€ par mois");
   });
 
-  it("inclut le type (brut/net)", () => {
-    expect(formatCompensation({ amount: 1000, amountMax: null, unit: null, type: "net" })).toBe("1000€ net");
-    expect(formatCompensation({ amount: 1000, amountMax: null, unit: null, type: "gross" })).toBe("1000€ brut");
+  it("ignore le type par défaut", () => {
+    expect(formatCompensation({ amount: 1000, amountMax: null, unit: null, type: "net" })).toBe("1000€");
+  });
+
+  it("inclut le type (brut/net) avec withType", () => {
+    expect(formatCompensation({ amount: 1000, amountMax: null, unit: null, type: "net" }, { withType: true })).toBe("1000€ net");
+    expect(formatCompensation({ amount: 1000, amountMax: null, unit: null, type: "gross" }, { withType: true })).toBe("1000€ brut");
   });
 
   it("inclut l'unité", () => {
@@ -42,8 +47,8 @@ describe("formatCompensation", () => {
     expect(formatCompensation({ amount: 12, amountMax: null, unit: "hour", type: null })).toBe("12€ par heure");
   });
 
-  it("combine montant, type et unité", () => {
-    expect(formatCompensation({ amount: 1000, amountMax: null, unit: "month", type: "net" })).toBe("1000€ net par mois");
+  it("combine montant, type et unité avec withType", () => {
+    expect(formatCompensation({ amount: 1000, amountMax: null, unit: "month", type: "net" }, { withType: true })).toBe("1000€ net par mois");
   });
 
   it("préserve les unités inconnues telles quelles", () => {

--- a/plateform/app/utils/mission.ts
+++ b/plateform/app/utils/mission.ts
@@ -32,12 +32,12 @@ const COMPENSATION_TYPE_LABELS: Record<string, string> = {
   net: "net",
 };
 
-export function formatCompensation(compensation: MissionDetailCompensation): string | null {
+export function formatCompensation(compensation: MissionDetailCompensation, options?: { withType?: boolean }): string | null {
   if (compensation.amount == null) return null;
-  const amount = compensation.amountMax ? `${compensation.amount} – ${compensation.amountMax}` : `${compensation.amount}`;
+  const amount = compensation.amountMax != null ? `Entre ${compensation.amount} et ${compensation.amountMax}€` : `${compensation.amount}€`;
+  const type = options?.withType && compensation.type ? ` ${COMPENSATION_TYPE_LABELS[compensation.type] ?? compensation.type}` : "";
   const unit = compensation.unit ? ` par ${UNIT_LABELS[compensation.unit] ?? compensation.unit}` : "";
-  const type = compensation.type ? ` ${COMPENSATION_TYPE_LABELS[compensation.type] ?? compensation.type}` : "";
-  return `${amount}€${type}${unit}`;
+  return `${amount}${type}${unit}`;
 }
 
 const MISSION_TYPE_LABELS: Record<string, string> = {
@@ -88,5 +88,6 @@ export function matchResultToBrowseMission(item: MissionMatchItem): MissionBrows
     publisherLogo: item.mission.media.publisherLogo,
     applicationUrl: null,
     schedule: item.mission.schedule,
+    compensation: item.mission.compensation,
   };
 }


### PR DESCRIPTION
## Description

Affiche un **badge DSFR (`fr-badge`)** de rémunération en haut à gauche des tuiles mission, par-dessus l'image.

La rémunération n'était jusqu'ici exposée que par `MissionDetailResponse` (page détail). Or la carte (`MissionCard`) est alimentée par deux autres contrats — `MissionBrowse` (liste `/missions`) et `MissionMatchItem` (résultats de matching) — qui ne portaient pas la donnée. Cette PR propage donc la rémunération jusqu'à ces deux DTO et factorise le formatage d'affichage.

Format du libellé :
- fourchette (`amountMax` défini) → « Entre x et y€ par mois »
- sinon → « x€ par mois »
- unité via le map existant (`month` → « par mois », `hour` → « par heure »)
- le type (brut/net) est **exclu du badge**, mais **conservé dans le CTA panel** de la page détail (option `withType`)

<img width="492" height="837" alt="image" src="https://github.com/user-attachments/assets/e7546b24-5065-4505-aec2-74d19253a21e" />

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/Retour-Q-A-plateforme-de-l-engagement-round-2-37a72a322d5080a1b6c1c94984803b64?source=copy_link#37c72a322d50802fb614f5ab2597fce7

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Détail des changements

**DTO partagés (`@engagement/dto`)**
- `MissionBrowse` et `MissionMatchMission` portent désormais `compensation: MissionDetailCompensation | null`.

**API — transformers**
- `mission-browse/transformers.ts` : `toMissionBrowse` mappe la rémunération (même logique `hasCompensation` que `toMissionDetailPayload`).
- `mission-match/transformers.ts` : `select` étendu aux 4 colonnes `compensation*`, reportées dans l'index puis dans `toMissionMatchItem`.

**Front (`plateform`)**
- `utils/mission.ts` : `formatCompensation(c, { withType? })` (fourchette « Entre x et y », type optionnel) ; `matchResultToBrowseMission` propage la rémunération.
- `cta-panel.tsx` : appel avec `{ withType: true }` → conserve l'affichage brut/net sur la page détail.
- `mission-card.tsx` : rendu du badge en position absolue sur l'image (`fr-badge--sm fr-badge--purple-glycine`).
- Tests `utils/__tests__/mission.test.ts` adaptés au nouveau format et à la signature.
