### PR TITLE
refactor(api): use typesense multi-search instead of get

### DIFF
--- a/api/src/services/search/providers/typesense/__tests__/index.test.ts
+++ b/api/src/services/search/providers/typesense/__tests__/index.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const performMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/services/search/providers/typesense/client", () => ({
+  typesenseClient: {
+    multiSearch: { perform: performMock },
+  },
+}));
+
+import { TypesenseSearchProvider } from "@/services/search/providers/typesense";
+
+describe("TypesenseSearchProvider.search", () => {
+  const provider = new TypesenseSearchProvider();
+
+  beforeEach(() => {
+    performMock.mockReset();
+  });
+
+  it("passe par multi_search (POST) pour éviter la limite de 4000 caractères du GET", async () => {
+    const response = { found: 2, hits: [{ document: { id: "m1" } }] };
+    performMock.mockResolvedValue({ results: [response] });
+
+    const params = { q: "*", query_by: "publisherId", filter_by: "publisherId:=`pub-1`", page: 1 };
+    const result = await provider.search("missions", params);
+
+    expect(performMock).toHaveBeenCalledWith({
+      searches: [{ collection: "missions", ...params }],
+    });
+    expect(result).toBe(response);
+  });
+
+  it("propage l'erreur d'une sous-recherche multi_search", async () => {
+    performMock.mockResolvedValue({ results: [{ code: 400, error: "Bad filter_by" }] });
+
+    await expect(provider.search("missions", { q: "*" })).rejects.toThrow("Bad filter_by");
+  });
+});

--- a/api/src/services/search/providers/typesense/index.ts
+++ b/api/src/services/search/providers/typesense/index.ts
@@ -1,4 +1,4 @@
-import type { SearchParams } from "typesense/lib/Typesense/Types";
+import type { MultiSearchRequestSchema } from "typesense/lib/Typesense/Types";
 
 import type { SearchProvider, SearchQueryParams, SearchQueryResponse } from "@/services/search/types";
 
@@ -6,7 +6,19 @@ import { typesenseClient } from "./client";
 
 export class TypesenseSearchProvider implements SearchProvider {
   async search<TDoc extends object>(collection: string, params: SearchQueryParams<TDoc>): Promise<SearchQueryResponse<TDoc>> {
-    return typesenseClient.collections<TDoc>(collection).documents().search(params as SearchParams<TDoc>) as unknown as Promise<SearchQueryResponse<TDoc>>;
+    // `multi_search` (POST) transporte les paramètres dans le corps JSON, là où `documents().search()`
+    // (GET) les met dans la query string de l'URL, plafonnée à 4000 caractères par Typesense — limite
+    // dépassée par le `filter_by` de l'allowlist de diffusion de certains diffuseurs.
+    const { results } = await typesenseClient.multiSearch.perform<[TDoc]>({
+      searches: [{ collection, ...params } as MultiSearchRequestSchema<TDoc, string>],
+    });
+
+    const result = results[0];
+    if (result.error) {
+      throw new Error(`[search:typesense] multi_search a échoué (code ${result.code}) : ${result.error}`);
+    }
+
+    return result as unknown as SearchQueryResponse<TDoc>;
   }
 
   async upsert<TDoc extends object>(collection: string, document: TDoc): Promise<TDoc> {


### PR DESCRIPTION
## Description

`TypesenseSearchProvider.search` utilisait `documents().search()`, qui s'exécute en **GET** : tous les paramètres de recherche, dont `filter_by`, transitent dans la query string de l'URL — que Typesense plafonne à **4000 caractères**.

Cette limitation a été détectée sur la plateforme de l'Engagement : son allowlist de diffusion génère un `filter_by` d'environ 5000 caractères, ce qui faisait échouer la recherche avec :

```
Request failed with HTTP code 400 | Server said: Query string exceeds max allowed length of 4000.
Use the /multi_search end-point for larger payloads.
```

La recherche passe désormais par l'endpoint **`multi_search` (POST)**, qui transporte les paramètres dans le corps JSON et supprime ainsi la limite de longueur d'URL. Le changement est confiné au provider : la requête logique et les paramètres sont identiques, seul le canal de transport change. Tous les appelants (mission-browse, etc.) en bénéficient de façon transparente.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- **Aucun reindex ni migration** : même payload, on bascule simplement GET → POST.
- **Gestion d'erreur adaptée** : `multi_search` peut répondre en HTTP 200 avec une erreur par sous-recherche ; le provider détecte `result.error` et lève une exception pour conserver le comportement « échec = exception » attendu par les appelants (`MissionBrowseIndexUnavailableError`).
- Une seule recherche est envoyée dans `searches[]` puis `results[0]` est déballé ; la capacité multi-requêtes reste disponible si besoin futur.
- **Piste de suivi (hors périmètre)** : la construction du `filter_by` de diffusion ne compacte pas la branche OR (quelques règles à enfants désactivent la compaction de toute l'allowlist). Optionnel maintenant que la limite d'URL est levée, mais intéressant pour la taille de filtre / le cache.
