### PR TITLE
fix(api): compact diffusion publisherId groups to bound filter_by ops

### DIFF
--- a/api/src/services/search/collections/missions/__tests__/diffusion-rules-filter.test.ts
+++ b/api/src/services/search/collections/missions/__tests__/diffusion-rules-filter.test.ts
@@ -57,6 +57,30 @@ describe("publisherDiffusionRulesToMissionFilter", () => {
     }
   });
 
+  it("compacte les publisherId purs en une liste même en présence de groupes à enfants (borne les opérations du filter_by)", () => {
+    const result = publisherDiffusionRulesToMissionFilter([
+      ...Array.from({ length: 110 }, (_, index) => buildRule({ id: `rule-${index}`, value: `annonceur-${index}`, position: index })),
+      buildRule({ id: "root-child", value: "annonceur-child", position: 110 }),
+      buildRule({ id: "child-1", combinedWithId: "root-child", field: "publisherOrganization.clientId", operator: "is_not", value: "po-1" }),
+    ]);
+
+    expect(result.kind).toBe("filter");
+    if (result.kind === "filter") {
+      // Les 110 publisherId purs sont regroupés en une seule liste, OR avec le seul groupe à enfants.
+      expect(result.filterBy).toContain("publisherId:=[`annonceur-0`,");
+      expect(result.filterBy).toContain("(publisherId:=`annonceur-child` && publisherOrganizationClientId:!=`po-1`)");
+      // Le nombre d'opérations (`||` / `&&` / `:=` …) reste très en-deçà du plafond Typesense de 100.
+      const ops = (result.filterBy.match(/&&|\|\||:=|:!=/g) ?? []).length;
+      expect(ops).toBeLessThan(10);
+      expect(result.missionWhere).toEqual({
+        OR: [
+          { publisherId: { in: Array.from({ length: 110 }, (_, index) => `annonceur-${index}`) } },
+          { AND: [{ publisherId: "annonceur-child" }, { publisherOrganization: { clientId: { not: "po-1" } } }] },
+        ],
+      });
+    }
+  });
+
   it("traduit les enfants publisherOrganization.clientId", () => {
     const result = publisherDiffusionRulesToMissionFilter([
       buildRule({ id: "root-1", value: "annonceur-1" }),

--- a/api/src/services/search/collections/missions/diffusion-rules-filter.ts
+++ b/api/src/services/search/collections/missions/diffusion-rules-filter.ts
@@ -153,19 +153,10 @@ const dedupeGroups = (groups: SupportedGroup[]): SupportedGroup[] => {
   });
 };
 
-const getPublisherIdOnlyGroups = (groups: SupportedGroup[]): string[] | null => {
-  const publisherIds: string[] = [];
-
-  for (const group of groups) {
-    const keys = Object.keys(group.missionWhere);
-    const publisherId = (group.missionWhere as { publisherId?: unknown }).publisherId;
-    if (keys.length !== 1 || typeof publisherId !== "string") {
-      return null;
-    }
-    publisherIds.push(publisherId);
-  }
-
-  return publisherIds;
+const getPublisherIdOnly = (group: SupportedGroup): string | null => {
+  const keys = Object.keys(group.missionWhere);
+  const publisherId = (group.missionWhere as { publisherId?: unknown }).publisherId;
+  return keys.length === 1 && typeof publisherId === "string" ? publisherId : null;
 };
 
 export const publisherDiffusionRulesToMissionFilter = (rules: PublisherDiffusionRuleRecord[]): MissionDiffusionRulesFilter => {
@@ -191,18 +182,45 @@ export const publisherDiffusionRulesToMissionFilter = (rules: PublisherDiffusion
     return { kind: "none", missionWhere: null };
   }
 
-  const publisherIds = getPublisherIdOnlyGroups(groups);
-  if (publisherIds && publisherIds.length > 1) {
-    return {
-      kind: "filter",
-      filterBy: buildSearchListFilter("publisherId", publisherIds),
-      missionWhere: { publisherId: { in: publisherIds } },
-    };
+  // On compacte les groupes « publisherId seul » en une unique liste `publisherId:=[…]` plutôt qu'une
+  // chaîne de `||` : cela borne à la fois la longueur du filter_by et son nombre d'opérations (Typesense
+  // en limite respectivement la query string à 4000 caractères et le filter_by à 100 opérations). Les
+  // groupes avec enfants (restrictions sur l'organisation) ne peuvent pas être compactés : on les laisse
+  // en OR à côté de la liste.
+  const purePublisherIds: string[] = [];
+  const childGroups: SupportedGroup[] = [];
+  for (const group of groups) {
+    const publisherId = getPublisherIdOnly(group);
+    if (publisherId !== null) {
+      purePublisherIds.push(publisherId);
+    } else {
+      childGroups.push(group);
+    }
+  }
+
+  if (childGroups.length === 0) {
+    return purePublisherIds.length === 1
+      ? { kind: "filter", filterBy: buildSearchEqualFilter("publisherId", purePublisherIds[0]), missionWhere: { publisherId: purePublisherIds[0] } }
+      : { kind: "filter", filterBy: buildSearchListFilter("publisherId", purePublisherIds), missionWhere: { publisherId: { in: purePublisherIds } } };
+  }
+
+  const filterParts: string[] = [];
+  const missionWhereParts: Prisma.MissionWhereInput[] = [];
+  if (purePublisherIds.length === 1) {
+    filterParts.push(buildSearchEqualFilter("publisherId", purePublisherIds[0]));
+    missionWhereParts.push({ publisherId: purePublisherIds[0] });
+  } else if (purePublisherIds.length > 1) {
+    filterParts.push(buildSearchListFilter("publisherId", purePublisherIds));
+    missionWhereParts.push({ publisherId: { in: purePublisherIds } });
+  }
+  for (const group of childGroups) {
+    filterParts.push(group.filterBy);
+    missionWhereParts.push(group.missionWhere);
   }
 
   return {
     kind: "filter",
-    filterBy: combineSearchOr(groups.map((group) => group.filterBy)),
-    missionWhere: groups.length === 1 ? groups[0].missionWhere : { OR: groups.map((group) => group.missionWhere) },
+    filterBy: combineSearchOr(filterParts),
+    missionWhere: missionWhereParts.length === 1 ? missionWhereParts[0] : { OR: missionWhereParts },
   };
 };


### PR DESCRIPTION
## Description

Suite à [#1200](https://github.com/betagouv/api-engagement/pull/1200) (passage de la recherche en `multi_search` POST), une **seconde limite Typesense** a été détectée sur la plateforme de l'Engagement (un de nos partenaires diffuseurs) :

```
filter_by has too many operations. Maximum allowed: 100.
```

Cette limite est **indépendante** de celle des 4000 caractères réglée par #1200 : Typesense plafonne aussi le `filter_by` à **100 opérations**.

### Cause

La traduction des règles de diffusion en `filter_by` ne compactait les `publisherId` en une liste `publisherId:=[…]` que si **tous** les groupes étaient des `publisherId` purs (compaction tout-ou-rien). Or une seule règle « à enfants » (restriction sur l'organisation, ex. `publisherOrganizationClientId`) suffisait à désactiver la compaction pour toute l'allowlist, produisant alors une chaîne de `||` avec **une opération par annonceur**.

Pour le diffuseur concerné (114 règles), cela donnait ~114 groupes en OR, soit largement plus de 100 opérations.

### Correction

On partitionne les groupes :
- les groupes `publisherId` purs sont regroupés en une **unique liste** `publisherId:=[…]` ;
- cette liste est combinée en OR uniquement avec les rares groupes « à enfants » (qui, eux, ne peuvent pas être compactés).

Résultat pour le diffuseur Engagement : ~114 opérations → **moins de 10**, et le `filter_by` passe d'environ 5000 à ~3350 caractères. Les deux limites Typesense (longueur et nombre d'opérations) sont désormais respectées. Le filtre côté base (`missionWhere`, utilisé par `findById`) reste sémantiquement équivalent.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- **Aucun reindex ni migration** : la logique ne change que la forme du `filter_by`, pas le schéma ni les documents indexés.
- Nouveau test unitaire couvrant le cas mixte (groupes `publisherId` purs + groupe à enfants) : vérifie la compaction en liste, l'OR avec le groupe à enfants, et que le nombre d'opérations reste très en-deçà de 100.
- Les cas déjà couverts (allowlist 100 % pure, groupes à enfants seuls, déduplication, règles non supportées) restent inchangés.
