### PR TITLE
feat(plateform): send utm properties to tracking service

### DIFF
--- a/plateform/app/services/tracking/index.ts
+++ b/plateform/app/services/tracking/index.ts
@@ -1,5 +1,6 @@
 import { TRACKING_PROVIDER } from "~/services/config";
 import { useQuizStore } from "~/stores/quiz";
+import { CAMPAIGN_UTM_KEYS, getCampaignParamsFromSearch, resolveActiveCampaign, type CampaignParams } from "~/utils/campaign-attribution";
 import { getInternalUserFlagAction, isInternalUserFlagEnabled, persistInternalUserFlagAction } from "~/utils/internal-user-flag";
 
 import { createProvider } from "./providers";
@@ -23,6 +24,7 @@ function getProvider(): TrackingProvider | null {
     // Identify + super properties avant la première capture (un track() de route peut précéder initTracking()).
     bootstrapIdentity();
     syncInternalUserFlag(provider);
+    syncCampaignSuperProperties(provider);
   }
   return provider;
 }
@@ -73,6 +75,27 @@ function syncInternalUserFlag(provider: TrackingProvider): void {
   }
 
   provider.unregister?.("internal_user");
+}
+
+// Super properties d'attribution de campagne (utm_source/campaign/medium) attachées à TOUS les
+// évènements. Modèle "last non-direct touch" + session glissante de 30 min (cf. resolveActiveCampaign) :
+// une nouvelle campagne écrase l'attribution, le direct/navigation interne la prolonge, l'inactivité
+// la purge. On `unregister` les UTM absents de l'attribution active pour ne pas laisser d'anciennes
+// valeurs persistées par PostHog au-delà du TTL.
+function syncCampaignSuperProperties(provider: TrackingProvider): void {
+  let campaign: CampaignParams = {};
+  try {
+    campaign = resolveActiveCampaign(window.location.search, window.localStorage);
+  } catch {
+    // localStorage indisponible : au minimum, attacher les UTM de l'URL courante.
+    campaign = getCampaignParamsFromSearch(window.location.search);
+  }
+
+  for (const key of CAMPAIGN_UTM_KEYS) {
+    if (campaign[key] === undefined) provider.unregister?.(key);
+  }
+
+  if (Object.keys(campaign).length > 0) provider.register?.(campaign);
 }
 
 // Déclenche l'init paresseuse (provider + identité + flag interne) au plus tôt, sans attendre un premier track().

--- a/plateform/app/utils/__tests__/campaign-attribution.test.ts
+++ b/plateform/app/utils/__tests__/campaign-attribution.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { CAMPAIGN_ATTRIBUTION_STORAGE_KEY, CAMPAIGN_SESSION_TTL_MS, getCampaignParamsFromSearch, resolveActiveCampaign } from "../campaign-attribution";
+
+// Faux Storage sur une Map, calqué sur le test internal-user-flag.
+function createStorage(initial?: [string, string][]) {
+  const map = new Map<string, string>(initial);
+  return {
+    map,
+    storage: {
+      getItem: (key: string) => map.get(key) ?? null,
+      setItem: (key: string, value: string) => map.set(key, value),
+      removeItem: (key: string) => map.delete(key),
+    },
+  };
+}
+
+describe("getCampaignParamsFromSearch", () => {
+  it("extrait les 3 UTM présents", () => {
+    expect(getCampaignParamsFromSearch("?utm_source=google&utm_campaign=ete&utm_medium=cpc")).toEqual({
+      utm_source: "google",
+      utm_campaign: "ete",
+      utm_medium: "cpc",
+    });
+  });
+
+  it("n'extrait que les UTM présents (sous-ensemble partiel)", () => {
+    expect(getCampaignParamsFromSearch("?utm_source=google")).toEqual({ utm_source: "google" });
+  });
+
+  it("ignore les paramètres non UTM et les valeurs vides", () => {
+    expect(getCampaignParamsFromSearch("?internal=1&utm_source=&utm_campaign=ete")).toEqual({ utm_campaign: "ete" });
+  });
+
+  it("retourne un objet vide sur une URL sans UTM (trafic direct)", () => {
+    expect(getCampaignParamsFromSearch("")).toEqual({});
+    expect(getCampaignParamsFromSearch("?internal=1")).toEqual({});
+  });
+
+  it("accepte une instance URLSearchParams", () => {
+    expect(getCampaignParamsFromSearch(new URLSearchParams("utm_medium=email"))).toEqual({ utm_medium: "email" });
+  });
+});
+
+describe("resolveActiveCampaign", () => {
+  it("persiste et retourne les UTM d'une nouvelle campagne", () => {
+    const { map, storage } = createStorage();
+
+    const active = resolveActiveCampaign("?utm_source=google&utm_medium=cpc", storage, 1000);
+
+    expect(active).toEqual({ utm_source: "google", utm_medium: "cpc" });
+    expect(JSON.parse(map.get(CAMPAIGN_ATTRIBUTION_STORAGE_KEY)!)).toEqual({
+      params: { utm_source: "google", utm_medium: "cpc" },
+      ts: 1000,
+    });
+  });
+
+  it("écrase une attribution stockée quand une nouvelle campagne arrive (last non-direct)", () => {
+    const { map, storage } = createStorage([[CAMPAIGN_ATTRIBUTION_STORAGE_KEY, JSON.stringify({ params: { utm_source: "old" }, ts: 500 })]]);
+
+    const active = resolveActiveCampaign("?utm_source=new&utm_campaign=promo", storage, 2000);
+
+    expect(active).toEqual({ utm_source: "new", utm_campaign: "promo" });
+    expect(JSON.parse(map.get(CAMPAIGN_ATTRIBUTION_STORAGE_KEY)!)).toEqual({
+      params: { utm_source: "new", utm_campaign: "promo" },
+      ts: 2000,
+    });
+  });
+
+  it("prolonge la session sur du direct dans la fenêtre TTL et met à jour le timestamp", () => {
+    const stored = { params: { utm_source: "google" }, ts: 1000 };
+    const { map, storage } = createStorage([[CAMPAIGN_ATTRIBUTION_STORAGE_KEY, JSON.stringify(stored)]]);
+
+    const now = 1000 + CAMPAIGN_SESSION_TTL_MS; // pile à la limite → encore valide
+    const active = resolveActiveCampaign("", storage, now);
+
+    expect(active).toEqual({ utm_source: "google" });
+    expect(JSON.parse(map.get(CAMPAIGN_ATTRIBUTION_STORAGE_KEY)!)).toEqual({ params: { utm_source: "google" }, ts: now });
+  });
+
+  it("purge et ne retourne rien sur du direct au-delà du TTL", () => {
+    const { map, storage } = createStorage([[CAMPAIGN_ATTRIBUTION_STORAGE_KEY, JSON.stringify({ params: { utm_source: "google" }, ts: 1000 })]]);
+
+    const active = resolveActiveCampaign("", storage, 1000 + CAMPAIGN_SESSION_TTL_MS + 1);
+
+    expect(active).toEqual({});
+    expect(map.has(CAMPAIGN_ATTRIBUTION_STORAGE_KEY)).toBe(false);
+  });
+
+  it("retourne un objet vide sur du direct sans attribution stockée", () => {
+    const { map, storage } = createStorage();
+
+    const active = resolveActiveCampaign("", storage, 1000);
+
+    expect(active).toEqual({});
+    expect(map.has(CAMPAIGN_ATTRIBUTION_STORAGE_KEY)).toBe(false);
+  });
+
+  it("ne conserve que les clés présentes d'une campagne partielle", () => {
+    const { storage } = createStorage();
+
+    const active = resolveActiveCampaign("?utm_source=google", storage, 1000);
+
+    expect(active).toEqual({ utm_source: "google" });
+  });
+
+  it("ignore une valeur stockée corrompue et traite comme trafic direct", () => {
+    const { map, storage } = createStorage([[CAMPAIGN_ATTRIBUTION_STORAGE_KEY, "{not-json"]]);
+
+    const active = resolveActiveCampaign("", storage, 1000);
+
+    expect(active).toEqual({});
+    expect(map.get(CAMPAIGN_ATTRIBUTION_STORAGE_KEY)).toBe("{not-json");
+  });
+});

--- a/plateform/app/utils/campaign-attribution.ts
+++ b/plateform/app/utils/campaign-attribution.ts
@@ -1,0 +1,76 @@
+// Attribution de campagne (UTM) attachée à tous les évènements de tracking.
+// Modèle : "last non-direct touch" + session glissante de 30 min.
+//   - Une nouvelle campagne (UTM dans l'URL) écrase l'attribution stockée.
+//   - Le trafic direct / la navigation interne (aucun UTM) n'écrase pas : l'attribution persiste.
+//   - Passé 30 min sans activité, l'attribution est purgée (retour direct = trafic direct).
+// Fonctions pures (storage et now injectés) pour rester testables sans `window`.
+
+export const CAMPAIGN_ATTRIBUTION_STORAGE_KEY = "plateform.campaign_attribution";
+
+// Fenêtre glissante d'inactivité au-delà de laquelle l'attribution expire (équivalent GA).
+export const CAMPAIGN_SESSION_TTL_MS = 30 * 60 * 1000;
+
+export const CAMPAIGN_UTM_KEYS = ["utm_source", "utm_campaign", "utm_medium"] as const;
+
+export type CampaignUtmKey = (typeof CAMPAIGN_UTM_KEYS)[number];
+
+// UTM présents pour une attribution donnée (sous-ensemble possible des 3 clés).
+export type CampaignParams = Partial<Record<CampaignUtmKey, string>>;
+
+// Forme persistée : les UTM + le timestamp de dernière activité (pour le TTL glissant).
+interface StoredCampaign {
+  params: CampaignParams;
+  ts: number;
+}
+
+// Extrait les UTM présents et non vides de l'URL. Accepte une querystring ou une URLSearchParams.
+export function getCampaignParamsFromSearch(search: string | URLSearchParams): CampaignParams {
+  const params = typeof search === "string" ? new URLSearchParams(search) : search;
+
+  const result: CampaignParams = {};
+  for (const key of CAMPAIGN_UTM_KEYS) {
+    const value = params.get(key);
+    if (value) result[key] = value;
+  }
+  return result;
+}
+
+function hasParams(params: CampaignParams): boolean {
+  return Object.keys(params).length > 0;
+}
+
+// Lecture défensive : retourne null si absent ou JSON invalide.
+function readStored(storage: Pick<Storage, "getItem">): StoredCampaign | null {
+  const raw = storage.getItem(CAMPAIGN_ATTRIBUTION_STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as StoredCampaign;
+    if (!parsed || typeof parsed.ts !== "number" || typeof parsed.params !== "object") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+// Résout l'attribution active et met à jour le storage (écrasement / prolongation / purge).
+// Retourne les UTM à enregistrer comme super properties ({} si aucune attribution active).
+export function resolveActiveCampaign(search: string | URLSearchParams, storage: Pick<Storage, "getItem" | "setItem" | "removeItem">, now: number = Date.now()): CampaignParams {
+  const fromUrl = getCampaignParamsFromSearch(search);
+
+  // Nouvelle campagne : écrase l'attribution précédente (last non-direct touch).
+  if (hasParams(fromUrl)) {
+    storage.setItem(CAMPAIGN_ATTRIBUTION_STORAGE_KEY, JSON.stringify({ params: fromUrl, ts: now }));
+    return fromUrl;
+  }
+
+  // Trafic direct / navigation interne : on prolonge la session tant qu'elle n'a pas expiré.
+  const stored = readStored(storage);
+  if (stored && now - stored.ts <= CAMPAIGN_SESSION_TTL_MS) {
+    storage.setItem(CAMPAIGN_ATTRIBUTION_STORAGE_KEY, JSON.stringify({ params: stored.params, ts: now }));
+    return stored.params;
+  }
+
+  // Session expirée ou absente : purge et pas d'attribution.
+  if (stored) storage.removeItem(CAMPAIGN_ATTRIBUTION_STORAGE_KEY);
+  return {};
+}


### PR DESCRIPTION
## Description

Ajoute le suivi des paramètres UTM (`utm_source`, `utm_campaign`, `utm_medium`) au service de tracking de `plateform`, en vue des campagnes d'acquisition à venir. Les UTM de l'URL d'entrée sont enregistrés comme **super properties** PostHog et donc attachés à **tous** les évènements du parcours (du `page.viewed` aux clics), de manière persistante.

Le mécanisme est calqué sur celui du flag `internal_user` : un `syncCampaignSuperProperties()` appelé à l'init du provider, qui lit `window.location.search` et `register()` les UTM présents (persistance assurée par PostHog + un stockage `localStorage` dédié pour la fenêtre d'attribution).

**Modèle d'attribution : « last non-direct touch » + session glissante de 30 min** (équivalent GA « source/medium de session ») :
- une **nouvelle campagne** (UTM dans l'URL) écrase l'attribution stockée → on mesure la perf de chaque campagne, y compris au retour via une autre ;
- le **trafic direct** et la **navigation interne** (aucun UTM) n'écrasent pas : l'attribution persiste sur tout le parcours ;
- passé **30 min d'inactivité**, l'attribution est purgée (un retour direct redevient du trafic direct).

Les UTM absents de l'attribution active sont `unregister()` pour ne pas laisser d'anciennes valeurs persistées par PostHog au-delà du TTL.

Côté analytics, le pivot dbt `stg_tracking__event` est déjà prêt à consommer les 3 UTM : aucun changement nécessaire.

<img width="728" height="108" alt="image" src="https://github.com/user-attachments/assets/417c8aba-9234-4f00-90b4-355077a2cb20" />


## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/Tracking-des-param-tres-utm-sur-les-v-nements-39672a322d508078adafe3888446b21e?source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Points d'attention pour le reviewer**
- Le refresh glissant du TTL se fait à chaque chargement de page (`getProvider()` est mémoïsé), pas à chaque navigation SPA. C'est suffisant : une fois `register()` appelé, la super property reste attachée à tous les events de la session SPA (PostHog les persiste). Le TTL fait office de frontière de session entre rechargements / re-visites.

**Recette**
- `/?utm_source=…&utm_campaign=…&utm_medium=…` → les events portent les 3 propriétés, y compris après navigation interne sans UTM.
- Re-visite avec des UTM différents → nouvelle attribution (écrasement).
- Re-visite directe peu après → UTM conservés ; après > 30 min d'inactivité → plus d'UTM.
- `/` sans UTM (localStorage vierge) → aucun UTM (trafic direct).
