### PR TITLE
fix(api): add indexes to speed up myorganization clicks query

### DIFF
--- a/api/prisma/migrations/20260701120000_add_mission_org_and_org_client_id_indexes/migration.sql
+++ b/api/prisma/migrations/20260701120000_add_mission_org_and_org_client_id_indexes/migration.sql
@@ -1,0 +1,10 @@
+-- CreateIndex
+-- Permet de résoudre une organisation par son client_id, puis de récupérer ses missions
+-- (jointure stat_event -> mission -> publisher_organization filtrée sur po.client_id).
+-- Sans ces index, le planner part de stat_event et scanne tous les clics des diffuseurs
+-- sur 30 jours avant de filtrer sur l'organisation (cf. GET /v0/myorganization/:id).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "publisher_organization_client_id_idx"
+ON "public"."publisher_organization" ("client_id");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "mission_publisher_organization_id_idx"
+ON "public"."mission" ("publisher_organization_id");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -649,6 +649,7 @@ model Mission {
   @@index([domainId], map: "mission_domain_id_idx")
   @@index([deletedAt], map: "mission_deleted_at_idx")
   @@index([statusCode], map: "mission_status_code_idx")
+  @@index([publisherOrganizationId], map: "mission_publisher_organization_id_idx")
   // Partial index managed manually in migration (Prisma doesn't support WHERE clause on indexes)
   // CREATE INDEX "mission_publisher_active_idx" ON "mission" (publisher_id, id)
   // WHERE deleted_at IS NULL AND status_code = 'ACCEPTED'
@@ -689,6 +690,7 @@ model PublisherOrganization {
 
   @@unique([publisherId, clientId], map: "publisher_organization_publisher_id_client_id_key")
   @@index([publisherId], map: "publisher_organization_publisher_id_idx")
+  @@index([clientId], map: "publisher_organization_client_id_idx")
   @@index([name], map: "publisher_organization_name_idx")
   // Supporte le filtrage des diffusion rules sur `parentOrganizations` (`has` → `@>`) côté v0/mission.
   @@index([parentOrganizations], type: Gin, map: "publisher_organization_parent_organizations_idx")


### PR DESCRIPTION
## Description

Corrige la lenteur de la route `GET /v0/myorganization/:organizationClientId`, dont la requête d'agrégation des clics par diffuseur pouvait scanner des millions d'événements.

**Cause** : la seule condition sélective est `po.client_id = $1` (une organisation), mais Postgres ne pouvait pas piloter la requête par l'organisation :
- `publisher_organization` n'avait aucun index sur `client_id` seul (l'unique `(publisher_id, client_id)` place `client_id` en 2ᵉ position, inutilisable pour un lookup par `client_id` seul).
- `mission` n'avait aucun index sur `publisher_organization_id` (Postgres n'indexe pas les FK automatiquement).

Le planner partait donc de `stat_event` et scannait tous les clics des ~268 diffuseurs (gros agrégateurs) sur 30 jours avant de filtrer sur l'organisation.

**Changements** :
- Ajout d'un index btree `mission_publisher_organization_id_idx` sur `mission (publisher_organization_id)`.
- Ajout d'un index btree `publisher_organization_client_id_idx` sur `publisher_organization (client_id)`.

Le nouveau plan devient : `publisher_organization` par `client_id` → missions de l'org par `publisher_organization_id` → clics par mission via l'index existant `stats_event_mission_is_bot_type_from_publisher_idx`.

## Liens

- [Ticket Notion](https://app.notion.com/p/jeveuxaider/Slow-query-sur-v0-myorganization-id-38772a322d50805bbbaaed9604a5ede6?v=1f872a322d5080a38ab2000ce606db06&source=copy_link) 

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [x] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

**Migrations DB** :
- `20260701120000_add_mission_org_and_org_client_id_indexes` : création des deux index.

**Points d'attention** :
- Les index sont créés en `CREATE INDEX CONCURRENTLY IF NOT EXISTS` (pas de verrou sur `mission` en production, migration idempotente), selon le pattern déjà utilisé dans le dépôt pour les index sur grosses tables.
- Aucun changement de code applicatif : la requête devient rapide une fois les index en place.