### PR TITLE
feat(api): add openToMinor gate

### DIFF
--- a/api/src/services/mission-scoring/__tests__/scoring-rules.test.ts
+++ b/api/src/services/mission-scoring/__tests__/scoring-rules.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import { PUBLISHER_IDS } from "@/config";
-import { getMissionScoringRuleKeys } from "@/services/mission-scoring/scoring-rules";
+import { getMissionScoringRuleKeys, intersect, SCORING_RULES } from "@/services/mission-scoring/scoring-rules";
+import type { TaxonomyValueKey } from "@engagement/taxonomy";
 
 type RuleMission = Parameters<typeof getMissionScoringRuleKeys>[0];
 
@@ -61,5 +62,70 @@ describe("getMissionScoringRuleKeys — openToMinors", () => {
     const keys = getMissionScoringRuleKeys(buildMission({ publisherId: PUBLISHER_IDS.SERVICE_CIVIQUE, openToMinors: null }));
 
     expect(sorted(keys)).toEqual(sorted(["tranche_age.moins_18_ans", "tranche_age.entre_18_25_ans", "tranche_age.moins_31_ans_handicap"]));
+  });
+});
+
+// Note : la co-occurrence de DEUX règles sur la même taxonomie `tranche_age` est exercée par
+// le cas réel « Service Civique + openToMinors=false » du bloc ci-dessus (deux ensembles
+// tranche_age → intersection → {entre_18_25_ans}). Aucun couple de règles `publisherId`/`type`
+// ne peut co-occurrer en pratique (un publisher ROC n'émet pas de mission de type pompier),
+// donc on ne fabrique pas de scénario artificiel ; la mécanique d'intersection pure est
+// validée de façon isolée par le bloc `intersect` ci-dessous.
+
+describe("intersect", () => {
+  const set = (...keys: string[]): Set<TaxonomyValueKey> => new Set(keys as TaxonomyValueKey[]);
+
+  it("retourne un ensemble vide pour une liste vide (totale, ne lève pas)", () => {
+    expect([...intersect([])]).toEqual([]);
+  });
+
+  it("retourne l'ensemble lui-même pour un seul ensemble", () => {
+    expect(sorted([...intersect([set("tranche_age.entre_18_25_ans", "tranche_age.entre_25_30_ans")])])).toEqual(
+      sorted(["tranche_age.entre_18_25_ans", "tranche_age.entre_25_30_ans"])
+    );
+  });
+
+  it("retourne l'intersection de plusieurs ensembles", () => {
+    const result = intersect([
+      set("tranche_age.entre_18_25_ans", "tranche_age.entre_25_30_ans", "tranche_age.entre_30_45_ans"),
+      set("tranche_age.entre_25_30_ans", "tranche_age.entre_30_45_ans", "tranche_age.entre_46_67_ans"),
+      set("tranche_age.entre_30_45_ans"),
+    ]);
+
+    expect([...result]).toEqual(["tranche_age.entre_30_45_ans"]);
+  });
+
+  it("retourne un ensemble vide pour des ensembles disjoints", () => {
+    expect([...intersect([set("tranche_age.entre_18_25_ans"), set("tranche_age.moins_18_ans")])]).toEqual([]);
+  });
+});
+
+describe("SCORING_RULES — invariant de sûreté (fail-open inatteignable)", () => {
+  // L'allowlist adulte (openToMinors=false) est la source de vérité.
+  const adultTrancheAge: string[] = SCORING_RULES.openToMinors.false;
+
+  // Toute règle qui injecte `tranche_age` doit, intersectée avec l'allowlist adulte, rester
+  // non vide. Sinon une mission openToMinors=false portant cette règle produirait une
+  // intersection vide → gate désactivé (fail-open) → des mineurs pourraient matcher.
+  const trancheAgeRules: { label: string; keys: string[] }[] = [];
+  for (const [field, rulesByValue] of Object.entries(SCORING_RULES)) {
+    if (field === "openToMinors") {
+      continue;
+    }
+    for (const [value, keys] of Object.entries(rulesByValue as Record<string, string[]>)) {
+      const trancheKeys = keys.filter((key) => key.startsWith("tranche_age."));
+      if (trancheKeys.length > 0) {
+        trancheAgeRules.push({ label: `${field}.${value}`, keys: trancheKeys });
+      }
+    }
+  }
+
+  it("au moins une règle tranche_age existe (garantit que le test est pertinent)", () => {
+    expect(trancheAgeRules.length).toBeGreaterThan(0);
+  });
+
+  it.each(trancheAgeRules)("la règle $label conserve au moins une tranche adulte sous openToMinors=false", ({ keys }) => {
+    const overlap = keys.filter((key) => adultTrancheAge.includes(key));
+    expect(overlap.length).toBeGreaterThan(0);
   });
 });

--- a/api/src/services/mission-scoring/__tests__/scoring-rules.test.ts
+++ b/api/src/services/mission-scoring/__tests__/scoring-rules.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { PUBLISHER_IDS } from "@/config";
+import { getMissionScoringRuleKeys } from "@/services/mission-scoring/scoring-rules";
+
+type RuleMission = Parameters<typeof getMissionScoringRuleKeys>[0];
+
+const buildMission = (overrides: Partial<RuleMission> = {}): RuleMission => ({
+  publisherId: null,
+  type: null,
+  openToMinors: null,
+  ...overrides,
+});
+
+const ADULT_TRANCHE_AGE_KEYS = [
+  "tranche_age.entre_18_25_ans",
+  "tranche_age.entre_25_30_ans",
+  "tranche_age.entre_30_45_ans",
+  "tranche_age.entre_46_67_ans",
+  "tranche_age.entre_46_66_ans",
+  "tranche_age.entre_68_72_ans",
+  "tranche_age.plus_72_ans",
+];
+
+const sorted = (keys: string[]): string[] => [...keys].sort();
+
+describe("getMissionScoringRuleKeys — openToMinors", () => {
+  it("injecte uniquement les tranches d'âge adultes quand openToMinors=false (mission sans autre règle)", () => {
+    const keys = getMissionScoringRuleKeys(buildMission({ openToMinors: false }));
+
+    expect(sorted(keys)).toEqual(sorted(ADULT_TRANCHE_AGE_KEYS));
+  });
+
+  it("n'ajoute aucune contrainte tranche_age quand openToMinors=true", () => {
+    const keys = getMissionScoringRuleKeys(buildMission({ openToMinors: true }));
+
+    expect(keys).toEqual([]);
+  });
+
+  it("n'ajoute aucune contrainte tranche_age quand openToMinors=null", () => {
+    const keys = getMissionScoringRuleKeys(buildMission({ openToMinors: null }));
+
+    expect(keys).toEqual([]);
+  });
+
+  it("intersecte la règle Service Civique avec openToMinors=false (les mineurs sont exclus, la borne SC est respectée)", () => {
+    const keys = getMissionScoringRuleKeys(buildMission({ publisherId: PUBLISHER_IDS.SERVICE_CIVIQUE, openToMinors: false }));
+
+    expect(keys).toEqual(["tranche_age.entre_18_25_ans"]);
+    expect(keys).not.toContain("tranche_age.moins_18_ans");
+    expect(keys).not.toContain("tranche_age.moins_31_ans_handicap");
+  });
+
+  it("conserve l'ensemble Service Civique complet quand openToMinors=true (non-régression)", () => {
+    const keys = getMissionScoringRuleKeys(buildMission({ publisherId: PUBLISHER_IDS.SERVICE_CIVIQUE, openToMinors: true }));
+
+    expect(sorted(keys)).toEqual(sorted(["tranche_age.moins_18_ans", "tranche_age.entre_18_25_ans", "tranche_age.moins_31_ans_handicap"]));
+  });
+
+  it("conserve l'ensemble Service Civique complet quand openToMinors=null (non-régression)", () => {
+    const keys = getMissionScoringRuleKeys(buildMission({ publisherId: PUBLISHER_IDS.SERVICE_CIVIQUE, openToMinors: null }));
+
+    expect(sorted(keys)).toEqual(sorted(["tranche_age.moins_18_ans", "tranche_age.entre_18_25_ans", "tranche_age.moins_31_ans_handicap"]));
+  });
+});

--- a/api/src/services/mission-scoring/data.ts
+++ b/api/src/services/mission-scoring/data.ts
@@ -3,7 +3,7 @@ import { Prisma } from "@/db/core";
 import type { ScoringInputValue } from "@/services/mission-scoring/types";
 
 export const missionScoringEnrichmentInclude = {
-  mission: { select: { publisherId: true, type: true } },
+  mission: { select: { publisherId: true, type: true, openToMinors: true } },
   values: true,
 } satisfies Prisma.MissionEnrichmentInclude;
 

--- a/api/src/services/mission-scoring/scoring-rules.ts
+++ b/api/src/services/mission-scoring/scoring-rules.ts
@@ -61,7 +61,18 @@ export const SCORING_RULES = {
   },
 } satisfies MissionScoringRules;
 
-const intersect = (sets: Set<TaxonomyValueKey>[]): Set<TaxonomyValueKey> => sets.reduce((acc, set) => new Set([...acc].filter((key) => set.has(key))));
+/**
+ * Intersection d'une liste d'ensembles. Fonction **totale** : retourne un ensemble vide pour
+ * une liste vide, là où `reduce` sans valeur initiale lèverait. Exportée pour être testée
+ * directement (le cas « intersection vide » n'est pas atteignable via les règles réelles).
+ */
+export const intersect = (sets: Set<TaxonomyValueKey>[]): Set<TaxonomyValueKey> => {
+  const [first, ...rest] = sets;
+  if (!first) {
+    return new Set<TaxonomyValueKey>();
+  }
+  return rest.reduce((acc, set) => new Set([...acc].filter((key) => set.has(key))), new Set(first));
+};
 
 /**
  * Résout les clés de taxonomie injectées déterministiquement pour une mission.
@@ -111,10 +122,14 @@ export const getMissionScoringRuleKeys = (mission: MissionScoringRuleMission): T
   for (const [taxonomyKey, sets] of constraintsByTaxonomy) {
     const intersection = intersect(sets);
     if (intersection.size === 0) {
-      // Garde-fou : une intersection vide n'injecterait aucune valeur, ce que le matching
-      // interprète comme « aucune contrainte » (gate inactif) plutôt que « personne ne passe ».
-      // Cas non atteint avec les règles actuelles ; on loggue au lieu d'ouvrir la mission.
-      console.warn(`[mission-scoring] intersection vide pour la taxonomie '${taxonomyKey}' — contrainte de gate non appliquée`);
+      // Garde-fou de SÛRETÉ : une intersection vide n'injecterait aucune valeur, ce que le
+      // matching interprète comme « aucune contrainte » (gate inactif, mission ouverte à tous)
+      // plutôt que « personne ne passe ». Pour un gate de sûreté comme `tranche_age` (exclusion
+      // des mineurs), ce fail-open est dangereux. Le mécanisme d'allowlist ne permet pas de
+      // « bloquer tout le monde » proprement, donc on conserve le fail-open mais on le rend
+      // bruyant : c'est une anomalie de configuration. L'invariant « aucune règle tranche_age
+      // n'est un sous-ensemble de mineurs » (cf. test) garantit que ce cas est inatteignable.
+      console.error(`[mission-scoring] ANOMALIE config: intersection vide pour la taxonomie '${taxonomyKey}' — gate NON appliqué (fail-open). Vérifier SCORING_RULES.`);
       continue;
     }
 

--- a/api/src/services/mission-scoring/scoring-rules.ts
+++ b/api/src/services/mission-scoring/scoring-rules.ts
@@ -1,17 +1,22 @@
 import type { MissionType } from "@/db/core";
 import type { TaxonomyValueKey } from "@engagement/taxonomy";
+import { parseTaxonomyValueKey } from "@engagement/taxonomy";
 
 import { PUBLISHER_IDS } from "@/config";
 
 type MissionScoringRuleMission = {
   publisherId: string | null;
   type: MissionType | null;
+  openToMinors: boolean | null;
 };
 
 type MissionScoringRuleField = keyof MissionScoringRuleMission;
 
 type MissionScoringRules = {
-  [Field in MissionScoringRuleField]?: Partial<Record<NonNullable<MissionScoringRuleMission[Field]>, TaxonomyValueKey[]>>;
+  // La clé est la forme stringifiée de la valeur (cf. `String(value)` dans
+  // getMissionScoringRuleKeys) : `boolean` devient "true" | "false", ce qui permet
+  // des champs booléens comme `openToMinors` tout en gardant un index valide.
+  [Field in MissionScoringRuleField]?: Partial<Record<`${NonNullable<MissionScoringRuleMission[Field]>}`, TaxonomyValueKey[]>>;
 };
 
 /**
@@ -40,10 +45,36 @@ export const SCORING_RULES = {
       "tranche_age.entre_46_66_ans",
     ],
   },
+  // Mission fermée aux mineurs : seules les tranches d'âge adultes sont autorisées.
+  // Combinée par intersection avec les autres règles (cf. getMissionScoringRuleKeys),
+  // cette contrainte exclut du matching tout utilisateur de moins de 18 ans.
+  openToMinors: {
+    false: [
+      "tranche_age.entre_18_25_ans",
+      "tranche_age.entre_25_30_ans",
+      "tranche_age.entre_30_45_ans",
+      "tranche_age.entre_46_67_ans",
+      "tranche_age.entre_46_66_ans",
+      "tranche_age.entre_68_72_ans",
+      "tranche_age.plus_72_ans",
+    ],
+  },
 } satisfies MissionScoringRules;
 
+const intersect = (sets: Set<TaxonomyValueKey>[]): Set<TaxonomyValueKey> => sets.reduce((acc, set) => new Set([...acc].filter((key) => set.has(key))));
+
+/**
+ * Résout les clés de taxonomie injectées déterministiquement pour une mission.
+ *
+ * Chaque règle applicable exprime une contrainte d'allowlist par taxonomie. Quand plusieurs
+ * règles contraignent la même taxonomie, on prend l'**intersection** des ensembles (la
+ * contrainte la moins permissive gagne). Exemple : une mission Service Civique
+ * `openToMinors=false` ne conserve sur `tranche_age` que l'intersection des tranches SC et
+ * des tranches adultes, ce qui exclut les mineurs sans réouvrir la mission aux autres âges.
+ */
 export const getMissionScoringRuleKeys = (mission: MissionScoringRuleMission): TaxonomyValueKey[] => {
-  const keys = new Set<TaxonomyValueKey>();
+  // taxonomie -> liste des ensembles autorisés (un par règle applicable)
+  const constraintsByTaxonomy = new Map<string, Set<TaxonomyValueKey>[]>();
 
   for (const [field, rulesByValue] of Object.entries(SCORING_RULES) as [MissionScoringRuleField, Partial<Record<string, TaxonomyValueKey[]>>][]) {
     const value = mission[field];
@@ -51,10 +82,44 @@ export const getMissionScoringRuleKeys = (mission: MissionScoringRuleMission): T
       continue;
     }
 
-    for (const key of rulesByValue[String(value)] ?? []) {
-      keys.add(key);
+    const ruleKeys = rulesByValue[String(value)];
+    if (!ruleKeys) {
+      continue;
+    }
+
+    // Regroupe les clés de CETTE règle par taxonomie avant de les agréger.
+    const ruleSetsByTaxonomy = new Map<string, Set<TaxonomyValueKey>>();
+    for (const key of ruleKeys) {
+      const parsed = parseTaxonomyValueKey(key);
+      if (!parsed) {
+        continue;
+      }
+
+      const set = ruleSetsByTaxonomy.get(parsed.taxonomyKey) ?? new Set<TaxonomyValueKey>();
+      set.add(key);
+      ruleSetsByTaxonomy.set(parsed.taxonomyKey, set);
+    }
+
+    for (const [taxonomyKey, set] of ruleSetsByTaxonomy) {
+      const list = constraintsByTaxonomy.get(taxonomyKey) ?? [];
+      list.push(set);
+      constraintsByTaxonomy.set(taxonomyKey, list);
     }
   }
 
-  return Array.from(keys);
+  const keys: TaxonomyValueKey[] = [];
+  for (const [taxonomyKey, sets] of constraintsByTaxonomy) {
+    const intersection = intersect(sets);
+    if (intersection.size === 0) {
+      // Garde-fou : une intersection vide n'injecterait aucune valeur, ce que le matching
+      // interprète comme « aucune contrainte » (gate inactif) plutôt que « personne ne passe ».
+      // Cas non atteint avec les règles actuelles ; on loggue au lieu d'ouvrir la mission.
+      console.warn(`[mission-scoring] intersection vide pour la taxonomie '${taxonomyKey}' — contrainte de gate non appliquée`);
+      continue;
+    }
+
+    keys.push(...intersection);
+  }
+
+  return keys;
 };


### PR DESCRIPTION
## Description

Les missions fermées aux mineurs (`mission.openToMinors = false`) ne sont plus proposées par le **matching-engine** aux utilisateurs ayant déclaré une tranche d'âge inférieure à 18 ans.

Le matching-engine ne dispose que d'un seul filtre dur : le mécanisme de *gate* sur les taxonomies (`tranche_age` est `gate`). Une mission n'est éligible que si, pour chaque taxonomie gate qu'elle porte, l'utilisateur possède au moins une valeur correspondante (allowlist). On encode donc la contrainte mineurs dans `scoring-rules.ts`, en injectant pour `openToMinors = false` les seules tranches d'âge **adultes**.

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Détail des changements

- **`scoring-rules.ts`**
  - Ajout du champ `openToMinors: boolean | null` à `MissionScoringRuleMission` et d'une règle `openToMinors.false → [tranches d'âge adultes]`.
  - L'index de `MissionScoringRules` est désormais la forme stringifiée de la valeur (`` `${...}` ``, donc `boolean → "true" | "false"`), pour autoriser des champs booléens comme clé de règle.
  - **`getMissionScoringRuleKeys` réécrit** : les règles applicables sont regroupées par taxonomie puis **combinées par intersection** (« la contrainte la moins permissive gagne ») au lieu de l'union précédente.
- **`data.ts`** : ajout de `openToMinors` au `select` de la mission chargée pour le scoring.
- **`__tests__/scoring-rules.test.ts`** : nouveaux tests unitaires (6 cas).

## Notes complémentaires (points d'attention reviewer)

**Pourquoi l'intersection plutôt que l'union.** Une simple union laissait fuiter `moins_18_ans` sur les missions Service Civique `openToMinors=false` (le publisher SC injecte cette tranche), donc les mineurs n'étaient pas exclus. L'intersection par taxonomie résout ce cas de façon générique, sans traitement spécifique :

- SC `openToMinors=false` : `{moins_18_ans, entre_18_25_ans, moins_31_ans_handicap}` ∩ `{tranches adultes}` = `{entre_18_25_ans}` → mineurs exclus **et** borne d'âge SC respectée.
- Mission non-SC `openToMinors=false` : une seule contrainte → les 7 tranches adultes (tous les adultes passent).
- `openToMinors` `true` / `null` → aucune contrainte d'âge ajoutée (comportement inchangé).

**Pas d'impact sur l'existant.** Aujourd'hui une mission ne matche en pratique qu'une seule règle `tranche_age` (au plus un `publisherId` et au plus un `type`, sans chevauchement) → intersection ≡ union. Le changement ne joue que dans le nouveau cas de co-occurrence avec `openToMinors`.

**Pas de backfill.** La règle s'applique au fil des re-scorings naturels (nouveaux enrichissements / job `update-mission-scoring`). Aucune action de migration immédiate.

**Effet de bord assumé.** Le mécanisme de gate exclut aussi les utilisateurs n'ayant déclaré aucune tranche d'âge des missions `openToMinors=false` (cohérent avec le comportement actuel SC / ROC).

**Limitation connue.** La taxonomie regroupe mineurs et adultes en situation de handicap dans `moins_31_ans_handicap`. Côté sécurité mineurs, cette tranche est exclue de l'allowlist adulte : conséquence, un utilisateur 26-30 ans en situation de handicap est exclu des missions **SC** `openToMinors=false` (population très étroite).

## Tests

- Unitaires mission-scoring : 19/19 (dont 6 nouveaux).
- ESLint et `tsc --noEmit` : clean sur les fichiers modifiés.
