### PR TITLE
fix(plateform): mobile feedback fixes

### DIFF
--- a/plateform/app/components/layout/header.tsx
+++ b/plateform/app/components/layout/header.tsx
@@ -1,7 +1,8 @@
-import { Link, useMatches } from "react-router";
+import { Link, useLocation, useMatches } from "react-router";
 
 export default function Header() {
   const matches = useMatches();
+  const location = useLocation();
   const activeMatch = [...matches].reverse().find((m) => m.data != null);
   const routeData = activeMatch?.data as { header?: string; backHref?: string | null } | undefined;
 
@@ -9,6 +10,7 @@ export default function Header() {
     return null;
   }
 
+  const isHome = location.pathname === "/";
   const backHref = routeData?.backHref;
 
   return (
@@ -37,7 +39,7 @@ export default function Header() {
         </div>
       </div>
 
-      {backHref === null ? (
+      {isHome || backHref === null ? (
         <div className="relative flex items-center px-4 py-2 lg:hidden">
           <p className="fr-logo fr-logo--sm mb-0">
             République

--- a/plateform/app/components/quiz/checkbox-group-rich.tsx
+++ b/plateform/app/components/quiz/checkbox-group-rich.tsx
@@ -18,8 +18,10 @@ export default function CheckboxGroupRich({ title, subtitle, onChange, options, 
   };
 
   return (
+    // `block!` : DSFR met fr-fieldset en display:flex, ce qui provoque un bug de layout iOS Safari
+    // (espace fantôme sous le titre après une navigation SPA, corrigé seulement au reload). block l'évite.
     <fieldset
-      className={`fr-fieldset ${error ? "fr-fieldset--error" : ""}`}
+      className={`fr-fieldset block! ${error ? "fr-fieldset--error" : ""}`}
       id="checkbox-group-rich"
       role="group"
       aria-describedby={`checkbox-group-rich-legend ${error && "checkbox-group-rich-messages"}`}

--- a/plateform/app/components/quiz/next-button.tsx
+++ b/plateform/app/components/quiz/next-button.tsx
@@ -21,7 +21,7 @@ export default function NextButton({ onClick, skip = false, ...props }: NextButt
           Voir les missions sans répondre à toutes les questions
         </button>
       )}
-      <div className="fixed inset-x-0 bottom-0 z-10 bg-white p-4 md:static md:bg-transparent md:p-0 md:flex md:flex-row md:gap-6">
+      <div className="fixed inset-x-0 bottom-0 z-10 bg-background p-4 md:static md:bg-transparent md:p-0 md:flex md:flex-row md:gap-6">
         <button type="button" onClick={onClick} className="fr-btn fr-btn--lg w-full! justify-center! md:w-auto!" {...props}>
           Continuer
         </button>

--- a/plateform/app/components/quiz/radio-group-rich.tsx
+++ b/plateform/app/components/quiz/radio-group-rich.tsx
@@ -13,8 +13,9 @@ type Props = {
 
 export default function RadioGroupRich({ title, subtitle, onChange, options, selected, error }: Props) {
   return (
+    // `block!` : contourne un bug de layout iOS Safari sur fr-fieldset (display:flex) — cf checkbox-group-rich.
     <fieldset
-      className={`fr-fieldset ${error ? "fr-fieldset--error" : ""}`}
+      className={`fr-fieldset block! ${error ? "fr-fieldset--error" : ""}`}
       id="radio-group-rich"
       role="group"
       aria-describedby={`radio-group-rich-legend ${error && "radio-group-rich-messages"}`}

--- a/plateform/app/components/quiz/radio-group.tsx
+++ b/plateform/app/components/quiz/radio-group.tsx
@@ -13,8 +13,9 @@ type Props = {
 
 export default function RadioGroup({ title, subtitle, onChange, options, selected, error }: Props) {
   return (
+    // `block!` : contourne un bug de layout iOS Safari sur fr-fieldset (display:flex) — cf checkbox-group-rich.
     <fieldset
-      className={`fr-fieldset ${error ? "fr-fieldset--error" : ""}`}
+      className={`fr-fieldset block! ${error ? "fr-fieldset--error" : ""}`}
       id="radio-group"
       role="group"
       aria-describedby={`radio-group-legend ${error && "radio-group-messages"}`}
@@ -27,7 +28,7 @@ export default function RadioGroup({ title, subtitle, onChange, options, selecte
         {options.map((o) => (
           <div
             key={o.value}
-            className={`fr-fieldset__element mb-0! border bg-white px-4! ${error ? "border-border-plain-error" : "border-border-default-grey"} ${o.disabled ? "opacity-60" : ""}`}
+            className={`fr-fieldset__element mb-0! border bg-background! px-4! ${error ? "border-border-plain-error" : "border-border-default-grey"} ${o.disabled ? "opacity-60" : ""}`}
           >
             <div className="fr-radio-group fr-radio-group--sm mt-0! mb-0! w-full max-w-none!">
               <input

--- a/plateform/app/routes/results.tsx
+++ b/plateform/app/routes/results.tsx
@@ -103,109 +103,107 @@ export default function ResultsPage() {
 
   if (isMobile) {
     return (
-      <main>
-        <section className="relative h-[calc(100dvh-3.5rem)] overflow-hidden">
-          {showMap && (
-            <div className="absolute inset-0 z-0" onClickCapture={handleCollapseSheet}>
-              <LazyMissionMap items={pinnedItems} center={mapCenter} onMarkerClick={handleMarkerClick} activeMissionId={activeMissionId} />
-            </div>
-          )}
+      <main className="flex-1 relative overflow-hidden">
+        {showMap && (
+          <div className="absolute inset-0 z-0" onClickCapture={handleCollapseSheet}>
+            <LazyMissionMap items={pinnedItems} center={mapCenter} onMarkerClick={handleMarkerClick} activeMissionId={activeMissionId} />
+          </div>
+        )}
 
-          {selectedMission && !expanded && (
-            <div
-              key={selectedMission.mission.id}
-              className={`absolute inset-x-3 bottom-3 z-[500] ${isClosingCard ? "animate-slide-down-fade" : "animate-slide-up-fade"}`}
-              onAnimationEnd={() => {
-                if (!isClosingCard) return;
-                setSelectedMission(null);
-                setIsClosingCard(false);
-              }}
-            >
-              <div className="relative">
-                <MissionCard mission={matchResultToBrowseMission(selectedMission)} link={{ type: "internal", to: buildMissionDetailHref(selectedMission, userScoringId) }} />
-                <div className="absolute right-3 top-3 z-10 flex items-center gap-2">
-                  <button
-                    type="button"
-                    className="flex h-8 w-8 items-center justify-center rounded-full bg-background! shadow-md"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      setEmailModalOpen(true);
-                    }}
-                    aria-label="Recevoir par email"
-                  >
-                    <i className="fr-icon-mail-send-line fr-icon--sm" aria-hidden="true" />
-                  </button>
-                  <button
-                    type="button"
-                    className="flex h-8 w-8 items-center justify-center rounded-full bg-background! shadow-md"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      setIsClosingCard(true);
-                    }}
-                    aria-label="Fermer la carte"
-                  >
-                    <i className="fr-icon-close-line fr-icon--sm" aria-hidden="true" />
-                  </button>
-                </div>
+        {selectedMission && !expanded && (
+          <div
+            key={selectedMission.mission.id}
+            className={`absolute inset-x-3 bottom-3 z-[500] ${isClosingCard ? "animate-slide-down-fade" : "animate-slide-up-fade"}`}
+            onAnimationEnd={() => {
+              if (!isClosingCard) return;
+              setSelectedMission(null);
+              setIsClosingCard(false);
+            }}
+          >
+            <div className="relative">
+              <MissionCard mission={matchResultToBrowseMission(selectedMission)} link={{ type: "internal", to: buildMissionDetailHref(selectedMission, userScoringId) }} />
+              <div className="absolute right-3 top-3 z-10 flex items-center gap-2">
+                <button
+                  type="button"
+                  className="flex h-8 w-8 items-center justify-center rounded-full bg-background! shadow-md"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setEmailModalOpen(true);
+                  }}
+                  aria-label="Recevoir par email"
+                >
+                  <i className="fr-icon-mail-send-line fr-icon--sm" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  className="flex h-8 w-8 items-center justify-center rounded-full bg-background! shadow-md"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setIsClosingCard(true);
+                  }}
+                  aria-label="Fermer la carte"
+                >
+                  <i className="fr-icon-close-line fr-icon--sm" aria-hidden="true" />
+                </button>
               </div>
             </div>
-          )}
-
-          <div
-            className={`absolute inset-x-0 bottom-0 z-[1000] flex flex-col rounded-t-3xl bg-background shadow-2xl transition-[top] duration-300 ${expanded ? "top-12" : "top-[calc(100%-5rem)]"} ${selectedMission ? "hidden" : ""}`}
-          >
-            <div className={`flex flex-col gap-2 px-6 py-4 ${expanded ? "items-start!" : "items-center! justify-center! h-full"}`} onClick={handleToggleSheet}>
-              {!loading && error && <p className="fr-error-text m-0! text-center!">{error}</p>}
-              {!loading && !error && (
-                <h2 className={`m-0! ${expanded ? "text-center!" : ""}`}>
-                  <Highlight>
-                    <span className="text-blue-france-sun">
-                      {pinnedItems.length} mission{pinnedItems.length > 1 ? "s" : ""}
-                    </span>
-                  </Highlight>
-                  pour toi
-                </h2>
-              )}
-
-              {expanded && (
-                <Link to={changeAnswersHref} className="fr-link fr-link--sm shrink-0">
-                  <span className="fr-icon-arrow-left-line fr-btn--icon-left" aria-hidden="true" />
-                  Changer mes réponses
-                </Link>
-              )}
-            </div>
-
-            <div ref={scrollRef} className={`flex-1 overflow-y-auto overscroll-contain ${expanded ? "" : "hidden"}`}>
-              <PinnedMissions items={pinnedItems} loading={loading} error={error} userScoringId={userScoringId} showDebug={showDebug} highlightedMissionId={activeMissionId} />
-
-              {showOther && (
-                <div className="px-6 pt-2 pb-8">
-                  <OtherMissions
-                    items={otherItems}
-                    page={page}
-                    hasNextPage={hasNextPage}
-                    pageLoading={pageLoading}
-                    visiblePageNumbers={visiblePageNumbers}
-                    userScoringId={userScoringId}
-                    showDebug={showDebug}
-                    onPageChange={setPage}
-                  />
-                </div>
-              )}
-
-              <Newsletter
-                title="Reçois tes missions par email"
-                subtitle="1 email par mois avec les missions qui pourraient t'intéresser."
-                ctaText="Recevoir mes missions"
-                hintText="En renseignant ton adresse électronique, tu acceptes de recevoir de nouvelles offres de missions. Tu pourras te désinscrire à tout moment."
-              />
-              <Partners style="compact" />
-              <FooterContent />
-            </div>
           </div>
-        </section>
+        )}
+
+        <div
+          className={`absolute inset-x-0 bottom-0 z-[1000] flex flex-col rounded-t-3xl bg-background shadow-2xl transition-[top] duration-300 ${expanded ? "top-12" : "top-[calc(100%-5rem)]"} ${selectedMission ? "hidden" : ""}`}
+        >
+          <div className={`flex flex-col gap-2 px-6 py-4 ${expanded ? "items-start!" : "items-center! justify-center! h-full"}`} onClick={handleToggleSheet}>
+            {!loading && error && <p className="fr-error-text m-0! text-center!">{error}</p>}
+            {!loading && !error && (
+              <h2 className={`m-0! ${expanded ? "text-center!" : ""}`}>
+                <Highlight>
+                  <span className="text-blue-france-sun">
+                    {pinnedItems.length} mission{pinnedItems.length > 1 ? "s" : ""}
+                  </span>
+                </Highlight>
+                pour toi
+              </h2>
+            )}
+
+            {expanded && (
+              <Link to={changeAnswersHref} className="fr-link fr-link--sm shrink-0">
+                <span className="fr-icon-arrow-left-line fr-btn--icon-left" aria-hidden="true" />
+                Changer mes réponses
+              </Link>
+            )}
+          </div>
+
+          <div ref={scrollRef} className={`flex-1 overflow-y-auto overscroll-contain ${expanded ? "" : "hidden"}`}>
+            <PinnedMissions items={pinnedItems} loading={loading} error={error} userScoringId={userScoringId} showDebug={showDebug} highlightedMissionId={activeMissionId} />
+
+            {showOther && (
+              <div className="px-6 pt-2 pb-8">
+                <OtherMissions
+                  items={otherItems}
+                  page={page}
+                  hasNextPage={hasNextPage}
+                  pageLoading={pageLoading}
+                  visiblePageNumbers={visiblePageNumbers}
+                  userScoringId={userScoringId}
+                  showDebug={showDebug}
+                  onPageChange={setPage}
+                />
+              </div>
+            )}
+
+            <Newsletter
+              title="Reçois tes missions par email"
+              subtitle="1 email par mois avec les missions qui pourraient t'intéresser."
+              ctaText="Recevoir mes missions"
+              hintText="En renseignant ton adresse électronique, tu acceptes de recevoir de nouvelles offres de missions. Tu pourras te désinscrire à tout moment."
+            />
+            <Partners style="compact" />
+            <FooterContent />
+          </div>
+        </div>
 
         <MatchingDebugModal items={[...pinnedItems, ...otherItems]} userValues={userValues} />
         <EmailMissionsModal userScoringId={userScoringId} open={emailModalOpen} onOpenChange={setEmailModalOpen} hideTrigger />
@@ -268,7 +266,10 @@ export default function ResultsPage() {
                       }}
                     >
                       <div className="relative">
-                        <MissionCard mission={matchResultToBrowseMission(selectedMission)} link={{ type: "internal", to: buildMissionDetailHref(selectedMission, userScoringId) }} />
+                        <MissionCard
+                          mission={matchResultToBrowseMission(selectedMission)}
+                          link={{ type: "internal", to: buildMissionDetailHref(selectedMission, userScoringId) }}
+                        />
                         <div className="absolute right-3 top-3 z-10 flex items-center gap-2">
                           <button
                             type="button"


### PR DESCRIPTION
## Description

Corrige plusieurs retours de feedback mobile sur la plateforme (parcours quiz + header).

**Changements** :
- `header.tsx` : affiche le bloc logo « République Française » sur la page d'accueil (`isHome`), en plus du cas `backHref === null`.
- `checkbox-group-rich.tsx`, `radio-group-rich.tsx`, `radio-group.tsx` : ajout de la classe `block!` sur `fr-fieldset` pour contourner un bug de layout iOS Safari (le DSFR met `fr-fieldset` en `display:flex`, ce qui provoque un espace fantôme sous le titre après une navigation SPA, corrigé seulement au reload).
- `next-button.tsx` et `radio-group.tsx` : remplacement de `bg-white` par `bg-background` pour respecter la couleur de fond du thème.

## Liens utiles

- 📝 Ticket Notion : [Erreur espacement](https://app.notion.com/p/jeveuxaider/Plusieurs-crans-font-appara-tre-un-espacement-sur-mobile-apr-s-la-question-motivation-38972a322d508036902bd41e71deb9e8?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)
- 📝 Ticket Notion : [Erreur sur la carte](https://app.notion.com/p/jeveuxaider/Sur-mobile-le-bottom-panel-sur-la-page-de-r-sulat-de-la-PDE-n-est-pas-tendanble-et-reste-blac-38972a322d508083bdf8f43e05250d97?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Points d'attention** :
- Le fix `block!` est un contournement du comportement DSFR sur iOS Safari — un commentaire explicatif est présent dans chaque fieldset concerné.
- Changements purement UI/CSS, aucune migration ni dépendance ajoutée.