### PR TITLE
fix(api): add results link to matching results email

### DIFF
--- a/api/src/services/brevo/mission-content.ts
+++ b/api/src/services/brevo/mission-content.ts
@@ -1,4 +1,5 @@
 export type MissionContent = {
+  id: string;
   title: string;
   imageUrl: string;
   durationLabel: string;

--- a/api/src/services/mission-email/index.ts
+++ b/api/src/services/mission-email/index.ts
@@ -1,4 +1,4 @@
-import { API_URL } from "@/config";
+import { API_URL, PLATEFORM_URL } from "@/config";
 import { missionMatchingResultRepository } from "@/repositories/mission-matching-result";
 import { userScoringRepository } from "@/repositories/user-scoring";
 import type { MissionContent } from "@/services/brevo";
@@ -102,6 +102,7 @@ const formatCompensationLabel = (mission: EmailMission) => {
 };
 
 const buildMissionEmailItem = (mission: EmailMission, publisherId: string, userScoringId?: string): MissionContent => ({
+  id: mission.id,
   title: mission.title,
   imageUrl: mission.domainLogo || mission.publisherLogo || "",
   durationLabel: formatDurationLabel(mission.duration),
@@ -206,6 +207,7 @@ export const sendMissionEmail = async (input: SendMissionEmailRequest): Promise<
     emailTo: [input.email],
     params: {
       descriptionMission: missions.length === 1 ? "les détails de ta mission" : "les détails de ta sélection de missions",
+      descriptionLink: `${PLATEFORM_URL}/results/${input.userScoringId}/${missions.length === 1 ? `missions/${missions[0].id}` : ``}`,
       contentHtml: buildMissionContentHtml(missions),
     },
     tags: ["user-scoring", "mission-matching-results"],


### PR DESCRIPTION
## Description

Ajoute un lien vers la plateforme dans l'email de missions correspondantes (`MISSION_MATCHING_RESULTS`), pour que le destinataire accède directement à ses résultats.

**Changements** :
- Ajout du champ `id` au type `MissionContent`.
- Renseignement de `id` pour chaque mission dans l'item d'email (`buildMissionEmailItem`).
- Nouveau paramètre `descriptionLink` envoyé au template Brevo :
  - une seule mission → lien direct vers la mission : `/results/:userScoringId/missions/:missionId` ;
  - plusieurs missions → lien vers la liste de résultats : `/results/:userScoringId`.

## Liens utiles

- 📝 Ticket Notion : _à compléter_

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- `PLATEFORM_URL` inclut déjà le schéma (il est utilisé tel quel comme origine CORS dans `middlewares/cors.ts`). Le lien ne préfixe donc **pas** `https://` pour éviter un double schéma (`https://http://...`).
- ESLint OK sur les fichiers modifiés. Typecheck global non exécuté (le script `build` de l'API est lourd : prisma generate + tsc complet) — changement vérifié par inspection : `EmailMission.id` et `PLATEFORM_URL` existent déjà.
- **À vérifier côté template Brevo** : le template `MISSION_MATCHING_RESULTS` doit bien consommer la variable `descriptionLink`.
- Aucune migration ni nouvelle dépendance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)