### PR TITLE
feat(analytics): analytics publisher_diffusion_rule

### DIFF
--- a/analytics/db/migrations/20260623113922_add_publisher_diffusion_rule.sql
+++ b/analytics/db/migrations/20260623113922_add_publisher_diffusion_rule.sql
@@ -1,0 +1,17 @@
+-- migrate:up
+CREATE TABLE IF NOT EXISTS "analytics_raw"."publisher_diffusion_rule" (
+  "id" TEXT PRIMARY KEY,
+  "publisher_id" TEXT NOT NULL,
+  "field" TEXT NOT NULL,
+  "field_type" TEXT,
+  "operator" TEXT NOT NULL,
+  "value" TEXT NOT NULL,
+  "combinator" TEXT NOT NULL,
+  "position" INTEGER NOT NULL DEFAULT 0,
+  "combined_with_id" TEXT,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- migrate:down
+DROP TABLE IF EXISTS "analytics_raw"."publisher_diffusion_rule";

--- a/analytics/dbt/analytics/.sqlfluff
+++ b/analytics/dbt/analytics/.sqlfluff
@@ -16,4 +16,4 @@ spacing_before = touch
 line_position = trailing
 
 [sqlfluff:rules:references.keywords]
-ignore_words = type,domain,day,year,month,week
+ignore_words = type,domain,day,year,month,week,position

--- a/analytics/dbt/analytics/models/intermediate/publisher/__models.yml
+++ b/analytics/dbt/analytics/models/intermediate/publisher/__models.yml
@@ -1,6 +1,52 @@
 version: 2
 
 models:
+  - name: int_publisher_diffusion_rule
+    description: >
+      Modèle intermédiaire (table complète) des règles de diffusion par partenaire, dérivé de
+      `stg_publisher_diffusion_rule`. Reconstruit intégralement à chaque run dbt.
+    columns:
+      - name: id
+        description: Identifiant unique de la règle.
+        tests:
+          - not_null
+          - unique
+      - name: publisher_id
+        description: Identifiant du partenaire diffuseur.
+        tests:
+          - not_null
+      - name: field
+        description: Champ ciblé par la règle.
+        tests:
+          - not_null
+      - name: field_type
+        description: Typage fonctionnel du champ (nullable).
+      - name: operator
+        description: Opérateur de comparaison.
+        tests:
+          - not_null
+      - name: value
+        description: Valeur comparée.
+        tests:
+          - not_null
+      - name: combinator
+        description: Combinaison logique avec les autres règles.
+        tests:
+          - not_null
+      - name: position
+        description: Ordre d'application de la règle.
+        tests:
+          - not_null
+      - name: combined_with_id
+        description: Identifiant de la règle parente (auto-référence, nullable).
+      - name: created_at
+        description: Timestamp de création.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Timestamp de dernière mise à jour.
+        tests:
+          - not_null
   - name: int_publisher_organization
     description: >
       Modèle intermédiaire incrémental des organisations rattachées aux partenaires, dérivé de

--- a/analytics/dbt/analytics/models/intermediate/publisher/int_publisher_diffusion_rule.sql
+++ b/analytics/dbt/analytics/models/intermediate/publisher/int_publisher_diffusion_rule.sql
@@ -1,0 +1,17 @@
+{{ config(
+    materialized = 'table'
+) }}
+
+select
+  id,
+  publisher_id,
+  field,
+  field_type,
+  operator,
+  value,
+  combinator,
+  position,
+  combined_with_id,
+  created_at,
+  updated_at
+from {{ ref('stg_publisher_diffusion_rule') }}

--- a/analytics/dbt/analytics/models/marts/publisher/__models.yml
+++ b/analytics/dbt/analytics/models/marts/publisher/__models.yml
@@ -80,6 +80,60 @@ models:
         description: Horodatage de dernière mise à jour.
         tests:
           - not_null
+  - name: publisher_diffusion_rule
+    description: >
+      Vue mart des règles de diffusion par partenaire, exposée depuis `int_publisher_diffusion_rule`.
+      Chaque ligne représente une condition de filtrage appliquée lors de la diffusion des missions
+      par un partenaire.
+    columns:
+      - name: id
+        description: Identifiant unique de la règle.
+        tests:
+          - not_null
+          - unique
+      - name: publisher_id
+        description: Identifiant du partenaire diffuseur.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('publisher')
+                field: id
+      - name: field
+        description: Champ ciblé par la règle (ex. `publisherOrganizationId`, `domain`).
+        tests:
+          - not_null
+      - name: field_type
+        description: Typage fonctionnel du champ (nullable).
+      - name: operator
+        description: Opérateur de comparaison (ex. `=`, `in`).
+        tests:
+          - not_null
+      - name: value
+        description: Valeur comparée.
+        tests:
+          - not_null
+      - name: combinator
+        description: Combinaison logique avec les autres règles du partenaire (ex. `and` / `or`).
+        tests:
+          - not_null
+      - name: position
+        description: Ordre d'application de la règle au sein du groupe.
+        tests:
+          - not_null
+      - name: combined_with_id
+        description: Identifiant de la règle parente à laquelle cette règle est combinée (auto-référence, nullable).
+        tests:
+          - relationships:
+              to: ref('publisher_diffusion_rule')
+              field: id
+              where: combined_with_id is not null
+      - name: created_at
+        description: Timestamp de création.
+      - name: updated_at
+        description: Timestamp de dernière mise à jour.
+        tests:
+          - not_null
   - name: publisher_organization
     description: >
       Vue mart des organisations rattachées aux partenaires, directement dérivée de `int_publisher_organization` pour

--- a/analytics/dbt/analytics/models/marts/publisher/publisher_diffusion_rule.sql
+++ b/analytics/dbt/analytics/models/marts/publisher/publisher_diffusion_rule.sql
@@ -1,0 +1,15 @@
+{{ config(materialized = 'view') }}
+
+select
+  id,
+  publisher_id,
+  field,
+  field_type,
+  operator,
+  value,
+  combinator,
+  position,
+  combined_with_id,
+  created_at,
+  updated_at
+from {{ ref('int_publisher_diffusion_rule') }}

--- a/analytics/dbt/analytics/models/raw.yml
+++ b/analytics/dbt/analytics/models/raw.yml
@@ -195,6 +195,34 @@ sources:
             description: Timestamp de création du partenaire.
           - name: updated_at
             description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
+      - name: publisher_diffusion_rule
+        description: >-
+          Règles de diffusion par partenaire, synchronisées depuis la table `publisher_diffusion_rule` de la base core.
+          Chaque ligne définit une condition de filtrage (champ / opérateur / valeur) appliquée lors de la diffusion
+          des missions par un partenaire. Les règles peuvent être combinées entre elles via `combined_with_id`.
+        columns:
+          - name: id
+            description: Identifiant unique de la règle (UUID).
+          - name: publisher_id
+            description: Identifiant du partenaire diffuseur propriétaire de la règle.
+          - name: field
+            description: Champ ciblé par la règle (ex. `publisherOrganizationId`, `domain`, `departmentCode`).
+          - name: field_type
+            description: Typage fonctionnel du champ ciblé (nullable).
+          - name: operator
+            description: Opérateur de comparaison appliqué (ex. `=`, `in`).
+          - name: value
+            description: Valeur comparée, sous forme texte.
+          - name: combinator
+            description: Combinaison logique avec les autres règles du même groupe (`and` / `or`).
+          - name: position
+            description: Ordre d'application de la règle au sein du groupe.
+          - name: combined_with_id
+            description: Identifiant de la règle parente à laquelle cette règle est rattachée (auto-référence, nullable).
+          - name: created_at
+            description: Timestamp de création de la règle.
+          - name: updated_at
+            description: Timestamp de dernière mise à jour, utilisé comme curseur d'export incrémental.
       - name: publisher_organization
         description: >-
           Organisations associées aux partenaires, synchronisées depuis la table `publisher_organization` de la base

--- a/analytics/dbt/analytics/models/staging/publisher/__models.yml
+++ b/analytics/dbt/analytics/models/staging/publisher/__models.yml
@@ -31,6 +31,52 @@ models:
         description: Timestamp de dernière mise à jour (curseur d'incrément).
         tests:
           - not_null
+  - name: stg_publisher_diffusion_rule
+    description: >
+      Staging des règles de diffusion par partenaire, exportées depuis `analytics_raw.publisher_diffusion_rule`.
+      Le modèle applique les conversions de type (timestamps, entier) avant exposition aux couches supérieures.
+    columns:
+      - name: id
+        description: Identifiant unique de la règle (UUID).
+        tests:
+          - not_null
+          - unique
+      - name: publisher_id
+        description: Identifiant du partenaire diffuseur auquel appartient la règle.
+        tests:
+          - not_null
+      - name: field
+        description: Champ ciblé par la règle (ex. `publisherOrganizationId`, `domain`).
+        tests:
+          - not_null
+      - name: field_type
+        description: Typage fonctionnel du champ (nullable).
+      - name: operator
+        description: Opérateur de comparaison (ex. `=`, `in`).
+        tests:
+          - not_null
+      - name: value
+        description: Valeur comparée (texte).
+        tests:
+          - not_null
+      - name: combinator
+        description: Combinaison logique avec les autres règles du partenaire (ex. `and` / `or`).
+        tests:
+          - not_null
+      - name: position
+        description: Ordre d'application de la règle au sein du groupe.
+        tests:
+          - not_null
+      - name: combined_with_id
+        description: Identifiant de la règle parente à laquelle cette règle est combinée (auto-référence, nullable).
+      - name: created_at
+        description: Timestamp de création de la règle.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Timestamp de dernière mise à jour (curseur d'incrément).
+        tests:
+          - not_null
   - name: stg_publisher_organization
     description: >
       Staging des organisations rattachées aux partenaires, exportées depuis `analytics_raw.publisher_organization`.

--- a/analytics/dbt/analytics/models/staging/publisher/stg_publisher_diffusion_rule.sql
+++ b/analytics/dbt/analytics/models/staging/publisher/stg_publisher_diffusion_rule.sql
@@ -1,0 +1,13 @@
+select
+  id,
+  publisher_id,
+  field,
+  field_type,
+  operator,
+  value as field_value,
+  combinator,
+  position::integer as position,
+  combined_with_id,
+  created_at::timestamp as created_at,
+  updated_at::timestamp as updated_at
+from {{ source('analytics_raw', 'publisher_diffusion_rule') }}

--- a/analytics/src/jobs/export-to-analytics-raw/config.ts
+++ b/analytics/src/jobs/export-to-analytics-raw/config.ts
@@ -235,6 +235,22 @@ export const exportDefinitions: ExportDefinition[] = [
     },
   },
   {
+    key: "publisher_diffusion_rule",
+    batchSize: 2000,
+    source: {
+      table: "publisher_diffusion_rule",
+      cursor: {
+        field: "updated_at",
+        idField: "id",
+      },
+      columns: ["id", "publisher_id", "field", "field_type", "operator", "value", "combinator", "position", "combined_with_id", "created_at", "updated_at"],
+    },
+    destination: {
+      table: "publisher_diffusion_rule",
+      conflictColumns: ["id"],
+    },
+  },
+  {
     key: "publisher_organization",
     batchSize: 1000,
     source: {


### PR DESCRIPTION
## Description

Synchronisation de la table `publisher_diffusion_rule` dans la base de données `analytics`

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/Porter-la-publisher_diffusion_rules-vers-dbt-38872a322d5080cb92f2fe3a0a03c25e?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire
