### PR TITLE
fix(plateform): missions radio filters on mobile

### DIFF
--- a/plateform/app/components/missions/filters.tsx
+++ b/plateform/app/components/missions/filters.tsx
@@ -180,10 +180,6 @@ function FilterAccordion({ filter, open, onToggleOpen, onChange }: FilterAccordi
 
   const toggleOption = (value: string) => {
     const isSelected = filter.selected.includes(value);
-    if (isSingle) {
-      onChange(isSelected ? [] : [value]);
-      return;
-    }
     onChange(isSelected ? filter.selected.filter((current) => current !== value) : [...filter.selected, value]);
   };
 
@@ -198,7 +194,7 @@ function FilterAccordion({ filter, open, onToggleOpen, onChange }: FilterAccordi
         <div className="mt-3 flex flex-col gap-2">
           {isSingle && (
             <div className="fr-radio-group">
-              <input type="radio" id={`${reactId}-all`} name={`${reactId}-group`} checked={filter.selected.length === 0} onChange={() => {}} onClick={() => onChange([])} />
+              <input type="radio" id={`${reactId}-all`} name={`${reactId}-group`} checked={filter.selected.length === 0} onChange={() => onChange([])} />
               <label className="fr-label" htmlFor={`${reactId}-all`}>
                 {filter.placeholder}
               </label>
@@ -210,14 +206,15 @@ function FilterAccordion({ filter, open, onToggleOpen, onChange }: FilterAccordi
             return (
               <div key={option.value} className="flex items-center justify-between gap-3">
                 <div className={isSingle ? "fr-radio-group" : "fr-checkbox-group"}>
-                  {/* Radio : `change` ne se déclenche pas au clic sur une valeur déjà cochée, on passe par `click` pour permettre la désélection. */}
+                  {/* Radio : la sélection passe par `change` (émis aussi au clavier) ; `click` ne sert qu'à
+                      désélectionner un radio déjà coché, seul cas où `change` ne peut pas se produire. */}
                   <input
                     type={isSingle ? "radio" : "checkbox"}
                     id={inputId}
                     name={isSingle ? `${reactId}-group` : undefined}
                     checked={isSelected}
-                    onChange={isSingle ? () => {} : () => toggleOption(option.value)}
-                    onClick={isSingle ? () => toggleOption(option.value) : undefined}
+                    onChange={() => (isSingle ? onChange([option.value]) : toggleOption(option.value))}
+                    onClick={isSingle && isSelected ? () => onChange([]) : undefined}
                   />
                   <label className="fr-label" htmlFor={inputId}>
                     {option.label}

--- a/plateform/app/components/missions/filters.tsx
+++ b/plateform/app/components/missions/filters.tsx
@@ -202,12 +202,14 @@ function FilterAccordion({ filter, open, onToggleOpen, onChange }: FilterAccordi
             return (
               <div key={option.value} className="flex items-center justify-between gap-3">
                 <div className={isSingle ? "fr-radio-group" : "fr-checkbox-group"}>
+                  {/* Radio : `change` ne se déclenche pas au clic sur une valeur déjà cochée, on passe par `click` pour permettre la désélection. */}
                   <input
                     type={isSingle ? "radio" : "checkbox"}
                     id={inputId}
                     name={isSingle ? `${reactId}-group` : undefined}
                     checked={isSelected}
-                    onChange={() => toggleOption(option.value)}
+                    onChange={isSingle ? () => {} : () => toggleOption(option.value)}
+                    onClick={isSingle ? () => toggleOption(option.value) : undefined}
                   />
                   <label className="fr-label" htmlFor={inputId}>
                     {option.label}

--- a/plateform/app/components/missions/filters.tsx
+++ b/plateform/app/components/missions/filters.tsx
@@ -196,6 +196,14 @@ function FilterAccordion({ filter, open, onToggleOpen, onChange }: FilterAccordi
 
       {open && (
         <div className="mt-3 flex flex-col gap-2">
+          {isSingle && (
+            <div className="fr-radio-group">
+              <input type="radio" id={`${reactId}-all`} name={`${reactId}-group`} checked={filter.selected.length === 0} onChange={() => {}} onClick={() => onChange([])} />
+              <label className="fr-label" htmlFor={`${reactId}-all`}>
+                {filter.placeholder}
+              </label>
+            </div>
+          )}
           {filter.options.map((option) => {
             const inputId = `${reactId}-${option.value}`;
             const isSelected = filter.selected.includes(option.value);

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -39,20 +39,11 @@ const buildTaxonomyFilterOptions = (key: FilterKey, facets: MissionBrowseFacetCo
   const taxonomyValues = TAXONOMY[key].values as Record<string, TaxonomyFilterValue>;
   const countByKey = new Map((facets ?? []).map((facet) => [facet.key, facet.count]));
 
-  const options = Object.entries(taxonomyValues).flatMap(([value, taxonomyValue]) => {
+  return Object.entries(taxonomyValues).flatMap(([value, taxonomyValue]) => {
     const count = countByKey.get(value) ?? 0;
-    countByKey.delete(value);
     if (taxonomyValue.hidden === true || count === 0) return [];
     return [{ value, label: taxonomyValue.label, count }];
   });
-
-  // Facettes hors taxonomie (données inattendues) : affichées en fin de liste, par volume décroissant.
-  const extras = [...countByKey.entries()]
-    .filter(([, count]) => count > 0)
-    .sort((a, b) => b[1] - a[1])
-    .map(([value, count]) => ({ value, label: value, count }));
-
-  return [...options, ...extras];
 };
 
 const getFilterValues = (searchParams: URLSearchParams): Record<FilterKey, string[]> =>

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -34,27 +34,25 @@ const FILTER_TYPE_BY_KEY: Record<FilterKey, MissionsFilterType> = {
 type BrowseParams = MissionBrowseFilters;
 type TaxonomyFilterValue = { label: string; hidden?: boolean };
 
-const sortFacets = (facets: MissionBrowseFacetCount[] | undefined) =>
-  (facets ?? [])
-    .filter((f) => f.count > 0)
-    .slice()
-    .sort((a, b) => b.count - a.count);
-
+// Les options suivent l'ordre de déclaration des valeurs dans TAXONOMY (pas le nombre de résultats).
 const buildTaxonomyFilterOptions = (key: FilterKey, facets: MissionBrowseFacetCount[] | undefined) => {
   const taxonomyValues = TAXONOMY[key].values as Record<string, TaxonomyFilterValue>;
+  const countByKey = new Map((facets ?? []).map((facet) => [facet.key, facet.count]));
 
-  return sortFacets(facets).flatMap((facet) => {
-    const taxonomyValue = taxonomyValues[facet.key];
-    if (taxonomyValue?.hidden === true) return [];
-
-    return [
-      {
-        value: facet.key,
-        label: taxonomyValue?.label ?? facet.key,
-        count: facet.count,
-      },
-    ];
+  const options = Object.entries(taxonomyValues).flatMap(([value, taxonomyValue]) => {
+    const count = countByKey.get(value) ?? 0;
+    countByKey.delete(value);
+    if (taxonomyValue.hidden === true || count === 0) return [];
+    return [{ value, label: taxonomyValue.label, count }];
   });
+
+  // Facettes hors taxonomie (données inattendues) : affichées en fin de liste, par volume décroissant.
+  const extras = [...countByKey.entries()]
+    .filter(([, count]) => count > 0)
+    .sort((a, b) => b[1] - a[1])
+    .map(([value, count]) => ({ value, label: value, count }));
+
+  return [...options, ...extras];
 };
 
 const getFilterValues = (searchParams: URLSearchParams): Record<FilterKey, string[]> =>


### PR DESCRIPTION
## Description

Corrections sur les filtres de la page `/missions` (plateforme) :

1. **Radio désélectionnable (filtres mobiles)** : sur un radio button déjà coché, l'événement `change` ne se déclenche jamais, ce qui rendait la désélection impossible. La bascule passe désormais par `click`, qui se déclenche toujours : un clic sur la valeur sélectionnée la désactive, comme pour une checkbox. 

2. **Ordre stable des options de filtres** : les options étaient triées par nombre de résultats, ce qui produisait un ordre changeant et perturbant (notamment pour les tranches d'âge). Elles suivent maintenant l'ordre de déclaration des valeurs dans `@engagement/taxonomy`, source de vérité du référentiel.

Les valeurs `hidden` et celles sans résultat restent masquées. Seules les valeurs présentes dans la taxonomy sont affichées (l'ancien fallback qui affichait les clés brutes inconnues est supprimé).

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/Q-A-Page-missions-38a72a322d508088b977cca73aa4f5ff?source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement (parcours mobile vérifié manuellement + typecheck)
- [ ] Tests unitaires ajoutés/modifiés si nécessaire (pas de nouvelle logique pure)
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire (non concerné)
