### PR TITLE
feat(tools): add generate changelog script

### DIFF
--- a/tools/scripts/.gitignore
+++ b/tools/scripts/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tools/scripts/generate-changelog.ts
+++ b/tools/scripts/generate-changelog.ts
@@ -1,0 +1,765 @@
+/**
+ * generate-changelog.ts
+ *
+ * Génère et publie le changelog d'un tag de release :
+ *  1. Liste les commits depuis le tag précédent (toutes les apps confondues)
+ *  2. Récupère les PRs associées via GitHub API
+ *  3. Extrait le contenu des tickets Notion (ou le body de la PR en fallback)
+ *  4. Synthétise l'impact pour un public non-tech via Claude
+ *  5. Crée une entrée dans la Notion changelog DB
+ *  6. Publie sur Slack
+ *
+ * Usage :
+ *   npx ts-node generate-changelog.ts --tag v1.2.3 [--dry-run]
+ *
+ * Variables d'environnement requises :
+ *   GITHUB_TOKEN, NOTION_API_KEY, NOTION_CHANGELOG_DATABASE_ID,
+ *   OPENAI_API_KEY, SLACK_TOKEN, SLACK_RELEASE_CHANNEL_ID
+ */
+
+import * as dotenv from "dotenv";
+dotenv.config(); // Charge scripts/.env si présent (ignoré en CI où les vars sont injectées)
+
+import { Client as NotionClient } from "@notionhq/client";
+import { execSync } from "child_process";
+import OpenAI from "openai";
+
+// ---------------------------------------------------------------------------
+// ⚙️  Configuration Notion DB — adapter aux noms réels de vos propriétés
+// ---------------------------------------------------------------------------
+const NOTION_DB_FIELDS = {
+  tag: "Tag", // Propriété de type Title
+  codeName: "Nom de code", // Propriété de type rich_text
+  date: "Date", // Propriété de type Date
+} as const;
+
+// Champs des tickets sources (liés aux PRs)
+const NOTION_TICKET_FIELDS = {
+  deliveredVersion: "Version livrée", // Relation vers la DB changelog
+} as const;
+
+// ---------------------------------------------------------------------------
+// ⚙️  Thème des noms de code — modifier uniquement ici pour changer de thème
+// ---------------------------------------------------------------------------
+const CODE_NAME_THEME = {
+  description: "prénoms traditionnels Francs (mérovingiens et carolingiens)",
+  examples: "Clovis, Pépin, Dagobert, Childebert, Caribert, Mérovée, Sigebert, Gontran, Thierry, Chilpéric",
+} as const;
+
+// ---------------------------------------------------------------------------
+// ⚙️  Limites de contexte OpenAI — ajuster si la limite TPM change
+// ---------------------------------------------------------------------------
+const OPENAI_LIMITS = {
+  /** Caractères max par source PR (ticket Notion ou body PR) — ~1 500 tokens */
+  maxCharsPerSource: 6_000,
+  /** Caractères max pour l'ensemble du bloc prContext — ~15 000 tokens */
+  maxTotalPrContextChars: 60_000,
+  /** Caractères max pour la liste des commits — ~2 500 tokens */
+  maxCommitListChars: 10_000,
+  /** Caractères max pour la liste des noms de code déjà utilisés */
+  maxExistingCodeNamesChars: 8_000,
+} as const;
+
+const CODE_NAME_GENERATION = {
+  maxAttempts: 5,
+} as const;
+
+const GITHUB_REPO = "betagouv/api-engagement";
+
+// ---------------------------------------------------------------------------
+// ⚙️  Apps connues — ordre d'affichage et décorateurs Slack
+// ---------------------------------------------------------------------------
+const APPS = [
+  { scope: "plateform", label: "Plateforme de l'engagement", decorator: "🇫🇷" },
+  { scope: "app", label: "Tableau de bord", decorator: "💻" },
+  { scope: "api", label: "API", decorator: "⚙️" },
+  { scope: "widget", label: "Widget", decorator: "🖼️" },
+  { scope: "analytics", label: "Analytics", decorator: "📊" },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Types internes
+// ---------------------------------------------------------------------------
+interface Commit {
+  sha: string;
+  message: string;
+  /** Scope du conventional commit (ex: "api", "app", "widget", "analytics"), ou null */
+  scope: string | null;
+}
+
+interface ChangelogSection {
+  app: string;
+  bullets: string[];
+}
+
+interface ChangelogResult {
+  /** Résumé global de la release (bullets courts, non-tech) */
+  impact: string[];
+  /** Détail par app */
+  sections: ChangelogSection[];
+}
+
+interface PR {
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  notionLinks: string[];
+}
+
+interface PRContext {
+  pr: PR;
+  /** Titre de la page Notion du ticket (si trouvée) */
+  notionTitle: string | null;
+  /** Contenu Notion si trouvé, sinon null → fallback sur pr.body */
+  notionContent: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Lecture des variables d'environnement
+// ---------------------------------------------------------------------------
+const { GITHUB_TOKEN, NOTION_API_KEY, NOTION_CHANGELOG_DATABASE_ID, OPENAI_API_KEY, SLACK_TOKEN, SLACK_RELEASE_CHANNEL_ID } = process.env;
+
+function validateEnv(): void {
+  const missing = ["GITHUB_TOKEN", "NOTION_API_KEY", "NOTION_CHANGELOG_DATABASE_ID", "OPENAI_API_KEY", "SLACK_TOKEN", "SLACK_RELEASE_CHANNEL_ID"].filter((v) => !process.env[v]);
+  if (missing.length > 0) {
+    throw new Error(`Variables d'environnement manquantes : ${missing.join(", ")}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Parsing des arguments
+// ---------------------------------------------------------------------------
+interface Args {
+  tag: string;
+  /** Si true, n'écrit pas dans Notion ni Slack — affiche le contenu dans le terminal */
+  dryRun: boolean;
+}
+
+function parseArgs(): Args {
+  const idx = process.argv.indexOf("--tag");
+  const tag = idx !== -1 ? process.argv[idx + 1] : undefined;
+  if (!tag) throw new Error("Usage : npx ts-node generate-changelog.ts --tag v1.2.3 [--dry-run]");
+  return { tag, dryRun: process.argv.includes("--dry-run") };
+}
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+function tagExists(tag: string): boolean {
+  try {
+    execSync(`git rev-parse --verify ${tag}`, { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findPreviousTag(currentTag: string): string | null {
+  try {
+    const tags = execSync("git tag --sort=-version:refname")
+      .toString()
+      .trim()
+      .split("\n")
+      .filter((t) => /^v\d/.test(t));
+
+    const currentIdx = tags.indexOf(currentTag);
+    if (currentIdx === -1) return tags[0] ?? null;
+    return tags[currentIdx + 1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function getCommits(from: string | null, to: string): Commit[] {
+  const range = from ? `${from}..${to}` : to;
+  const output = execSync(`git log ${range} --no-merges --format="%H %s"`).toString().trim();
+
+  if (!output) return [];
+  return output.split("\n").map((line) => {
+    const spaceIdx = line.indexOf(" ");
+    const message = line.substring(spaceIdx + 1);
+    const scopeMatch = message.match(/^\w+\(([^)]+)\):/);
+    return {
+      sha: line.substring(0, spaceIdx),
+      message,
+      scope: scopeMatch?.[1]?.toLowerCase() ?? null,
+    };
+  });
+}
+
+function getPeriod(from: string | null, to: string): { start: string; end: string } {
+  const range = from ? `${from}..${to}` : to;
+  try {
+    const dates = execSync(`git log ${range} --no-merges --format="%as"`).toString().trim().split("\n").filter(Boolean).sort();
+    if (dates.length === 0) return { start: "?", end: "?" };
+    const fmt = (iso: string) => {
+      const [, m, d] = iso.split("-");
+      return `${d}/${m}`;
+    };
+    return { start: fmt(dates[0]), end: fmt(dates[dates.length - 1]) };
+  } catch {
+    return { start: "?", end: "?" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GitHub API
+// ---------------------------------------------------------------------------
+async function getPRsForCommit(sha: string): Promise<PR[]> {
+  const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/commits/${sha}/pulls`, {
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!response.ok) return [];
+
+  const data = (await response.json()) as Array<{
+    number: number;
+    title: string;
+    body: string | null;
+    html_url: string;
+  }>;
+
+  return data.map((pr) => ({
+    number: pr.number,
+    title: pr.title,
+    body: pr.body ?? "",
+    url: pr.html_url,
+    notionLinks: extractNotionLinks(pr.body ?? ""),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Notion helpers
+// ---------------------------------------------------------------------------
+function extractNotionLinks(text: string): string[] {
+  const regex = /https:\/\/(?:www\.)?notion\.so\/[^\s)>\]"]+/g;
+  return [...new Set(text.match(regex) ?? [])];
+}
+
+function extractNotionPageId(url: string): string | null {
+  // UUID avec tirets
+  const uuidMatch = url.match(/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})(?:[?#]|$)/);
+  if (uuidMatch) return uuidMatch[1].replace(/-/g, "");
+  // 32 hex chars sans tirets
+  const hexMatch = url.match(/([a-f0-9]{32})(?:[?#]|$)/);
+  if (hexMatch) return hexMatch[1];
+  return null;
+}
+
+function toNotionUUID(id: string): string {
+  const c = id.replace(/-/g, "");
+  return `${c.slice(0, 8)}-${c.slice(8, 12)}-${c.slice(12, 16)}-${c.slice(16, 20)}-${c.slice(20)}`;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function richTextToString(richText: any[]): string {
+  return (richText ?? []).map((r: { plain_text: string }) => r.plain_text).join("");
+}
+
+function normalizeCodeName(codeName: string): string {
+  return codeName
+    .trim()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9]+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function cleanGeneratedCodeName(codeName: string): string {
+  return codeName.trim().replace(/^["'«\s]+|["'».\s]+$/g, "");
+}
+
+function formatExcludedCodeNames(existingCodeNames: string[]): string {
+  const sorted = [...new Set(existingCodeNames.map((name) => name.trim()).filter(Boolean))].sort((a, b) => a.localeCompare(b, "fr"));
+  const list = sorted.join(", ");
+  return list.length > OPENAI_LIMITS.maxExistingCodeNamesChars ? list.slice(0, OPENAI_LIMITS.maxExistingCodeNamesChars) + ", ..." : list;
+}
+
+async function listExistingCodeNames(notion: NotionClient): Promise<string[]> {
+  const codeNames: string[] = [];
+  let startCursor: string | undefined;
+
+  do {
+    const response = await notion.databases.query({
+      database_id: NOTION_CHANGELOG_DATABASE_ID!,
+      page_size: 100,
+      start_cursor: startCursor,
+    });
+
+    response.results.forEach((page) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const props = (page as any).properties as Record<string, any> | undefined;
+      const codeNameProp = props?.[NOTION_DB_FIELDS.codeName];
+      if (codeNameProp?.type !== "rich_text") return;
+
+      const codeName = richTextToString(codeNameProp.rich_text).trim();
+      if (codeName) codeNames.push(codeName);
+    });
+
+    startCursor = response.has_more ? (response.next_cursor ?? undefined) : undefined;
+  } while (startCursor);
+
+  return [...new Set(codeNames)];
+}
+
+async function fetchNotionPageContent(url: string, notion: NotionClient): Promise<{ title: string; content: string } | null> {
+  try {
+    const rawId = extractNotionPageId(url);
+    if (!rawId) return null;
+    const pageId = toNotionUUID(rawId);
+
+    const page = await notion.pages.retrieve({ page_id: pageId });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const props = (page as any).properties as Record<string, any>;
+    const titleProp = Object.values(props).find((p) => p.type === "title");
+    const title = titleProp ? richTextToString(titleProp.title) : "(sans titre)";
+
+    const blocksResponse = await notion.blocks.children.list({
+      block_id: pageId,
+      page_size: 50,
+    });
+
+    const textTypes = ["paragraph", "heading_1", "heading_2", "heading_3", "bulleted_list_item", "numbered_list_item", "quote", "callout"];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const content = (blocksResponse.results as any[])
+      .map((block) => {
+        if (textTypes.includes(block.type)) {
+          return richTextToString(block[block.type]?.rich_text ?? []);
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+
+    return { title, content };
+  } catch (err) {
+    console.warn(`  ⚠️  Impossible de récupérer la page Notion ${url} : ${err}`);
+    return null;
+  }
+}
+
+async function getContextsForPRs(prs: PR[], notion: NotionClient): Promise<PRContext[]> {
+  return Promise.all(
+    prs.map(async (pr) => {
+      if (pr.notionLinks.length > 0) {
+        const fetched = await fetchNotionPageContent(pr.notionLinks[0], notion);
+        return {
+          pr,
+          notionTitle: fetched?.title ?? null,
+          notionContent: fetched ? `# ${fetched.title}\n${fetched.content}` : null,
+        };
+      }
+      return { pr, notionTitle: null, notionContent: null };
+    })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI LLM
+// ---------------------------------------------------------------------------
+function truncateForPrompt(text: string, maxChars: number, label: string): string {
+  return text.length > maxChars ? text.slice(0, maxChars) + `\n[…${label} tronqué, ${text.length - maxChars} caractères omis]` : text;
+}
+
+async function synthesizeWithOpenAI(tag: string, commits: Commit[], contexts: PRContext[], openai: OpenAI): Promise<ChangelogResult> {
+  const appLabels = APPS.map((a) => `"${a.label}" (scope: ${a.scope})`).join(", ");
+
+  const rawCommitList = commits.map((c) => `- [scope:${c.scope ?? "?"}] ${c.message}`).join("\n");
+  const commitList = truncateForPrompt(rawCommitList, OPENAI_LIMITS.maxCommitListChars, "liste des commits");
+
+  const rawPrContext = contexts
+    .map(({ pr, notionContent }) => {
+      const sources = [
+        notionContent ? `Ticket Notion :\n${notionContent}` : null,
+        pr.body ? `Description de PR :\n${pr.body}` : null,
+      ].filter((source): source is string => source !== null);
+
+      const raw = sources.join("\n\n---\n\n") || "(pas de description)";
+      const source = truncateForPrompt(raw, OPENAI_LIMITS.maxCharsPerSource, "contenu PR/Notion");
+      return `### PR #${pr.number} : ${pr.title}\nURL : ${pr.url}\n${source}`;
+    })
+    .join("\n\n");
+
+  const prContext = truncateForPrompt(rawPrContext, OPENAI_LIMITS.maxTotalPrContextChars, "contexte global");
+
+  const prompt = `Tu rédiges le changelog de la version ${tag} d'"API Engagement" \
+(plateforme de mise en relation bénévoles / associations).
+
+Apps connues : ${appLabels}.
+Chaque commit est préfixé par son scope entre crochets pour t'aider à le rattacher à la bonne app.
+
+Commits de cette version :
+${commitList}
+
+Contexte (tickets et descriptions de PRs) :
+${prContext || "(aucun contexte disponible)"}
+
+Règles communes :
+- Ignore les commits purement techniques (refacto, CI, tests, dépendances, typo) sauf impact concret
+- Base-toi d'abord sur les tickets Notion et les descriptions de PR, puis utilise les commits pour compléter
+- Sois exhaustif : ne regroupe pas plusieurs changements fonctionnels distincts dans un seul bullet
+- Conserve les détails métier importants : écrans concernés, règles fonctionnelles, statuts, champs, exports, notifications, APIs, partenaires
+- Chaque bullet doit rester compréhensible par un public non-tech, mais peut être précis et contenir 1 à 2 phrases
+- Ton attendu : factuel, sobre, descriptif, proche d'une note de release interne
+- Évite le vocabulaire promotionnel ou vague : "meilleure", "amélioration significative", "optimisation", "notable", "facilitant", "garantissant", "visibilité accrue", "expérience utilisateur"
+- Préfère décrire ce qui change concrètement : "Ajout de...", "Modification de...", "Correction de...", "Affichage de...", "Synchronisation de...", "Utilisation de..."
+- Ne déduis pas de bénéfice si le contexte ne le dit pas explicitement
+- Public cible : équipe globalement non-tech (direction, partenaires)
+- Langue : français
+
+Section "impact" :
+- 2 à 4 bullets résumant factuellement les grandes zones de changement de la release (cross-app, vue d'ensemble)
+- Décrire les domaines concernés et les changements principaux, sans tournure marketing
+
+Section "sections" :
+- Un bullet par changement fonctionnel visible par l'utilisateur ou utile aux équipes métier, groupé par app
+- Produis autant de bullets que nécessaire pour couvrir la release, sans limite artificielle
+- Ajoute les changements de fiabilité, données, suivi ou automatisation quand ils ont un effet opérationnel clair
+- N'inclure que les apps qui ont des changements visibles
+- Ordre des apps : Plateforme de l'Engagement, Tableau de bord, API, Widget, Analytics
+
+Réponds UNIQUEMENT avec un objet JSON de la forme :
+{
+  "impact": ["bullet résumé 1", "bullet résumé 2"],
+  "sections": [{"app": "Tableau de bord", "bullets": ["..."]}, {"app": "API", "bullets": ["..."]}]
+}`;
+
+  const response = await openai.chat.completions.create({
+    model: "gpt-4o",
+    max_tokens: 4096,
+    response_format: { type: "json_object" },
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const text = response.choices[0]?.message?.content;
+  if (!text) throw new Error("Réponse OpenAI inattendue");
+
+  const parsed = JSON.parse(text) as { impact?: string[]; sections?: ChangelogSection[] };
+  return { impact: parsed.impact ?? [], sections: parsed.sections ?? [] };
+}
+
+// ---------------------------------------------------------------------------
+// Code name generator
+// ---------------------------------------------------------------------------
+async function generateCodeName(tag: string, existingCodeNames: string[], openai: OpenAI): Promise<string> {
+  const excludedCodeNames = formatExcludedCodeNames(existingCodeNames);
+  const normalizedExistingCodeNames = new Set(existingCodeNames.map(normalizeCodeName));
+
+  for (let attempt = 1; attempt <= CODE_NAME_GENERATION.maxAttempts; attempt += 1) {
+    const previousAttempts = attempt > 1 ? `Tentative ${attempt}/${CODE_NAME_GENERATION.maxAttempts} : propose un autre prénom. ` : "";
+
+    const response = await openai.chat.completions.create({
+      model: "gpt-4o-mini",
+      max_tokens: 20,
+      messages: [
+        {
+          role: "user",
+          content:
+            `Génère un ${CODE_NAME_THEME.description} aléatoire pour nommer la version ${tag} d'un logiciel. ` +
+            `Exemples : ${CODE_NAME_THEME.examples}. ` +
+            (excludedCodeNames ? `Noms déjà attribués à exclure absolument : ${excludedCodeNames}. ` : "") +
+            previousAttempts +
+            `Réponds uniquement avec le prénom, sans ponctuation ni explication.`,
+        },
+      ],
+    });
+    const name = cleanGeneratedCodeName(response.choices[0]?.message?.content ?? "");
+    if (!name) throw new Error("Réponse OpenAI inattendue pour le nom de code");
+    if (!normalizedExistingCodeNames.has(normalizeCodeName(name))) return name;
+
+    console.warn(`  ⚠️  Nom de code déjà attribué ignoré : ${name}`);
+  }
+
+  throw new Error(`Impossible de générer un nom de code inédit après ${CODE_NAME_GENERATION.maxAttempts} tentative(s)`);
+}
+
+// ---------------------------------------------------------------------------
+// Notion DB entry
+// ---------------------------------------------------------------------------
+async function createNotionEntry(tag: string, codeName: string, result: ChangelogResult, contexts: PRContext[], notion: NotionClient): Promise<{ url: string; pageId: string }> {
+  const today = new Date().toISOString().split("T")[0];
+
+  // rich_text avec lien optionnel
+  type RichTextItem = { type?: "text"; text: { content: string; link?: { url: string } } };
+  type NotionBlock =
+    | { object: "block"; type: "heading_1"; heading_1: { rich_text: RichTextItem[] } }
+    | { object: "block"; type: "heading_2"; heading_2: { rich_text: RichTextItem[] } }
+    | { object: "block"; type: "bulleted_list_item"; bulleted_list_item: { rich_text: RichTextItem[] } }
+    | { object: "block"; type: "divider"; divider: Record<string, never> };
+
+  // Section Impact
+  const impactBlocks: NotionBlock[] = [
+    { object: "block", type: "heading_1", heading_1: { rich_text: [{ text: { content: "🥊 Impact" } }] } },
+    ...result.impact.map((bullet) => ({
+      object: "block" as const,
+      type: "bulleted_list_item" as const,
+      bulleted_list_item: { rich_text: [{ text: { content: bullet } }] },
+    })),
+  ];
+
+  // Section Changelog — masquée si vide
+  const changelogBlocks: NotionBlock[] =
+    result.sections.length > 0
+      ? [
+          { object: "block", type: "divider", divider: {} },
+          { object: "block", type: "heading_1", heading_1: { rich_text: [{ text: { content: "📋 Changelog" } }] } },
+          ...result.sections.flatMap((section) => [
+            {
+              object: "block" as const,
+              type: "heading_2" as const,
+              heading_2: { rich_text: [{ text: { content: section.app } }] },
+            },
+            ...section.bullets.map((bullet) => ({
+              object: "block" as const,
+              type: "bulleted_list_item" as const,
+              bulleted_list_item: { rich_text: [{ text: { content: bullet } }] },
+            })),
+          ]),
+        ]
+      : [];
+
+  // Section Tickets — label = titre du ticket Notion (fallback : titre de la PR)
+  const ticketEntries = [
+    ...new Map(contexts.filter((c) => c.pr.notionLinks.length > 0).map((c) => [c.pr.notionLinks[0], { title: c.notionTitle ?? c.pr.title, url: c.pr.notionLinks[0] }])).values(),
+  ];
+  const ticketBlocks: NotionBlock[] =
+    ticketEntries.length > 0
+      ? [
+          { object: "block", type: "divider", divider: {} },
+          { object: "block", type: "heading_1", heading_1: { rich_text: [{ text: { content: "🎟️ Tickets" } }] } },
+          ...ticketEntries.map(({ title, url }) => ({
+            object: "block" as const,
+            type: "bulleted_list_item" as const,
+            bulleted_list_item: { rich_text: [{ text: { content: title, link: { url } } }] },
+          })),
+        ]
+      : [];
+
+  // Section Commits — lien vers la release GitHub
+  const releaseUrl = `https://github.com/${GITHUB_REPO}/releases/tag/${tag}`;
+  const commitBlocks: NotionBlock[] = [
+    { object: "block", type: "divider", divider: {} },
+    { object: "block", type: "heading_1", heading_1: { rich_text: [{ text: { content: "📝 Commits" } }] } },
+    {
+      object: "block",
+      type: "bulleted_list_item",
+      bulleted_list_item: {
+        rich_text: [{ text: { content: "Voir la release", link: { url: releaseUrl } } }],
+      },
+    },
+  ];
+
+  const page = await notion.pages.create({
+    parent: { database_id: NOTION_CHANGELOG_DATABASE_ID! },
+    properties: {
+      [NOTION_DB_FIELDS.tag]: {
+        title: [{ text: { content: tag } }],
+      },
+      [NOTION_DB_FIELDS.codeName]: {
+        rich_text: [{ text: { content: codeName } }],
+      },
+      [NOTION_DB_FIELDS.date]: {
+        date: { start: today },
+      },
+    },
+    children: [...impactBlocks, ...changelogBlocks, ...ticketBlocks, ...commitBlocks],
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pageId = (page as any).id as string;
+  return { url: `https://notion.so/${pageId.replace(/-/g, "")}`, pageId };
+}
+
+// ---------------------------------------------------------------------------
+// Relier les tickets Notion à l'entrée de release
+// ---------------------------------------------------------------------------
+async function linkTicketsToRelease(ticketUrls: string[], changelogPageId: string, notion: NotionClient): Promise<void> {
+  const pageIds = [...new Set(ticketUrls)]
+    .map((url) => {
+      const raw = extractNotionPageId(url);
+      return raw ? toNotionUUID(raw) : null;
+    })
+    .filter((id): id is string => id !== null);
+
+  if (pageIds.length === 0) return;
+
+  console.log(`🔗 Mise à jour de ${pageIds.length} ticket(s) Notion (champ "${NOTION_TICKET_FIELDS.deliveredVersion}")...`);
+
+  await Promise.all(
+    pageIds.map(async (pageId) => {
+      try {
+        // Lire les relations existantes pour ne pas les écraser
+        const page = await notion.pages.retrieve({ page_id: pageId });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const props = (page as any).properties as Record<string, any>;
+        const existingRelations: Array<{ id: string }> = props[NOTION_TICKET_FIELDS.deliveredVersion]?.relation ?? [];
+
+        // Ajouter la release seulement si elle n'est pas déjà liée
+        if (existingRelations.some((r) => r.id === changelogPageId)) return;
+
+        await notion.pages.update({
+          page_id: pageId,
+          properties: {
+            [NOTION_TICKET_FIELDS.deliveredVersion]: {
+              relation: [...existingRelations, { id: changelogPageId }],
+            },
+          },
+        });
+      } catch (err) {
+        console.warn(`  ⚠️  Impossible de mettre à jour le ticket ${pageId} : ${err}`);
+      }
+    })
+  );
+
+  console.log(`✅ ${pageIds.length} ticket(s) mis à jour`);
+}
+
+// ---------------------------------------------------------------------------
+// Slack
+// ---------------------------------------------------------------------------
+function buildSlackMessage(tag: string, codeName: string, sections: ChangelogSection[], period: { start: string; end: string }, prCount: number, notionUrl: string): string {
+  const appDecoratorMap = Object.fromEntries(APPS.map((a) => [a.label, a.decorator]));
+
+  const body = sections
+    .map((section) => {
+      const decorator = appDecoratorMap[section.app] ?? "—";
+      const bullets = section.bullets.map((b) => `• ${b}`).join("\n");
+      return `${decorator}   ${section.app}\n${bullets}`;
+    })
+    .join("\n\n");
+
+  return [
+    `*Résumé de MEP — ${codeName} (${tag})*`,
+    `Période : ${period.start} → ${period.end}  |  ${prCount} PR mergées.`,
+    "",
+    body,
+    "",
+    `📋 Voir le changelog complet : ${notionUrl}`,
+  ].join("\n");
+}
+
+async function postToSlack(tag: string, codeName: string, sections: ChangelogSection[], period: { start: string; end: string }, prCount: number, notionUrl: string): Promise<void> {
+  const text = buildSlackMessage(tag, codeName, sections, period, prCount, notionUrl);
+
+  const response = await fetch("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${SLACK_TOKEN}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({
+      channel: SLACK_RELEASE_CHANNEL_ID,
+      text,
+      unfurl_links: false,
+    }),
+  });
+
+  const data = (await response.json()) as { ok: boolean; error?: string };
+  if (!data.ok) throw new Error(`Slack API error : ${data.error}`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main(): Promise<void> {
+  validateEnv();
+
+  const args = parseArgs();
+  const tagIsReal = tagExists(args.tag);
+
+  if (!tagIsReal && !args.dryRun) {
+    throw new Error(`Le tag "${args.tag}" n'existe pas en tant que ref git. Utilisez --dry-run pour prévisualiser.`);
+  }
+
+  // Si le tag n'existe pas encore, on cible HEAD (mode preview avant release)
+  const toRef = tagIsReal ? args.tag : "HEAD";
+  const prevTag = findPreviousTag(args.tag);
+
+  console.log(`\n📋 Génération du changelog pour ${args.tag}${!tagIsReal ? " (aperçu — tag non encore créé)" : ""}...`);
+  console.log(`📌 Range : ${prevTag ?? "(début du repo)"}..${toRef}`);
+
+  const notion = new NotionClient({ auth: NOTION_API_KEY });
+  const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
+
+  // 1. Commits
+  const commits = getCommits(prevTag, toRef);
+  console.log(`✅ ${commits.length} commit(s) trouvé(s)`);
+  if (commits.length === 0) {
+    console.log("Aucun commit à traiter, arrêt.");
+    return;
+  }
+
+  // 3. PRs associées
+  console.log("🔍 Récupération des PRs depuis GitHub...");
+  const prsByCommit = await Promise.all(commits.map((c) => getPRsForCommit(c.sha)));
+  const prMap = new Map<number, PR>();
+  prsByCommit.flat().forEach((pr) => prMap.set(pr.number, pr));
+  const prs = [...prMap.values()];
+  console.log(`✅ ${prs.length} PR(s) associée(s)`);
+
+  // 4. Contexte Notion / PR body
+  console.log("📚 Récupération du contenu Notion...");
+  const contexts = await getContextsForPRs(prs, notion);
+  const notionCount = contexts.filter((c) => c.notionContent !== null).length;
+  console.log(`✅ ${notionCount}/${prs.length} PR(s) avec ticket Notion`);
+
+  // 5. Période
+  const period = getPeriod(prevTag, toRef);
+  console.log(`📅 Période : ${period.start} → ${period.end}`);
+
+  // 6. Synthèse OpenAI
+  console.log("🤖 Synthèse avec OpenAI...");
+  const result = await synthesizeWithOpenAI(args.tag, commits, contexts, openai);
+  console.log(`\n  🥊 Impact (${result.impact.length} point(s))`);
+  result.impact.forEach((b) => console.log(`    • ${b}`));
+  result.sections.forEach((s) => {
+    console.log(`\n  ${s.app} (${s.bullets.length} point(s))`);
+    s.bullets.forEach((b) => console.log(`    • ${b}`));
+  });
+  console.log();
+
+  // 7. Nom de code
+  console.log("📚 Récupération des noms de code déjà attribués...");
+  const existingCodeNames = await listExistingCodeNames(notion);
+  console.log(`✅ ${existingCodeNames.length} nom(s) de code existant(s) trouvé(s)`);
+
+  console.log("🎲 Génération du nom de code...");
+  const codeName = await generateCodeName(args.tag, existingCodeNames, openai);
+  console.log(`✅ Nom de code : ${codeName}`);
+
+  if (args.dryRun) {
+    console.log("\n[DRY RUN] Message Slack qui aurait été envoyé :\n");
+    console.log(buildSlackMessage(args.tag, codeName, result.sections, period, prs.length, "https://notion.so/<page-id>"));
+    console.log("\n[DRY RUN] Contenu Notion :\n");
+    console.log(JSON.stringify(result, null, 2));
+    console.log("\n[DRY RUN] Aucune écriture effectuée.");
+    return;
+  }
+
+  // 8. Entrée Notion
+  console.log("📝 Création de l'entrée Notion...");
+  const notionPage = await createNotionEntry(args.tag, codeName, result, contexts, notion);
+  console.log(`✅ Page Notion créée : ${notionPage.url}`);
+
+  // 9. Relier les tickets à la release
+  const ticketUrls = contexts.flatMap((c) => c.pr.notionLinks);
+  await linkTicketsToRelease(ticketUrls, notionPage.pageId, notion);
+
+  // 10. Publication Slack
+  console.log("💬 Publication sur Slack...");
+  await postToSlack(args.tag, codeName, result.sections, period, prs.length, notionPage.url);
+  console.log("✅ Publié sur Slack");
+
+  console.log(`\n🎉 Changelog ${args.tag} publié avec succès !`);
+}
+
+main().catch((err) => {
+  console.error("❌ Erreur :", err);
+  process.exit(1);
+});

--- a/tools/scripts/package-lock.json
+++ b/tools/scripts/package-lock.json
@@ -1,0 +1,698 @@
+{
+  "name": "api-engagement-scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "api-engagement-scripts",
+      "version": "1.0.0",
+      "dependencies": {
+        "@notionhq/client": "2.2.15",
+        "dotenv": "16.5.0",
+        "openai": "4.103.0"
+      },
+      "devDependencies": {
+        "@types/node": "22.15.29",
+        "ts-node": "10.9.2",
+        "typescript": "5.9.3"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@notionhq/client": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.2.15.tgz",
+      "integrity": "sha512-XhdSY/4B1D34tSco/GION+23GMjaS9S2zszcqYkMHo8RcWInymF6L1x+Gk7EmHdrSxNFva2WM8orhC4BwQCwgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
+      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai": {
+      "version": "4.103.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.103.0.tgz",
+      "integrity": "sha512-eWcz9kdurkGOFDtd5ySS5y251H2uBgq9+1a2lTBnjMMzlexJ40Am5t6Mu76SSE87VvitPa0dkIAp75F+dZVC0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/tools/scripts/package.json
+++ b/tools/scripts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "api-engagement-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "generate-changelog": "ts-node generate-changelog.ts"
+  },
+  "dependencies": {
+    "openai": "4.103.0",
+    "@notionhq/client": "2.2.15",
+    "dotenv": "16.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "22.15.29",
+    "ts-node": "10.9.2",
+    "typescript": "5.9.3"
+  }
+}

--- a/tools/scripts/tsconfig.json
+++ b/tools/scripts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "ts-node": {
+    "transpileOnly": true
+  },
+  "compilerOptions": {
+    "target": "es2021",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Description

Ajoute un script de génération et publication de changelog de release dans `tools/scripts`.

Le script `generate-changelog.ts` permet de générer un changelog à partir d'un tag de release en agrégeant les commits, les PR associées, les tickets Notion liés aux PRs et les descriptions de PR. Le résultat est synthétisé avec OpenAI, puis publié dans la base Notion changelog et sur Slack.

Fonctionnalités principales :

- récupération des commits depuis le tag précédent ;
- récupération des PRs associées aux commits via l'API GitHub ;
- extraction des liens Notion présents dans les corps de PR ;
- lecture du contenu des tickets Notion quand ils sont disponibles ;
- utilisation combinée du contenu Notion et du corps des PRs pour produire un changelog plus exhaustif ;
- génération d'un résumé d'impact et d'un détail par application ;
- génération d'un nom de code de release en excluant les noms déjà utilisés dans la base Notion ;
- création de l'entrée de changelog dans Notion ;
- liaison des tickets Notion à la release via le champ `Version livrée` ;
- publication du résumé de mise en production dans Slack ;
- support du mode `--dry-run` pour prévisualiser sans écrire dans Notion ni Slack.

La PR ajoute aussi le package `tools/scripts` avec ses dépendances (`openai`, `@notionhq/client`, `dotenv`, `ts-node`, `typescript`) et une configuration TypeScript dédiée.

## Liens utiles

- 📝 Ticket Notion : non renseigné

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Variables d'environnement attendues par le script :

- `GITHUB_TOKEN`
- `NOTION_API_KEY`
- `NOTION_CHANGELOG_DATABASE_ID`
- `OPENAI_API_KEY`
- `SLACK_TOKEN`
- `SLACK_RELEASE_CHANNEL_ID`

Commande d'utilisation :

```bash
npx ts-node generate-changelog.ts --tag v1.2.3 --dry-run
```

Le mode `--dry-run` est à privilégier pour relire le changelog généré avant création de la page Notion et publication Slack.
