### PR TITLE
feat(plateform): disable tracking for internal user

### DIFF
--- a/plateform/app/components/layout/internal-user-flag-indicator.tsx
+++ b/plateform/app/components/layout/internal-user-flag-indicator.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { disableInternalUserFlag } from "~/services/tracking";
+import { isInternalUserFlagEnabled } from "~/utils/internal-user-flag";
+
+export default function InternalUserFlagIndicator() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    try {
+      setVisible(isInternalUserFlagEnabled(window.location.search, window.localStorage));
+    } catch {
+      setVisible(isInternalUserFlagEnabled(window.location.search, { getItem: () => null }));
+    }
+  }, []);
+
+  function handleReactivateTracking() {
+    disableInternalUserFlag();
+    const url = new URL(window.location.href);
+    url.searchParams.delete("internal");
+    window.history.replaceState(window.history.state, "", url);
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div className="group fixed bottom-3 left-3 z-[2000] flex items-end gap-2">
+      <button
+        type="button"
+        className="flex size-11 items-center justify-center rounded-full bg-title-grey text-background shadow-card"
+        aria-label="Navigation interne exclue des statistiques"
+        aria-describedby="internal-user-flag-help"
+      >
+        <span className="fr-icon-eye-off-line fr-icon--sm" aria-hidden="true" />
+      </button>
+      <div
+        id="internal-user-flag-help"
+        className="pointer-events-none mb-0 hidden w-72 rounded-md border border-border-default-grey bg-background p-3 text-title-grey shadow-card group-hover:block group-focus-within:block"
+      >
+        <p className="fr-text--sm mb-2!">
+          Mode interne actif : les prochains événements de ce navigateur sont marqués <strong>internal_user</strong> et peuvent être exclus des statistiques.
+        </p>
+        <button type="button" className="fr-btn fr-btn--sm fr-btn--secondary pointer-events-auto w-full! justify-center!" onClick={handleReactivateTracking}>
+          Réactiver le tracking
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/plateform/app/root.tsx
+++ b/plateform/app/root.tsx
@@ -8,6 +8,7 @@ import { type ReactNode, useEffect } from "react";
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
 import Footer from "~/components/layout/footer";
 import Header from "~/components/layout/header";
+import InternalUserFlagIndicator from "~/components/layout/internal-user-flag-indicator";
 import { PUBLISHER_ID } from "~/services/config";
 import { initTracking } from "~/services/tracking";
 import { serializeForInlineScript } from "~/utils/string";
@@ -52,6 +53,7 @@ export default function Root() {
       <Header />
       <Outlet />
       <Footer />
+      <InternalUserFlagIndicator />
     </>
   );
 }

--- a/plateform/app/services/tracking/index.ts
+++ b/plateform/app/services/tracking/index.ts
@@ -1,6 +1,6 @@
 import { TRACKING_PROVIDER } from "~/services/config";
 import { useQuizStore } from "~/stores/quiz";
-import { getInternalUserFlagAction, persistInternalUserFlagAction } from "~/utils/internal-user-flag";
+import { getInternalUserFlagAction, isInternalUserFlagEnabled, persistInternalUserFlagAction } from "~/utils/internal-user-flag";
 
 import { createProvider } from "./providers";
 import type { TrackingProperties, TrackingProvider, TrackingProviderName, TrackingTraits } from "./types";
@@ -39,22 +39,20 @@ function syncIdentitySuperProperties(state: { quizAttemptId: string; userScoring
 
 function syncInternalUserFlag(provider: TrackingProvider): void {
   const action = getInternalUserFlagAction(window.location.search);
+  let enabled = action === "enable";
   try {
     persistInternalUserFlagAction(action, window.localStorage);
+    enabled = isInternalUserFlagEnabled(window.location.search, window.localStorage);
   } catch {
     // Le marqueur UI ne doit pas empêcher la synchronisation PostHog.
   }
 
-  switch (action) {
-    case "enable":
-      provider.register?.({ internal_user: true });
-      break;
-    case "disable":
-      provider.unregister?.("internal_user");
-      break;
-    case "none":
-      break;
+  if (enabled) {
+    provider.register?.({ internal_user: true });
+    return;
   }
+
+  provider.unregister?.("internal_user");
 }
 
 // Initialise le tracking côté client : identifie l'utilisateur par le `distinctId` persistant du

--- a/plateform/app/services/tracking/index.ts
+++ b/plateform/app/services/tracking/index.ts
@@ -1,6 +1,6 @@
 import { TRACKING_PROVIDER } from "~/services/config";
 import { useQuizStore } from "~/stores/quiz";
-import { getInternalUserFlagAction } from "~/utils/internal-user-flag";
+import { getInternalUserFlagAction, persistInternalUserFlagAction } from "~/utils/internal-user-flag";
 
 import { createProvider } from "./providers";
 import type { TrackingProperties, TrackingProvider, TrackingProviderName, TrackingTraits } from "./types";
@@ -38,7 +38,14 @@ function syncIdentitySuperProperties(state: { quizAttemptId: string; userScoring
 }
 
 function syncInternalUserFlag(provider: TrackingProvider): void {
-  switch (getInternalUserFlagAction(window.location.search)) {
+  const action = getInternalUserFlagAction(window.location.search);
+  try {
+    persistInternalUserFlagAction(action, window.localStorage);
+  } catch {
+    // Le marqueur UI ne doit pas empêcher la synchronisation PostHog.
+  }
+
+  switch (action) {
     case "enable":
       provider.register?.({ internal_user: true });
       break;
@@ -75,6 +82,20 @@ export function initTracking(): void {
 // et non du store). No-op pendant le SSR.
 export function setQuizSessionId(userScoringId: string): void {
   getProvider()?.register?.({ quiz_session_id: userScoringId });
+}
+
+// Désactive le flag interne depuis l'UI de debug. No-op pendant le SSR.
+export function disableInternalUserFlag(): void {
+  const provider = getProvider();
+  if (!provider) return;
+
+  try {
+    persistInternalUserFlagAction("disable", window.localStorage);
+  } catch {
+    // Le marqueur UI ne doit pas empêcher la synchronisation PostHog.
+  }
+
+  provider.unregister?.("internal_user");
 }
 
 // Retire les clés à valeur `undefined` : permet aux events de passer une propriété optionnelle

--- a/plateform/app/services/tracking/index.ts
+++ b/plateform/app/services/tracking/index.ts
@@ -20,6 +20,7 @@ function getProvider(): TrackingProvider | null {
   if (!provider) {
     provider = createProvider(TRACKING_PROVIDER as TrackingProviderName);
     provider.init?.();
+    syncInternalUserFlag(provider);
   }
   return provider;
 }

--- a/plateform/app/services/tracking/index.ts
+++ b/plateform/app/services/tracking/index.ts
@@ -1,5 +1,6 @@
 import { TRACKING_PROVIDER } from "~/services/config";
 import { useQuizStore } from "~/stores/quiz";
+import { getInternalUserFlagAction } from "~/utils/internal-user-flag";
 
 import { createProvider } from "./providers";
 import type { TrackingProperties, TrackingProvider, TrackingProviderName, TrackingTraits } from "./types";
@@ -36,12 +37,27 @@ function syncIdentitySuperProperties(state: { quizAttemptId: string; userScoring
   });
 }
 
+function syncInternalUserFlag(provider: TrackingProvider): void {
+  switch (getInternalUserFlagAction(window.location.search)) {
+    case "enable":
+      provider.register?.({ internal_user: true });
+      break;
+    case "disable":
+      provider.unregister?.("internal_user");
+      break;
+    case "none":
+      break;
+  }
+}
+
 // Initialise le tracking côté client : identifie l'utilisateur par le `distinctId` persistant du
 // quiz (réconciliation des sessions dans PostHog, consentement assumé pour l'instant) et enregistre
 // les super properties d'identité, maintenues à jour via un abonnement au store.
 // TODO(cookie-banner) : sans consentement, ne pas appeler `identify` (rester anonyme/cookieless).
 export function initTracking(): void {
-  if (!getProvider()) return;
+  const provider = getProvider();
+  if (!provider) return;
+  syncInternalUserFlag(provider);
   identify(useQuizStore.getState().distinctId);
   syncIdentitySuperProperties(useQuizStore.getState());
 

--- a/plateform/app/services/tracking/providers/local.ts
+++ b/plateform/app/services/tracking/providers/local.ts
@@ -23,5 +23,9 @@ export function createLocalProvider(): TrackingProvider {
     register(properties: TrackingProperties) {
       console.log("[tracking] register super properties", properties);
     },
+
+    unregister(property: string) {
+      console.log("[tracking] unregister super property", property);
+    },
   };
 }

--- a/plateform/app/services/tracking/providers/posthog.ts
+++ b/plateform/app/services/tracking/providers/posthog.ts
@@ -50,5 +50,10 @@ export function createPosthogProvider(): TrackingProvider {
       if (!ready) return;
       posthog.register(properties);
     },
+
+    unregister(property: string) {
+      if (!ready) return;
+      posthog.unregister(property);
+    },
   };
 }

--- a/plateform/app/services/tracking/types.ts
+++ b/plateform/app/services/tracking/types.ts
@@ -23,6 +23,8 @@ export interface TrackingProvider {
   identify?(distinctId: string, traits?: TrackingTraits): void;
   // Enregistre des "super properties" attachées automatiquement à tous les évènements suivants.
   register?(properties: TrackingProperties): void;
+  // Retire une super property attachée automatiquement aux évènements suivants.
+  unregister?(property: string): void;
 }
 
 // Providers supportés : `posthog` en production, `local` (console.log) pour le développement.

--- a/plateform/app/utils/__tests__/internal-user-flag.test.ts
+++ b/plateform/app/utils/__tests__/internal-user-flag.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { getInternalUserFlagAction } from "../internal-user-flag";
+
+describe("getInternalUserFlagAction", () => {
+  it("active le flag avec internal=1", () => {
+    expect(getInternalUserFlagAction("?internal=1")).toBe("enable");
+  });
+
+  it("désactive le flag avec internal=0", () => {
+    expect(getInternalUserFlagAction("?internal=0")).toBe("disable");
+  });
+
+  it("ne fait rien sans paramètre internal", () => {
+    expect(getInternalUserFlagAction("?utm_source=test")).toBe("none");
+    expect(getInternalUserFlagAction("")).toBe("none");
+  });
+
+  it("ignore les valeurs non supportées", () => {
+    expect(getInternalUserFlagAction("?internal=true")).toBe("none");
+    expect(getInternalUserFlagAction("?internal=2")).toBe("none");
+    expect(getInternalUserFlagAction("?internal=")).toBe("none");
+  });
+
+  it("utilise la première valeur quand internal est présent plusieurs fois", () => {
+    expect(getInternalUserFlagAction("?internal=1&internal=0")).toBe("enable");
+    expect(getInternalUserFlagAction("?internal=0&internal=1")).toBe("disable");
+  });
+
+  it("accepte une instance URLSearchParams", () => {
+    expect(getInternalUserFlagAction(new URLSearchParams("internal=1"))).toBe("enable");
+  });
+});

--- a/plateform/app/utils/__tests__/internal-user-flag.test.ts
+++ b/plateform/app/utils/__tests__/internal-user-flag.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getInternalUserFlagAction } from "../internal-user-flag";
+import { INTERNAL_USER_FLAG_STORAGE_KEY, getInternalUserFlagAction, isInternalUserFlagEnabled, persistInternalUserFlagAction } from "../internal-user-flag";
 
 describe("getInternalUserFlagAction", () => {
   it("active le flag avec internal=1", () => {
@@ -28,5 +28,67 @@ describe("getInternalUserFlagAction", () => {
 
   it("accepte une instance URLSearchParams", () => {
     expect(getInternalUserFlagAction(new URLSearchParams("internal=1"))).toBe("enable");
+  });
+});
+
+describe("persistInternalUserFlagAction", () => {
+  it("persiste le flag quand il est activé", () => {
+    const storage = new Map<string, string>();
+
+    persistInternalUserFlagAction(
+      "enable",
+      {
+        getItem: (key) => storage.get(key) ?? null,
+        removeItem: (key) => storage.delete(key),
+        setItem: (key, value) => storage.set(key, value),
+      },
+    );
+
+    expect(storage.get(INTERNAL_USER_FLAG_STORAGE_KEY)).toBe("1");
+  });
+
+  it("retire le flag quand il est désactivé", () => {
+    const storage = new Map<string, string>([[INTERNAL_USER_FLAG_STORAGE_KEY, "1"]]);
+
+    persistInternalUserFlagAction(
+      "disable",
+      {
+        getItem: (key) => storage.get(key) ?? null,
+        removeItem: (key) => storage.delete(key),
+        setItem: (key, value) => storage.set(key, value),
+      },
+    );
+
+    expect(storage.has(INTERNAL_USER_FLAG_STORAGE_KEY)).toBe(false);
+  });
+
+  it("ne modifie rien sans action", () => {
+    const storage = new Map<string, string>([[INTERNAL_USER_FLAG_STORAGE_KEY, "1"]]);
+
+    persistInternalUserFlagAction(
+      "none",
+      {
+        getItem: (key) => storage.get(key) ?? null,
+        removeItem: (key) => storage.delete(key),
+        setItem: (key, value) => storage.set(key, value),
+      },
+    );
+
+    expect(storage.get(INTERNAL_USER_FLAG_STORAGE_KEY)).toBe("1");
+  });
+});
+
+describe("isInternalUserFlagEnabled", () => {
+  it("retourne true sur une URL d'activation", () => {
+    expect(isInternalUserFlagEnabled("?internal=1", { getItem: () => null })).toBe(true);
+  });
+
+  it("retourne false sur une URL de désactivation", () => {
+    expect(isInternalUserFlagEnabled("?internal=0", { getItem: () => "1" })).toBe(false);
+  });
+
+  it("lit le stockage local sans paramètre internal", () => {
+    expect(isInternalUserFlagEnabled("", { getItem: () => "1" })).toBe(true);
+    expect(isInternalUserFlagEnabled("", { getItem: () => null })).toBe(false);
   });
 });

--- a/plateform/app/utils/internal-user-flag.ts
+++ b/plateform/app/utils/internal-user-flag.ts
@@ -1,5 +1,7 @@
 export type InternalUserFlagAction = "enable" | "disable" | "none";
 
+export const INTERNAL_USER_FLAG_STORAGE_KEY = "api-engagement.internal_user";
+
 export function getInternalUserFlagAction(search: string | URLSearchParams): InternalUserFlagAction {
   const params = typeof search === "string" ? new URLSearchParams(search) : search;
 
@@ -11,4 +13,23 @@ export function getInternalUserFlagAction(search: string | URLSearchParams): Int
     default:
       return "none";
   }
+}
+
+export function persistInternalUserFlagAction(action: InternalUserFlagAction, storage: Pick<Storage, "getItem" | "removeItem" | "setItem">): void {
+  if (action === "enable") {
+    storage.setItem(INTERNAL_USER_FLAG_STORAGE_KEY, "1");
+    return;
+  }
+
+  if (action === "disable") {
+    storage.removeItem(INTERNAL_USER_FLAG_STORAGE_KEY);
+  }
+}
+
+export function isInternalUserFlagEnabled(search: string | URLSearchParams, storage: Pick<Storage, "getItem">): boolean {
+  const action = getInternalUserFlagAction(search);
+  if (action === "enable") return true;
+  if (action === "disable") return false;
+
+  return storage.getItem(INTERNAL_USER_FLAG_STORAGE_KEY) === "1";
 }

--- a/plateform/app/utils/internal-user-flag.ts
+++ b/plateform/app/utils/internal-user-flag.ts
@@ -1,0 +1,14 @@
+export type InternalUserFlagAction = "enable" | "disable" | "none";
+
+export function getInternalUserFlagAction(search: string | URLSearchParams): InternalUserFlagAction {
+  const params = typeof search === "string" ? new URLSearchParams(search) : search;
+
+  switch (params.get("internal")) {
+    case "1":
+      return "enable";
+    case "0":
+      return "disable";
+    default:
+      return "none";
+  }
+}


### PR DESCRIPTION
## Description

Cette PR ajoute un mode interne côté Plateforme pour éviter que les navigations de l'équipe soient comptabilisées comme du trafic utilisateur dans PostHog.

Le mode s'active avec `?internal=1` et pose la super property PostHog `internal_user: true` sur les événements suivants du navigateur. Le flag est conservé dans le `localStorage` du navigateur afin de rester actif sur les pages suivantes.

Il se désactive avec `?internal=0` ou depuis l'indicateur affiché en bas à gauche de l'interface.

Un indicateur visuel permet de voir quand le mode interne est actif. Au survol ou au focus, il explique l'état courant et propose de réactiver le tracking normal.

<img width="1669" height="376" alt="image" src="https://github.com/user-attachments/assets/10c52906-9ec3-4249-af98-fd3aa92b3965" />

## Liens utiles

- Ticket Notion : https://app.notion.com/p/jeveuxaider/Exclure-les-donn-es-des-admins-sur-la-plateforme-de-l-engagement-38a72a322d5080cbba5bcab10aecab62?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Configuration PostHog à faire hors code : dans `Settings -> Filter out internal and test users`, ajouter un filtre sur la propriété d'événement `internal_user is not set`, puis activer le toggle par défaut sur les nouveaux insights.

Limites connues / hors scope :

- Le flag est propre à chaque navigateur/appareil.
- Il n'y a pas de rétroactivité : seuls les événements émis après activation portent `internal_user: true`.
- L'URL d'activation n'est pas secrète ; un visiteur qui l'utilise s'exclut lui-même des statistiques PostHog.
- Le tag `jstag.js` API Engagement n'est pas modifié par cette PR et reste hors scope.
- L'exclusion des exports analytics côté API/dbt reste hors scope de cette PR.
- La bascule du flag pendant une navigation SPA sans rechargement complet de la page reste hors scope.
