### PR TITLE
fix(api): compute publisher diffusion rules

### DIFF
--- a/api/prisma/migrations/20260629120123_add_mission_active_publisher_start_at_index/migration.sql
+++ b/api/prisma/migrations/20260629120123_add_mission_active_publisher_start_at_index/migration.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "mission_active_publisher_start_at_idx"
+ON "public"."mission" ("publisher_id", "start_at" DESC, "id")
+WHERE "deleted_at" IS NULL AND "status_code" = 'ACCEPTED'::"public"."MissionStatusCode";

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -652,6 +652,8 @@ model Mission {
   // Partial index managed manually in migration (Prisma doesn't support WHERE clause on indexes)
   // CREATE INDEX "mission_publisher_active_idx" ON "mission" (publisher_id, id)
   // WHERE deleted_at IS NULL AND status_code = 'ACCEPTED'
+  // CREATE INDEX "mission_active_publisher_start_at_idx" ON "mission" (publisher_id, start_at DESC, id)
+  // WHERE deleted_at IS NULL AND status_code = 'ACCEPTED'
   @@map("mission")
 }
 

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -570,6 +570,97 @@ const baseInclude: MissionInclude = {
   jobBoards: true,
 };
 
+const MAX_SPLIT_DIFFUSION_SCOPES = 8;
+const MAX_SPLIT_PAGE_WINDOW = 10_000;
+
+type MissionPageIndexRow = {
+  id: string;
+  startAt: Date | null;
+  scopeIndex: number;
+  rowIndex: number;
+};
+
+const compareMissionPageIndexRows = (a: MissionPageIndexRow, b: MissionPageIndexRow) => {
+  if (a.startAt === null && b.startAt !== null) {
+    return -1;
+  }
+  if (a.startAt !== null && b.startAt === null) {
+    return 1;
+  }
+  if (a.startAt !== null && b.startAt !== null) {
+    const dateDiff = b.startAt.getTime() - a.startAt.getTime();
+    if (dateDiff !== 0) {
+      return dateDiff;
+    }
+  }
+  return a.scopeIndex - b.scopeIndex || a.rowIndex - b.rowIndex;
+};
+
+const hydrateMissionPage = async (ids: string[], select: MissionSelect | null, moderatedBy: string | null = null): Promise<MissionRecord[]> => {
+  if (!ids.length) {
+    return [];
+  }
+
+  const missions = await missionRepository.findMany({
+    where: { id: { in: ids } },
+    include: select ? undefined : baseInclude,
+    select: select ?? undefined,
+  });
+  const missionById = new Map(missions.map((mission) => [mission.id, mission]));
+
+  return ids
+    .map((id) => missionById.get(id))
+    .filter((mission): mission is Mission => Boolean(mission))
+    .map((mission) => toMissionRecord(mission as MissionWithRelations, moderatedBy));
+};
+
+const tryFindMissionsBySplitDiffusionScopes = async (
+  filters: MissionSearchFilters,
+  select: MissionSelect | null = null
+): Promise<{ data: MissionRecord[]; total: number } | null> => {
+  if (!filters.diffuseurPublisherId || filters.includeDeleted || filters.deletedAt || (filters.statusCode ?? "ACCEPTED") !== "ACCEPTED") {
+    return null;
+  }
+
+  const pageWindow = filters.skip + filters.limit;
+  if (pageWindow > MAX_SPLIT_PAGE_WINDOW) {
+    return null;
+  }
+
+  const diffusionFilter = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateFilter(filters.diffuseurPublisherId, filters.publisherIds);
+  const hasDistinctScopes = diffusionFilter.scopes.length > 1 && new Set(diffusionFilter.scopePublisherIds).size === diffusionFilter.scopePublisherIds.length;
+  if (!hasDistinctScopes || diffusionFilter.scopes.length > MAX_SPLIT_DIFFUSION_SCOPES) {
+    return null;
+  }
+
+  const baseWhere = await buildWhere({ ...filters, diffuseurPublisherId: undefined, publisherIds: [] });
+  const scopeWheres = diffusionFilter.scopes.map((scope) => ({ AND: [baseWhere, scope] }) satisfies Prisma.MissionWhereInput);
+
+  const [scopeRows, scopeCounts] = await Promise.all([
+    filters.limit === 0
+      ? Promise.resolve(scopeWheres.map(() => [] as Array<{ id: string; startAt: Date | null }>))
+      : Promise.all(
+          scopeWheres.map((where) =>
+            prisma.mission.findMany({
+              where,
+              select: { id: true, startAt: true },
+              orderBy: { startAt: Prisma.SortOrder.desc },
+              take: pageWindow,
+            })
+          )
+        ),
+    Promise.all(scopeWheres.map((where) => missionRepository.count(where))),
+  ]);
+
+  const orderedRows = scopeRows.flatMap((rows, scopeIndex) => rows.map((row, rowIndex) => ({ ...row, scopeIndex, rowIndex }))).sort(compareMissionPageIndexRows);
+  const pageIds = orderedRows.slice(filters.skip, filters.skip + filters.limit).map((row) => row.id);
+
+  return {
+    data: await hydrateMissionPage(pageIds, select, filters.moderationAcceptedFor ?? null),
+    total: scopeCounts.reduce((sum, count) => sum + count, 0),
+  };
+};
+
 export const missionService = {
   async enqueueMissionProcessing(missionId: string): Promise<void> {
     try {
@@ -653,6 +744,11 @@ export const missionService = {
   },
 
   async findMissions(filters: MissionSearchFilters, select: MissionSelect | null = null): Promise<{ data: MissionRecord[]; total: number }> {
+    const splitDiffusionResult = await tryFindMissionsBySplitDiffusionScopes(filters, select);
+    if (splitDiffusionResult) {
+      return splitDiffusionResult;
+    }
+
     const where = await buildWhere(filters);
 
     const [missions, total] = await Promise.all([

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -184,6 +184,8 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
     const filter = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateFilter("diffuseur-1");
 
     expect(filter.publisherIds).toEqual(["annonceur-1", "annonceur-2"]);
+    expect(filter.scopePublisherIds).toEqual(["annonceur-1", "annonceur-2"]);
+    expect(filter.scopes).toEqual([{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }]);
     expect(filter.where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }] });
   });
 });

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -20,6 +20,13 @@ type PublisherDiffusionRuleWithChildren = PublisherDiffusionRule & {
   combinedWith?: PublisherDiffusionRule | null;
 };
 
+type MissionDiffuseurCandidateFilter = {
+  where: Prisma.MissionWhereInput;
+  publisherIds: string[];
+  scopes: Prisma.MissionWhereInput[];
+  scopePublisherIds: string[];
+};
+
 /**
  * Critères communs des scope roots : une racine par annonceur diffusé
  * (`publisherId` du diffuseur + `value` = id de l'annonceur).
@@ -78,13 +85,13 @@ const buildScopeCondition = (rule: PublisherDiffusionRule, childrenByParentId: M
  * annonceur (`publisherId === X`) combiné à ses critères enfants. `publisherIds`
  * restreint optionnellement aux annonceurs demandés (param `publisher` de la route).
  */
-const buildAllowlistFilter = (rules: PublisherDiffusionRule[], publisherIds?: string[]): { where: Prisma.MissionWhereInput; publisherIds: string[] } => {
+const buildAllowlistFilter = (rules: PublisherDiffusionRule[], publisherIds?: string[]): MissionDiffuseurCandidateFilter => {
   const { roots, childrenByParentId } = groupRulesByParent(rules);
 
   if (publisherIds?.length) {
     const configuredPublisherIds = roots.filter((root) => root.field === "publisherId" && root.operator === "is").map((root) => root.value);
     if (configuredPublisherIds.length > 0 && !publisherIds.some((id) => configuredPublisherIds.includes(id))) {
-      return { where: IMPOSSIBLE_MISSION_WHERE, publisherIds: [] };
+      return { where: IMPOSSIBLE_MISSION_WHERE, publisherIds: [], scopes: [], scopePublisherIds: [] };
     }
   }
 
@@ -95,12 +102,13 @@ const buildAllowlistFilter = (rules: PublisherDiffusionRule[], publisherIds?: st
     .filter((scope): scope is Prisma.MissionWhereInput => scope !== null && Object.keys(scope).length > 0);
 
   const candidatePublisherIds = Array.from(new Set(scopeRoots.map((root) => root.value)));
+  const scopePublisherIds = scopeRoots.map((root) => root.value);
 
   if (scopes.length === 0) {
-    return { where: {}, publisherIds: candidatePublisherIds };
+    return { where: {}, publisherIds: candidatePublisherIds, scopes, scopePublisherIds };
   }
   const where = optimizeMissionDiffusionRuleWhere(scopes.length === 1 ? scopes[0] : { OR: scopes });
-  return { where, publisherIds: candidatePublisherIds };
+  return { where, publisherIds: candidatePublisherIds, scopes, scopePublisherIds };
 };
 
 const findOrderedRules = (publisherId: string): Promise<PublisherDiffusionRule[]> =>
@@ -179,7 +187,7 @@ export const publisherDiffusionRuleService = {
     return where;
   },
 
-  async buildMissionDiffuseurCandidateFilter(publisherId: string, publisherIds?: string[]): Promise<{ where: Prisma.MissionWhereInput; publisherIds: string[] }> {
+  async buildMissionDiffuseurCandidateFilter(publisherId: string, publisherIds?: string[]): Promise<MissionDiffuseurCandidateFilter> {
     const rules = await findOrderedRules(publisherId);
     return buildAllowlistFilter(rules, publisherIds);
   },

--- a/api/tests/integration/api/endpoints/v0/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v0/mission.test.ts
@@ -164,6 +164,53 @@ describe("Mission API Integration Tests", () => {
       expect(ids).toEqual(expect.arrayContaining([scopedMissionA.id, scopedMissionB.id]));
     });
 
+    it("should apply organization exclusions when listing multiple diffusion scopes", async () => {
+      const annonceurA = await createTestPublisher({ name: "Excluded List Publisher A" });
+      const annonceurB = await createTestPublisher({ name: "Excluded List Publisher B" });
+      const diffuseur = await createTestPublisher({
+        name: "Excluded List Diffuseur",
+        publishers: [{ publisherId: annonceurA.id }, { publisherId: annonceurB.id }],
+      });
+
+      const includedMissionA = await createTestMission({
+        publisherId: annonceurA.id,
+        title: "Included mission A",
+        clientId: `included-a-${randomUUID()}`,
+        startAt: new Date("2026-01-03"),
+      });
+      const excludedMissionB = await createTestMission({
+        organizationClientId: `excluded-org-${randomUUID()}`,
+        publisherId: annonceurB.id,
+        title: "Excluded mission B",
+        clientId: `excluded-b-${randomUUID()}`,
+        startAt: new Date("2026-01-02"),
+      });
+      const includedMissionB = await createTestMission({
+        organizationClientId: `included-org-${randomUUID()}`,
+        publisherId: annonceurB.id,
+        title: "Included mission B",
+        clientId: `included-b-${randomUUID()}`,
+        startAt: new Date("2026-01-01"),
+      });
+
+      await publisherDiffusionRuleService.createScopedRule({
+        diffuseurPublisherId: diffuseur.id,
+        annonceurPublisherId: annonceurB.id,
+        field: "publisherOrganization.clientId",
+        fieldType: "string",
+        operator: "is_not",
+        value: excludedMissionB.organizationClientId!,
+      });
+
+      const response = await request(app).get("/v0/mission").set("x-api-key", diffuseur.apikey!);
+
+      expect(response.status).toBe(200);
+      expect(response.body.total).toBe(2);
+      const ids = response.body.data.map((mission: any) => mission._id);
+      expect(ids).toEqual(expect.arrayContaining([includedMissionA.id, includedMissionB.id]));
+      expect(ids).not.toContain(excludedMissionB.id);
+    });
+
     it("should expose compensation fields on missions", async () => {
       const response = await request(app).get("/v0/mission").set("x-api-key", apiKey);
       expect(response.status).toBe(200);


### PR DESCRIPTION
## Description

Cette PR optimise la requête de listing `/v0/mission`, identifiée en slow query avec montée CPU en cas d’appels concurrents.

Le problème venait du filtre de diffusion généré sous forme de gros `OR` :

- missions d’un annonceur A ;
- ou missions d’un annonceur B avec exclusions d’organisations ;
- le tout trié par `start_at DESC`.

Dans ce cas, PostgreSQL pouvait choisir un scan global sur `mission_start_at_idx`, puis filtrer `publisher_id`, `status_code`, `deleted_at` et joindre `publisher_organization`. Sous charge, ce plan devient coûteux.

Cette PR ajoute deux optimisations :
1. Un index partiel dédié aux missions publiques actives, triées par annonceur 
2. Un chemin de lecture spécifique pour les règles de diffusion multi-scopes :
- on découpe les scopes annonceurs en requêtes séparées ;
- chaque requête ne récupère que id et startAt ;
- on fusionne les IDs en mémoire ;
- on hydrate uniquement la page finale.

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/Exploration-optimisation-v0-mission-38772a322d50807f983bdb47b54419a3?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [x] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

Une précédente tentative sur la branche `arnaud/refacto/publisher-rule-query-resolution` découpait déjà le gros OR en requêtes par branche, mais chaque branche récupérait directement les missions complètes avec toutes les relations (baseInclude) avant de fusionner les résultats.

Cela pouvait créer un effet multiplicateur : `nombre de branches * (skip + limit) missions complètes hydratées`

Avec plusieurs appels simultanés, cela augmentait fortement :
- le nombre de requêtes SQL
- les jointures sur les relations
- le volume de données transféré
- la pression mémoire côté API
- la pression sur le pool PostgreSQL.
- 
La nouvelle approche limite ce risque : les branches ne chargent que des lignes légères { id, startAt }, puis seules les missions réellement retournées dans la page finale sont hydratées complètement.

Des garde-fous évitent aussi d’appliquer cette stratégie dans les cas risqués :
- maximum 8 scopes de diffusion
- maximum skip + limit = 10 000
- uniquement pour les missions ACCEPTED non supprimées
- uniquement si les scopes sont disjoints par annonceur
- pas d’application aux facets/agrégations.

