### PR TITLE
feat(plateform): sync results map pins with mission list cards

### DIFF
--- a/plateform/app/components/results/lazy-mission-map.tsx
+++ b/plateform/app/components/results/lazy-mission-map.tsx
@@ -7,12 +7,15 @@ interface LazyMissionMapProps {
   items: MissionMatchItem[];
   center: [number, number];
   onMarkerClick?: (item: MissionMatchItem) => void;
+  selectionPadding?: [number, number];
+  activeMissionId?: string | null;
+  onMissionHover?: (missionId: string | null) => void;
 }
 
-export default function LazyMissionMap({ items, center, onMarkerClick }: LazyMissionMapProps) {
+export default function LazyMissionMap({ items, center, onMarkerClick, selectionPadding, activeMissionId, onMissionHover }: LazyMissionMapProps) {
   return (
     <Suspense fallback={<div className="h-full fr-background-alt--grey" />}>
-      <MissionMap items={items} center={center} onMarkerClick={onMarkerClick} />
+      <MissionMap items={items} center={center} onMarkerClick={onMarkerClick} selectionPadding={selectionPadding} activeMissionId={activeMissionId} onMissionHover={onMissionHover} />
     </Suspense>
   );
 }

--- a/plateform/app/components/results/mission-map.tsx
+++ b/plateform/app/components/results/mission-map.tsx
@@ -1,8 +1,8 @@
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import type { MissionMatchItem } from "@engagement/dto";
-import { useEffect, useId, useMemo } from "react";
-import { MapContainer, Marker, Popup, TileLayer, useMap } from "react-leaflet";
+import { useEffect, useId, useMemo, useRef } from "react";
+import { MapContainer, Marker, Popup, TileLayer, Tooltip, useMap } from "react-leaflet";
 import { TILE_LAYER_PROPS, createEmojiIcon } from "~/components/ui/location-map";
 import { type GeoPosition, getNearbyPosition } from "~/utils/geo";
 
@@ -15,6 +15,13 @@ type MapMission = {
 
 const classicIcon = createEmojiIcon("📍");
 const remoteIcon = createEmojiIcon("👨‍💻");
+const activeIcon = L.divIcon({
+  className: "",
+  html: `<div class="mission-map__emoji-marker mission-map__emoji-marker--active">📍</div>`,
+  iconSize: [22, 22],
+  iconAnchor: [11, 11],
+  popupAnchor: [0, -12],
+});
 
 const getAddressLabel = (item: MissionMatchItem): string | null => item.mission.location.closestAddress ?? item.mission.location.city;
 
@@ -48,9 +55,22 @@ interface Props {
   items: MissionMatchItem[];
   center: [number, number];
   onMarkerClick?: (item: MissionMatchItem) => void;
+  // Marge (x, y en px) à garder dégagée à droite/en bas pour que le pin cliqué ne passe pas sous la carte mission.
+  selectionPadding?: [number, number];
+  // Mission actuellement survolée/sélectionnée : son pin est mis en couleur et passe au premier plan.
+  activeMissionId?: string | null;
+  // Survol d'un pin → remonte l'id (ou null) pour surligner la carte correspondante dans la liste.
+  onMissionHover?: (missionId: string | null) => void;
 }
 
-export default function MissionMap({ items, center, onMarkerClick }: Props) {
+export default function MissionMap({ items, center, onMarkerClick, selectionPadding, activeMissionId, onMissionHover }: Props) {
+  const mapRef = useRef<L.Map | null>(null);
+
+  const handleMarkerSelect = (item: MissionMatchItem, position: GeoPosition) => {
+    if (selectionPadding && mapRef.current) mapRef.current.panInside(position, { paddingBottomRight: selectionPadding });
+    onMarkerClick?.(item);
+  };
+
   const missions = useMemo<MapMission[]>(
     () => {
       const positionedMissions = items.map((item, index) => {
@@ -73,7 +93,7 @@ export default function MissionMap({ items, center, onMarkerClick }: Props) {
     [center, items],
   );
 
-  const boundsPositions = missions.length > 0 ? missions.map((mission) => mission.position) : [center];
+  const boundsPositions = useMemo<[number, number][]>(() => (missions.length > 0 ? missions.map((mission) => mission.position) : [center]), [missions, center]);
 
   const descriptionId = useId();
   const accessibleLabel = `Carte des ${items.length} mission${items.length > 1 ? "s" : ""} proposée${items.length > 1 ? "s" : ""}`;
@@ -83,35 +103,48 @@ export default function MissionMap({ items, center, onMarkerClick }: Props) {
       <p id={descriptionId} className="sr-only">
         Carte interactive localisant les missions proposées. La liste des missions présente les mêmes informations sous forme textuelle accessible.
       </p>
-      <MapContainer center={center} zoom={12} className="mission-map" zoomControl={false}>
+      <MapContainer ref={mapRef} center={center} zoom={12} className="mission-map" zoomControl={false}>
         <TileLayer {...TILE_LAYER_PROPS} />
         <BoundsFitter positions={boundsPositions} />
-        {missions.map(({ item, position, addressLabel, usesRemoteIcon }) => (
-          <Marker
-            key={item.mission.id}
-            position={position}
-            icon={usesRemoteIcon ? remoteIcon : classicIcon}
-            eventHandlers={onMarkerClick ? { click: () => onMarkerClick(item) } : undefined}
-          >
-            {!onMarkerClick && (
-              <Popup>
-                <strong>{item.mission.title}</strong>
-                {addressLabel && (
-                  <>
-                    <br />
-                    {addressLabel}
-                  </>
-                )}
-                {!addressLabel && (
-                  <>
-                    <br />
-                    Mission à distance ou sans adresse précise
-                  </>
-                )}
-              </Popup>
-            )}
-          </Marker>
-        ))}
+        {missions.map(({ item, position, addressLabel, usesRemoteIcon }) => {
+          const isActive = item.mission.id === activeMissionId;
+          return (
+            <Marker
+              key={item.mission.id}
+              position={position}
+              icon={isActive ? activeIcon : usesRemoteIcon ? remoteIcon : classicIcon}
+              zIndexOffset={isActive ? 1000 : 0}
+              eventHandlers={{
+                ...(onMarkerClick ? { click: () => handleMarkerSelect(item, position) } : {}),
+                ...(onMissionHover ? { mouseover: () => onMissionHover(item.mission.id), mouseout: () => onMissionHover(null) } : {}),
+              }}
+            >
+              {onMissionHover && (
+                <Tooltip direction="top" offset={[0, -8]} opacity={1} className="mission-map__tooltip">
+                  <strong className="mission-map__tooltip-title">{item.mission.title}</strong>
+                  <span className="mission-map__tooltip-address">{addressLabel ?? "Mission à distance ou sans adresse précise"}</span>
+                </Tooltip>
+              )}
+              {!onMarkerClick && (
+                <Popup>
+                  <strong>{item.mission.title}</strong>
+                  {addressLabel && (
+                    <>
+                      <br />
+                      {addressLabel}
+                    </>
+                  )}
+                  {!addressLabel && (
+                    <>
+                      <br />
+                      Mission à distance ou sans adresse précise
+                    </>
+                  )}
+                </Popup>
+              )}
+            </Marker>
+          );
+        })}
       </MapContainer>
     </div>
   );

--- a/plateform/app/components/results/pinned-missions.tsx
+++ b/plateform/app/components/results/pinned-missions.tsx
@@ -10,9 +10,11 @@ interface PinnedMissionsProps {
   error: string | null;
   userScoringId: string | undefined;
   showDebug: boolean;
+  highlightedMissionId?: string | null;
+  onMissionHover?: (missionId: string | null) => void;
 }
 
-export default function PinnedMissions({ items, loading, error, userScoringId, showDebug }: PinnedMissionsProps) {
+export default function PinnedMissions({ items, loading, error, userScoringId, showDebug, highlightedMissionId, onMissionHover }: PinnedMissionsProps) {
   return (
     <div className="relative w-full px-6">
       {!loading && error && (
@@ -25,7 +27,12 @@ export default function PinnedMissions({ items, loading, error, userScoringId, s
         <>
           <div className="grid grid-cols-1 gap-6 pb-6 md:grid-cols-2 md:px-4">
             {items.map((item) => (
-              <div key={item.mission.id} className="relative w-full md:max-w-[330px]">
+              <div
+                key={item.mission.id}
+                className={`relative w-full transition-shadow md:max-w-[330px] ${item.mission.id === highlightedMissionId ? "shadow-card ring-2 ring-blue-france-sun" : ""}`}
+                onMouseEnter={() => onMissionHover?.(item.mission.id)}
+                onMouseLeave={() => onMissionHover?.(null)}
+              >
                 <MissionCard mission={matchResultToBrowseMission(item)} link={{ type: "internal", to: buildMissionDetailHref(item, userScoringId) }} />
                 {showDebug && <DebugButton missionId={item.mission.id} />}
               </div>

--- a/plateform/app/components/ui/location-map.tsx
+++ b/plateform/app/components/ui/location-map.tsx
@@ -19,9 +19,9 @@ export const createEmojiIcon = (emoji: string) =>
   L.divIcon({
     className: "",
     html: `<div class="mission-map__emoji-marker">${emoji}</div>`,
-    iconSize: [28, 28],
-    iconAnchor: [14, 14],
-    popupAnchor: [0, -16],
+    iconSize: [22, 22],
+    iconAnchor: [11, 11],
+    popupAnchor: [0, -12],
   });
 
 const pinIcon = createEmojiIcon("📍");

--- a/plateform/app/main.css
+++ b/plateform/app/main.css
@@ -222,13 +222,43 @@
 .mission-map__emoji-marker {
   align-items: center;
   background: rgb(246 246 255 / 92%);
-  border: 3px solid #ffffff;
+  border: 1px solid #ffffff;
   border-radius: 9999px;
   box-shadow: 0 3px 10px rgb(0 0 0 / 16%);
   display: grid;
-  font-size: 13px;
-  height: 28px;
+  font-size: 12px;
+  height: 22px;
   justify-items: center;
   line-height: 1;
-  width: 28px;
+  width: 22px;
+}
+
+.mission-map__emoji-marker--active {
+  background: #000091;
+  transform: scale(1.18);
+}
+
+.mission-map__tooltip.leaflet-tooltip {
+  border: none;
+  border-radius: 12px;
+  box-shadow: 0 4px 16px rgb(0 0 0 / 16%);
+  max-width: 320px;
+  min-width: 220px;
+  padding: 10px 14px;
+  white-space: normal;
+}
+
+.mission-map__tooltip-title {
+  color: var(--text-title-grey);
+  display: block;
+  font-size: 13px;
+  line-height: 1.3;
+}
+
+.mission-map__tooltip-address {
+  color: var(--text-mention-grey);
+  display: block;
+  font-size: 12px;
+  line-height: 1.3;
+  margin-top: 2px;
 }

--- a/plateform/app/routes/results.tsx
+++ b/plateform/app/routes/results.tsx
@@ -34,13 +34,15 @@ export default function ResultsPage() {
   const { pinnedItems, otherItems, page, setPage, hasNextPage, loading, pageLoading, error, visiblePageNumbers } = useMissionResults(userScoringId);
   const [expanded, setExpanded] = useState(false);
   const [selectedMission, setSelectedMission] = useState<MissionMatchItem | null>(null);
+  const [hoveredMissionId, setHoveredMissionId] = useState<string | null>(null);
   const [isClosingCard, setIsClosingCard] = useState(false);
   const [emailModalOpen, setEmailModalOpen] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const locAnswer = answers["localisation"];
   const geo = locAnswer?.type === "params" ? (locAnswer.params as { lat: number; lon: number }) : null;
-  const mapCenter: [number, number] = geo ? [geo.lat, geo.lon] : FRANCE_CENTER;
+  // Mémoïsé pour garder une identité stable : sinon chaque rendu (ex. sélection d'un pin) recale la carte sur l'ensemble des pins.
+  const mapCenter = useMemo<[number, number]>(() => (geo ? [geo.lat, geo.lon] : FRANCE_CENTER), [geo]);
   const userValues = useMemo<MatchingDebugUserValue[]>(
     () =>
       Object.values(answers).flatMap((answer) => {
@@ -70,6 +72,9 @@ export default function ResultsPage() {
   const showMap = !loading && pinnedItems.length > 0;
   const showOther = !loading && !error && (otherItems.length > 0 || page > 1);
   const showDebug = searchParams.get("debug") === "true";
+
+  // Mission mise en avant (survol prioritaire sur sélection) : pin coloré + carte surlignée dans la liste.
+  const activeMissionId = hoveredMissionId ?? selectedMission?.mission.id ?? null;
 
   // Dernier step visible du quiz selon les réponses courantes → "Changer mes réponses" y renvoie.
   const lastQuizStep = QUIZ_FLOW.filter((s) => !s.condition || evalCondition(s.condition, answers)).at(-1);
@@ -102,7 +107,7 @@ export default function ResultsPage() {
         <section className="relative h-[calc(100dvh-3.5rem)] overflow-hidden">
           {showMap && (
             <div className="absolute inset-0 z-0" onClickCapture={handleCollapseSheet}>
-              <LazyMissionMap items={pinnedItems} center={mapCenter} onMarkerClick={handleMarkerClick} />
+              <LazyMissionMap items={pinnedItems} center={mapCenter} onMarkerClick={handleMarkerClick} activeMissionId={activeMissionId} />
             </div>
           )}
 
@@ -173,7 +178,7 @@ export default function ResultsPage() {
             </div>
 
             <div ref={scrollRef} className={`flex-1 overflow-y-auto overscroll-contain ${expanded ? "" : "hidden"}`}>
-              <PinnedMissions items={pinnedItems} loading={loading} error={error} userScoringId={userScoringId} showDebug={showDebug} />
+              <PinnedMissions items={pinnedItems} loading={loading} error={error} userScoringId={userScoringId} showDebug={showDebug} highlightedMissionId={activeMissionId} />
 
               {showOther && (
                 <div className="px-6 pt-2 pb-8">
@@ -230,9 +235,72 @@ export default function ResultsPage() {
                   Changer mes réponses
                 </Link>
               </div>
-              <PinnedMissions items={pinnedItems} loading={loading} error={error} userScoringId={userScoringId} showDebug={showDebug} />
+              <PinnedMissions
+                items={pinnedItems}
+                loading={loading}
+                error={error}
+                userScoringId={userScoringId}
+                showDebug={showDebug}
+                highlightedMissionId={activeMissionId}
+                onMissionHover={setHoveredMissionId}
+              />
             </div>
-            <div className="sticky top-0 max-h-[720px] flex-1 py-12">{showMap && <LazyMissionMap items={pinnedItems} center={mapCenter} />}</div>
+            <div className="sticky top-0 max-h-[720px] flex-1 py-12">
+              {showMap && (
+                <div className="relative h-full">
+                  <LazyMissionMap
+                    items={pinnedItems}
+                    center={mapCenter}
+                    onMarkerClick={handleMarkerClick}
+                    selectionPadding={[380, 0]}
+                    activeMissionId={activeMissionId}
+                    onMissionHover={setHoveredMissionId}
+                  />
+
+                  {selectedMission && (
+                    <div
+                      key={selectedMission.mission.id}
+                      className={`absolute right-4 top-4 z-[500] w-[330px] ${isClosingCard ? "animate-slide-down-fade" : "animate-slide-up-fade"}`}
+                      onAnimationEnd={() => {
+                        if (!isClosingCard) return;
+                        setSelectedMission(null);
+                        setIsClosingCard(false);
+                      }}
+                    >
+                      <div className="relative">
+                        <MissionCard mission={matchResultToBrowseMission(selectedMission)} link={{ type: "internal", to: buildMissionDetailHref(selectedMission, userScoringId) }} />
+                        <div className="absolute right-3 top-3 z-10 flex items-center gap-2">
+                          <button
+                            type="button"
+                            className="flex h-8 w-8 items-center justify-center rounded-full bg-background! shadow-md"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              setEmailModalOpen(true);
+                            }}
+                            aria-label="Recevoir par email"
+                          >
+                            <i className="fr-icon-mail-send-line fr-icon--sm" aria-hidden="true" />
+                          </button>
+                          <button
+                            type="button"
+                            className="flex h-8 w-8 items-center justify-center rounded-full bg-background! shadow-md"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              setIsClosingCard(true);
+                            }}
+                            aria-label="Fermer la carte"
+                          >
+                            <i className="fr-icon-close-line fr-icon--sm" aria-hidden="true" />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
           </section>
           <MatchingDebugModal items={[...pinnedItems, ...otherItems]} userValues={userValues} />
         </GradientBg>
@@ -260,6 +328,7 @@ export default function ResultsPage() {
         hintText="En renseignant ton adresse électronique, tu acceptes de recevoir de nouvelles offres de missions. Tu pourras te désinscrire à tout moment."
       />
       <Partners style="compact" />
+      <EmailMissionsModal userScoringId={userScoringId} open={emailModalOpen} onOpenChange={setEmailModalOpen} hideTrigger />
     </>
   );
 }


### PR DESCRIPTION
## Description

Rend la carte des résultats interactive et la synchronise avec la liste des missions, dans les deux sens.

**Changements** :
- Clic sur un pin (desktop) : ouverture de la carte mission en superposition (haut droite), avec recentrage (`panInside`) pour que le pin reste visible et ne passe pas sous la carte.
- Survol d'un pin → surligne la carte correspondante dans la liste + affiche un tooltip (titre + adresse).
- Survol d'une carte de la liste → met en couleur le pin correspondant sur la carte (sens inverse).
- Pin actif (survol ou sélection) coloré en bleu France et passé au premier plan.
- Mémoïsation de `mapCenter` et `boundsPositions` : évite que la carte se recale sur l'ensemble des pins à chaque rendu (notamment au clic).
- Pins réduits (22px, bordure 1px) pour un rendu plus fin.

## Liens utiles

- 📝 Ticket Notion : _à compléter_

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- `npm --workspace=plateform run typecheck` et `npm --workspace=plateform run lint` passent.
- Changement essentiellement visuel/interactif : **vérification manuelle dans le navigateur recommandée** (desktop et mobile), en particulier le rendu du tooltip, la couleur du pin actif et le recentrage au clic.
- Impact desktop et mobile vérifié au niveau du code : le survol/tooltip est limité au desktop ; le mobile conserve sa fiche en bas d'écran et bénéficie de la coloration du pin sélectionné.
- Aucune migration ni nouvelle dépendance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)