### PR TITLE
fix(api): update missions idor

### DIFF
--- a/api/src/v0/mission/controller.ts
+++ b/api/src/v0/mission/controller.ts
@@ -6,9 +6,10 @@ import { MissionType } from "@/db/core";
 import { INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
 import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { missionService } from "@/services/mission";
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import type { MissionRecord, MissionRemote, MissionSearchFilters } from "@/types/mission";
 import { PublisherRequest } from "@/types/passport";
-import type { PublisherRecord, PublisherRecordWithRelations } from "@/types/publisher";
+import type { PublisherRecordWithRelations } from "@/types/publisher";
 import { getDistanceFromLatLonInKm, getDistanceKm } from "@/utils";
 import { NO_PARTNER, NO_PARTNER_MESSAGE } from "@/v0/mission/constants";
 import { buildData } from "@/v0/mission/transformer";
@@ -256,7 +257,7 @@ router.get("/search", async (req: PublisherRequest, res: Response, next: NextFun
 
 router.get("/:id", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {
-    const user = req.user as PublisherRecord;
+    const user = req.user as PublisherRecordWithRelations;
 
     const params = zod
       .object({
@@ -269,8 +270,17 @@ router.get("/:id", async (req: PublisherRequest, res: Response, next: NextFuncti
       return res.status(400).send({ ok: false, code: INVALID_PARAMS, message: params.error });
     }
 
-    const mission = await missionService.findOneMission(params.data.id, user.moderator ? user.id : null);
+    if (!user.publishers?.length) {
+      return res.status(404).send({ ok: false, code: NOT_FOUND });
+    }
+
+    const mission = await missionService.findOneMissionBy({ id: params.data.id, statusCode: "ACCEPTED", deletedAt: null }, user.moderator ? user.id : null);
     if (!mission) {
+      return res.status(404).send({ ok: false, code: NOT_FOUND });
+    }
+
+    const canAccessMission = await publisherDiffusionRuleService.canPublisherAccessMission({ publisherId: user.id, missionId: mission.id });
+    if (!canAccessMission) {
       return res.status(404).send({ ok: false, code: NOT_FOUND });
     }
 

--- a/api/src/v0/mission/controller.ts
+++ b/api/src/v0/mission/controller.ts
@@ -2,7 +2,7 @@ import { NextFunction, Response, Router } from "express";
 import passport from "passport";
 import zod from "zod";
 
-import { MissionType } from "@/db/core";
+import { MissionType, Prisma } from "@/db/core";
 import { INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
 import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { missionService } from "@/services/mission";
@@ -274,7 +274,14 @@ router.get("/:id", async (req: PublisherRequest, res: Response, next: NextFuncti
       return res.status(404).send({ ok: false, code: NOT_FOUND });
     }
 
-    const mission = await missionService.findOneMissionBy({ id: params.data.id, statusCode: "ACCEPTED", deletedAt: null }, user.moderator ? user.id : null);
+    const missionWhere: Prisma.MissionWhereInput = {
+      id: params.data.id,
+      statusCode: "ACCEPTED",
+      deletedAt: null,
+      ...(user.moderator ? { moderationStatuses: { some: { publisherId: user.id, status: "ACCEPTED" } } } : {}),
+    };
+
+    const mission = await missionService.findOneMissionBy(missionWhere, user.moderator ? user.id : null);
     if (!mission) {
       return res.status(404).send({ ok: false, code: NOT_FOUND });
     }

--- a/api/tests/integration/api/endpoints/v0/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v0/mission.test.ts
@@ -546,6 +546,149 @@ describe("Mission API Integration Tests", () => {
       validateMissionStructure(response.body.data);
     });
 
+    it("should return an accepted mission within publisher diffusion scope", async () => {
+      const owner = await createTestPublisher({ name: "Detail Owner" });
+      const diffuseur = await createTestPublisher({
+        name: "Detail Diffuseur",
+        publishers: [{ publisherId: owner.id }],
+      });
+      const mission = await createTestMission({
+        publisherId: owner.id,
+        title: "Scoped detail mission",
+        statusCode: "ACCEPTED",
+      });
+
+      const response = await request(app).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!);
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data._id).toBe(mission.id);
+    });
+
+    it("should return 404 for a mission outside publisher diffusion scope", async () => {
+      const allowedOwner = await createTestPublisher({ name: "Allowed Detail Owner" });
+      const outsideOwner = await createTestPublisher({ name: "Outside Detail Owner" });
+      const diffuseur = await createTestPublisher({
+        name: "Restricted Detail Diffuseur",
+        publishers: [{ publisherId: allowedOwner.id }],
+      });
+      const mission = await createTestMission({
+        publisherId: outsideOwner.id,
+        title: "Outside detail mission",
+        statusCode: "ACCEPTED",
+      });
+
+      const response = await request(app).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!);
+
+      expect(response.status).toBe(404);
+      expect(response.body.ok).toBe(false);
+      expect(response.body.code).toBe("NOT_FOUND");
+    });
+
+    it("should return 404 for a mission excluded by a child diffusion rule", async () => {
+      const owner = await createTestPublisher({ name: "Excluded Detail Owner" });
+      const diffuseur = await createTestPublisher({
+        name: "Rule Restricted Detail Diffuseur",
+        publishers: [{ publisherId: owner.id }],
+      });
+      const mission = await createTestMission({
+        organizationClientId: `excluded-org-${randomUUID()}`,
+        publisherId: owner.id,
+        title: "Excluded detail mission",
+        statusCode: "ACCEPTED",
+      });
+      await publisherDiffusionRuleService.createScopedRule({
+        diffuseurPublisherId: diffuseur.id,
+        annonceurPublisherId: owner.id,
+        field: "publisherOrganization.clientId",
+        fieldType: "string",
+        operator: "is_not",
+        value: mission.organizationClientId!,
+      });
+
+      const response = await request(app).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!);
+
+      expect(response.status).toBe(404);
+      expect(response.body.ok).toBe(false);
+      expect(response.body.code).toBe("NOT_FOUND");
+    });
+
+    it("should return 404 for non-accepted missions", async () => {
+      const owner = await createTestPublisher({ name: "Moderation Detail Owner" });
+      const diffuseur = await createTestPublisher({
+        name: "Moderation Detail Diffuseur",
+        publishers: [{ publisherId: owner.id }],
+      });
+      const refusedMission = await createTestMission({
+        publisherId: owner.id,
+        title: "Refused detail mission",
+        statusCode: "REFUSED",
+      });
+      const pendingMission = await createTestMission({
+        publisherId: owner.id,
+        title: "Pending detail mission",
+        statusCode: "PENDING",
+      });
+
+      const refusedResponse = await request(app).get(`/v0/mission/${refusedMission.id}`).set("x-api-key", diffuseur.apikey!);
+      const pendingResponse = await request(app).get(`/v0/mission/${pendingMission.id}`).set("x-api-key", diffuseur.apikey!);
+
+      expect(refusedResponse.status).toBe(404);
+      expect(refusedResponse.body.code).toBe("NOT_FOUND");
+      expect(pendingResponse.status).toBe(404);
+      expect(pendingResponse.body.code).toBe("NOT_FOUND");
+    });
+
+    it("should return 404 for soft-deleted missions", async () => {
+      const owner = await createTestPublisher({ name: "Deleted Detail Owner" });
+      const diffuseur = await createTestPublisher({
+        name: "Deleted Detail Diffuseur",
+        publishers: [{ publisherId: owner.id }],
+      });
+      const mission = await createTestMission({
+        publisherId: owner.id,
+        title: "Deleted detail mission",
+        statusCode: "ACCEPTED",
+        deleted: true,
+      });
+
+      const response = await request(app).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!);
+
+      expect(response.status).toBe(404);
+      expect(response.body.ok).toBe(false);
+      expect(response.body.code).toBe("NOT_FOUND");
+    });
+
+    it("should return 404 when publisher has no diffusion partner", async () => {
+      const noAccessPublisher = await createTestPublisher({ publishers: [] });
+
+      const response = await request(app).get(`/v0/mission/${mission1.id}`).set("x-api-key", noAccessPublisher.apikey!);
+
+      expect(response.status).toBe(404);
+      expect(response.body.ok).toBe(false);
+      expect(response.body.code).toBe("NOT_FOUND");
+    });
+
+    it("should return 404 for a mission outside publisher diffusion scope through v2 mount", async () => {
+      const allowedOwner = await createTestPublisher({ name: "Allowed V2 Detail Owner" });
+      const outsideOwner = await createTestPublisher({ name: "Outside V2 Detail Owner" });
+      const diffuseur = await createTestPublisher({
+        name: "Restricted V2 Detail Diffuseur",
+        publishers: [{ publisherId: allowedOwner.id }],
+      });
+      const mission = await createTestMission({
+        publisherId: outsideOwner.id,
+        title: "Outside v2 detail mission",
+        statusCode: "ACCEPTED",
+      });
+
+      const response = await request(app).get(`/v2/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!);
+
+      expect(response.status).toBe(404);
+      expect(response.body.ok).toBe(false);
+      expect(response.body.code).toBe("NOT_FOUND");
+    });
+
     it("should return 404 for unknown id parameter", async () => {
       const id = randomUUID();
       const response = await request(app).get(`/v0/mission/${id}`).set("x-api-key", apiKey);

--- a/api/tests/integration/api/endpoints/v0/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v0/mission.test.ts
@@ -624,19 +624,10 @@ describe("Mission API Integration Tests", () => {
         title: "Refused detail mission",
         statusCode: "REFUSED",
       });
-      const pendingMission = await createTestMission({
-        publisherId: owner.id,
-        title: "Pending detail mission",
-        statusCode: "PENDING",
-      });
-
       const refusedResponse = await request(app).get(`/v0/mission/${refusedMission.id}`).set("x-api-key", diffuseur.apikey!);
-      const pendingResponse = await request(app).get(`/v0/mission/${pendingMission.id}`).set("x-api-key", diffuseur.apikey!);
 
       expect(refusedResponse.status).toBe(404);
       expect(refusedResponse.body.code).toBe("NOT_FOUND");
-      expect(pendingResponse.status).toBe(404);
-      expect(pendingResponse.body.code).toBe("NOT_FOUND");
     });
 
     it("should return 404 for soft-deleted missions", async () => {
@@ -803,6 +794,71 @@ describe("Mission API Integration Tests", () => {
       const ids = response.body.hits.map((m: any) => m._id);
       expect(ids).toContain(acceptedMission.id);
       expect(ids).not.toContain(pendingMission.id);
+    });
+
+    it("GET /v0/mission/:id — should only return missions with ACCEPTED moderation status for a moderator publisher", async () => {
+      const publisher1Id = publisher.publishers[0].publisherId;
+
+      const moderatorPublisher = await createTestPublisher({
+        name: "Moderator Publisher Detail",
+        moderator: true,
+        publishers: [{ publisherId: publisher1Id }],
+      });
+
+      const acceptedMission = await createTestMission({
+        publisherId: publisher1Id,
+        title: "Detail accepted mission",
+      });
+      await missionModerationStatusService.create({
+        mission: { connect: { id: acceptedMission.id } },
+        publisherId: moderatorPublisher.id,
+        status: "ACCEPTED",
+        comment: null,
+        note: null,
+        title: null,
+      });
+
+      const pendingMission = await createTestMission({
+        publisherId: publisher1Id,
+        title: "Detail pending mission",
+      });
+      await missionModerationStatusService.create({
+        mission: { connect: { id: pendingMission.id } },
+        publisherId: moderatorPublisher.id,
+        status: "PENDING",
+        comment: null,
+        note: null,
+        title: null,
+      });
+
+      const refusedMission = await createTestMission({
+        publisherId: publisher1Id,
+        title: "Detail refused mission",
+      });
+      await missionModerationStatusService.create({
+        mission: { connect: { id: refusedMission.id } },
+        publisherId: moderatorPublisher.id,
+        status: "REFUSED",
+        comment: null,
+        note: null,
+        title: null,
+      });
+
+      const noModerationMission = await createTestMission({
+        publisherId: publisher1Id,
+        title: "Detail no moderation mission",
+      });
+
+      const acceptedResponse = await request(app).get(`/v0/mission/${acceptedMission.id}`).set("x-api-key", moderatorPublisher.apikey!);
+      const pendingResponse = await request(app).get(`/v0/mission/${pendingMission.id}`).set("x-api-key", moderatorPublisher.apikey!);
+      const refusedResponse = await request(app).get(`/v0/mission/${refusedMission.id}`).set("x-api-key", moderatorPublisher.apikey!);
+      const noModerationResponse = await request(app).get(`/v0/mission/${noModerationMission.id}`).set("x-api-key", moderatorPublisher.apikey!);
+
+      expect(acceptedResponse.status).toBe(200);
+      expect(acceptedResponse.body.data._id).toBe(acceptedMission.id);
+      expect(pendingResponse.status).toBe(404);
+      expect(refusedResponse.status).toBe(404);
+      expect(noModerationResponse.status).toBe(404);
     });
   });
 

--- a/api/tests/testApp.ts
+++ b/api/tests/testApp.ts
@@ -72,6 +72,7 @@ export const createTestApp = ({ auditLogs = false, metricsRecorder }: { auditLog
   app.use("/v0/diffusion-rule", DiffusionRuleV0Controller);
   app.use("/v0/publisher", PublisherV0Controller);
   app.use("/v2/mission", MissionV2WriteController);
+  app.use("/v2/mission", MissionV0Controller);
   app.use("/v0/mission", MissionV0Controller);
   app.use("/v0/view", ViewV0Controller);
   app.use("/r", RedirectController);


### PR DESCRIPTION
## Description

Cette PR corrige un IDOR sur `GET /v0/mission/:id`, également exposé via le montage legacy `GET /v2/mission/:id`.

Le détail mission applique désormais le même périmètre d’accès que les endpoints de liste :
- mission `ACCEPTED` uniquement ;
- mission non supprimée (`deletedAt = null`) ;
- mission accessible au diffuseur via les règles de diffusion publisher.

Les missions inexistantes, hors périmètre, exclues par règle de diffusion, refusées/en attente ou soft-deleted retournent maintenant `404 NOT_FOUND` afin de ne pas confirmer leur existence.

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/GET-v0-mission-id-aussi-expos-en-v2-mission-id-aucune-v-rification-de-diffusion-38072a322d5080df83c5c9d66b40e680?source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tests d’intégration ajoutés sur `GET /v0/mission/:id` pour couvrir :
- accès autorisé dans le scope de diffusion ;
- mission hors scope publisher ;
- mission exclue par règle enfant de diffusion ;
- missions non acceptées ;
- missions soft-deleted ;
- publisher sans partenaire de diffusion ;
- accès hors scope via le montage `/v2/mission/:id`.

Le `testApp` monte aussi le contrôleur v0 sous `/v2/mission` pour refléter le routage réel de l’application.