### PR TITLE
fix(api): email mission fallback image

### DIFF
--- a/api/src/services/brevo/mission-content.ts
+++ b/api/src/services/brevo/mission-content.ts
@@ -46,12 +46,17 @@ const buildCriteriaRows = (mission: MissionContent) => {
   ].join("");
 };
 
-const buildBannerRow = (mission: MissionContent) => `
+const buildBannerRow = (mission: MissionContent) => {
+  if (!mission.imageUrl) {
+    return "";
+  }
+  return `
   <tr>
     <td style="padding-bottom: 16px;">
       <img src="${buildBannerImageUrl(mission.imageUrl)}" alt="" width="100%" style="display: block; width: 100%; height: auto; border: 0;" />
     </td>
   </tr>`;
+};
 
 const buildTitleRow = (mission: MissionContent, fontSize: number) => `
   <tr>

--- a/api/src/services/mission-email/index.ts
+++ b/api/src/services/mission-email/index.ts
@@ -103,7 +103,7 @@ const formatCompensationLabel = (mission: EmailMission) => {
 
 const buildMissionEmailItem = (mission: EmailMission, publisherId: string, userScoringId?: string): MissionContent => ({
   title: mission.title,
-  imageUrl: mission.domainLogo ?? mission.publisherLogo ?? "",
+  imageUrl: mission.domainLogo || mission.publisherLogo || "",
   durationLabel: formatDurationLabel(mission.duration),
   startAtLabel: formatStartAtLabel(mission.startAt),
   compensationLabel: formatCompensationLabel(mission),

--- a/api/src/services/mission-email/index.ts
+++ b/api/src/services/mission-email/index.ts
@@ -103,7 +103,7 @@ const formatCompensationLabel = (mission: EmailMission) => {
 
 const buildMissionEmailItem = (mission: EmailMission, publisherId: string, userScoringId?: string): MissionContent => ({
   title: mission.title,
-  imageUrl: mission.domainLogo ?? "",
+  imageUrl: mission.domainLogo ?? mission.publisherLogo ?? "",
   durationLabel: formatDurationLabel(mission.duration),
   startAtLabel: formatStartAtLabel(mission.startAt),
   compensationLabel: formatCompensationLabel(mission),


### PR DESCRIPTION
## Description

Les missions sans image (champ `image` non renseigné), comme celles créées par `scripts/missions-sdis/create-spv-missions.ts`, n'affichaient aucune bannière dans les emails de missions : la bannière était mappée uniquement sur `domainLogo`, donc vide, ce qui générait une image cassée (`images.weserv.nl/?url=&...`).

Cette PR aligne l'email sur le reste de la codebase (`mission-browse`, `mission-match`) en ajoutant un fallback sur le logo éditeur.

Ticket Notion : https://app.notion.com/p/jeveuxaider/Images-SPV-manquantes-dans-les-mails-d-envoi-38772a322d5080e7aaf1ffa14f18d40a?source=copy_link

## Type de changement

- [x] Correction de bug

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
