### PR TITLE
fix(api): add plateforme engagement brevo list id

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -87,7 +87,7 @@ export const PUBLISHER_IDS = {
   VACANCES_ET_FAMILLES: "619fb1e17d373e07aea8be32",
   VILLE_DE_NANTES: "6347be8883b660072d4c1c53",
   ROC: "65d7715cc0d3764cbed3afaf",
-  PLATEFORME_ENGAGEMENT: ENV === "production" ? "6c6a6ed4cf9795a1d770c1e2" : "6c6a6ed4cf9795a1d770c1e2",
+  PLATEFORME_ENGAGEMENT: "6c6a6ed4cf9795a1d770c1e2",
 };
 
 export const DEFAULT_AVATAR = "https://api-engagement-bucket.s3.fr-par.scw.cloud/img/default.jpg";

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -87,6 +87,7 @@ export const PUBLISHER_IDS = {
   VACANCES_ET_FAMILLES: "619fb1e17d373e07aea8be32",
   VILLE_DE_NANTES: "6347be8883b660072d4c1c53",
   ROC: "65d7715cc0d3764cbed3afaf",
+  PLATEFORME_ENGAGEMENT: ENV === "production" ? "6c6a6ed4cf9795a1d770c1e2" : "6c6a6ed4cf9795a1d770c1e2",
 };
 
 export const DEFAULT_AVATAR = "https://api-engagement-bucket.s3.fr-par.scw.cloud/img/default.jpg";

--- a/api/src/services/newsletter/index.ts
+++ b/api/src/services/newsletter/index.ts
@@ -8,6 +8,7 @@ import { createOrUpdateContact } from "@/services/brevo";
 // Par defaut on reutilise la liste des contacts engagement (22) pour ne rien casser en attendant.
 const NEWSLETTER_BREVO_LIST_BY_PUBLISHER: Record<string, number> = {
   [PUBLISHER_IDS.API_ENGAGEMENT]: 22,
+  [PUBLISHER_IDS.PLATEFORME_ENGAGEMENT]: 23,
 };
 
 type SubscribeResult = { ok: true } | { ok: false; reason: "publisher_not_allowed" | "brevo_failed" };


### PR DESCRIPTION
## Description

Ajoute le publisher « Plateforme Engagement » à la liste des `PUBLISHER_IDS` et le mappe à la liste de contacts Brevo dédiée (23) pour les inscriptions newsletter, au lieu de la liste engagement par défaut (22).

**Changements** :
- `api/src/config.ts` : ajout de l'ID `PLATEFORME_ENGAGEMENT`
- `api/src/services/newsletter/index.ts` : mapping du publisher vers la liste Brevo 23

## Liens utiles

- 📝 Ticket Notion : N/A

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Point d'attention** : le ternaire `ENV === "production" ? ... : ...` pour `PLATEFORME_ENGAGEMENT` utilise pour l'instant le même ID des deux côtés — l'ID staging est à confirmer/renseigner si différent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)