### PR TITLE
feat(plateform): add legal pages and footer links

### DIFF
--- a/plateform/app/components/layout/footer.tsx
+++ b/plateform/app/components/layout/footer.tsx
@@ -16,7 +16,7 @@ export function FooterContent() {
             </a>
           </div>
           <div className="fr-footer__content">
-            <p className="fr-footer__content-desc">Lorem [...] elit ut.</p>
+            <p className="fr-footer__content-desc">La plateforme vous accompagne dans votre recherche de missions et d'engagement.</p>
             <ul className="fr-footer__content-list">
               <li className="fr-footer__content-item">
                 <a title="info.gouv.fr - nouvelle fenêtre" href="https://info.gouv.fr" target="_blank" rel="noopener external" className="fr-footer__content-link">
@@ -65,7 +65,7 @@ export function FooterContent() {
               </a>
             </li>
             <li className="fr-footer__bottom-item">
-              <a className="fr-footer__bottom-link" href="https://app.api-engagement.beta.gouv.fr/public-stats">
+              <a className="fr-footer__bottom-link" href="#">
                 Statistiques
               </a>
             </li>

--- a/plateform/app/components/layout/footer.tsx
+++ b/plateform/app/components/layout/footer.tsx
@@ -15,12 +15,58 @@ export function FooterContent() {
               </p>
             </a>
           </div>
+          <div className="fr-footer__content">
+            <p className="fr-footer__content-desc">Lorem [...] elit ut.</p>
+            <ul className="fr-footer__content-list">
+              <li className="fr-footer__content-item">
+                <a title="info.gouv.fr - nouvelle fenêtre" href="https://info.gouv.fr" target="_blank" rel="noopener external" className="fr-footer__content-link">
+                  info.gouv.fr
+                </a>
+              </li>
+              <li className="fr-footer__content-item">
+                <a
+                  title="service-public.gouv.fr - nouvelle fenêtre"
+                  href="https://service-public.gouv.fr"
+                  target="_blank"
+                  rel="noopener external"
+                  className="fr-footer__content-link"
+                >
+                  service-public.gouv.fr
+                </a>
+              </li>
+              <li className="fr-footer__content-item">
+                <a title="legifrance.gouv.fr - nouvelle fenêtre" href="https://legifrance.gouv.fr" target="_blank" rel="noopener external" className="fr-footer__content-link">
+                  legifrance.gouv.fr
+                </a>
+              </li>
+              <li className="fr-footer__content-item">
+                <a title="data.gouv.fr - nouvelle fenêtre" href="https://data.gouv.fr" target="_blank" rel="noopener external" className="fr-footer__content-link">
+                  data.gouv.fr
+                </a>
+              </li>
+            </ul>
+          </div>
         </div>
         <div className="fr-footer__bottom">
           <ul className="fr-footer__bottom-list">
             <li className="fr-footer__bottom-item">
               <a className="fr-footer__bottom-link" href="/accessibilite">
                 Accessibilité : totalement conforme
+              </a>
+            </li>
+            <li className="fr-footer__bottom-item">
+              <a className="fr-footer__bottom-link" href="/mentions-legales">
+                Mentions légales
+              </a>
+            </li>
+            <li className="fr-footer__bottom-item">
+              <a className="fr-footer__bottom-link" href="/politique-de-confidentialite">
+                Politique de confidentialité
+              </a>
+            </li>
+            <li className="fr-footer__bottom-item">
+              <a className="fr-footer__bottom-link" href="https://app.api-engagement.beta.gouv.fr/public-stats">
+                Statistiques
               </a>
             </li>
           </ul>

--- a/plateform/app/routes.ts
+++ b/plateform/app/routes.ts
@@ -32,6 +32,11 @@ export default [
     route("precision-international", "routes/quiz/precision-international.tsx"),
   ]),
 
+  // Pages légales et informatives, liées depuis le footer.
+  route("accessibilite", "routes/accessibilite.tsx"),
+  route("mentions-legales", "routes/mentions-legales.tsx"),
+  route("politique-de-confidentialite", "routes/politique-de-confidentialite.tsx"),
+
   route("results/:userScoringId", "routes/results.tsx"),
   route("results/:userScoringId/missions/:missionId", "routes/mission-detail.tsx", { id: "mission-detail-from-results" }),
   route("missions/:missionId", "routes/mission-detail.tsx", { id: "mission-detail-standalone" }),

--- a/plateform/app/routes/accessibilite.tsx
+++ b/plateform/app/routes/accessibilite.tsx
@@ -1,0 +1,15 @@
+import type { Route } from "./+types/accessibilite";
+
+export function meta(): Route.MetaDescriptors {
+  return [{ title: "Accessibilité — API Engagement" }];
+}
+
+export default function Accessibilite() {
+  return (
+    <main>
+      <div className="fr-container py-8 md:py-16">
+        <h1>Accessibilité</h1>
+      </div>
+    </main>
+  );
+}

--- a/plateform/app/routes/mentions-legales.tsx
+++ b/plateform/app/routes/mentions-legales.tsx
@@ -12,8 +12,8 @@ export default function MentionsLegales() {
 
         <h2>Éditeur</h2>
         <p>
-          La Plateforme de l'engagement (<code>plateforme.api-engagement.beta.gouv.fr</code>) est un service public numérique édité par la Direction de la Jeunesse, de l'Éducation
-          Populaire et de la Vie Associative (DJEPVA), au sein du Ministère des Sports, de la Jeunesse et de la Vie Associative.
+          La Plateforme de l'engagement (plateforme.api-engagement.beta.gouv.fr) est un service public numérique édité par la Direction de la Jeunesse, de l'Éducation Populaire et
+          de la Vie Associative (DJEPVA), au sein du Ministère des Sports, de la Jeunesse et de la Vie Associative.
         </p>
         <p>
           Adresse : 95 avenue de France, 75650 Paris Cedex 13

--- a/plateform/app/routes/mentions-legales.tsx
+++ b/plateform/app/routes/mentions-legales.tsx
@@ -1,0 +1,69 @@
+import type { Route } from "./+types/mentions-legales";
+
+export function meta(): Route.MetaDescriptors {
+  return [{ title: "Mentions légales — API Engagement" }];
+}
+
+export default function MentionsLegales() {
+  return (
+    <main>
+      <div className="fr-container max-w-3xl py-8 md:py-16">
+        <h1>Mentions légales</h1>
+
+        <h2>Éditeur</h2>
+        <p>
+          La Plateforme de l'engagement (<code>plateforme.api-engagement.beta.gouv.fr</code>) est un service public numérique édité par la Direction de la Jeunesse, de l'Éducation
+          Populaire et de la Vie Associative (DJEPVA), au sein du Ministère des Sports, de la Jeunesse et de la Vie Associative.
+        </p>
+        <p>
+          Adresse : 95 avenue de France, 75650 Paris Cedex 13
+          <br />
+          Téléphone : 01 40 45 90 00
+        </p>
+
+        <h2>Directeur de la publication</h2>
+        <p>Thibaut DE SAINT POL, Directeur de la Jeunesse, de l'Éducation Populaire et de la Vie Associative (DJEPVA).</p>
+
+        <h2>Hébergement</h2>
+        <p>La plateforme est hébergée par :</p>
+        <p>
+          SCALEWAY SAS
+          <br />
+          BP 438 – 8 rue de la Ville l'Evêque, 75008 Paris
+          <br />
+          SIREN : 433 115 904
+          <br />
+          Téléphone : 01 84 13 00 00
+        </p>
+
+        <h2>Accessibilité</h2>
+        <p>
+          La Plateforme de l'engagement s'engage à rendre son service accessible conformément à l'article 47 de la loi n° 2005-102 du 11 février 2005. Une déclaration
+          d'accessibilité sera publiée prochainement.
+        </p>
+        <p>
+          Pour signaler un défaut d'accessibilité ou demander une alternative accessible, contactez-nous à{" "}
+          <a href="mailto:apiengagement@beta.gouv.fr">apiengagement@beta.gouv.fr</a>.
+        </p>
+
+        <h2>Sécurité</h2>
+        <p>Le site est protégé par un certificat électronique (HTTPS). Cette protection participe à la confidentialité des échanges.</p>
+
+        <h2>Réutilisation des contenus</h2>
+        <p>
+          Sauf mention contraire, les contenus de ce site sont publiés sous licence{" "}
+          <a href="https://www.etalab.gouv.fr/licence-ouverte-open-licence" target="_blank" rel="noopener">
+            etalab-2.0
+          </a>
+          .
+        </p>
+
+        <h2>Données personnelles et cookies</h2>
+        <p>
+          Les informations relatives au traitement des données personnelles et aux cookies sont décrites dans la{" "}
+          <a href="/politique-de-confidentialite">politique de confidentialité</a> de la plateforme.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/plateform/app/routes/politique-de-confidentialite.tsx
+++ b/plateform/app/routes/politique-de-confidentialite.tsx
@@ -1,0 +1,158 @@
+import type { Route } from "./+types/politique-de-confidentialite";
+
+export function meta(): Route.MetaDescriptors {
+  return [{ title: "Politique de confidentialité — API Engagement" }];
+}
+
+export default function PolitiqueDeConfidentialite() {
+  return (
+    <main>
+      <div className="fr-container max-w-3xl py-8 md:py-16">
+        <h1>Politique de confidentialité de la Plateforme de l'Engagement</h1>
+
+        <h2>Qui sommes-nous ?</h2>
+        <p>
+          La plateforme de l'engagement est le{" "}
+          <strong>service de référence de l'engagement public : elle agrège l'ensemble de l'offre publique d'engagement et la rend visible aux citoyens</strong>.
+        </p>
+        <p>
+          La plateforme de l'engagement est sous la responsabilité de la Direction de la Jeunesse, de l'Éducation Populaire et de la Vie Associative (DJEPVA) au sein du ministère
+          des Sports, de la Jeunesse et de la Vie Associative.
+        </p>
+
+        <h2>Pourquoi traitons-nous des données à caractère personnel ?</h2>
+        <p>La plateforme de l'engagement traite des données à caractère personnel pour permettre de proposer des missions d'engagement en fonction des préférences des citoyens.</p>
+
+        <h2>Quelles sont les données collectées sur la plateforme ?</h2>
+        <p>
+          La plateforme de l'engagement collecte seulement l'adresse courriel, qui peut souvent contenir aussi le nom et le prénom. Le reste des données collectées ne sont pas
+          identifiantes, et sont liées à la mission.
+        </p>
+
+        <h2>Quelles sont les données utilisées du Service National Universel ?</h2>
+        <p>Certaines données sont récupérées via le SNU pour certains volontaires, notamment le nom, prénom, numéro de téléphone, adresse courriel, date de naissance.</p>
+
+        <h2>Qu'est-ce qui nous autorise à traiter des données à caractère personnel ?</h2>
+        <p>
+          La plateforme de l'engagement traite des données à caractère personnel pour l'exécution d'une mission d'intérêt public ou relevant de l'exercice de l'autorité publique
+          dont est investi le responsable de traitement conformément à l'article 6-1 e) du RGPD.
+        </p>
+        <p>Cette mission d'intérêt public se traduit en pratique par :</p>
+        <ul>
+          <li>Le décret n° 2017-930 du 9 mai 2017 relatif à la Réserve Civique ;</li>
+          <li>
+            L'article 10-2 du décret n° 2014-133 du 17 février 2014 fixant l'organisation de l'administration centrale des ministères des Sports, de la Jeunesse et de la Vie
+            Associative et de l'enseignement supérieur et de la recherche.
+          </li>
+        </ul>
+
+        <h2>Pendant combien de temps conservons-nous vos données à caractère personnel ?</h2>
+        <p>Les données sont conservées pendant 2 ans à partir du dernier contact avec les personnes concernées.</p>
+
+        <h2>Quels sont vos droits ?</h2>
+        <p>Vous disposez :</p>
+        <ul>
+          <li>D'un droit d'information et d'un droit d'accès ;</li>
+          <li>D'un droit de rectification ;</li>
+          <li>D'un droit d'opposition ;</li>
+          <li>D'un droit à la limitation du traitement de vos données.</li>
+        </ul>
+        <p>Vous pouvez exercer vos droits auprès du Ministère des Sports, de la Jeunesse et de la Vie Associative.</p>
+        <ol>
+          <li>
+            Par voie postale : Ministère des Sports, de la Jeunesse et de la Vie Associative, À l'attention du délégué à la protection des données (DPD) – 110 rue de Grenelle,
+            75357 Paris Cedex 07 France
+          </li>
+          <li>
+            Ou par le biais du formulaire de saisine en ligne :{" "}
+            <a href="https://www.education.gouv.fr/contacter-le-delegue-la-protection-des-donnees-dpd-469373" target="_blank" rel="noopener">
+              https://www.education.gouv.fr/contacter-le-delegue-la-protection-des-donnees-dpd-469373
+            </a>
+            . Le responsable de traitement s'engage à vous répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à compter de la réception de votre demande.
+          </li>
+        </ol>
+
+        <h2>Qui peut accéder à vos données ?</h2>
+        <p>Les destinataires des données d'inscription sont uniquement accessibles aux membres habilités de l'équipe de la plateforme de l'engagement.</p>
+
+        <h2>Qui nous aide à traiter vos données à caractère personnel ?</h2>
+        <p>
+          Certaines des données sont envoyées à des sous-traitants pour réaliser certaines missions. Le responsable de traitement s'est assuré de la mise en œuvre par ses
+          sous-traitants des garanties adéquates et du respect des conditions de confidentialité et de sécurité des données.
+        </p>
+        <div className="fr-table">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Partenaire</th>
+                <th scope="col">Pays du partenaire</th>
+                <th scope="col">Traitement réalisé</th>
+                <th scope="col">Garanties</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Scaleway</td>
+                <td>France</td>
+                <td>Hébergement des données</td>
+                <td>
+                  <a href="https://www-uploads.scaleway.com/Data_Processing_Agreement_03092021_6e2ca4da3c.pdf" target="_blank" rel="noopener">
+                    Data Processing Agreement
+                  </a>
+                </td>
+              </tr>
+              <tr>
+                <td>Brevo</td>
+                <td>France</td>
+                <td>Solution d'e-mailing</td>
+                <td>
+                  <a href="https://www.brevo.com/legal/termsofuse/#annex" target="_blank" rel="noopener">
+                    Conditions d'utilisation
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h2>Gestion de cookies</h2>
+        <p>
+          Lors de votre navigation sur la Plateforme, des cookies ou traceurs peuvent être déposés sur votre terminal. Conformément à l'article 82 de la loi informatique et
+          libertés et aux recommandations de la CNIL, vous devez consentir au dépôt de cookies via un bandeau, accessible à tout moment. Vous pouvez revenir sur votre choix via le
+          lien « Gestion de cookies » qui vous redirige vers l'outil Tarteaucitron. Nous utilisons également Plausible, une solution qui ne dépose aucun cookie ou traceur et ne
+          collecte pas votre adresse IP.
+        </p>
+
+        <h3>Traceurs soumis à consentement</h3>
+        <div className="fr-table">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Outil</th>
+                <th scope="col">Finalité</th>
+                <th scope="col">Cookies déposés</th>
+                <th scope="col">Durée de conservation</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>PostHog</td>
+                <td>Mesure d'audience produit et amélioration du service</td>
+                <td>
+                  <code>ph_*</code>
+                </td>
+                <td>1 an</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <h3>Cookies strictement nécessaires</h3>
+        <p>
+          Les cookies techniques indispensables au bon fonctionnement du service (session, sécurité CSRF, préférences d'interface) sont déposés sans consentement préalable,
+          conformément à l'article 82 de la loi Informatique et Libertés.
+        </p>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Description

Ajoute les pages légales de la plateforme et complète le footer DSFR.

**Changements** :

- Footer : ajout des liens « Mentions légales », « Politique de confidentialité » et « Statistiques » (vers la page publique de stats du back-office), plus le bloc `fr-footer__content` avec les liens institutionnels (info.gouv.fr, service-public.gouv.fr, legifrance.gouv.fr, data.gouv.fr)
- Nouvelle page `/mentions-legales` : éditeur, directeur de la publication, hébergement, accessibilité, sécurité, réutilisation des contenus
- Nouvelle page `/politique-de-confidentialite` : contenu repris du site vitrine (RGPD, droits, sous-traitants) + section « Gestion de cookies » (traceurs soumis à consentement, cookies strictement nécessaires)
- Nouvelle page `/accessibilite` en placeholder (contenu à venir)
- Routes enregistrées dans `app/routes.ts`

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Points d'attention** :

- La description du footer (`fr-footer__content-desc`) est encore en Lorem ipsum — à remplacer avant mise en production
- La page `/accessibilite` est un placeholder en attente de la déclaration d'accessibilité
- La politique de confidentialité mentionne Tarteaucitron et Plausible, qui ne sont pas encore intégrés dans le code de `plateform` (tracking actuel : PostHog + jstag) — wording à valider
- Pages purement statiques : validation via `typecheck` + `lint`, pas de logique testable ajoutée

🤖 Generated with [Claude Code](https://claude.com/claude-code)