### PR TITLE
fix(plateform): round 2 feedback plateforme

### DIFF
--- a/plateform/app/components/landing/hero.tsx
+++ b/plateform/app/components/landing/hero.tsx
@@ -7,9 +7,9 @@ interface HeroProps {
 export default function Hero({ onStartQuiz }: HeroProps) {
   return (
     <section className="fr-container pt-4! lg:pt-16!">
-      <div className="relative z-10 w-full lg:max-w-xl">
+      <div className="relative z-10 w-full lg:max-w-md lg:min-w-[320px] xl:max-w-xl">
         <h4 className="fr-h4">Tu veux te rendre utile ?</h4>
-        <h1 className="text-4xl! md:text-5xl! lg:text-7xl! text-title-grey">
+        <h1 className="text-4xl! md:text-5xl! lg:text-6xl! xl:text-7xl! text-title-grey">
           À chacun
           <br /> sa façon d'<Highlight>agir</Highlight>
         </h1>

--- a/plateform/app/components/landing/mission-examples.tsx
+++ b/plateform/app/components/landing/mission-examples.tsx
@@ -38,7 +38,7 @@ export default function MissionExamples({ missions, className }: Props) {
           ref={scrollRef}
           id="missions-carousel"
           onScroll={updateScrollState}
-          className="snap-x snap-mandatory md:snap-none overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [margin-left:calc(50%-50vw)] [margin-right:calc(50%-50vw)] md:ml-0"
+          className="snap-x snap-mandatory md:snap-none overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ml-[calc(50%-50vw)] mr-[calc(50%-50vw)] md:pl-[calc(50vw-50%)]"
           aria-live="polite"
           aria-atomic="false"
         >
@@ -63,7 +63,7 @@ export default function MissionExamples({ missions, className }: Props) {
                     <p className="fr-h6 line-clamp-2 mb-0!">{mission.title}</p>
                     <div className="fr-mt-auto flex items-center gap-2">
                       {mission.publisherLogo && (
-                        <div className="size-6 rounded object-contain bg-white">
+                        <div className="size-10 rounded object-contain bg-white">
                           <img src={mission.publisherLogo} alt="" className="size-full object-contain" />
                         </div>
                       )}

--- a/plateform/app/components/landing/mission-examples.tsx
+++ b/plateform/app/components/landing/mission-examples.tsx
@@ -107,17 +107,16 @@ export default function MissionExamples({ missions, className }: Props) {
             <span aria-hidden className="fr-icon-arrow-left-s-line" />
           </button>
         )}
-        {canScrollRight && (
-          <button
-            type="button"
-            onClick={() => handleScroll("right")}
-            aria-label="Voir les missions suivantes"
-            aria-controls="missions-carousel"
-            className="bg-background! text-title-grey absolute right-0 top-1/2 hidden size-12 -translate-y-1/2 translate-x-1/2 items-center justify-center rounded-full shadow-md md:flex"
-          >
-            <span aria-hidden className="fr-icon-arrow-right-s-line" />
-          </button>
-        )}
+        <button
+          type="button"
+          onClick={() => handleScroll("right")}
+          disabled={!canScrollRight}
+          aria-label="Voir les missions suivantes"
+          aria-controls="missions-carousel"
+          className="bg-background! text-title-grey absolute right-0 top-1/2 hidden size-12 -translate-y-1/2 translate-x-1/2 items-center justify-center rounded-full shadow-md md:flex disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <span aria-hidden className="fr-icon-arrow-right-s-line" />
+        </button>
       </div>
     </section>
   );

--- a/plateform/app/components/layout/modal.tsx
+++ b/plateform/app/components/layout/modal.tsx
@@ -43,7 +43,7 @@ export default function Modal({ open, children, onClose, title, beforeTitle, tit
                   Fermer
                 </button>
               </div>
-              <div className="fr-modal__content">
+              <div className="fr-modal__content mb-4!">
                 {beforeTitle}
                 <h2 id={titleId} className="fr-modal__title">
                   {titleIcon && <span className={`${titleIcon} fr-icon--lg`} aria-hidden="true" />}

--- a/plateform/app/components/mission-detail/cta-panel.tsx
+++ b/plateform/app/components/mission-detail/cta-panel.tsx
@@ -1,7 +1,7 @@
 import type { MissionDetailResponse } from "@engagement/dto";
 import type { ReactNode } from "react";
 import EmailMissionModal from "~/components/mission-detail/email-mission-details-modal";
-import { formatCompensation, formatDeadline, formatStartDate } from "~/utils/mission";
+import { formatCompensation, formatStartDate } from "~/utils/mission";
 
 interface MissionCtaPanelProps {
   mission: MissionDetailResponse;
@@ -21,10 +21,13 @@ function InfoRow({ icon, children }: { icon: string; children: ReactNode }) {
 export default function MissionCtaPanel({ mission, userScoringId, className = "" }: MissionCtaPanelProps) {
   const durationLabel = formatStartDate(mission.startAt, mission.duration);
   const compensationLabel = mission.compensation ? formatCompensation(mission.compensation, { withType: true }) : null;
-  const deadlineLabel = formatDeadline(mission.endAt);
+  // const deadlineLabel = formatDeadline(mission.endAt);
+  const deadlineLabel = "Candidature ouverte jusqu'au 18 juin 2026";
 
   return (
-    <aside className={`shadow-card flex flex-col gap-6 bg-background p-6! ${className}`}>
+    <aside className={`md:shadow-card flex flex-col gap-6 bg-background px-5! py-5! md:p-6! ${className}`}>
+      <hr className="h-px! pb-0! bg-border-default-grey -mx-5! md:hidden!" />
+
       {(durationLabel || mission.schedule) && (
         <InfoRow icon="fr-icon-time-line">
           {durationLabel && <span className="text-title-grey font-bold">{durationLabel}</span>}
@@ -33,19 +36,25 @@ export default function MissionCtaPanel({ mission, userScoringId, className = ""
       )}
 
       {compensationLabel && (
-        <InfoRow icon="fr-icon-money-euro-circle-line">
-          <span className="text-title-grey font-bold">{compensationLabel}</span>
-        </InfoRow>
+        <>
+          <hr className="h-px! pb-0! bg-border-default-grey -mx-5! md:hidden!" />
+          <InfoRow icon="fr-icon-money-euro-circle-line">
+            <span className="text-title-grey font-bold">{compensationLabel}</span>
+          </InfoRow>
+        </>
       )}
 
       {deadlineLabel && (
-        <InfoRow icon="fr-icon-calendar-line">
-          <span className="text-title-grey text-sm font-bold">{deadlineLabel}</span>
-          <span className="text-mention-grey text-xs">Les candidatures peuvent fermer plus tôt si la mission est pourvue</span>
-        </InfoRow>
+        <>
+          <hr className="h-px! pb-0! bg-border-default-grey -mx-5! md:hidden!" />
+          <InfoRow icon="fr-icon-calendar-line">
+            <span className="text-title-grey text-sm font-bold">{deadlineLabel}</span>
+            <span className="text-mention-grey text-xs">Les candidatures peuvent fermer plus tôt si la mission est pourvue</span>
+          </InfoRow>
+        </>
       )}
 
-      <hr className="fr-hr fr-mb-0! pb-0.5!" />
+      <hr className="h-px! pb-0! bg-border-default-grey -mx-5! md:mx-0!" />
 
       <div className="flex flex-col gap-3">
         <a href={mission.applicationUrl} target="_blank" rel="noopener noreferrer" className="fr-btn w-full! justify-center!">
@@ -53,6 +62,8 @@ export default function MissionCtaPanel({ mission, userScoringId, className = ""
         </a>
 
         <EmailMissionModal missionId={mission.id} userScoringId={userScoringId} />
+
+        {deadlineLabel && <p className="text-mention-grey text-sm! md:hidden text-center!">{deadlineLabel}</p>}
       </div>
     </aside>
   );

--- a/plateform/app/components/mission-detail/cta-panel.tsx
+++ b/plateform/app/components/mission-detail/cta-panel.tsx
@@ -7,6 +7,7 @@ interface MissionCtaPanelProps {
   mission: MissionDetailResponse;
   userScoringId?: string;
   className?: string;
+  deadlineLabel?: string;
 }
 
 function InfoRow({ icon, children }: { icon: string; children: ReactNode }) {
@@ -18,11 +19,9 @@ function InfoRow({ icon, children }: { icon: string; children: ReactNode }) {
   );
 }
 
-export default function MissionCtaPanel({ mission, userScoringId, className = "" }: MissionCtaPanelProps) {
+export default function MissionCtaPanel({ mission, userScoringId, deadlineLabel = "", className = "" }: MissionCtaPanelProps) {
   const durationLabel = formatStartDate(mission.startAt, mission.duration);
   const compensationLabel = mission.compensation ? formatCompensation(mission.compensation, { withType: true }) : null;
-  // const deadlineLabel = formatDeadline(mission.endAt);
-  const deadlineLabel = "Candidature ouverte jusqu'au 18 juin 2026";
 
   return (
     <aside className={`md:shadow-card flex flex-col gap-6 bg-background px-5! py-5! md:p-6! ${className}`}>

--- a/plateform/app/components/mission-detail/cta-panel.tsx
+++ b/plateform/app/components/mission-detail/cta-panel.tsx
@@ -24,7 +24,7 @@ export default function MissionCtaPanel({ mission, userScoringId, className = ""
   const deadlineLabel = formatDeadline(mission.endAt);
 
   return (
-    <aside className={`shadow-card flex flex-col gap-6 bg-white p-6! ${className}`}>
+    <aside className={`shadow-card flex flex-col gap-6 bg-background p-6! ${className}`}>
       {(durationLabel || mission.schedule) && (
         <InfoRow icon="fr-icon-time-line">
           {durationLabel && <span className="text-title-grey font-bold">{durationLabel}</span>}

--- a/plateform/app/components/mission-detail/description-card.tsx
+++ b/plateform/app/components/mission-detail/description-card.tsx
@@ -8,9 +8,9 @@ export default function MissionDescriptionCard({ mission }: MissionDescriptionCa
   if (!mission.descriptionHtml && !mission.description) return null;
 
   return (
-    <section className="fr-card fr-card--no-arrow shadow-card bg-none! p-0!">
+    <section className="md:shadow-card bg-background md:bg-white! p-0! mt-6! md:mt-0!">
       <div className="fr-card__body">
-        <div className="fr-card__content p-6! md:p-12!">
+        <div className="fr-card__content px-5! py-5! md:p-12!">
           <h2 className="fr-h1 mb-4!">Présentation de la mission</h2>
           {mission.descriptionHtml ? (
             <div className="mission-description prose text-title-grey max-w-none" dangerouslySetInnerHTML={{ __html: mission.descriptionHtml }} />

--- a/plateform/app/components/mission-detail/hero-card.tsx
+++ b/plateform/app/components/mission-detail/hero-card.tsx
@@ -13,26 +13,24 @@ export default function MissionHeroCard({ mission }: MissionHeroCardProps) {
   const domainLabel = getDomainLabel(mission.domain);
 
   return (
-    <section className="fr-card fr-card--no-arrow shadow-card bg-none! p-0!">
-      <div className="fr-card__body">
-        <div className="fr-card__content flex! flex-col! gap-4 p-6! md:p-12!">
-          {domainLabel && (
-            <div className="order-1">
-              <p className="fr-tag fr-tag--sm text-blue-france-sun! bg-blue-france-925!">{domainLabel}</p>
-            </div>
-          )}
+    <section className="md:shadow-card bg-background p-0!">
+      <div className="flex flex-col gap-4 px-5! py-5! md:p-12!">
+        {domainLabel && (
+          <div className="order-1">
+            <p className="fr-tag fr-tag--sm text-blue-france-sun! bg-blue-france-925!">{domainLabel}</p>
+          </div>
+        )}
 
-          <h1 className="fr-h1 mb-0! order-2">{mission.title}</h1>
+        <h1 className="fr-h1 mb-0! order-2">{mission.title}</h1>
 
-          {orgDisplayName && (
-            <div className="order-3 flex items-center gap-4">
-              {logo && <img src={logo} alt="" className="h-8 w-14 flex-none object-contain" loading="eager" />}
-              <p className="fr-text--sm fr-mb-0 text-mention-grey">
-                {publisherTypeLabel} proposée par <span className="text-title-grey font-semibold">{orgDisplayName}</span>
-              </p>
-            </div>
-          )}
-        </div>
+        {orgDisplayName && (
+          <div className="order-3 flex items-center gap-4">
+            {logo && <img src={logo} alt="" className="h-8 w-14 flex-none object-contain" loading="eager" />}
+            <p className="fr-text--sm fr-mb-0 text-mention-grey">
+              {publisherTypeLabel} proposée par <span className="text-title-grey font-semibold">{orgDisplayName}</span>
+            </p>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/plateform/app/components/mission-detail/location-card.tsx
+++ b/plateform/app/components/mission-detail/location-card.tsx
@@ -15,24 +15,37 @@ export default function MissionLocationCard({ location }: MissionLocationCardPro
 
   if (!locationDisplay) return null;
 
+  const mapsQuery = hasLocationCoordinates ? `${locationLat},${locationLon}` : (location.address ?? location.city ?? "");
+  const mapsHref = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(mapsQuery)}`;
+
   return (
-    <section className="fr-card fr-card--no-arrow shadow-card overflow-hidden bg-none! p-0!">
+    <section className="md:shadow-card md:overflow-hidden bg-background p-0!">
       {hasLocationCoordinates && (
-        <Suspense fallback={<div className="h-[180px] w-full bg-[#f0f0f0]" />}>
-          <LocationMap lat={locationLat} lon={locationLon} />
+        <Suspense fallback={<div className="hidden h-[180px] w-full bg-[#f0f0f0] md:block" />}>
+          <div className="hidden md:block">
+            <LocationMap lat={locationLat} lon={locationLon} />
+          </div>
         </Suspense>
       )}
 
-      <div className="fr-card__body">
-        <div className="fr-card__content p-6! md:p-12!">
-          <div className="flex items-start gap-4">
-            <i className="fr-icon-map-pin-2-line fr-icon--sm text-mention-grey mt-0.5 flex-none" aria-hidden="true" />
-            <p className="fr-mb-0 flex flex-col gap-2">
-              {location.city && <span className="text-title-grey font-bold">{location.city}</span>}
-              {location.address && <span className="fr-text--sm text-mention-grey">{location.address}</span>}
-            </p>
-          </div>
+      <div className="flex flex-col gap-4 px-5! md:p-12!">
+        <hr className="h-px! pb-0! bg-border-default-grey! -mx-5! md:hidden! bg-none!" />
+        <div className="flex items-start gap-4">
+          <i className="fr-icon-map-pin-2-line fr-icon--sm text-mention-grey mt-0.5 flex-none" aria-hidden="true" />
+          <p className="fr-mb-0 flex flex-col gap-2">
+            {location.city && <span className="text-title-grey font-bold">{location.city}</span>}
+            {location.address && <span className="fr-text--sm text-mention-grey mb-0!">{location.address}</span>}
+          </p>
         </div>
+
+        <a
+          href={mapsHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="fr-btn fr-btn--secondary fr-icon-map-pin-2-line fr-btn--icon-left w-full! justify-center! md:hidden!"
+        >
+          Ouvrir sur Google Maps
+        </a>
       </div>
     </section>
   );

--- a/plateform/app/components/mission-detail/similar-missions.tsx
+++ b/plateform/app/components/mission-detail/similar-missions.tsx
@@ -28,36 +28,48 @@ export default function SimilarMissions({ userScoringId, currentMissionId }: Pro
   };
 
   return (
-    <section className="fr-background-alt--blue-france px-5 py-10 md:px-6">
+    <section className="fr-background-alt--blue-france px-5 py-10 pb-28 md:px-6 md:pb-10">
       <div className="mx-auto max-w-7xl">
         <div className="mb-6 flex items-center justify-between">
           <h2 className="fr-h4 mb-0!">
             Découvre <Highlight>ta sélection</Highlight> de missions
           </h2>
-          <div className="flex gap-3">
-            <button
-              type="button"
-              onClick={() => scrollBy(-1)}
-              className="fr-btn fr-btn--secondary fr-btn--icon-only fr-icon-arrow-left-s-line size-10! justify-center! items-center! p-0! rounded-full!"
-              aria-label="Précédent"
-            />
-            <button
-              type="button"
-              onClick={() => scrollBy(1)}
-              className="fr-btn fr-btn--secondary fr-btn--icon-only fr-icon-arrow-right-s-line size-10! justify-center! items-center! p-0! rounded-full!"
-              aria-label="Suivant"
-            />
+          <div className="hidden gap-3 md:flex">
+            <NavButtons onScroll={scrollBy} />
           </div>
         </div>
 
         <div ref={scrollRef} className="flex snap-x snap-mandatory gap-5 overflow-x-auto pb-2 scrollbar-none">
           {items.map((item) => (
-            <div key={item.mission.id} className="w-[280px] flex-none snap-start md:w-[283px]">
+            <div key={item.mission.id} className="w-[310px] flex-none snap-start md:w-[283px]">
               <MissionCard mission={matchResultToBrowseMission(item)} link={{ type: "internal", to: buildMissionDetailHref(item, userScoringId) }} />
             </div>
           ))}
         </div>
+
+        <div className="mt-6 flex justify-center gap-3 md:hidden">
+          <NavButtons onScroll={scrollBy} />
+        </div>
       </div>
     </section>
+  );
+}
+
+function NavButtons({ onScroll }: { onScroll: (direction: -1 | 1) => void }) {
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => onScroll(-1)}
+        className="fr-btn fr-btn--secondary fr-btn--icon-only fr-icon-arrow-left-s-line size-10! justify-center! items-center! p-0! rounded-full!"
+        aria-label="Précédent"
+      />
+      <button
+        type="button"
+        onClick={() => onScroll(1)}
+        className="fr-btn fr-btn--secondary fr-btn--icon-only fr-icon-arrow-right-s-line size-10! justify-center! items-center! p-0! rounded-full!"
+        aria-label="Suivant"
+      />
+    </>
   );
 }

--- a/plateform/app/components/missions/mission-card.tsx
+++ b/plateform/app/components/missions/mission-card.tsx
@@ -47,15 +47,17 @@ export default function MissionCard({ mission, link }: MissionCardProps) {
 
           <h3 className="fr-card__title mb-0! leading-tight!">{title}</h3>
 
-          <div className="fr-card__end flex flex-col gap-1 mt-3! p-0!">
-            {mission.city && <p className="fr-card__detail fr-icon-map-pin-2-line m-0! block! truncate!">{mission.city}</p>}
-            {mission.schedule && <p className="fr-card__detail fr-icon-time-line m-0! block! truncate!">{mission.schedule}</p>}
-            {mission.organizationName && <p className="fr-card__detail fr-icon-building-line m-0! block! truncate!">{mission.organizationName}</p>}
+          <div className="fr-card__end flex flex-col gap-2 justify-between mt-3! p-0!">
+            <div className="flex flex-col gap-1">
+              {mission.city && <p className="fr-card__detail fr-icon-map-pin-2-line m-0! block! truncate!">{mission.city}</p>}
+              {mission.schedule && <p className="fr-card__detail fr-icon-time-line m-0! block! truncate!">{mission.schedule}</p>}
+              {mission.organizationName && <p className="fr-card__detail fr-icon-building-line m-0! block! truncate!">{mission.organizationName}</p>}
+            </div>
 
             {(mission.publisherName ?? mission.publisherLogo) && (
               <div className="text-mention-grey fr-mt-2w flex items-center justify-end gap-2 text-xs">
                 {mission.publisherName && <span className="line-clamp-1">{mission.publisherName}</span>}
-                {mission.publisherLogo && <img src={mission.publisherLogo} alt="" className="max-h-6 max-w-16 object-contain" loading="lazy" />}
+                {mission.publisherLogo && <img src={mission.publisherLogo} alt="" className="max-w-20 object-contain" loading="lazy" />}
               </div>
             )}
           </div>

--- a/plateform/app/components/results/email-missions-modal.tsx
+++ b/plateform/app/components/results/email-missions-modal.tsx
@@ -69,13 +69,7 @@ export default function EmailMissionsModal({ userScoringId, open: controlledOpen
         </button>
       )}
 
-      <Modal
-        open={open}
-        onClose={handleClose}
-        title="Reçois tes missions par email"
-        beforeTitle={<MailIllustration className="mx-auto mb-6 h-[120px]" />}
-        className="[&_.fr-modal\_\_content]:max-h-[90vh]"
-      >
+      <Modal open={open} onClose={handleClose} title="Reçois tes missions par email" beforeTitle={<MailIllustration className="mx-auto mb-6 h-[100px]" />} className="">
         {success ? (
           <div className="flex flex-col items-center gap-4 py-4 text-center">
             <div className="fr-alert fr-alert--success w-full">

--- a/plateform/app/components/ui/mail-illustration.tsx
+++ b/plateform/app/components/ui/mail-illustration.tsx
@@ -8,7 +8,7 @@ interface MailIllustrationProps {
 export default function MailIllustration({ className }: MailIllustrationProps) {
   return (
     <div className={`relative flex items-center justify-center${className ? ` ${className}` : ""}`} aria-hidden="true">
-      <img src={TraceSvg} alt="" className="absolute top-0 left-0 w-2/3 opacity-60" />
+      <img src={TraceSvg} alt="" className="absolute top-0 left-0 w-[60%] opacity-60" />
       <img src={MailSendSvg} alt="" className="-rotate-[11deg] w-[113px] relative z-10" />
     </div>
   );

--- a/plateform/app/routes/_index.tsx
+++ b/plateform/app/routes/_index.tsx
@@ -1,9 +1,4 @@
 import { useLoaderData, useNavigate } from "react-router";
-
-export async function clientLoader({ serverLoader }: Route.ClientLoaderArgs) {
-  const serverData = await serverLoader();
-  return { ...serverData, backHref: null };
-}
 import Hero from "~/components/landing/hero";
 import HowItWorks from "~/components/landing/how-it-works";
 import MissionExamples from "~/components/landing/mission-examples";
@@ -14,6 +9,11 @@ import Partners from "~/components/layout/partners";
 import GradientBg from "~/components/ui/gradient-bg";
 import { browseMissions } from "~/services/api/missions";
 import { useQuizStore } from "~/stores/quiz";
+
+export async function clientLoader({ serverLoader }: Route.ClientLoaderArgs) {
+  const serverData = await serverLoader();
+  return { ...serverData, backHref: null };
+}
 
 import type { Route } from "./+types/_index";
 
@@ -56,21 +56,21 @@ export default function Landing() {
   return (
     <main>
       <GradientBg className="bg-size-[100%_640px]">
-        <div className="relative md:min-h-[640px] md:overflow-hidden">
+        <div className="relative lg:min-h-[640px] lg:overflow-hidden">
           <Hero onStartQuiz={handleStartQuiz} />
-          <div className="relative overflow-hidden w-full md:absolute md:right-[-140px] md:top-0 md:h-[640px] md:w-auto md:max-w-[1024px]">
+          <div className="relative overflow-hidden w-full lg:absolute lg:right-[-140px] lg:top-0 lg:h-[640px] lg:w-[80%] xl:w-auto lg:max-w-[1024px]">
             <svg
               aria-hidden
               viewBox="0 0 100 100"
               preserveAspectRatio="none"
-              className="absolute left-1/2 top-0 -translate-x-1/2 h-[680px] w-[680px] md:top-[20px] md:h-[480px] md:w-[580px] text-yellow-moutarde-975 dark:text-transparent"
+              className="absolute left-1/2 top-0 -translate-x-1/2 h-[680px] w-[680px] lg:top-[20px] lg:h-[480px] lg:w-[580px] text-yellow-moutarde-975 dark:text-transparent"
             >
               <ellipse cx="50" cy="50" rx="50" ry="50" fill="currentColor" />
             </svg>
-            <img src={LandingPng} alt="" className="relative block object-cover h-[420px] w-full md:h-[640px] md:w-auto md:object-contain" />
+            <img src={LandingPng} alt="" className="relative block object-cover h-[420px] w-full lg:h-[640px] lg:w-full lg:object-contain lg:object-right" />
           </div>
         </div>
-        <MissionExamples missions={examples} className="-mt-14 md:-mt-16" />
+        <MissionExamples missions={examples} className="-mt-14 lg:-mt-16" />
       </GradientBg>
       <HowItWorks />
       <Testimonials />

--- a/plateform/app/routes/mission-detail.tsx
+++ b/plateform/app/routes/mission-detail.tsx
@@ -72,12 +72,12 @@ export default function MissionDetailPage() {
             </div>
           )}
 
-          <div className="mx-auto max-w-[1200px] px-5 py-6 md:px-6 md:py-10">
-            <Link to={backPath} className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-line fr-btn--icon-left mb-6">
+          <div className="mx-auto max-w-[1200px] pb-6 md:pt-6 md:px-6 md:py-10 bg-beige-gris-galet-975 md:bg-transparent">
+            <Link to={backPath} className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-line fr-btn--icon-left mb-6 hidden! md:block!">
               {backLabel}
             </Link>
-            <div className="flex flex-col gap-6 md:flex-row md:items-start">
-              <div className="flex min-w-0 flex-1 flex-col gap-6">
+            <div className="flex flex-col md:flex-row md:items-start gap-6">
+              <div className="flex min-w-0 flex-1 flex-col gap-0! md:gap-6!">
                 <MissionHeroCard mission={mission} />
                 {mission.location && <MissionLocationCard location={mission.location} />}
                 <div className="md:hidden">

--- a/plateform/app/routes/mission-detail.tsx
+++ b/plateform/app/routes/mission-detail.tsx
@@ -73,6 +73,9 @@ export default function MissionDetailPage() {
           )}
 
           <div className="mx-auto max-w-[1200px] px-5 py-6 md:px-6 md:py-10">
+            <Link to={backPath} className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-line fr-btn--icon-left mb-6">
+              {backLabel}
+            </Link>
             <div className="flex flex-col gap-6 md:flex-row md:items-start">
               <div className="flex min-w-0 flex-1 flex-col gap-6">
                 <MissionHeroCard mission={mission} />

--- a/plateform/app/routes/mission-detail.tsx
+++ b/plateform/app/routes/mission-detail.tsx
@@ -13,6 +13,7 @@ import MissionLocationCard from "~/components/mission-detail/location-card";
 import SimilarMissions from "~/components/mission-detail/similar-missions";
 import GradientBg from "~/components/ui/gradient-bg";
 import { fetchMissionDetail } from "~/services/mission-browse";
+import { formatDeadline } from "~/utils/mission";
 
 export default function MissionDetailPage() {
   const { missionId, userScoringId } = useParams<{ missionId: string; userScoringId?: string }>();
@@ -33,6 +34,7 @@ export default function MissionDetailPage() {
 
   const backPath = userScoringId ? `/results/${userScoringId}` : "/";
   const backLabel = userScoringId ? "Retour aux résultats" : "Accueil";
+  const deadlineLabel = mission ? formatDeadline(mission.endAt) : null;
 
   if (loading) {
     return (
@@ -72,7 +74,7 @@ export default function MissionDetailPage() {
             </div>
           )}
 
-          <div className="mx-auto max-w-[1200px] pb-6 md:pt-6 md:px-6 md:py-10 bg-beige-gris-galet-975 md:bg-transparent">
+          <div className={`mx-auto max-w-[1200px] ${userScoringId ? "pb-6" : "pb-28"} md:pt-6 md:px-6 md:py-10 bg-beige-gris-galet-975 md:bg-transparent`}>
             <Link to={backPath} className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-line fr-btn--icon-left mb-6 hidden! md:block!">
               {backLabel}
             </Link>
@@ -105,8 +107,9 @@ export default function MissionDetailPage() {
 
       <div className="fixed right-0 bottom-0 left-0 z-10 border-t border-[#DDD] bg-white px-5 py-4 md:hidden">
         <a href={mission.applicationUrl} target="_blank" rel="noopener noreferrer" className="fr-btn w-full! justify-center!">
-          Découvrir la mission
+          Postuler
         </a>
+        {deadlineLabel && <p className="text-mention-grey text-sm! md:hidden text-center! mt-4! mb-0!">{deadlineLabel}</p>}
       </div>
     </>
   );

--- a/plateform/app/routes/mission-detail.tsx
+++ b/plateform/app/routes/mission-detail.tsx
@@ -75,7 +75,7 @@ export default function MissionDetailPage() {
           )}
 
           <div className={`mx-auto max-w-[1200px] ${userScoringId ? "pb-6" : "pb-28"} md:pt-6 md:px-6 md:py-10 bg-beige-gris-galet-975 md:bg-transparent`}>
-            <Link to={backPath} className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-line fr-btn--icon-left mb-6 hidden! md:block!">
+            <Link to={backPath} className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-line fr-btn--icon-left mb-6 hidden! md:inline-flex!">
               {backLabel}
             </Link>
             <div className="flex flex-col md:flex-row md:items-start gap-6">

--- a/plateform/app/routes/quiz/age.tsx
+++ b/plateform/app/routes/quiz/age.tsx
@@ -3,6 +3,7 @@ import { useOutletContext } from "react-router";
 import Label from "~/components/quiz/label";
 import NextButton from "~/components/quiz/next-button";
 import { useQuizStore } from "~/stores/quiz";
+import { isValidAge } from "~/utils/quiz";
 import type { QuizOutletContext } from "./_layout";
 
 const MIN_AGE = 16;
@@ -11,17 +12,18 @@ const MAX_AGE = 99;
 const STEP_ID = "age";
 // Step custom : stocke une valeur numérique brute (pas de taxonomyKey).
 // Utilisée uniquement dans les conditions des steps suivants (ex: handicap).
+
 export default function AgeStep() {
   const { answers, setAnswer } = useQuizStore();
   const { goNext, saveScoring } = useOutletContext<QuizOutletContext>();
   const [value, setValue] = useState<string>("");
 
   useEffect(() => {
-    if (answers[STEP_ID]?.type === "numeric") setValue(String(answers[STEP_ID].value));
+    if (answers[STEP_ID]?.type === "numeric" && isValidAge(answers[STEP_ID].value, MIN_AGE, MAX_AGE)) setValue(String(answers[STEP_ID].value));
   }, [answers[STEP_ID]]);
 
   const numeric = Number(value);
-  const valid = value !== "" && Number.isFinite(numeric) && numeric >= MIN_AGE && numeric <= MAX_AGE;
+  const valid = isValidAge(numeric, MIN_AGE, MAX_AGE);
 
   const handleSubmit = (e: SubmitEvent) => {
     e.preventDefault();
@@ -39,7 +41,7 @@ export default function AgeStep() {
         Quel âge as-tu ?
       </Label>
 
-      <select id="age-input" className="fr-select max-w-80!" value={value} onChange={(e) => setValue(e.target.value)}>
+      <select id="age-input" className="fr-select md:max-w-80!" value={value} onChange={(e) => setValue(e.target.value)}>
         <option value="">Sélectionnez votre âge</option>
         {Array.from({ length: MAX_AGE - MIN_AGE + 1 }, (_, i) => (
           <option key={i} value={i + MIN_AGE}>

--- a/plateform/app/routes/quiz/localisation.tsx
+++ b/plateform/app/routes/quiz/localisation.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState, type KeyboardEvent, type SubmitEvent } from "react";
 import { useOutletContext } from "react-router";
-import QuizTransition from "~/components/quiz/quiz-transition";
 import Label from "~/components/quiz/label";
 import MissionCard from "~/components/quiz/mission-card";
 import NextButton from "~/components/quiz/next-button";
+import QuizTransition from "~/components/quiz/quiz-transition";
 import Highlight from "~/components/ui/highlight";
-import { searchAddress, reverseGeocode, type GeoSuggestion } from "~/services/geolocation";
+import { reverseGeocode, searchAddress, type GeoSuggestion } from "~/services/geolocation";
 import { useQuizStore } from "~/stores/quiz";
 import type { QuizOutletContext } from "./_layout";
 
@@ -217,7 +217,7 @@ export default function LocalisationStep() {
             <ul
               id={LISTBOX_ID}
               role="listbox"
-              className="absolute z-50 top-full left-0 right-0 mt-1 bg-white border border-border-default-grey max-h-60 overflow-auto shadow-md list-none! p-0! m-0!"
+              className="absolute z-50 top-full left-0 right-0 mt-1 bg-background border border-border-default-grey max-h-60 overflow-auto shadow-md list-none! p-0! m-0!"
             >
               {options.map((option, index) => (
                 <li

--- a/plateform/app/routes/results.tsx
+++ b/plateform/app/routes/results.tsx
@@ -1,10 +1,6 @@
 import type { MissionMatchItem } from "@engagement/dto";
 import { useMemo, useRef, useState } from "react";
 import { Link, useParams, useSearchParams } from "react-router";
-
-export async function clientLoader() {
-  return { backHref: null };
-}
 import { FooterContent } from "~/components/layout/footer";
 import Newsletter from "~/components/layout/newsletter";
 import Partners from "~/components/layout/partners";
@@ -23,6 +19,10 @@ import { useMissionResults } from "~/hooks/useMissionResults";
 import { useQuizStore } from "~/stores/quiz";
 import { evalCondition } from "~/utils/conditions";
 import { buildMissionDetailHref, matchResultToBrowseMission } from "~/utils/mission";
+
+export async function clientLoader() {
+  return { backHref: null };
+}
 
 const FRANCE_CENTER: [number, number] = [46.6, 2.3];
 
@@ -149,7 +149,7 @@ export default function ResultsPage() {
           )}
 
           <div
-            className={`absolute inset-x-0 bottom-0 z-[1000] flex flex-col rounded-t-3xl bg-white shadow-2xl transition-[top] duration-300 ${expanded ? "top-12" : "top-[calc(100%-5rem)]"} ${selectedMission ? "hidden" : ""}`}
+            className={`absolute inset-x-0 bottom-0 z-[1000] flex flex-col rounded-t-3xl bg-background shadow-2xl transition-[top] duration-300 ${expanded ? "top-12" : "top-[calc(100%-5rem)]"} ${selectedMission ? "hidden" : ""}`}
           >
             <div className={`flex flex-col gap-2 px-6 py-4 ${expanded ? "items-start!" : "items-center! justify-center! h-full"}`} onClick={handleToggleSheet}>
               {!loading && error && <p className="fr-error-text m-0! text-center!">{error}</p>}

--- a/plateform/app/utils/quiz.ts
+++ b/plateform/app/utils/quiz.ts
@@ -30,3 +30,9 @@ export const buildPayload = (answers: QuizAnswers) => {
 
   return { answers: apiAnswers };
 };
+
+export const isValidAge = (age: unknown, min = 16, max = 99) => {
+  if (age === "" || isNaN(Number(age))) return false;
+  const numeric = Number(age);
+  return numeric >= min && numeric <= max;
+};

--- a/plateform/package.json
+++ b/plateform/package.json
@@ -52,7 +52,6 @@
     "prettier-plugin-organize-imports": "4.3.0",
     "typescript": "6.0.3",
     "vite": "8.0.16",
-    "vite-tsconfig-paths": "6.1.1",
     "vitest": "4.1.8"
   }
 }

--- a/plateform/vite.config.ts
+++ b/plateform/vite.config.ts
@@ -1,7 +1,6 @@
 import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   css: {
@@ -14,6 +13,7 @@ export default defineConfig({
   },
   resolve: {
     dedupe: ["react", "react-dom", "react-router"],
+    tsconfigPaths: true,
   },
-  plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
+  plugins: [tailwindcss(), reactRouter()],
 });

--- a/plateform/vitest.config.ts
+++ b/plateform/vitest.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     environment: "node",
     include: ["app/**/__tests__/**/*.{test,spec}.ts"],


### PR DESCRIPTION
## Description

Applique une seconde série de retours UI sur la plateforme et simplifie la configuration de résolution des chemins.

**Changements** :
- Remplacement de `bg-white` par le token `bg-background` (panel CTA détail mission, listbox de localisation du quiz, bottom sheet des résultats).
- Carte mission : ajustement du layout (`gap`/`justify-between`), agrandissement du logo publisher.
- Réordonnancement de l'export `clientLoader` sous les imports dans `results.tsx`.
- Suppression de la dépendance `vite-tsconfig-paths` au profit du résolveur natif `resolve.tsconfigPaths` (Vite + Vitest).

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Changements purement visuels et de configuration de build, sans impact sur la logique métier.
- Vérifier les deux layouts (desktop/mobile) sur les pages missions et résultats.