### PR TITLE
refactor(api): publisher diffusion rules management

### DIFF
--- a/api/src/services/publisher-diffusion-rule/config.ts
+++ b/api/src/services/publisher-diffusion-rule/config.ts
@@ -1,0 +1,35 @@
+import type { Prisma } from "@/db/core";
+
+// Polarité normalisée d'une règle enfant : inclusion (`is`) ou exclusion (`isNot`).
+export type ChildPolarity = "is" | "isNot";
+
+export type ChildFieldConfig = {
+  // Champ correspondant dans l'index de recherche (cf. `schemas/`).
+  indexField: string;
+  // Opérateurs de règle acceptés, regroupés par polarité ; tout autre opérateur est non supporté.
+  operators: Record<ChildPolarity, readonly string[]>;
+  // Condition Prisma équivalente, pour chaque polarité.
+  missionWhere: Record<ChildPolarity, (value: string) => Prisma.MissionWhereInput>;
+};
+
+// Registre des champs enfants supportés par le filtre de diffusion.
+// Ajouter un champ = ajouter une entrée ici (et le champ correspondant dans le schéma d'index).
+export const SUPPORTED_CHILD_FIELDS: Record<string, ChildFieldConfig> = {
+  publisherOrganizationId: {
+    indexField: "publisherOrganizationId",
+    operators: { is: ["is"], isNot: ["is_not"] },
+    missionWhere: {
+      is: (value) => ({ publisherOrganizationId: value }),
+      isNot: (value) => ({ publisherOrganizationId: { not: value } }),
+    },
+  },
+  // Champ array indexé : appartenance exacte, donc `contains` ≡ `is` et `does_not_contain` ≡ `is_not`.
+  "publisherOrganization.parentOrganizations": {
+    indexField: "publisherOrganizationParentOrganizations",
+    operators: { is: ["is", "contains"], isNot: ["is_not", "does_not_contain"] },
+    missionWhere: {
+      is: (value) => ({ publisherOrganization: { parentOrganizations: { has: value } } }),
+      isNot: (value) => ({ NOT: { publisherOrganization: { parentOrganizations: { has: value } } } }),
+    },
+  },
+};

--- a/api/src/services/search/collections/missions/diffusion-rules-filter.ts
+++ b/api/src/services/search/collections/missions/diffusion-rules-filter.ts
@@ -1,5 +1,7 @@
 import type { Prisma } from "@/db/core";
 import { captureException } from "@/error";
+import type { ChildFieldConfig, ChildPolarity } from "@/services/publisher-diffusion-rule/config";
+import { SUPPORTED_CHILD_FIELDS } from "@/services/publisher-diffusion-rule/config";
 import { buildSearchEqualFilter, buildSearchListFilter, buildSearchNotEqualFilter, combineSearchAnd, combineSearchOr } from "@/services/search/filter";
 import type { PublisherDiffusionRuleRecord } from "@/types/publisher-diffusion-rule";
 
@@ -69,6 +71,16 @@ const buildChildrenByParentId = (rules: PublisherDiffusionRuleRecord[]): Map<str
   return childrenByParentId;
 };
 
+const resolveChildPolarity = (config: ChildFieldConfig, operator: string): ChildPolarity | null => {
+  if (config.operators.is.includes(operator)) {
+    return "is";
+  }
+  if (config.operators.isNot.includes(operator)) {
+    return "isNot";
+  }
+  return null;
+};
+
 const buildSupportedChildGroup = (rule: PublisherDiffusionRuleRecord): SupportedGroup | null => {
   const value = rule.value.trim();
   if (!value) {
@@ -76,34 +88,22 @@ const buildSupportedChildGroup = (rule: PublisherDiffusionRuleRecord): Supported
     return null;
   }
 
-  if (rule.field === "publisherOrganizationId") {
-    if (rule.operator !== "is" && rule.operator !== "is_not") {
-      reportUnsupportedRule(rule, "unsupported_child_operator_or_empty_value");
-      return null;
-    }
-    const isNot = rule.operator === "is_not";
-    return {
-      filterBy: isNot ? buildSearchNotEqualFilter("publisherOrganizationId", value) : buildSearchEqualFilter("publisherOrganizationId", value),
-      missionWhere: { publisherOrganizationId: isNot ? { not: value } : value },
-    };
+  const config = SUPPORTED_CHILD_FIELDS[rule.field];
+  if (!config) {
+    reportUnsupportedRule(rule, "unsupported_child_field");
+    return null;
   }
 
-  if (rule.field === "publisherOrganization.parentOrganizations") {
-    // Champ array indexé par mission-browse : appartenance exacte, donc `contains` ≡ `is`
-    // et `does_not_contain` ≡ `is_not`.
-    const isNot = rule.operator === "is_not" || rule.operator === "does_not_contain";
-    if (!isNot && rule.operator !== "is" && rule.operator !== "contains") {
-      reportUnsupportedRule(rule, "unsupported_child_operator_or_empty_value");
-      return null;
-    }
-    return {
-      filterBy: isNot ? buildSearchNotEqualFilter("publisherOrganizationParentOrganizations", value) : buildSearchEqualFilter("publisherOrganizationParentOrganizations", value),
-      missionWhere: isNot ? { NOT: { publisherOrganization: { parentOrganizations: { has: value } } } } : { publisherOrganization: { parentOrganizations: { has: value } } },
-    };
+  const polarity = resolveChildPolarity(config, rule.operator);
+  if (!polarity) {
+    reportUnsupportedRule(rule, "unsupported_child_operator_or_empty_value");
+    return null;
   }
 
-  reportUnsupportedRule(rule, "unsupported_child_field");
-  return null;
+  return {
+    filterBy: polarity === "isNot" ? buildSearchNotEqualFilter(config.indexField, value) : buildSearchEqualFilter(config.indexField, value),
+    missionWhere: config.missionWhere[polarity](value),
+  };
 };
 
 const buildSupportedRuleGroup = (


### PR DESCRIPTION
## Description

Refactorise la traduction des règles de diffusion en filtre de recherche des missions (diffusion-rules-filter.ts) pour rendre l'ajout d'un champ trivial et le code plus lisible.

Avant, chaque champ supporté (publisherOrganizationId, publisherOrganization.parentOrganizations) était un bloc if qui répétait la même mécanique : vérification de l'opérateur, calcul de la polarité isNot, puis construction manuelle du filterBy (Typesense) et du missionWhere (Prisma).

Cette logique est désormais déclarative : un registre central SUPPORTED_CHILD_FIELDS décrit, par champ, uniquement ce qui varie (champ d'index, opérateurs acceptés par polarité, condition Prisma). La fonction buildSupportedChildGroup devient générique et factorise la partie commune (trim/valeur vide, report Sentry, choix equal/notEqual).

👉 Ajouter un champ = ajouter une entrée dans le registre, sans toucher à la logique de parcours.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Note complémentaire

- Une fois l'api de création de `publisher-diffusion-rule` branchée sur l'`app`, il faudrait utilisé la config pour afficher les champs disponible dans la création de règles