### PR TITLE
fix(api): account takeover on signup endpoint

### DIFF
--- a/api/src/controllers/user.ts
+++ b/api/src/controllers/user.ts
@@ -6,15 +6,15 @@ import zod from "zod";
 
 import { APP_URL, ENV, SECRET } from "@/config";
 import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND, REQUEST_EXPIRED, RESSOURCE_ALREADY_EXIST } from "@/error";
+import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { sendTemplate, TEMPLATE_IDS } from "@/services/brevo";
 import { loginHistoryService } from "@/services/login-history";
 import { publisherService } from "@/services/publisher";
 import { userService } from "@/services/user";
 import { UserRequest } from "@/types/passport";
-import { appendAuditEvent } from "@/utils/audit-log";
 import type { UserUpdatePatch } from "@/types/user";
-import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { hasLetter, hasNumber, hasSpecialChar } from "@/utils";
+import { appendAuditEvent } from "@/utils/audit-log";
 
 const FORGET_PASSWORD_EXPIRATION = 1000 * 60 * 60 * 2; // 2 hours
 const AUTH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7; // 7 day
@@ -256,7 +256,7 @@ router.post("/signup", async (req: UserRequest, res: Response, next: NextFunctio
   try {
     const body = zod
       .object({
-        id: zod.string(),
+        token: zod.string().min(1),
         firstname: zod.string(),
         lastname: zod.string(),
         password: zod.string(),
@@ -272,9 +272,12 @@ router.post("/signup", async (req: UserRequest, res: Response, next: NextFunctio
       return res.status(400).send({ ok: false, code: "INVALID_PASSWORD" });
     }
 
-    const user = await userService.findUserById(body.data.id, { includeDeleted: true });
+    const user = await userService.findUserByInvitationToken(body.data.token);
     if (!user) {
       return res.status(404).send({ ok: false, code: NOT_FOUND, message: `User not found` });
+    }
+    if (!user.invitationExpiresAt || user.invitationExpiresAt < new Date()) {
+      return res.status(403).send({ ok: false, code: REQUEST_EXPIRED, message: `Token expired` });
     }
 
     await userService.updateUser(user.id, {

--- a/api/tests/integration/api/endpoints/user.test.ts
+++ b/api/tests/integration/api/endpoints/user.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { userService } from "@/services/user";
 import { createTestPublisher } from "../../../fixtures";
 import { createTestUser } from "../../../fixtures/user";
 import { createTestApp } from "../../../testApp";
@@ -66,7 +67,10 @@ describe("Dashboard user controller", () => {
     const { token: adminToken } = await createTestUser({ role: "admin" });
     const { user: targetUser } = await createTestUser({ publishers: [publisher.id] });
 
-    const res = await request(app).get(`/user/loginas/${targetUser.id}`).set({ Authorization: `jwt ${adminToken}` }).set("x-request-id", "request-loginas");
+    const res = await request(app)
+      .get(`/user/loginas/${targetUser.id}`)
+      .set({ Authorization: `jwt ${adminToken}` })
+      .set("x-request-id", "request-loginas");
 
     expect(res.status).toBe(200);
     expect(getAuditLogs(consoleInfoSpy)).toContainEqual(
@@ -81,5 +85,76 @@ describe("Dashboard user controller", () => {
         metadata: { publisherId: publisher.id },
       })
     );
+  });
+
+  describe("POST /user/signup", () => {
+    const VALID_PASSWORD = "SuperSecret123!";
+
+    const createInvitedUser = (data: Parameters<typeof createTestUser>[0] = {}) =>
+      createTestUser({
+        invitationToken: "invitation-token-test",
+        invitationExpiresAt: new Date(Date.now() + 1000 * 60 * 60),
+        ...data,
+      });
+
+    it("completes signup with a valid invitation token", async () => {
+      const { user } = await createInvitedUser();
+
+      const res = await request(app).post("/user/signup").send({ token: "invitation-token-test", firstname: "Jane", lastname: "Doe", password: VALID_PASSWORD });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+
+      const updated = await userService.findUserById(user.id);
+      expect(updated?.firstname).toBe("Jane");
+      expect(updated?.invitationToken).toBeNull();
+      expect(updated?.invitationExpiresAt).toBeNull();
+      expect(updated?.invitationCompletedAt).not.toBeNull();
+
+      const login = await request(app).post("/user/login").send({ email: user.email, password: VALID_PASSWORD });
+      expect(login.status).toBe(200);
+    });
+
+    it("rejects an unknown invitation token without touching any account", async () => {
+      const { user } = await createInvitedUser();
+
+      const res = await request(app).post("/user/signup").send({ token: "wrong-token", firstname: "Evil", lastname: "Hacker", password: VALID_PASSWORD });
+
+      expect(res.status).toBe(404);
+
+      const untouched = await userService.findUserById(user.id);
+      expect(untouched?.firstname).toBe(user.firstname);
+      expect(untouched?.invitationToken).toBe("invitation-token-test");
+    });
+
+    it("rejects an expired invitation token", async () => {
+      await createInvitedUser({ invitationExpiresAt: new Date(Date.now() - 1000) });
+
+      const res = await request(app).post("/user/signup").send({ token: "invitation-token-test", firstname: "Jane", lastname: "Doe", password: VALID_PASSWORD });
+
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe("REQUEST_EXPIRED");
+    });
+
+    it("rejects the legacy payload with a user id instead of a token", async () => {
+      const { user } = await createInvitedUser();
+
+      const res = await request(app).post("/user/signup").send({ id: user.id, firstname: "Evil", lastname: "Hacker", password: VALID_PASSWORD });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("INVALID_BODY");
+
+      const untouched = await userService.findUserById(user.id);
+      expect(untouched?.firstname).toBe(user.firstname);
+    });
+
+    it("rejects a weak password even with a valid token", async () => {
+      await createInvitedUser();
+
+      const res = await request(app).post("/user/signup").send({ token: "invitation-token-test", firstname: "Jane", lastname: "Doe", password: "weak" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("INVALID_PASSWORD");
+    });
   });
 });

--- a/app/src/scenes/account/index.jsx
+++ b/app/src/scenes/account/index.jsx
@@ -189,7 +189,7 @@ const ResetPasswordModal = () => {
       toast.success("Mot de passe mis à jour");
       setOpen(false);
     } catch (error) {
-      captureError(error, { extra: { values } });
+      captureError(error);
     }
   };
 

--- a/app/src/scenes/auth/ForgotPassword.jsx
+++ b/app/src/scenes/auth/ForgotPassword.jsx
@@ -25,7 +25,7 @@ const Forgot = () => {
       await api.post("/user/forgot-password", { email: values.email });
       setDone(true);
     } catch (error) {
-      captureError(error, { extra: { values } });
+      captureError(error);
     }
     setLoading(false);
   };

--- a/app/src/scenes/auth/Login.jsx
+++ b/app/src/scenes/auth/Login.jsx
@@ -50,7 +50,7 @@ const Login = () => {
       setAuth(res.data.user, res.data.publisher);
       navigate("/performance");
     } catch (error) {
-      captureError(error, { extra: { values } });
+      captureError(error);
     }
     setLoading(false);
   };

--- a/app/src/scenes/auth/ResetPassword.jsx
+++ b/app/src/scenes/auth/ResetPassword.jsx
@@ -102,7 +102,7 @@ const ResetPasswordForm = ({ user, token }) => {
       }
       setSuccess(true);
     } catch (error) {
-      captureError(error, { extra: { values } });
+      captureError(error);
     } finally {
       setLoading(false);
     }

--- a/app/src/scenes/auth/Signup.jsx
+++ b/app/src/scenes/auth/Signup.jsx
@@ -49,13 +49,13 @@ const Signup = () => {
           <p className="text-color-grey-200 text-sm">La clé fournie est expirée, contactez nous pour avoir un nouveau mail d'inscription</p>
         </WarningAlert>
       ) : (
-        <SignupForm user={user} />
+        <SignupForm user={user} token={token} />
       )}
     </div>
   );
 };
 
-const SignupForm = ({ user }) => {
+const SignupForm = ({ user, token }) => {
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
   const [show, setShow] = useState(false);
@@ -112,7 +112,7 @@ const SignupForm = ({ user }) => {
 
     setLoading(true);
     try {
-      const res = await api.post("/user/signup", { ...values, id: user.id });
+      const res = await api.post("/user/signup", { firstname: values.firstname, lastname: values.lastname, password: values.password, token });
       if (!res.ok) {
         if (res.code === "INVALID_PASSWORD") setErrors({ password: "Le mot de passe ne respecte pas les critères de sécurité" });
         else throw res;

--- a/app/src/scenes/auth/Signup.jsx
+++ b/app/src/scenes/auth/Signup.jsx
@@ -31,7 +31,7 @@ const Signup = () => {
       }
       setUser(res.data);
     } catch (error) {
-      captureError(error, { extra: { token } });
+      captureError(error, { extra: { hasToken: !!token } });
     }
   };
 
@@ -120,7 +120,7 @@ const SignupForm = ({ user, token }) => {
       toast.success("Compte créé avec succès");
       navigate("/login");
     } catch (error) {
-      captureError(error, { extra: { values } });
+      captureError(error);
     }
     setLoading(false);
   };


### PR DESCRIPTION
## Description

Corrige une vulnérabilité **d'account takeover (High, CVSS 7.4)** remontée par l'audit de sécurité, et supprime au passage la fuite de secrets vers Sentry sur les écrans d'authentification.

### 1. Account takeover via `POST /user/signup` (`api`)

La route publique `POST /user/signup` acceptait un `id` d'utilisateur en clair dans le body et écrasait ses credentials (prénom, nom, **mot de passe**) **sans vérifier le token d'invitation**. Un attaquant connaissant l'`id` d'un compte pouvait donc en prendre le contrôle.

La route exige désormais un `token` (validé côté serveur), en miroir du pattern déjà en place sur `PUT /user/reset-password` :
- résolution de l'utilisateur via `findUserByInvitationToken` (plus de lookup par `id`) ;
- contrôle d'expiration du token (`403 REQUEST_EXPIRED`) ;
- token inconnu → `404` sans toucher aucun compte.

Le front (`app/src/scenes/auth/Signup.jsx`) envoie maintenant le `token` — déjà présent dans le lien d'invitation email — au lieu de l'`id`.

### 2. Fuite de mots de passe vers Sentry (`app`)

Plusieurs `captureError(error, { extra: { values } })` sur les formulaires d'auth transmettaient `password`/`confirmPassword` (et emails) en clair à Sentry en cas d'erreur. Nettoyé sur : `Signup`, `Login`, `ForgotPassword`, `ResetPassword` et le changement de mot de passe dans `account/`. Le token d'invitation loggué dans `Signup` est remplacé par un booléen `hasToken`.

## Liens utiles

https://app.notion.com/p/jeveuxaider/Account-takeover-sur-user-signup-39072a322d5080508851c99bc6bfad3b?source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Tests** : 5 tests d'intégration ajoutés dans `api/tests/integration/api/endpoints/user.test.ts` (token valide → 200 + login OK + nettoyage des champs d'invitation, token inconnu → 404, token expiré → 403, **payload legacy avec `id` → 400** en non-régression sécurité, mot de passe faible → 400). Suite complète du fichier : 9/9 verts. Builds TS (api) et Vite (app) OK.

**Déploiement** : front et API partent dans la même PR → pas de fenêtre d'incompatibilité. Les invitations en cours restent valides (le token est déjà dans les liens email envoyés).

**Points d'attention reviewer** :
- Comportement soft-delete conservé : `findUserByInvitationToken` ne filtre pas `deletedAt` (équivalent de l'ancien `includeDeleted: true`), un compte supprimé puis ré-invité peut toujours finaliser son inscription.
- Route interne du dashboard, hors API versionnée partenaire (v0/v1/v2) → aucun impact sur le contrat public.
- Hors périmètre : les autres `extra: { values }` du repo (widget, publisher, campaign, user/Create, profil compte) ne contiennent pas de secret et n'ont pas été touchés.
