### PR TITLE
fix(plateform): use theme background instead of white in dark mode

### DIFF
--- a/plateform/app/components/mission-detail/description-card.tsx
+++ b/plateform/app/components/mission-detail/description-card.tsx
@@ -8,7 +8,7 @@ export default function MissionDescriptionCard({ mission }: MissionDescriptionCa
   if (!mission.descriptionHtml && !mission.description) return null;
 
   return (
-    <section className="md:shadow-card bg-background md:bg-white! p-0! mt-6! md:mt-0!">
+    <section className="md:shadow-card bg-background p-0! mt-6! md:mt-0!">
       <div className="fr-card__body">
         <div className="fr-card__content px-5! py-5! md:p-12!">
           <h2 className="fr-h1 mb-4!">Présentation de la mission</h2>

--- a/plateform/app/components/ui/combobox.tsx
+++ b/plateform/app/components/ui/combobox.tsx
@@ -79,7 +79,7 @@ export default function Combobox({ label, placeholder, options, selected, onChan
       </button>
 
       {open && (
-        <div id={panelId} className="absolute right-0 left-0 z-50 min-w-80 mt-1 border border-border-default-grey bg-white! shadow-lg">
+        <div id={panelId} className="absolute right-0 left-0 z-50 min-w-80 mt-1 border border-border-default-grey bg-background! shadow-lg">
           <div className="relative m-4">
             <input
               type="text"


### PR DESCRIPTION
## Description

Corrige des fonds blancs codés en dur qui cassaient l'affichage en mode sombre sur la plateforme.

**Changements** :
- `mission-detail/description-card.tsx` : suppression du `md:bg-white!` sur la carte de présentation de la mission (le `bg-background` du thème s'applique désormais partout)
- `ui/combobox.tsx` : le panneau déroulant passe de `bg-white!` à `bg-background!`

## Liens utiles

- 📝 Ticket Notion : N/A

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Fix purement CSS (2 classes Tailwind), aucun impact fonctionnel en mode clair : `bg-background` correspond au blanc du thème DSFR en light mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)