### PR TITLE
fix(plateform): enable tracking to every quiz step

### DIFF
--- a/plateform/app/routes/quiz/localisation.tsx
+++ b/plateform/app/routes/quiz/localisation.tsx
@@ -23,12 +23,14 @@ export default function LocalisationStep() {
   const locAnswer = answers["localisation"];
   // `label` est persisté avec les coordonnées pour ré-afficher la saisie au retour sur l'écran
   // (ignoré côté API : le transformer `location` ne lit que lat/lon/country_code).
-  const savedLocation = locAnswer?.type === "params" ? (locAnswer.params as { lat: number; lon: number; country_code?: string; label?: string }) : null;
+  const savedLocation = locAnswer?.type === "params" ? (locAnswer.params as { lat: number; lon: number; country_code?: string; label?: string; postcode?: string }) : null;
 
   const [value, setValue] = useState(savedLocation?.label ?? "");
   const [options, setOptions] = useState<GeoSuggestion[]>([]);
   const [selected, setSelected] = useState<GeoSuggestion | null>(
-    savedLocation ? { label: savedLocation.label ?? "", lat: savedLocation.lat, lon: savedLocation.lon, country_code: savedLocation.country_code } : null,
+    savedLocation
+      ? { label: savedLocation.label ?? "", lat: savedLocation.lat, lon: savedLocation.lon, country_code: savedLocation.country_code, postcode: savedLocation.postcode }
+      : null,
   );
   const [showOptions, setShowOptions] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
@@ -155,6 +157,7 @@ export default function LocalisationStep() {
       params: {
         lat: selected.lat,
         lon: selected.lon,
+        ...(selected.postcode ? { postcode: selected.postcode } : {}),
         ...(selected.country_code ? { country_code: selected.country_code } : {}),
         ...(selected.label ? { label: selected.label } : {}),
       },

--- a/plateform/app/services/geolocation.ts
+++ b/plateform/app/services/geolocation.ts
@@ -1,4 +1,4 @@
-export type GeoSuggestion = { label: string; lat: number; lon: number; country_code?: string };
+export type GeoSuggestion = { label: string; lat: number; lon: number; country_code?: string; postcode?: string };
 
 type AddressFeature = {
   properties: { label: string; name: string; postcode: string; type: string; id: string };
@@ -16,6 +16,7 @@ export async function searchAddress(query: string): Promise<GeoSuggestion[]> {
     lat: f.geometry.coordinates[1],
     lon: f.geometry.coordinates[0],
     country_code: "fr",
+    postcode: f.properties.postcode,
   }));
 }
 
@@ -29,5 +30,6 @@ export async function reverseGeocode(lat: number, lon: number): Promise<GeoSugge
     lat: f.geometry.coordinates[1],
     lon: f.geometry.coordinates[0],
     country_code: "fr",
+    postcode: f.properties.postcode,
   };
 }

--- a/plateform/app/services/tracking/__tests__/utils.test.ts
+++ b/plateform/app/services/tracking/__tests__/utils.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import type { ScreenAnswer } from "~/types/quiz";
+import { resolveAnswerValue, resolveGeoProps } from "../utils";
+
+describe("resolveAnswerValue", () => {
+  it("retourne la valeur unique pour une sélection simple", () => {
+    const answer: ScreenAnswer = { type: "options", taxonomy: "statut", option_ids: ["lyceen"] };
+    expect(resolveAnswerValue(answer)).toBe("lyceen");
+  });
+
+  it("retourne le tableau des valeurs pour une multi-sélection", () => {
+    const answer: ScreenAnswer = { type: "options", taxonomy: "domaine", option_ids: ["sante", "education"] };
+    expect(resolveAnswerValue(answer)).toEqual(["sante", "education"]);
+  });
+
+  it("retourne undefined pour une sélection vide", () => {
+    const answer: ScreenAnswer = { type: "options", taxonomy: "domaine", option_ids: [] };
+    expect(resolveAnswerValue(answer)).toBeUndefined();
+  });
+
+  it("retourne le nombre brut pour une réponse numeric (age)", () => {
+    const answer: ScreenAnswer = { type: "numeric", value: 22 };
+    expect(resolveAnswerValue(answer)).toBe(22);
+  });
+
+  it("retourne le label pour une réponse params géolocalisée", () => {
+    const answer: ScreenAnswer = { type: "params", taxonomy: "location", params: { lat: 48.85, lon: 2.35, label: "Paris (75001)" } };
+    expect(resolveAnswerValue(answer)).toBe("Paris (75001)");
+  });
+
+  it("retourne undefined pour une réponse params sans label", () => {
+    const answer: ScreenAnswer = { type: "params", taxonomy: "tranche_age", params: { age: 22, handicap: false } };
+    expect(resolveAnswerValue(answer)).toBeUndefined();
+  });
+
+  it("retourne la valeur pour une réponse text", () => {
+    const answer: ScreenAnswer = { type: "text", value: "infirmier" };
+    expect(resolveAnswerValue(answer)).toBe("infirmier");
+  });
+
+  it("retourne undefined quand la réponse est absente", () => {
+    expect(resolveAnswerValue(undefined)).toBeUndefined();
+  });
+});
+
+describe("resolveGeoProps", () => {
+  it("extrait les props géo d'une réponse params localisée", () => {
+    const answer: ScreenAnswer = {
+      type: "params",
+      taxonomy: "location",
+      params: { lat: 48.8566, lon: 2.3522, postcode: "75001", country_code: "fr", label: "Paris (75001)" },
+    };
+    expect(resolveGeoProps(answer)).toEqual({
+      geo_lat: 48.8566,
+      geo_lon: 2.3522,
+      geo_postcode: "75001",
+      geo_country_code: "fr",
+    });
+  });
+
+  it("renvoie des props undefined pour un params sans données géo (tranche_age)", () => {
+    const answer: ScreenAnswer = { type: "params", taxonomy: "tranche_age", params: { age: 22, handicap: false } };
+    expect(resolveGeoProps(answer)).toEqual({
+      geo_lat: undefined,
+      geo_lon: undefined,
+      geo_postcode: undefined,
+      geo_country_code: undefined,
+    });
+  });
+
+  it("renvoie un objet vide pour une réponse non-params", () => {
+    const answer: ScreenAnswer = { type: "options", taxonomy: "statut", option_ids: ["lyceen"] };
+    expect(resolveGeoProps(answer)).toEqual({});
+  });
+
+  it("renvoie un objet vide quand la réponse est absente", () => {
+    expect(resolveGeoProps(undefined)).toEqual({});
+  });
+});

--- a/plateform/app/services/tracking/__tests__/utils.test.ts
+++ b/plateform/app/services/tracking/__tests__/utils.test.ts
@@ -34,9 +34,9 @@ describe("resolveAnswerValue", () => {
     expect(resolveAnswerValue(answer)).toBeUndefined();
   });
 
-  it("retourne la valeur pour une réponse text", () => {
-    const answer: ScreenAnswer = { type: "text", value: "infirmier" };
-    expect(resolveAnswerValue(answer)).toBe("infirmier");
+  it("omet la valeur d'une réponse text (saisie libre : données perso / haute cardinalité)", () => {
+    const answer: ScreenAnswer = { type: "text", value: "BTS SIO au lycée Jean Moulin" };
+    expect(resolveAnswerValue(answer)).toBeUndefined();
   });
 
   it("retourne undefined quand la réponse est absente", () => {

--- a/plateform/app/services/tracking/events.ts
+++ b/plateform/app/services/tracking/events.ts
@@ -17,7 +17,7 @@ import type {
   QuizCompletionType,
   QuizEntrySource,
 } from "./types";
-import { ANSWER_VALUE_EXCLUDED_STEPS, buildQuizPath, countAnsweredSteps, optionAnswer } from "./utils";
+import { buildQuizPath, countAnsweredSteps, optionAnswer, resolveAnswerValue, resolveGeoProps } from "./utils";
 
 // Catalogue des évènements métier tracés côté front : nom de l'évènement + forme des propriétés
 // (spec produit, propriétés en snake_case côté PostHog). Les types vivent dans ./types, les helpers
@@ -121,21 +121,18 @@ export function trackQuizStarted(params: { entrySource: QuizEntrySource }): void
 }
 
 // `quiz.step_completed` (core_value) : à chaque validation d'étape (goNext).
+// answer_value remonte la réponse de chaque étape (cf. resolveAnswerValue). Pour les étapes
+// géolocalisées (localisation), les coordonnées/CP brutes sont ajoutées via resolveGeoProps.
 export function trackQuizStepCompleted(params: { stepName: StepId; answers: QuizAnswers; stepIndex: number; totalVisibleSteps: number }): void {
   const answer = params.answers[params.stepName];
-  // answer_value uniquement pour les étapes catégorielles non sensibles (omis pour age/localisation/handicap).
-  // Multi-sélection → tableau de toutes les valeurs ; sélection unique → chaîne simple ; sinon undefined (clé omise).
-  let answerValue: string | string[] | undefined;
-  if (!ANSWER_VALUE_EXCLUDED_STEPS.has(params.stepName) && answer?.type === "options" && answer.option_ids.length > 0) {
-    answerValue = answer.option_ids.length === 1 ? answer.option_ids[0] : answer.option_ids;
-  }
 
   track("quiz.step_completed", {
     step_name: params.stepName,
     quiz_path: buildQuizPath(params.answers),
     step_index: params.stepIndex,
     total_visible_steps: params.totalVisibleSteps,
-    answer_value: answerValue,
+    answer_value: resolveAnswerValue(answer),
+    ...resolveGeoProps(answer),
   });
 }
 

--- a/plateform/app/services/tracking/utils.ts
+++ b/plateform/app/services/tracking/utils.ts
@@ -1,5 +1,5 @@
 import { QUIZ_FLOW, type StepId } from "~/config/quiz-flow";
-import type { QuizAnswers } from "~/types/quiz";
+import type { QuizAnswers, ScreenAnswer } from "~/types/quiz";
 
 import type { EmailMissionDetailEntrySource, MissionDetailEntrySource, QuizEntrySource } from "./types";
 
@@ -29,8 +29,46 @@ export function countAnsweredSteps(answers: QuizAnswers): number {
   return QUIZ_FLOW.filter((step) => answers[step.id] !== undefined).length;
 }
 
-// Steps dont la réponse n'est pas remontée dans answer_value (non catégoriels ou sensibles).
-export const ANSWER_VALUE_EXCLUDED_STEPS = new Set<StepId>(["age", "localisation", "handicap"]);
+// Valeur remontée dans `answer_value` selon le type de réponse du step :
+//   - options : valeur unique (sélection simple) ou tableau (multi-sélection) ; undefined si vide.
+//   - numeric : nombre brut (ex. age).
+//   - params  : `label` lisible (ex. localisation) ; les coordonnées/CP sont remontés à part via resolveGeoProps.
+//   - text    : texte brut.
+export function resolveAnswerValue(answer: ScreenAnswer | undefined): string | number | string[] | undefined {
+  if (!answer) return undefined;
+  switch (answer.type) {
+    case "options":
+      if (answer.option_ids.length === 0) return undefined;
+      return answer.option_ids.length === 1 ? answer.option_ids[0] : answer.option_ids;
+    case "numeric":
+      return answer.value;
+    case "params": {
+      const label = (answer.params as { label?: unknown }).label;
+      return typeof label === "string" && label ? label : undefined;
+    }
+    case "text":
+      return answer.value || undefined;
+  }
+}
+
+// Propriétés géo brutes remontées pour les steps de type "params" géolocalisés (ex. localisation),
+// pour des analyses futures (distance, temps de trajet…). Générique : un step params sans lat/lon
+// (ex. tranche_age) produit des valeurs undefined, filtrées par `track()` avant envoi.
+export function resolveGeoProps(answer: ScreenAnswer | undefined): {
+  geo_lat?: number;
+  geo_lon?: number;
+  geo_postcode?: string;
+  geo_country_code?: string;
+} {
+  if (answer?.type !== "params") return {};
+  const params = answer.params as { lat?: unknown; lon?: unknown; postcode?: unknown; country_code?: unknown };
+  return {
+    geo_lat: typeof params.lat === "number" ? params.lat : undefined,
+    geo_lon: typeof params.lon === "number" ? params.lon : undefined,
+    geo_postcode: typeof params.postcode === "string" ? params.postcode : undefined,
+    geo_country_code: typeof params.country_code === "string" ? params.country_code : undefined,
+  };
+}
 
 // ============================================================================
 // Résolveurs d'entry_source

--- a/plateform/app/services/tracking/utils.ts
+++ b/plateform/app/services/tracking/utils.ts
@@ -33,7 +33,8 @@ export function countAnsweredSteps(answers: QuizAnswers): number {
 //   - options : valeur unique (sélection simple) ou tableau (multi-sélection) ; undefined si vide.
 //   - numeric : nombre brut (ex. age).
 //   - params  : `label` lisible (ex. localisation) ; les coordonnées/CP sont remontés à part via resolveGeoProps.
-//   - text    : texte brut.
+//   - text    : omis. Saisie libre (ex. precision_parcoursup_formation_nom) → risque de données
+//               personnelles et haute cardinalité, hors périmètre analytique d'answer_value.
 export function resolveAnswerValue(answer: ScreenAnswer | undefined): string | number | string[] | undefined {
   if (!answer) return undefined;
   switch (answer.type) {
@@ -47,7 +48,7 @@ export function resolveAnswerValue(answer: ScreenAnswer | undefined): string | n
       return typeof label === "string" && label ? label : undefined;
     }
     case "text":
-      return answer.value || undefined;
+      return undefined;
   }
 }
 


### PR DESCRIPTION
## Description

L'event `quiz.step_completed` doit envoyer une propriété `answer_value` pour **chaque** étape (analyse de la distribution des réponses). Trois étapes — `age`, `handicap` et `localisation` — en étaient exclues via `ANSWER_VALUE_EXCLUDED_STEPS`. Cette exclusion venait des specs du plan de tracking mais était en réalité un **oubli, pas un choix** : cette PR les fait remonter.

En complément, l'étape `localisation` est enrichie avec les données géo brutes (coordonnées exactes, code postal, `country_code`) pour des analyses futures (temps de trajet, distance…). Le principe retenu : **capter l'info à la source dans les `params` du `setAnswer`**, ce qui rend le stockage évolutif pour d'autres écrans.

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/Tracking-ajout-answer_value-pour-les-tapes-age-handicap-localisation-39872a322d5080c18f07f960a155036b?d=37e72a322d5083e094ba83280f013b29

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Points d'attention reviewer :**
- Les `params` enrichis transitent aussi vers l'API scoring via `buildPayload`, mais le transformer `location` ne lit que `lat`/`lon`/`country_code` → champs supplémentaires ignorés (comme `label` aujourd'hui). Sans impact backend.
- Pas de champ `city` dédié : le `label` contient déjà la ville (« Ville (CP) » pour les communes, label complet pour les adresses). Ajout trivial dans `geolocation.ts` si besoin ultérieur.
- **RGPD** : `handicap` (donnée de santé, catégorie particulière) et les coordonnées exactes sont des données personnelles/sensibles. La remontée est conforme à la décision produit ; à garder en tête pour le futur bandeau de consentement (TODO cookie-banner déjà présent dans `tracking/index.ts`).
