### PR TITLE
fix(api): update mission enrichment job priority

### DIFF
--- a/api/src/jobs/update-mission-enrichment/handler.ts
+++ b/api/src/jobs/update-mission-enrichment/handler.ts
@@ -11,6 +11,7 @@ const LOG_PREFIX = "[update-mission-enrichment-job]";
 export interface UpdateMissionEnrichmentJobPayload {
   publisherId?: string;
   limit?: number;
+  onlyMissing?: boolean; // ne traite que les missions sans aucun enrichment
 }
 
 export interface UpdateMissionEnrichmentJobResult extends JobResult {
@@ -21,22 +22,48 @@ export interface UpdateMissionEnrichmentJobResult extends JobResult {
 export class UpdateMissionEnrichmentHandler implements BaseHandler<UpdateMissionEnrichmentJobPayload, UpdateMissionEnrichmentJobResult> {
   name = "Enrichissement des missions";
 
-  async handle({ publisherId, limit }: UpdateMissionEnrichmentJobPayload = {}): Promise<UpdateMissionEnrichmentJobResult> {
+  async handle({ publisherId, limit, onlyMissing }: UpdateMissionEnrichmentJobPayload = {}): Promise<UpdateMissionEnrichmentJobResult> {
     try {
-      const missions = await prisma.mission.findMany({
-        where: {
-          ...(publisherId ? { publisherId } : {}),
-          deletedAt: null,
-          enrichments: {
-            none: { promptVersion: CURRENT_PROMPT_VERSION, status: "completed" },
-          },
-        },
+      const baseWhere = {
+        ...(publisherId ? { publisherId } : {}),
+        deletedAt: null,
+      };
+
+      // Phase 1 — missions sans AUCUN enrichment (priorité absolue)
+      const missingMissions = await prisma.mission.findMany({
+        where: { ...baseWhere, enrichments: { none: {} } },
         select: { id: true },
         take: limit,
         orderBy: { updatedAt: "desc" },
       });
 
-      console.log(`${LOG_PREFIX} ${missions.length} missions to enrich (publisher: ${publisherId ?? "all"}, version: ${CURRENT_PROMPT_VERSION})`);
+      // Phase 2 — missions avec enrichment mais pas de v3 "completed" (stock obsolète)
+      let staleMissions: { id: string }[] = [];
+      if (!onlyMissing) {
+        const remaining = limit !== undefined ? limit - missingMissions.length : undefined;
+        if (remaining === undefined || remaining > 0) {
+          staleMissions = await prisma.mission.findMany({
+            where: {
+              ...baseWhere,
+              enrichments: {
+                some: {},
+                none: { promptVersion: CURRENT_PROMPT_VERSION, status: "completed" },
+              },
+            },
+            select: { id: true },
+            take: remaining,
+            orderBy: { updatedAt: "desc" },
+          });
+        }
+      }
+
+      const missions = [...missingMissions, ...staleMissions];
+
+      console.log(
+        `${LOG_PREFIX} ${missions.length} missions to enrich ` +
+          `(${missingMissions.length} sans enrichment + ${staleMissions.length} obsolètes, ` +
+          `publisher: ${publisherId ?? "all"}, version: ${CURRENT_PROMPT_VERSION}, onlyMissing: ${onlyMissing ?? false})`
+      );
 
       let processed = 0;
       let failed = 0;


### PR DESCRIPTION
## Description

Le job `update-mission-enrichment` priorise désormais les missions sans **aucun** enrichment.

Suite au passage du prompt en `v3` (`CURRENT_PROMPT_VERSION`), le job cherche à ré-enrichir tout le stock (~32k missions). Le filtre précédent (`enrichments: { none: { promptVersion: v3, status: "completed" } }`) noyait les ~7k missions **jamais enrichies** parmi les ~25k missions à enrichment obsolète (v1/v2), et le tri `updatedAt: desc` mélangeait les deux populations. Conséquence : une mission sans aucune donnée pouvait attendre derrière des milliers de simples ré-enrichissements.

## Changements

Sélection en **deux phases mutuellement exclusives** dans `handler.ts` :

- **Phase 1** — `enrichments: { none: {} }` : missions sans aucun enrichment, traitées en priorité.
- **Phase 2** — `enrichments: { some: {}, none: { v3 completed } }` : stock obsolète, traité ensuite.

Les deux `where` sont disjoints (`none: {}` vs `some: {}`) → aucun doublon. Le `limit` est consommé par la phase 1 d'abord ; la phase 2 ne prend que le budget restant.

Ajout d'un flag payload `onlyMissing?: boolean` pour ne lancer **que** la phase 1 :

```bash
npm run job -- update-mission-enrichment '{"onlyMissing":true,"limit":50}' --env staging
```

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- **Aucune migration ni changement de schéma** : uniquement de la logique de requête.
- **Idempotence préservée** : `missionEnrichmentService.enrich` re-vérifie l'état (claimForRun + skip si déjà v3 completed / in-flight). La sélection en deux phases ne change rien à cette garantie.
- Le log de tête détaille désormais les compteurs par phase et le mode (`onlyMissing`).