### PR TITLE
fix(api): mission not found error on redirect

### DIFF
--- a/api/src/controllers/redirect.ts
+++ b/api/src/controllers/redirect.ts
@@ -102,10 +102,12 @@ router.get("/apply", cors({ origin: "*" }), async (req: Request, res: Response) 
     }
 
     if (query.data.mission) {
+      // La mission peut être introuvable sans que ce soit une anomalie : le candidat peut postuler
+      // à une mission qui existe chez l'annonceur (ex. Service Civique) mais qui n'a pas encore été
+      // importée en base, ou à une mission différente de celle qu'il a cliquée. Dans ces cas, on
+      // retombe plus bas sur la mission du click (cf. `if (click && !mission)`) pour ne pas perdre
+      // l'apply. On ne remonte donc pas d'erreur ici.
       mission = await missionService.findMissionByClientAndPublisher(query.data.mission, click.toPublisherId || query.data.publisher || "");
-      if (!mission) {
-        captureException(new Error(`[Apply] Mission not found`), { extra: { missionId: query.data.mission, publisherId: click.toPublisherId || query.data.publisher } });
-      }
     }
 
     const statBot = await statBotService.findStatBotByUser(identity.user);
@@ -144,6 +146,10 @@ router.get("/apply", cors({ origin: "*" }), async (req: Request, res: Response) 
     }
 
     if (click && !mission) {
+      // Fallback quand la mission n'a pas pu être résolue (mission pas encore importée, ou mission
+      // différente de celle cliquée) : on rattache l'événement à la mission du click pour ne pas le
+      // perdre. L'attribution mission peut alors différer de la mission réellement visée, mais
+      // l'annonceur (toPublisher) reste correct.
       obj.missionId = click.missionId;
       obj.toPublisherId = click.toPublisherId;
       obj.toPublisherName = click.toPublisherName;
@@ -220,10 +226,10 @@ router.get("/account", cors({ origin: "*" }), async (req: Request, res: Response
     }
 
     if (query.data.mission) {
+      // Voir la route /apply : la mission peut légitimement être introuvable (pas encore importée,
+      // ou différente de celle cliquée). On retombe plus bas sur la mission du click, sans remonter
+      // d'erreur.
       mission = await missionService.findMissionByClientAndPublisher(query.data.mission, click.toPublisherId || query.data.publisher || "");
-      if (!mission) {
-        captureException(new Error(`[Account] Mission not found`), { extra: { missionId: query.data.mission, publisherId: click.toPublisherId || query.data.publisher } });
-      }
     }
 
     const statBot = await statBotService.findStatBotByUser(identity.user);
@@ -258,6 +264,10 @@ router.get("/account", cors({ origin: "*" }), async (req: Request, res: Response
     }
 
     if (click && !mission) {
+      // Fallback quand la mission n'a pas pu être résolue (mission pas encore importée, ou mission
+      // différente de celle cliquée) : on rattache l'événement à la mission du click pour ne pas le
+      // perdre. L'attribution mission peut alors différer de la mission réellement visée, mais
+      // l'annonceur (toPublisher) reste correct.
       obj.missionId = click.missionId;
       obj.toPublisherId = click.toPublisherId;
       obj.toPublisherName = click.toPublisherName;


### PR DESCRIPTION
## Description

Supprime les erreurs Sentry `[Apply] Mission not found` / `[Account] Mission not found` remontées en continu sur `/r/apply` et `/r/account`, et documente le comportement attendu.

Ces erreurs ne traduisent **pas un bug** : un candidat peut valider sa candidature sur le site de l'annonceur (ex. Service Civique) pour une mission qui :
- n'a **pas encore été importée** en base au moment du pixel (course entre la candidature et le job d'import), ou
- est **différente** de la mission qu'il a cliquée.

Dans ces cas, la mission n'est pas résolue par `findMissionByClientAndPublisher`, et le code retombe déjà sur la mission du click (`if (click && !mission)`) pour **ne pas perdre l'événement**. L'apply est donc bien enregistré (candidat, attributs, annonceur corrects) ; seul le rattachement à la mission précise peut différer. Le `captureException` ne faisait qu'ajouter du bruit pour un comportement nominal.

### Exemple investigué
- Click du 17/06 sur la mission `d4c3e431…` (annonceur Service Civique).
- Apply du 23/06 21:58 sur `client_id=6a3a98bd…` → mission absente en base → erreur Sentry.
- Mission `6a3a98bd…` importée le 24/06 04:58 (~7h plus tard).
- L'apply a quand même été enregistré via le fallback sur la mission du click.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Le `[Apply] Click not found` / `[Account] Click not found` (vrai signal d'anomalie) est **conservé**.
- Pas de changement de comportement runtime : seuls les `captureException` "Mission not found" sont retirés et le cas est documenté en commentaire aux deux endroits (résolution + fallback).
- Limite connue, non traitée ici : pour ces cas de course d'import, l'apply reste attribué à la mission cliquée et n'est pas re-rattaché a posteriori (aucun job de réconciliation). Impact mineur : l'annonceur/diffuseur reste correct, seule la granularité « mission précise » est faussée.
