### PR TITLE
refactor(api,app): disable report urls

### DIFF
--- a/api/src/controllers/report.ts
+++ b/api/src/controllers/report.ts
@@ -1,43 +1,15 @@
-import { NextFunction, Request, Response, Router } from "express";
-import zod from "zod";
+import { Request, Response, Router } from "express";
 
-import { captureException, INVALID_PARAMS, NOT_FOUND } from "@/error";
 import { ipRateLimiter } from "@/middlewares/rate-limit";
-import { reportService } from "@/services/report";
-import { getPresignedUrl } from "@/services/s3";
 
 const router = Router();
 router.use(ipRateLimiter);
 
-router.get("/:id", async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const params = zod
-      .object({
-        id: zod.uuid(),
-      })
-      .safeParse(req.params);
-
-    if (!params.success) {
-      return res.status(400).send({ ok: false, code: INVALID_PARAMS, message: params.error });
-    }
-
-    const report = await reportService.findOneReportById(params.data.id);
-    if (!report) {
-      return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Report not found" });
-    }
-    if (!report.url) {
-      captureException(new Error(`Report ${report.id} has no url`), `Report ${report.id} has no url`);
-      return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Report not found" });
-    }
-
-    if (report.objectName) {
-      const signedUrl = await getPresignedUrl(report.objectName);
-      return res.redirect(signedUrl);
-    }
-    res.redirect(report.url);
-  } catch (error) {
-    next(error);
-  }
+// Endpoint décommissionné : la redirection publique vers les rapports (URL S3 présignée)
+// exposait une IDOR (aucun contrôle de propriété sur le `Report` multi-tenant). La feature
+// est dormante et vouée à disparaître ; on renvoie 410 Gone pour les liens encore dans la nature.
+router.get("/:id", async (_req: Request, res: Response) => {
+  return res.status(410).send({ ok: false, message: "This report endpoint has been decommissioned" });
 });
 
 export default router;

--- a/api/src/jobs/report/send.ts
+++ b/api/src/jobs/report/send.ts
@@ -38,7 +38,6 @@ const sendReport = async (report: ReportRecord): Promise<{ ok: boolean; data?: a
         applyImprove: `${applyRaise < 0 ? "-" : "+"} ${Math.abs(applyRaise).toLocaleString("fr", { style: "percent", maximumFractionDigits: 2 })}`,
         rate: rate.toLocaleString("fr", { style: "percent", maximumFractionDigits: 2 }),
         rateImprove: `${rateRaise < 0 ? "-" : "+"} ${Math.abs(rateRaise).toLocaleString("fr", { style: "percent", maximumFractionDigits: 2 })}`,
-        reportURL: `https://api.api-engagement.beta.gouv.fr/report/${report.id}`,
         dashboardURL: `https://app.api-engagement.beta.gouv.fr/performance?from=${new Date(report.year, report.month, 1).toISOString()}&to=${new Date(report.year, report.month + 1, 1).toISOString()}`,
       } as any,
     };

--- a/api/tests/integration/api/report.test.ts
+++ b/api/tests/integration/api/report.test.ts
@@ -7,41 +7,22 @@ import { createTestApp } from "../../testApp";
 
 const app = createTestApp();
 
-const SIGNED_URL = "https://mock-bucket.example.com/signed-url?token=mock";
-
 describe("Report endpoints (integration)", () => {
   describe("GET /report/:id", () => {
-    it("redirects to a presigned URL when objectName is set", async () => {
+    it("returns 410 Gone for an existing report (endpoint decommissioned)", async () => {
       const publisher = await createTestPublisher();
       const report = await createTestReport({ publisherId: publisher.id, objectName: `publishers/${publisher.id}/reports/202501.pdf` });
 
       const res = await request(app).get(`/report/${report.id}`).redirects(0);
 
-      expect(res.status).toBe(302);
-      expect(res.headers.location).toBe(SIGNED_URL);
+      expect(res.status).toBe(410);
+      expect(res.body.ok).toBe(false);
     });
 
-    it("redirects to report.url when objectName is null (legacy fallback)", async () => {
-      const publisher = await createTestPublisher();
-      const legacyUrl = `https://bucket.example.com/publishers/${publisher.id}/reports/202501.pdf`;
-      const report = await createTestReport({ publisherId: publisher.id, objectName: null, url: legacyUrl });
+    it("returns 410 Gone for any id, regardless of existence", async () => {
+      const res = await request(app).get("/report/00000000-0000-0000-0000-000000000000").redirects(0);
 
-      const res = await request(app).get(`/report/${report.id}`).redirects(0);
-
-      expect(res.status).toBe(302);
-      expect(res.headers.location).toBe(legacyUrl);
-    });
-
-    it("returns 404 when the report does not exist", async () => {
-      const res = await request(app).get("/report/00000000-0000-0000-0000-000000000000");
-
-      expect(res.status).toBe(404);
-    });
-
-    it("returns 400 for an invalid UUID", async () => {
-      const res = await request(app).get("/report/not-a-uuid");
-
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(410);
     });
   });
 });

--- a/app/src/scenes/admin-report/index.jsx
+++ b/app/src/scenes/admin-report/index.jsx
@@ -6,9 +6,7 @@ import Select from "@/components/Select";
 import Table from "@/components/Table";
 import { MONTHS, REPORT_STATUS, YEARS } from "@/constants";
 import api from "@/services/api";
-import { API_URL } from "@/services/config";
 import { captureError } from "@/services/error";
-import { RiDownload2Line } from "react-icons/ri";
 
 const TABLE_HEADER = [{ title: "Partenaire", key: "publisherName" }, { title: "Statut", key: "status" }, { title: "Stat" }];
 
@@ -161,11 +159,6 @@ const AdminReport = () => {
                       </>
                     )}
                   </div>
-                  {item.id && (
-                    <a className="border-blue-france text-blue-france shrink-0 border p-2" href={`${API_URL}/report/${item.id}`} target="_blank" rel="noreferrer">
-                      <RiDownload2Line className="text-blue-france" role="img" aria-label="Télécharger le rapport" />
-                    </a>
-                  )}
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
## Description

Neutralisation d'une faille **IDOR (HIGH)** sur la route publique `GET /report/:id`.

La route était montée sans authentification (`corsPublic` + `ipRateLimiter` uniquement) et redirigeait (302) vers une URL S3 présignée à partir d'un simple UUID, **sans aucun contrôle de propriété** sur le `Report` (modèle multi-tenant via `publisherId`). N'importe qui sur Internet pouvait donc télécharger le rapport mensuel confidentiel d'un autre annonceur (statistiques, contacts `sentTo`) à partir d'un UUID — UUID qui fuitaient via les e-mails de rapport et les listes du back-office.

La route ne pouvait pas simplement passer sous `passport.authenticate`, car ses **deux seuls consommateurs sont des liens de navigation** (sans header `Authorization`) :
- le bouton de téléchargement du back-office (`<a target="_blank">`) ;
- le lien `reportURL` injecté dans les e-mails Brevo, cliqué par des destinataires non loggés.

La feature est par ailleurs **dormante** (aucune planification cron ; job lançable uniquement à la main via `run-job`) et **vouée à disparaître**. On choisit donc de **couper l'exposition publique maintenant** plutôt que de réintroduire une authentification sur une feature en sursis.

Ticket Notion : https://app.notion.com/p/jeveuxaider/GET-report-id-route-totalement-non-authentifi-e-38072a322d5080b39003d347284d513b?source=copy_link

## Type de changement

- [x] Correction de bug (sécurité)
- [x] Refactoring

## Changements

- **`api/src/controllers/report.ts`** : le handler `GET /:id` renvoie désormais `410 Gone` de façon inconditionnelle (plus de lookup DB ni de génération d'URL présignée). Les liens e-mail déjà dans la nature reçoivent ainsi une réponse propre. Imports devenus inutiles supprimés.
- **`app/src/scenes/admin-report/index.jsx`** : suppression du bouton de téléchargement (et des imports orphelins `API_URL` / `RiDownload2Line`).
- **`api/src/jobs/report/send.ts`** : suppression du `reportURL` injecté dans les e-mails (défense en profondeur — évite de re-semer des liens IDOR si le job est relancé à la main).
- **`api/tests/integration/api/report.test.ts`** : suite réécrite pour asserter le `410` (report existant + id inexistant).

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- **Hors périmètre** : la suppression complète du contrôleur, du modèle `Report`, du job `jobs/report/**` et de la page back-office `admin-report` est laissée à un chantier de décommission dédié. Cette PR se limite à fermer la faille. La méthode `reportService.findOneReportById` n'était utilisée que par ce handler et devient candidate au retrait lors de cette décommission.
- Vérifications : tests d'intégration `report.test.ts` 2/2 ✅, ESLint api + app propre ✅.
