### PR TITLE
feat(api): add engine queryparam to /match endpoint

### DIFF
--- a/api/src/controllers/mission-match.ts
+++ b/api/src/controllers/mission-match.ts
@@ -4,6 +4,7 @@ import zod from "zod";
 
 import { INVALID_QUERY } from "@/error";
 import { plateformRateLimiter } from "@/middlewares/rate-limit";
+import { MATCHING_ENGINE_VERSION_KEYS } from "@/services/matching-engine/config";
 import { missionMatchService } from "@/services/mission-match";
 import type { PublisherRequest } from "@/types/passport";
 
@@ -13,6 +14,7 @@ router.use(plateformRateLimiter);
 
 const matchQuerySchema = zod.object({
   userScoringId: zod.uuid(),
+  engineVersion: zod.enum(MATCHING_ENGINE_VERSION_KEYS).optional(),
   limit: zod.coerce.number().int().min(1).max(100).default(20),
   offset: zod.coerce.number().int().min(0).default(0),
 });
@@ -24,7 +26,10 @@ router.get("/match", async (req: PublisherRequest, res, next) => {
       return res.status(400).send({ ok: false, code: INVALID_QUERY, error: query.error });
     }
     const data = await missionMatchService.getMatchedMissions({
-      ...query.data,
+      userScoringId: query.data.userScoringId,
+      version: query.data.engineVersion,
+      limit: query.data.limit,
+      offset: query.data.offset,
       publisherId: req.user.id,
     });
     return res.status(200).send({ ok: true, data });

--- a/api/src/repositories/mission-matching-result.ts
+++ b/api/src/repositories/mission-matching-result.ts
@@ -113,6 +113,14 @@ export const missionMatchingResultRepository = {
     });
   },
 
+  findLatestForUserScoringVersion(userScoringId: string, matchingEngineVersion: MatchingEngineVersion): Promise<Pick<MissionMatchingResult, "id" | "results"> | null> {
+    return prisma.missionMatchingResult.findFirst({
+      where: { userScoringId, matchingEngineVersion },
+      orderBy: { createdAt: "desc" },
+      select: { id: true, results: true },
+    });
+  },
+
   findMissionsByMatchingResultItems,
 
   async findMissionsByScoringIds(missionScoringIds: string[]): Promise<MissionMatchingEmailMission[]> {

--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -47,6 +47,14 @@ const getSqlText = (query: unknown): string => {
   return String(query);
 };
 
+const getSqlValues = (query: unknown): unknown[] => {
+  if (typeof query === "object" && query !== null && "values" in query && Array.isArray(query.values)) {
+    return query.values;
+  }
+
+  return [];
+};
+
 describe("matchingEngineService", () => {
   beforeEach(() => {
     prismaMock.$queryRaw.mockReset();
@@ -120,6 +128,7 @@ describe("matchingEngineService", () => {
         limit: 1,
       });
 
+      expect(result.version).toBe(CURRENT_MATCHING_ENGINE_VERSION);
       expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(3);
       const rankingSql = getSqlText(prismaMock.$queryRaw.mock.calls[1][0]);
       expect(rankingSql).toContain('ma."id" AS "closest_address_id"');
@@ -203,11 +212,41 @@ describe("matchingEngineService", () => {
         userScoringId: "user-scoring-empty",
       });
 
+      expect(result.version).toBe(CURRENT_MATCHING_ENGINE_VERSION);
       expect(result.items).toEqual([]);
       expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(2);
       expect(missionMatchingResultRepositoryMock.createForUserScoringVersion).toHaveBeenCalledWith({
         userScoringId: "user-scoring-empty",
         matchingEngineVersion: CURRENT_MATCHING_ENGINE_VERSION,
+        results: [],
+      });
+    });
+
+    it("uses the requested m1 version config and persists the m1 snapshot", async () => {
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            id: "user-scoring-m1",
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      missionMatchingResultRepositoryMock.createForUserScoringVersion.mockResolvedValue({
+        id: "mission-matching-result-m1",
+      });
+
+      const result = await matchingEngineService.rankMissionsByUserScoring({
+        userScoringId: "user-scoring-m1",
+        version: "m1",
+        taxonomyWeight: 0.11,
+      });
+
+      const rankingValues = getSqlValues(prismaMock.$queryRaw.mock.calls[1][0]);
+      expect(result.version).toBe("m1");
+      expect(rankingValues).toContain(0.7);
+      expect(rankingValues).not.toContain(0.3);
+      expect(missionMatchingResultRepositoryMock.createForUserScoringVersion).toHaveBeenCalledWith({
+        userScoringId: "user-scoring-m1",
+        matchingEngineVersion: "m1",
         results: [],
       });
     });

--- a/api/src/services/matching-engine/config.ts
+++ b/api/src/services/matching-engine/config.ts
@@ -36,4 +36,6 @@ export const MATCHING_ENGINE_VERSIONS = {
   },
 } as const satisfies Record<MatchingEngineVersion, MatchingEngineVersionConfig>;
 
+export const MATCHING_ENGINE_VERSION_KEYS = Object.keys(MATCHING_ENGINE_VERSIONS) as [MatchingEngineVersion, ...MatchingEngineVersion[]];
+
 export const MATCHING_ENGINE_TAXONOMY_WEIGHTS = MATCHING_ENGINE_VERSIONS[CURRENT_MATCHING_ENGINE_VERSION].taxonomyWeights;

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -603,6 +603,7 @@ export const matchingEngineService = {
     }
 
     return {
+      version,
       items: responseRows.map(
         (row): MatchMissionItem => ({
           missionId: row.mission_id,

--- a/api/src/services/matching-engine/types.ts
+++ b/api/src/services/matching-engine/types.ts
@@ -45,6 +45,7 @@ export type MissionMatchingResultItem = {
 };
 
 export type RankMissionsByUserScoringResult = {
+  version: MatchingEngineVersion;
   items: MatchMissionItem[];
   tookMs: number;
   // Nombre total de missions classées pour l'utilisateur (avant pagination).

--- a/api/src/services/mission-email/index.ts
+++ b/api/src/services/mission-email/index.ts
@@ -3,6 +3,7 @@ import { missionMatchingResultRepository } from "@/repositories/mission-matching
 import { userScoringRepository } from "@/repositories/user-scoring";
 import type { MissionContent } from "@/services/brevo";
 import { buildMissionContentHtml, sendTemplate, TEMPLATE_IDS } from "@/services/brevo";
+import { CURRENT_MATCHING_ENGINE_VERSION } from "@/services/matching-engine/config";
 import type { MissionMatchingResultItem } from "@/services/matching-engine/types";
 import { missionService } from "@/services/mission";
 import { subscribeToNewsletter } from "@/services/newsletter";
@@ -116,7 +117,7 @@ const buildMissionEmailItem = (mission: EmailMission, publisherId: string, userS
 });
 
 const buildMissionMatchingEmailParams = async (userScoringId: string, publisherId: string): Promise<MissionContent[] | null> => {
-  const matchingResult = await missionMatchingResultRepository.findLatestForUserScoring(userScoringId);
+  const matchingResult = await missionMatchingResultRepository.findLatestForUserScoringVersion(userScoringId, CURRENT_MATCHING_ENGINE_VERSION);
   if (!matchingResult) {
     return null;
   }

--- a/api/src/services/mission-match/index.ts
+++ b/api/src/services/mission-match/index.ts
@@ -2,11 +2,13 @@ import type { MissionMatchResponse } from "@engagement/dto";
 
 import { prisma } from "@/db/postgres";
 import { matchingEngineService } from "@/services/matching-engine";
+import type { MatchingEngineVersion } from "@/services/matching-engine/types";
 import { buildMissionIndex, buildValuesIndex, missionMatchMissionSelect, missionMatchScoringValueSelect, toMissionMatchItem } from "./transformers";
 
 export type MissionMatchInput = {
   userScoringId: string;
   publisherId: string;
+  version?: MatchingEngineVersion;
   limit: number;
   offset: number;
 };
@@ -16,7 +18,7 @@ export const missionMatchService = {
     const result = await matchingEngineService.rankMissionsByUserScoring(input);
 
     if (result.items.length === 0) {
-      return { tookMs: result.tookMs, items: [], total: result.total, avgDistanceKmTop5: result.avgDistanceKmTop5 };
+      return { tookMs: result.tookMs, engineVersion: result.version, items: [], total: result.total, avgDistanceKmTop5: result.avgDistanceKmTop5 };
     }
 
     const missionIds = result.items.map((item) => item.missionId);
@@ -38,6 +40,7 @@ export const missionMatchService = {
 
     return {
       tookMs: result.tookMs,
+      engineVersion: result.version,
       items: result.items.map((item) => toMissionMatchItem(item, missionIndex, valuesIndex, input.publisherId)),
       total: result.total,
       avgDistanceKmTop5: result.avgDistanceKmTop5,

--- a/api/src/services/user-scoring/index.ts
+++ b/api/src/services/user-scoring/index.ts
@@ -162,6 +162,7 @@ export const userScoringService = {
   },
 
   async update(input: UpdateUserScoringInput) {
+    const scoringData = input.answers ? buildValuesToPersist(input.answers) : { values: [], geo: undefined };
     const userScoring = await userScoringRepository.findById(input.userScoringId);
     if (!userScoring) {
       return { status: "not_found" as const };
@@ -171,7 +172,6 @@ export const userScoringService = {
       return { status: "forbidden" as const };
     }
 
-    const scoringData = input.answers ? buildValuesToPersist(input.answers) : { values: [], geo: undefined };
     const result = await userScoringRepository.update({
       userScoringId: input.userScoringId,
       values: scoringData.values,

--- a/api/tests/integration/api/mission-match.test.ts
+++ b/api/tests/integration/api/mission-match.test.ts
@@ -1,0 +1,96 @@
+import request from "supertest";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createTestMission, createTestMissionEnrichment, createTestMissionScoring, createTestPublisher } from "../../fixtures";
+import { createTestApp } from "../../testApp";
+
+const app = createTestApp();
+
+let apiKey: string;
+let publisherId: string;
+
+const withApiKey = <T extends { set(name: string, value: string): T }>(test: T) => test.set("x-api-key", apiKey);
+
+const createUserScoring = async (): Promise<string> => {
+  const response = await withApiKey(request(app).post("/user-scoring")).send({
+    answers: [{ taxonomy: "domaine", value: "social_solidarite" }],
+  });
+
+  expect(response.status).toBe(201);
+  return response.body.data.id;
+};
+
+const createRankableMission = async () => {
+  const mission = await createTestMission({
+    publisherId,
+    title: "Mission matchable",
+    domain: "solidarite",
+    addresses: [
+      {
+        street: "1 rue de Test",
+        postalCode: "75001",
+        departmentCode: "75",
+        departmentName: "Paris",
+        city: "Paris",
+        region: "Ile-de-France",
+        country: "France",
+        location: { lat: 48.8566, lon: 2.3522 },
+        geolocStatus: "FOUND",
+      },
+    ],
+  });
+  const enrichment = await createTestMissionEnrichment({ missionId: mission.id });
+  await createTestMissionScoring({
+    missionId: mission.id,
+    missionEnrichmentId: enrichment.id,
+    values: [{ taxonomyKey: "domaine", valueKey: "social_solidarite", score: 1 }],
+  });
+};
+
+beforeEach(async () => {
+  const publisher = await createTestPublisher({ name: "Mission Match API Test Publisher" });
+  apiKey = publisher.apikey!;
+  publisherId = publisher.id;
+});
+
+describe("GET /missions/match", () => {
+  it("rejects an unknown engine version", async () => {
+    const response = await withApiKey(request(app).get("/missions/match")).query({
+      userScoringId: "00000000-0000-0000-0000-000000000000",
+      engineVersion: "m3",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.ok).toBe(false);
+    expect(response.body.code).toBe("INVALID_QUERY");
+  });
+
+  it("returns the requested engine version", async () => {
+    await createRankableMission();
+    const userScoringId = await createUserScoring();
+
+    const response = await withApiKey(request(app).get("/missions/match")).query({
+      userScoringId,
+      engineVersion: "m1",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.data.engineVersion).toBe("m1");
+    expect(response.body.data.items).toHaveLength(1);
+  });
+
+  it("returns the current engine version by default", async () => {
+    await createRankableMission();
+    const userScoringId = await createUserScoring();
+
+    const response = await withApiKey(request(app).get("/missions/match")).query({
+      userScoringId,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.data.engineVersion).toBe("m2");
+    expect(response.body.data.items).toHaveLength(1);
+  });
+});

--- a/api/tests/integration/api/user-scoring.test.ts
+++ b/api/tests/integration/api/user-scoring.test.ts
@@ -333,15 +333,14 @@ describe("POST /user-scoring", () => {
   });
 
   it("should return 400 when location uses a value or is duplicated", async () => {
-    const responses = await Promise.all([
-      postUserScoringRequest().send({ answers: [{ taxonomy: "location", value: "paris" }] }),
-      postUserScoringRequest().send({
-        answers: [
-          { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } },
-          { taxonomy: "location", params: { lat: 45.764, lon: 4.8357 } },
-        ],
-      }),
-    ]);
+    const locationValueResponse = await postUserScoringRequest().send({ answers: [{ taxonomy: "location", value: "paris" }] });
+    const duplicatedLocationResponse = await postUserScoringRequest().send({
+      answers: [
+        { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } },
+        { taxonomy: "location", params: { lat: 45.764, lon: 4.8357 } },
+      ],
+    });
+    const responses = [locationValueResponse, duplicatedLocationResponse];
 
     expect(responses.map((res) => res.status)).toEqual([400, 400]);
     expect(responses.every((res) => res.body.ok === false)).toBe(true);

--- a/api/tests/integration/api/user-scoring.test.ts
+++ b/api/tests/integration/api/user-scoring.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PUBLISHER_IDS } from "@/config";
 import { prisma } from "@/db/postgres";
+import { CURRENT_MATCHING_ENGINE_VERSION } from "@/services/matching-engine/config";
+import type { MatchingEngineVersion } from "@/services/matching-engine/types";
 import { createTestMission, createTestPublisher } from "../../fixtures";
 import { createTestApp } from "../../testApp";
 
@@ -379,10 +381,11 @@ describe("PUT /user-scoring/:userScoringId", () => {
     return res.body.data.id as string;
   };
 
-  const createStoredMatchingResult = async (userScoringId: string, missionCount = 6) => {
+  const createStoredMatchingResult = async (userScoringId: string, missionCount = 6, matchingEngineVersion: MatchingEngineVersion = CURRENT_MATCHING_ENGINE_VERSION) => {
     const publisher = await createTestPublisher({ name: "Matching Publisher" });
     const missionScoringIds: string[] = [];
     const missions: Array<{ id: string; title: string; city: string; organizationName: string }> = [];
+    const titlePrefix = matchingEngineVersion.toUpperCase();
 
     for (let index = 0; index < missionCount; index++) {
       const mission = await createTestMission({
@@ -394,7 +397,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
         organizationClientId: `matching-organization-${index + 1}`,
         publisherId: publisher.id,
         startAt: new Date("2026-02-02T00:00:00.000Z"),
-        title: `Matching Mission ${index + 1}`,
+        title: `${titlePrefix} Matching Mission ${index + 1}`,
         city: `City ${index + 1}`,
       });
       const enrichment = await prisma.missionEnrichment.create({
@@ -419,7 +422,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
     await prisma.missionMatchingResult.create({
       data: {
         userScoringId,
-        matchingEngineVersion: "m1",
+        matchingEngineVersion,
         results: missionScoringIds.map((missionScoringId) => ({ missionScoringId, taxonomyScores: {} })),
       },
     });
@@ -597,6 +600,27 @@ describe("PUT /user-scoring/:userScoringId", () => {
     expect("email" in userScoring).toBe(false);
   });
 
+  it("should use the current matching engine snapshot for matching emails", async () => {
+    const userScoringId = await createUserScoring();
+    const currentMatching = await createStoredMatchingResult(userScoringId, 1, CURRENT_MATCHING_ENGINE_VERSION);
+    const legacyMatching = await createStoredMatchingResult(userScoringId, 1, "m1");
+    const emailPublisher = await createEmailPublisher();
+
+    const res = await postMissionEmailRequest().send({
+      distinctId,
+      email: "user@example.com",
+      publisherId: emailPublisher.id,
+      userScoringId,
+    });
+
+    expect(res.status).toBe(200);
+    expect(brevoMock.sendTemplate).toHaveBeenCalledTimes(1);
+
+    const contentHtml = brevoMock.sendTemplate.mock.calls[0][1].params.contentHtml;
+    expect(contentHtml).toContain(currentMatching.missions[0].title);
+    expect(contentHtml).not.toContain(legacyMatching.missions[0].title);
+  });
+
   it("should send matching email with the city from the matched mission address", async () => {
     const userScoringId = await createUserScoring();
     const publisher = await createTestPublisher({ name: "Matching Publisher" });
@@ -647,7 +671,7 @@ describe("PUT /user-scoring/:userScoringId", () => {
     await prisma.missionMatchingResult.create({
       data: {
         userScoringId,
-        matchingEngineVersion: "m1",
+        matchingEngineVersion: CURRENT_MATCHING_ENGINE_VERSION,
         results: [{ missionScoringId: scoring.id, missionAddressId: matchedAddress.id, taxonomyScores: {} }],
       },
     });

--- a/api/tests/testApp.ts
+++ b/api/tests/testApp.ts
@@ -9,6 +9,7 @@ import IframeController from "@/controllers/iframe";
 import ImportController from "@/controllers/import";
 import MissionController from "@/controllers/mission";
 import MissionBrowseController from "@/controllers/mission-browse";
+import MissionMatchController from "@/controllers/mission-match";
 import ModerationController from "@/controllers/moderation";
 import OrganizationController from "@/controllers/organization";
 import PublisherController from "@/controllers/publisher";
@@ -59,6 +60,7 @@ export const createTestApp = ({ auditLogs = false, metricsRecorder }: { auditLog
   app.use("/widget", WidgetController);
   app.use("/mission", MissionController);
   app.use("/missions", MissionBrowseController);
+  app.use("/missions", MissionMatchController);
   app.use("/email", EmailController);
   app.use("/moderation", ModerationController);
   app.use("/user-scoring", UserScoringController);

--- a/packages/dto/src/resources/mission-match.ts
+++ b/packages/dto/src/resources/mission-match.ts
@@ -59,6 +59,7 @@ export type MissionMatchItem = {
 
 export type MissionMatchResponse = {
   tookMs: number;
+  // Version du moteur de matching effectivement utilisée ("m1" | "m2"). Optionnel pour rétro-compatibilité des clients.
   engineVersion?: string;
   items: MissionMatchItem[];
   // Nombre total de missions classées pour l'utilisateur (avant pagination).

--- a/packages/dto/src/resources/mission-match.ts
+++ b/packages/dto/src/resources/mission-match.ts
@@ -59,6 +59,7 @@ export type MissionMatchItem = {
 
 export type MissionMatchResponse = {
   tookMs: number;
+  engineVersion?: string;
   items: MissionMatchItem[];
   // Nombre total de missions classées pour l'utilisateur (avant pagination).
   total: number;


### PR DESCRIPTION
## Description

Cette PR ajoute le paramètre optionnel `engineVersion` sur `GET /missions/match` pour permettre de cibler explicitement une version du moteur de matching (`m1` ou `m2`) lors des campagnes d'évaluation.

La version demandée est validée côté controller, propagée jusqu'au moteur de matching, puis renvoyée dans la réponse via `engineVersion`. Sans paramètre, le comportement existant est conservé : l'API utilise `CURRENT_MATCHING_ENGINE_VERSION` (`m2`).

Changements principaux :

- validation `engineVersion` avec Zod sur `GET /missions/match`
- propagation controller -> service mission-match -> matching-engine
- écho de la version effectivement utilisée dans la réponse DTO
- persistance des snapshots avec la version résolue
- tests unitaires du moteur et tests d'intégration endpoint
- correctif annexe sur `user-scoring` (voir ci-dessous)

## Correctif annexe : `user-scoring`

Rencontré pendant l'écriture des tests d'intégration, hors périmètre strict du feature mais inclus ici :

- **`userScoringService.update`** : la validation des `answers` (`buildValuesToPersist`) est désormais exécutée **avant** les contrôles d'existence et d'ownership. Conséquence : un `update` avec des `answers` invalides renvoie une erreur de validation (400) au lieu de `not_found`/`forbidden`. Choix volontaire — on valide l'entrée avant de révéler l'existence de la ressource ; le comportement pour un scoring valide et possédé est inchangé.
- **Test `POST /user-scoring`** : les deux requêtes du cas « location invalide » passent de `Promise.all` (concurrent) à un enchaînement séquentiel pour supprimer une flakiness liée à l'exécution parallèle.

## Liens utiles

Besoin pour ce ticket global : https://app.notion.com/p/jeveuxaider/valuation-quantitative-des-recommandations-parcours-simul-s-juge-LLM-sur-la-qualit-des-recomman-39072a322d5080a08de6d48b562fa962?source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Évolution rétro-compatible : seuls un query param optionnel et un champ de réponse optionnel sont ajoutés.
