### PR TITLE
fix(app): improve form labels and accessibility (RGAA)

### DIFF
--- a/app/src/components/Autocomplete.jsx
+++ b/app/src/components/Autocomplete.jsx
@@ -12,6 +12,7 @@ const Autocomplete = ({
   className,
   id,
   ariaDescribedby,
+  hideLabel = false,
   getLabel = (o) => o,
   getValue = (o) => o,
   getCount = null,
@@ -150,9 +151,11 @@ const Autocomplete = ({
   return (
     <div className="relative w-full" ref={containerRef}>
       <div className="relative w-full">
-        <label htmlFor={inputId} className="sr-only">
-          {placeholder}
-        </label>
+        {!hideLabel && (
+          <label htmlFor={inputId} className="sr-only">
+            {placeholder}
+          </label>
+        )}
         <input
           ref={inputRef}
           id={inputId}

--- a/app/src/components/ChartDetailsTable.jsx
+++ b/app/src/components/ChartDetailsTable.jsx
@@ -16,7 +16,11 @@ const ChartDetailsTable = ({
   valueFormatter,
 }) => {
   if (mode === "none" || mode === "external" || !id || !data.length) {
-    return null;
+    return (
+      <p id={id} aria-label="Aucune donnée" className="sr-only">
+        Aucune donnée
+      </p>
+    );
   }
 
   const tableClassName = className.trim();

--- a/app/src/components/Pie.jsx
+++ b/app/src/components/Pie.jsx
@@ -22,7 +22,7 @@ export const colors = [
   "rgba(255,239,213,255)",
 ];
 const Pie = ({ data, labelKey, keys, legendPosition = "bottom" }) => {
-  if (!data || !data.length) return <div className={`p-4 text-center text-sm font-bold text-black`}>Aucune donnée</div>;
+  if (!data || !data.length) return <p className="p-4 text-center text-sm font-bold text-black">Aucune donnée</p>;
 
   const options = {
     responsive: true,

--- a/app/src/components/Toggle.jsx
+++ b/app/src/components/Toggle.jsx
@@ -1,10 +1,11 @@
 import { RiCheckLine } from "react-icons/ri";
 
-const Toggle = ({ value, onChange = () => null, className = "", ...rest }) => {
+const Toggle = ({ id = "toggle-id", value, onChange = () => null, className = "", ...rest }) => {
   const checked = Boolean(value);
 
   return (
     <button
+      id={id}
       {...rest}
       type="button"
       role="switch"

--- a/app/src/components/Tooltip.jsx
+++ b/app/src/components/Tooltip.jsx
@@ -32,24 +32,10 @@ const Tooltip = ({
 
   return (
     <>
-      <button
-        type="button"
-        className={composedTriggerClassName}
-        data-tooltip-id={tooltipId}
-        aria-describedby={tooltipId}
-        aria-label={ariaLabel}
-      >
+      <button type="button" className={composedTriggerClassName} data-tooltip-id={tooltipId} aria-describedby={tooltipId} aria-label={ariaLabel}>
         {children}
       </button>
-      <ReactTooltip
-        id={tooltipId}
-        role="tooltip"
-        openEvents={openEvents}
-        closeEvents={closeEvents}
-        closeOnEsc
-        className={tooltipClassName}
-        {...tooltipProps}
-      >
+      <ReactTooltip id={tooltipId} role="tooltip" openEvents={openEvents} closeEvents={closeEvents} className={tooltipClassName} {...tooltipProps}>
         {content}
       </ReactTooltip>
     </>

--- a/app/src/scenes/broadcast/Campaigns.jsx
+++ b/app/src/scenes/broadcast/Campaigns.jsx
@@ -149,8 +149,15 @@ const Campaigns = () => {
 
             {user.role === "admin" && (
               <div className="flex items-center">
-                <Toggle aria-label="Afficher les campagnes désactivées" value={!filters.active} onChange={(checked) => setFilters({ ...filters, active: !checked, page: 1 })} />
-                <label className="ml-2">Afficher les campagnes désactivées</label>
+                <Toggle
+                  id="toggle-show-inactive-campaigns"
+                  aria-label="Afficher les campagnes désactivées"
+                  value={!filters.active}
+                  onChange={(checked) => setFilters({ ...filters, active: !checked, page: 1 })}
+                />
+                <label className="ml-2" htmlFor="toggle-show-inactive-campaigns">
+                  Afficher les campagnes désactivées
+                </label>
               </div>
             )}
           </div>

--- a/app/src/scenes/broadcast/Widgets.jsx
+++ b/app/src/scenes/broadcast/Widgets.jsx
@@ -88,8 +88,15 @@ const Widgets = () => {
             </p>
             {user.role === "admin" && (
               <div className="flex items-center">
-                <Toggle aria-label="Afficher les widgets désactivés" value={!filters.active} onChange={(checked) => setFilters({ ...filters, active: !checked, page: 1 })} />
-                <label className="ml-2">Afficher les widgets désactivés</label>
+                <Toggle
+                  id="toggle-show-inactive-widgets"
+                  aria-label="Afficher les widgets désactivés"
+                  value={!filters.active}
+                  onChange={(checked) => setFilters({ ...filters, active: !checked, page: 1 })}
+                />
+                <label className="ml-2" htmlFor="toggle-show-inactive-widgets">
+                  Afficher les widgets désactivés
+                </label>
               </div>
             )}
           </div>

--- a/app/src/scenes/broadcast/moderation/modal/components/OrganizationTab.jsx
+++ b/app/src/scenes/broadcast/moderation/modal/components/OrganizationTab.jsx
@@ -89,6 +89,7 @@ const OrganizationTab = ({ data, onChange }) => {
 
             <Autocomplete
               id="organization-siren"
+              hideLabel
               options={organizations}
               value={values.siren}
               onChange={(e) => handleChange("siren", e)}
@@ -112,6 +113,7 @@ const OrganizationTab = ({ data, onChange }) => {
             </label>
             <Autocomplete
               id="organization-rna"
+              hideLabel
               options={organizations}
               value={values.rna}
               onChange={(e) => handleChange("rna", e)}

--- a/app/src/scenes/settings/Flux.jsx
+++ b/app/src/scenes/settings/Flux.jsx
@@ -94,7 +94,7 @@ const Flux = () => {
         <div className="h-px w-full bg-gray-900" />
 
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
-          <label className="font-semibold sm:w-[35%]">Dernière synchronisation</label>
+          <p className="font-semibold sm:w-[35%]">Dernière synchronisation</p>
           <div className="flex flex-1 gap-2">
             {imports.length > 0 && lastSync < new Date(Date.now() - 24 * 60 * 60 * 1000) ? (
               <div className="items-center">


### PR DESCRIPTION
## Description

Corrige plusieurs constats d'accessibilité (RGAA) dans le back-office, principalement liés aux libellés de formulaire et aux contrôles.

**Changements** :
- `Autocomplete` : ajout d'une prop `hideLabel` pour éviter un double `<label>` quand le composant parent fournit déjà un libellé visible (corrige l'erreur WAVE « multiple form labels » sur les champs SIREN/RNA de l'onglet Organisation)
- `Toggle` : ajout d'une prop `id` pour permettre l'association explicite `label`/contrôle
- `Campaigns` / `Widgets` : association des `<label>` aux toggles via `htmlFor`
- `Flux` : remplacement d'un `<label>` sans contrôle par un `<p>`
- `Pie` : balise sémantique `<p>` pour l'état « Aucune donnée »
- `ChartDetailsTable` : fallback `sr-only` « Aucune donnée » au lieu de `null` (cible `aria-describedby` toujours présente)
- `Tooltip` : nettoyage (suppression de `closeOnEsc`, reformatage)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Modifications purement front (`app/`), aucune migration ni changement d'API.
- `hideLabel` est `false` par défaut : `QueryBuilder`, qui n'a pas de libellé externe, conserve son libellé `sr-only`.