### PR TITLE
refactor(api): store diffusion rules on publisherOrganizationId

### DIFF
--- a/api/prisma/migrations/20260618000000_diffusion_rule_client_id_to_publisher_organization_id/migration.sql
+++ b/api/prisma/migrations/20260618000000_diffusion_rule_client_id_to_publisher_organization_id/migration.sql
@@ -1,0 +1,14 @@
+-- Migration de données : convertit les diffusion rules portant sur `publisherOrganization.clientId`
+-- vers `publisherOrganizationId`. La valeur (clientId) est résolue vers l'id de l'organisation de
+-- l'annonceur. L'annonceur est identifié par la règle racine parente (`combined_with_id`),
+-- dont `value` est le publisher_id de l'annonceur, et l'organisation est unique par
+-- (publisher_id, client_id).
+UPDATE "publisher_diffusion_rule" AS "rule"
+SET "field" = 'publisherOrganizationId',
+    "value" = "org"."id"
+FROM "publisher_diffusion_rule" AS "root"
+JOIN "publisher_organization" AS "org"
+  ON "org"."publisher_id" = "root"."value"
+WHERE "rule"."field" = 'publisherOrganization.clientId'
+  AND "root"."id" = "rule"."combined_with_id"
+  AND "org"."client_id" = "rule"."value";

--- a/api/src/v0/diffusion-rule/controller.ts
+++ b/api/src/v0/diffusion-rule/controller.ts
@@ -6,6 +6,7 @@ import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND, RESS
 import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { publisherService } from "@/services/publisher";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
+import publisherOrganizationService from "@/services/publisher-organization";
 import { PublisherRequest } from "@/types/passport";
 import type { PublisherRecord } from "@/types/publisher";
 
@@ -22,9 +23,11 @@ const listQuerySchema = zod
     message: "field and value must be provided together",
   });
 
+const ALLOWED_RULE_FIELDS = ["publisherOrganization.clientId", "publisherOrganization.parentOrganizations"] as const;
+
 const ruleBodySchema = zod.object({
   publisherIds: zod.array(zod.string()).min(1),
-  field: zod.string().min(1),
+  field: zod.enum(ALLOWED_RULE_FIELDS),
   fieldType: zod.string().optional().nullable(),
   operator: zod.string().min(1),
   value: zod.string().min(1),
@@ -60,8 +63,22 @@ router.get("/", async (req: PublisherRequest, res: Response, next: NextFunction)
       rulesByDiffuseur.set(rule.publisherId, list);
     });
 
+    // Les règles sont stockées sur publisherOrganizationId ; on les réexpose sur le clientId de l'annonceur
+    // pour conserver le contrat d'API (publisherOrganization.clientId).
+    const organizationIds = roots.flatMap((root) => (root.combinedRules ?? []).filter((rule) => rule.field === "publisherOrganizationId").map((rule) => rule.value));
+    const organizations = organizationIds.length ? await publisherOrganizationService.findMany({ publisherId: user.id, ids: organizationIds }) : [];
+    const clientIdByOrganizationId = new Map(organizations.map((organization) => [organization.id, organization.clientId]));
+
+    const toPublicRule = (rule: (typeof roots)[number]) => {
+      const clientId = clientIdByOrganizationId.get(rule.value);
+      if (rule.field === "publisherOrganizationId" && clientId !== undefined) {
+        return { ...rule, field: "publisherOrganization.clientId", value: clientId };
+      }
+      return rule;
+    };
+
     const data = diffuseurs.map((diffuseur) => {
-      const combinedRules = rulesByDiffuseur.get(diffuseur.id)?.[0].combinedRules ?? [];
+      const combinedRules = (rulesByDiffuseur.get(diffuseur.id)?.[0].combinedRules ?? []).map(toPublicRule);
       const base = {
         id: diffuseur.id,
         name: diffuseur.name,
@@ -107,15 +124,29 @@ router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction
       return res.status(403).send({ ok: false, code: FORBIDDEN, message: "No diffuseur match the request" });
     }
 
+    // On stocke une règle sur l'id de l'organisation plutôt que sur son clientId : le clientId reçu est résolu
+    // vers l'organisation de l'annonceur (clé unique publisherId + clientId) pour obtenir publisherOrganizationId.
+    let field: string = body.data.field;
+    let value = body.data.value;
+    if (body.data.field === "publisherOrganization.clientId") {
+      const organization = await publisherOrganizationService.findOneByClientIdAndPublisher(value, user.id);
+      if (!organization) {
+        res.locals = { code: NOT_FOUND, message: "Publisher organization not found" };
+        return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Publisher organization not found" });
+      }
+      field = "publisherOrganizationId";
+      value = organization.id;
+    }
+
     const created = await Promise.all(
       diffuseurIds.map((diffuseurId) =>
         publisherDiffusionRuleService.createScopedRule({
           diffuseurPublisherId: diffuseurId,
           annonceurPublisherId: user.id,
-          field: body.data.field,
+          field,
           fieldType: body.data.fieldType ?? "string",
           operator: body.data.operator,
-          value: body.data.value,
+          value,
         })
       )
     );
@@ -125,10 +156,11 @@ router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction
       data: created.map((rule) => ({
         id: rule.id,
         publisherId: rule.publisherId,
-        field: rule.field,
+        // On réexpose le champ tel que reçu (publisherOrganization.clientId) plutôt que le publisherOrganizationId stocké.
+        field: body.data.field,
         fieldType: rule.fieldType,
         operator: rule.operator,
-        value: rule.value,
+        value: body.data.value,
       })),
       total: created.length,
     });

--- a/api/tests/integration/api/endpoints/v0/diffusion-rule.test.ts
+++ b/api/tests/integration/api/endpoints/v0/diffusion-rule.test.ts
@@ -2,9 +2,9 @@ import request from "supertest";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
-import { PublisherMissionType, type PublisherRecord } from "@/types";
+import { type PublisherRecord } from "@/types";
 
-import { createTestPublisher } from "../../../../fixtures";
+import { createTestPublisher, createTestPublisherOrganization } from "../../../../fixtures";
 import { createTestApp } from "../../../../testApp";
 
 describe("DiffusionRule API Integration Tests", () => {
@@ -14,6 +14,7 @@ describe("DiffusionRule API Integration Tests", () => {
   let diffuseur1: PublisherRecord;
   let diffuseur2: PublisherRecord;
   let otherDiffuseur: PublisherRecord;
+  let organization: { id: string; clientId: string };
 
   beforeEach(async () => {
     publisher = await createTestPublisher();
@@ -25,6 +26,7 @@ describe("DiffusionRule API Integration Tests", () => {
       publishers: [{ publisherId: publisher.id }],
     });
     otherDiffuseur = await createTestPublisher();
+    organization = await createTestPublisherOrganization({ publisherId: publisher.id, clientId: "org-1" });
   });
 
   /**
@@ -255,8 +257,8 @@ describe("DiffusionRule API Integration Tests", () => {
 
       const persisted = await publisherDiffusionRuleService.findRules({
         publisherIds: [diffuseur1.id, diffuseur2.id, otherDiffuseur.id],
-        field: validRule.field,
-        value: validRule.value,
+        field: "publisherOrganizationId",
+        value: organization.id,
       });
       expect(persisted.map((rule) => rule.publisherId).sort()).toEqual([diffuseur1.id, diffuseur2.id].sort());
     });
@@ -265,7 +267,7 @@ describe("DiffusionRule API Integration Tests", () => {
       const response = await request(app)
         .post("/v0/diffusion-rule")
         .set("x-api-key", apiKey)
-        .send({ publisherIds: [diffuseur1.id], field: "type", operator: "is_not", value: "benevolat" });
+        .send({ publisherIds: [diffuseur1.id], field: "publisherOrganization.parentOrganizations", operator: "does_not_contain", value: "Marine nationale" });
 
       expect(response.status).toBe(201);
       expect(response.body.data[0].fieldType).toBe("string");
@@ -289,8 +291,8 @@ describe("DiffusionRule API Integration Tests", () => {
 
       const persisted = await publisherDiffusionRuleService.findRules({
         publisherId: diffuseur1.id,
-        field: validRule.field,
-        value: validRule.value,
+        field: "publisherOrganizationId",
+        value: organization.id,
       });
       expect(persisted).toHaveLength(1);
     });
@@ -314,8 +316,8 @@ describe("DiffusionRule API Integration Tests", () => {
       // La règle d'origine n'a pas été modifiée ni dupliquée.
       const persisted = await publisherDiffusionRuleService.findRules({
         publisherId: diffuseur1.id,
-        field: validRule.field,
-        value: validRule.value,
+        field: "publisherOrganizationId",
+        value: organization.id,
       });
       expect(persisted).toHaveLength(1);
       expect(persisted[0].operator).toBe("is_not");


### PR DESCRIPTION
## Description

Stocke désormais les diffusion rules sur `publisherOrganizationId` plutôt que sur le `clientId` de l'organisation, tout en conservant le contrat d'API public (`publisherOrganization.clientId`).

**Changements** :
- POST `/v0/diffusion-rule` : le champ `field` n'accepte plus que `publisherOrganization.clientId` et `publisherOrganization.parentOrganizations` (`zod.enum`). Un `clientId` reçu est résolu vers l'organisation de l'annonceur (clé unique `publisherId + clientId`) et stocké en `publisherOrganizationId` ; renvoie `404` si l'organisation est introuvable.
- GET `/v0/diffusion-rule` : réexpose les règles stockées en `publisherOrganizationId` sous la forme `publisherOrganization.clientId` (résolution `id → clientId`), pour le rendu comme pour le calcul du flag `diffuse`.
- POST : la réponse réexpose `field`/`value` tels que reçus.
- Migration de données convertissant les règles existantes `publisherOrganization.clientId` → `publisherOrganizationId`.

## Liens utiles

- 📝 Ticket Notion : _à compléter_

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

**Migrations DB** :
- `20260618000000_diffusion_rule_client_id_to_publisher_organization_id` : migration de données (UPDATE) convertissant les règles `publisherOrganization.clientId` en `publisherOrganizationId`. Migration manuelle (pas de changement de schéma).

**Points d'attention** :
- Les consommateurs lisant encore `publisherOrganization.clientId` directement (`app` → `Administration.jsx`, `jobs/letudiant/utils.ts`, `v0/myorganization/controller.ts`) ne matcheront plus une fois les règles migrées : à traiter dans une PR de suivi.
- Les règles dont l'organisation est introuvable au moment de la migration restent inchangées.
