### PR TITLE
feat(plateform): page view events

### DIFF
--- a/plateform/app/routes/_index.tsx
+++ b/plateform/app/routes/_index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { useLoaderData, useNavigate } from "react-router";
 import Hero from "~/components/landing/hero";
 import HowItWorks from "~/components/landing/how-it-works";
@@ -8,6 +9,7 @@ import Newsletter from "~/components/layout/newsletter";
 import Partners from "~/components/layout/partners";
 import GradientBg from "~/components/ui/gradient-bg";
 import { browseMissions } from "~/services/api/missions";
+import { trackPageViewed } from "~/services/tracking/events";
 import { useQuizStore } from "~/stores/quiz";
 
 export async function clientLoader({ serverLoader }: Route.ClientLoaderArgs) {
@@ -47,6 +49,13 @@ export default function Landing() {
   const { examples } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
   const reset = useQuizStore((s) => s.reset);
+  const pageViewedFired = useRef(false);
+
+  useEffect(() => {
+    if (pageViewedFired.current) return;
+    pageViewedFired.current = true;
+    trackPageViewed({ pageName: "homepage" });
+  }, []);
 
   const handleStartQuiz = () => {
     reset();

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -105,6 +105,10 @@ export default function MissionsPage() {
     setLoading(true);
     setError(null);
 
+    // Consommé par cette requête : si elle est abortée ou échoue, l'event de filtre est abandonné.
+    const pendingFilterTrack = pendingFilterTrackRef.current;
+    pendingFilterTrackRef.current = null;
+
     const browseInput: BrowseParams = { page, pageSize: PAGE_SIZE };
     if (filterValues.departmentCode.length) browseInput.departmentCode = filterValues.departmentCode;
     if (filterValues.dispositif.length) browseInput.dispositif = filterValues.dispositif;
@@ -119,17 +123,12 @@ export default function MissionsPage() {
         setTotal(res.total);
         setFacets(res.facets);
 
-        const pendingFilterTrack = pendingFilterTrackRef.current;
         if (pendingFilterTrack) {
-          pendingFilterTrackRef.current = null;
           trackMissionsFilterApplied({ ...pendingFilterTrack, resultsCount: res.total });
         }
       })
       .catch((err) => {
         if (controller.signal.aborted) return;
-        // Recherche en échec : on abandonne le tracking du filtre plutôt que d'émettre
-        // un results_count erroné lors d'un fetch ultérieur (ex. pagination).
-        pendingFilterTrackRef.current = null;
         setError(err instanceof Error ? err.message : "Erreur inconnue");
       })
       .finally(() => {
@@ -192,9 +191,8 @@ export default function MissionsPage() {
     if (!FILTER_KEYS.includes(key as FilterKey)) return;
     const filterKey = key as FilterKey;
 
-    // missions_filter.applied : on émet uniquement lors d'une sélection (valeur ajoutée),
-    // pas lors d'une désélection. active_filter_count = total des valeurs actives après ce changement.
-    // L'event part au retour de la recherche (cf. pendingFilterTrackRef) pour porter results_count.
+    // missions_filter.applied : émis uniquement lors d'une sélection (pas la désélection),
+    // au retour de la recherche pour porter results_count.
     const addedValue = next.find((value) => !filterValues[filterKey].includes(value));
     if (addedValue) {
       const activeFilterCount = FILTER_KEYS.reduce((sum, k) => sum + (k === filterKey ? next.length : filterValues[k].length), 0);

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -1,7 +1,7 @@
 import type { MissionBrowse, MissionBrowseFacetCount, MissionBrowseFilters } from "@engagement/dto";
 import { TAXONOMY } from "@engagement/taxonomy";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useSearchParams } from "react-router";
 import Newsletter from "~/components/layout/newsletter";
@@ -11,7 +11,7 @@ import MissionCard from "~/components/missions/mission-card";
 import GradientBg from "~/components/ui/gradient-bg";
 import Pagination from "~/components/ui/pagination";
 import { browseMissions } from "~/services/mission-browse";
-import { trackMissionClickedFromBrowse, trackMissionsFilterApplied } from "~/services/tracking/events";
+import { trackMissionClickedFromBrowse, trackMissionsFilterApplied, trackPageViewed } from "~/services/tracking/events";
 import type { MissionDetailNavState, MissionsFilterType } from "~/services/tracking/types";
 import type { Route } from "./+types/missions";
 
@@ -90,6 +90,16 @@ export default function MissionsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const pageViewedFired = useRef(false);
+  // Filtre appliqué en attente de tracking : results_count n'est connu qu'au retour de la recherche.
+  const pendingFilterTrackRef = useRef<{ filterType: MissionsFilterType; filterValue: string; activeFilterCount: number } | null>(null);
+
+  useEffect(() => {
+    if (pageViewedFired.current) return;
+    pageViewedFired.current = true;
+    trackPageViewed({ pageName: "missions_list" });
+  }, []);
+
   useEffect(() => {
     const controller = new AbortController();
     setLoading(true);
@@ -108,9 +118,18 @@ export default function MissionsPage() {
         setItems(res.data);
         setTotal(res.total);
         setFacets(res.facets);
+
+        const pendingFilterTrack = pendingFilterTrackRef.current;
+        if (pendingFilterTrack) {
+          pendingFilterTrackRef.current = null;
+          trackMissionsFilterApplied({ ...pendingFilterTrack, resultsCount: res.total });
+        }
       })
       .catch((err) => {
         if (controller.signal.aborted) return;
+        // Recherche en échec : on abandonne le tracking du filtre plutôt que d'émettre
+        // un results_count erroné lors d'un fetch ultérieur (ex. pagination).
+        pendingFilterTrackRef.current = null;
         setError(err instanceof Error ? err.message : "Erreur inconnue");
       })
       .finally(() => {
@@ -175,10 +194,11 @@ export default function MissionsPage() {
 
     // missions_filter.applied : on émet uniquement lors d'une sélection (valeur ajoutée),
     // pas lors d'une désélection. active_filter_count = total des valeurs actives après ce changement.
+    // L'event part au retour de la recherche (cf. pendingFilterTrackRef) pour porter results_count.
     const addedValue = next.find((value) => !filterValues[filterKey].includes(value));
     if (addedValue) {
       const activeFilterCount = FILTER_KEYS.reduce((sum, k) => sum + (k === filterKey ? next.length : filterValues[k].length), 0);
-      trackMissionsFilterApplied({ filterType: FILTER_TYPE_BY_KEY[filterKey], filterValue: addedValue, activeFilterCount });
+      pendingFilterTrackRef.current = { filterType: FILTER_TYPE_BY_KEY[filterKey], filterValue: addedValue, activeFilterCount };
     }
 
     setSearchParams((prev) => {

--- a/plateform/app/services/tracking/events.ts
+++ b/plateform/app/services/tracking/events.ts
@@ -13,6 +13,7 @@ import type {
   MissionClickedSection,
   MissionDetailEntrySource,
   MissionsFilterType,
+  PageViewedPageName,
   QuizCompletionType,
   QuizEntrySource,
 } from "./types";
@@ -28,6 +29,7 @@ import { ANSWER_VALUE_EXCLUDED_STEPS, buildQuizPath, countAnsweredSteps, optionA
 
 // Catégorie de chaque évènement (documentation/priorisation, non transmise à PostHog).
 export const EVENT_CATALOG = {
+  "page.viewed": "lifecycle",
   "quiz.started": "lifecycle",
   "quiz.step_completed": "core_value",
   "quiz.completed": "core_value",
@@ -40,6 +42,15 @@ export const EVENT_CATALOG = {
   "email_missions.sent": "feature_usage",
   "email_mission_detail.sent": "feature_usage",
 } satisfies Record<string, EventCategory>;
+
+// ============================================================================
+// page.viewed
+// ============================================================================
+
+// `page.viewed` (lifecycle) : visite d'une page (pageview manuel, capture_pageview désactivé).
+export function trackPageViewed(params: { pageName: PageViewedPageName }): void {
+  track("page.viewed", { page_name: params.pageName });
+}
 
 // ============================================================================
 // mission.clicked
@@ -209,11 +220,13 @@ export function trackMissionDetailViewed(params: {
 // ============================================================================
 
 // `missions_filter.applied` (feature_usage) : sélection d'une valeur de filtre sur /missions.
-export function trackMissionsFilterApplied(params: { filterType: MissionsFilterType; filterValue: string; activeFilterCount: number }): void {
+// Émis après le retour de la recherche : results_count = nombre de missions après application du filtre.
+export function trackMissionsFilterApplied(params: { filterType: MissionsFilterType; filterValue: string; activeFilterCount: number; resultsCount: number }): void {
   track("missions_filter.applied", {
     filter_type: params.filterType,
     filter_value: params.filterValue,
     active_filter_count: params.activeFilterCount,
+    results_count: params.resultsCount,
   });
 }
 

--- a/plateform/app/services/tracking/index.ts
+++ b/plateform/app/services/tracking/index.ts
@@ -19,6 +19,8 @@ function getProvider(): TrackingProvider | null {
   if (!provider) {
     provider = createProvider(TRACKING_PROVIDER as TrackingProviderName);
     provider.init?.();
+    // Identify + super properties avant la première capture (un track() de route peut précéder initTracking()).
+    bootstrapIdentity();
   }
   return provider;
 }
@@ -36,12 +38,10 @@ function syncIdentitySuperProperties(state: { quizAttemptId: string; userScoring
   });
 }
 
-// Initialise le tracking côté client : identifie l'utilisateur par le `distinctId` persistant du
-// quiz (réconciliation des sessions dans PostHog, consentement assumé pour l'instant) et enregistre
-// les super properties d'identité, maintenues à jour via un abonnement au store.
+// Bootstrap d'identité (une seule fois, à l'init du provider) : identify par le `distinctId`
+// persistant du quiz et super properties d'identité, maintenues à jour via un abonnement au store.
 // TODO(cookie-banner) : sans consentement, ne pas appeler `identify` (rester anonyme/cookieless).
-export function initTracking(): void {
-  if (!getProvider()) return;
+function bootstrapIdentity(): void {
   identify(useQuizStore.getState().distinctId);
   syncIdentitySuperProperties(useQuizStore.getState());
 
@@ -53,6 +53,11 @@ export function initTracking(): void {
     lastSessionId = state.userScoringId;
     syncIdentitySuperProperties(state);
   });
+}
+
+// Déclenche l'init paresseuse (provider + identité) au plus tôt, sans attendre un premier track().
+export function initTracking(): void {
+  getProvider();
 }
 
 // Force l'enregistrement du quiz_session_id (ex. accès direct à /results/:id où l'id vient de l'URL

--- a/plateform/app/services/tracking/types.ts
+++ b/plateform/app/services/tracking/types.ts
@@ -35,6 +35,10 @@ export type TrackingProviderName = "local" | "posthog";
 // Catégorie du plan de télémétrie (documentation/priorisation, non envoyée à PostHog).
 export type EventCategory = "lifecycle" | "core_value" | "feature_usage";
 
+// --- page.viewed ---
+// Page visitée (discriminant du pageview manuel : capture_pageview est désactivé côté PostHog).
+export type PageViewedPageName = "homepage" | "missions_list";
+
 // --- mission.clicked ---
 // Surface d'où provient le clic sur une carte mission.
 export type MissionClickedSection = "pinned" | "other" | "homepage_examples" | "missions_list" | "similar";


### PR DESCRIPTION
## Description

Ajoute les événements PostHog manquants sur `plateform/` conformément à la spec produit, en s'appuyant sur le service de tracking existant (`app/services/tracking/`) :

- **`page.viewed`** (nouveau, catégorie `lifecycle`) : pageview manuel (le `capture_pageview` automatique de PostHog est volontairement désactivé), émis une seule fois au mount avec `page_name` comme propriété discriminante :
  - `homepage` sur `/`
  - `missions_list` sur `/missions`
- **`missions_filter.applied`** (étendu) : ajout de la propriété `results_count` (nombre de missions retournées après application du filtre). L'événement est désormais émis **au retour de la recherche** (et non plus au clic) afin de porter le compte réel — le payload est mis en attente dans un ref le temps du fetch. Les propriétés existantes (`filter_type`, `filter_value`, `active_filter_count`) sont conservées telles quelles.

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/Cr-er-de-nouveaux-events-pour-tracker-les-visites-sur-la-HP-et-missions-39172a322d5080b9ba05c1d26c2ce465?v=a893fbb6a11e4e0d9731ba131b675132&source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire (pas de logique pure nouvelle ; suite existante passante : 68 tests)
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
