### PR TITLE
fix(api): allow diffuseur to diffuse its own missions

### DIFF
--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -44,12 +44,12 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
     });
   });
 
-  it("réduit un annonceur sans enfant à son simple publisherId", async () => {
+  it("ajoute le scope implicite du diffuseur à l'annonceur configuré", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ id: "root-1", value: "annonceur-1" })]);
 
     const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1");
 
-    expect(where).toEqual({ publisherId: "annonceur-1" });
+    expect(where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "publisher-1" }] });
   });
 
   it("combine l'annonceur avec ses critères enfants (publisherId AND <critère>)", async () => {
@@ -62,7 +62,10 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
     const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1");
 
     expect(where).toEqual({
-      AND: [{ publisherId: "annonceur-1" }, { publisherOrganization: { is: { AND: [{ clientId: { not: "po-1" } }, { clientId: { not: "po-2" } }] } } }],
+      OR: [
+        { AND: [{ publisherId: "annonceur-1" }, { publisherOrganization: { is: { AND: [{ clientId: { not: "po-1" } }, { clientId: { not: "po-2" } }] } } }] },
+        { publisherId: "publisher-1" },
+      ],
     });
   });
 
@@ -74,7 +77,7 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
 
     const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1");
 
-    expect(where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }] });
+    expect(where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }, { publisherId: "publisher-1" }] });
   });
 
   it("restreint les scopes aux annonceurs demandés", async () => {
@@ -95,6 +98,41 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
 
     expect(where).toEqual({ id: { in: [] } });
   });
+
+  it("autorise le diffuseur à diffuser ses propres missions même hors allowlist", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ id: "root-1", value: "annonceur-1" })]);
+
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1", ["publisher-1"]);
+
+    expect(where).toEqual({ publisherId: "publisher-1" });
+  });
+
+  it("combine le scope implicite du diffuseur avec les annonceurs demandés de l'allowlist", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ id: "root-1", value: "annonceur-1" })]);
+
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1", ["publisher-1", "annonceur-1"]);
+
+    expect(where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "publisher-1" }] });
+  });
+
+  it("exclut les annonceurs hors allowlist même quand le diffuseur est demandé", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ id: "root-1", value: "annonceur-1" })]);
+
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1", ["publisher-1", "annonceur-2"]);
+
+    expect(where).toEqual({ publisherId: "publisher-1" });
+  });
+
+  it("n'ajoute pas de scope implicite quand le diffuseur a un scope explicite avec critères", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
+      buildRule({ id: "root-1", value: "publisher-1" }),
+      buildRule({ id: "child-1", combinedWithId: "root-1", field: "type", operator: "is", value: "benevolat" }),
+    ]);
+
+    const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1", ["publisher-1"]);
+
+    expect(where).toEqual({ AND: [{ publisherId: "publisher-1" }, { type: "benevolat" }] });
+  });
 });
 
 describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", () => {
@@ -110,12 +148,12 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
     expect(where).toEqual({});
   });
 
-  it("un seul annonceur sans critère → filtre positif publisherId", async () => {
+  it("un seul annonceur sans critère → OR avec le scope implicite du diffuseur", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ id: "root-1", value: "annonceur-1" })]);
 
     const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("diffuseur-1");
 
-    expect(where).toEqual({ publisherId: "annonceur-1" });
+    expect(where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "diffuseur-1" }] });
   });
 
   it("plusieurs annonceurs → OR des scopes (allowlist)", async () => {
@@ -126,7 +164,7 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
 
     const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("diffuseur-1");
 
-    expect(where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }] });
+    expect(where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }, { publisherId: "diffuseur-1" }] });
   });
 
   it("applique les critères enfants en AND dans le scope", async () => {
@@ -137,7 +175,9 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
 
     const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("diffuseur-1");
 
-    expect(where).toEqual({ AND: [{ publisherId: "annonceur-1" }, { publisherOrganization: { clientId: { not: "po-1" } } }] });
+    expect(where).toEqual({
+      OR: [{ AND: [{ publisherId: "annonceur-1" }, { publisherOrganization: { clientId: { not: "po-1" } } }] }, { publisherId: "diffuseur-1" }],
+    });
   });
 
   it("descend récursivement quand un critère enfant a lui-même un enfant", async () => {
@@ -149,7 +189,9 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
 
     const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("diffuseur-1");
 
-    expect(where).toEqual({ AND: [{ publisherId: "annonceur-1" }, { AND: [{ type: "benevolat" }, { publisherOrganization: { clientId: { not: "po-1" } } }] }] });
+    expect(where).toEqual({
+      OR: [{ AND: [{ publisherId: "annonceur-1" }, { AND: [{ type: "benevolat" }, { publisherOrganization: { clientId: { not: "po-1" } } }] }] }, { publisherId: "diffuseur-1" }],
+    });
   });
 
   it("ignore les racines top-level qui ne sont pas des scopes annonceur (field ≠ publisherId)", async () => {
@@ -160,7 +202,7 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
 
     const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("diffuseur-1");
 
-    expect(where).toEqual({ publisherId: "annonceur-1" });
+    expect(where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "diffuseur-1" }] });
   });
 
   it("ignore les racines publisherId qui ne sont pas des scopes positifs", async () => {
@@ -171,10 +213,10 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
 
     const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("diffuseur-1");
 
-    expect(where).toEqual({ publisherId: "annonceur-1" });
+    expect(where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "diffuseur-1" }] });
   });
 
-  it("renvoie la liste des annonceurs configurés avec le where", async () => {
+  it("renvoie la liste des annonceurs configurés avec le where, sans le scope implicite du diffuseur", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([
       buildRule({ id: "root-1", value: "annonceur-1" }),
       buildRule({ id: "root-2", value: "annonceur-2", position: 1 }),
@@ -184,9 +226,9 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
     const filter = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateFilter("diffuseur-1");
 
     expect(filter.publisherIds).toEqual(["annonceur-1", "annonceur-2"]);
-    expect(filter.scopePublisherIds).toEqual(["annonceur-1", "annonceur-2"]);
-    expect(filter.scopes).toEqual([{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }]);
-    expect(filter.where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }] });
+    expect(filter.scopePublisherIds).toEqual(["annonceur-1", "annonceur-2", "diffuseur-1"]);
+    expect(filter.scopes).toEqual([{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }, { publisherId: "diffuseur-1" }]);
+    expect(filter.where).toEqual({ OR: [{ publisherId: "annonceur-1" }, { publisherId: "annonceur-2" }, { publisherId: "diffuseur-1" }] });
   });
 });
 
@@ -214,7 +256,7 @@ describe("publisherDiffusionRuleService.canPublisherAccessMission", () => {
     expect(canAccess).toBe(true);
     expect(prismaMock.mission.count).toHaveBeenCalledWith({
       where: {
-        AND: [{ id: "mission-1" }, { publisherId: "annonceur-1" }],
+        AND: [{ id: "mission-1" }, { OR: [{ publisherId: "annonceur-1" }, { publisherId: "publisher-1" }] }],
       },
     });
   });

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -82,27 +82,38 @@ const buildScopeCondition = (rule: PublisherDiffusionRule, childrenByParentId: M
 
 /**
  * Allowlist des missions diffusables : `OR` des scopes, chaque scope étant un
- * annonceur (`publisherId === X`) combiné à ses critères enfants. `publisherIds`
- * restreint optionnellement aux annonceurs demandés (param `publisher` de la route).
+ * annonceur (`publisherId === X`) combiné à ses critères enfants. Le diffuseur
+ * est toujours implicitement autorisé à diffuser ses propres missions, même
+ * s'il ne figure pas dans sa propre allowlist. `publisherIds` restreint
+ * optionnellement aux annonceurs demandés (param `publisher` de la route).
  */
-const buildAllowlistFilter = (rules: PublisherDiffusionRule[], publisherIds?: string[]): MissionDiffuseurCandidateFilter => {
+const buildAllowlistFilter = (rules: PublisherDiffusionRule[], diffuseurPublisherId: string, publisherIds?: string[]): MissionDiffuseurCandidateFilter => {
   const { roots, childrenByParentId } = groupRulesByParent(rules);
+  const allowlistRoots = roots.filter((root) => root.field === "publisherId" && root.operator === "is");
+  const diffuseurIsRequested = !publisherIds || publisherIds.includes(diffuseurPublisherId);
 
-  if (publisherIds?.length) {
-    const configuredPublisherIds = roots.filter((root) => root.field === "publisherId" && root.operator === "is").map((root) => root.value);
-    if (configuredPublisherIds.length > 0 && !publisherIds.some((id) => configuredPublisherIds.includes(id))) {
+  if (publisherIds?.length && allowlistRoots.length > 0 && !diffuseurIsRequested) {
+    const configuredPublisherIds = allowlistRoots.map((root) => root.value);
+    if (!publisherIds.some((id) => configuredPublisherIds.includes(id))) {
       return { where: IMPOSSIBLE_MISSION_WHERE, publisherIds: [], scopes: [], scopePublisherIds: [] };
     }
   }
 
-  const scopeRoots = roots.filter((root) => root.field === "publisherId" && root.operator === "is" && (!publisherIds || publisherIds.includes(root.value)));
+  const scopeRoots = allowlistRoots.filter((root) => !publisherIds || publisherIds.includes(root.value));
 
   const scopes = scopeRoots
     .map((root) => buildScopeCondition(root, childrenByParentId))
     .filter((scope): scope is Prisma.MissionWhereInput => scope !== null && Object.keys(scope).length > 0);
 
+  // `publisherIds` (candidats) ne liste que les annonceurs explicitement configurés :
+  // le scope implicite du diffuseur n'y est pas ajouté (ex. feeds XML par annonceur).
   const candidatePublisherIds = Array.from(new Set(scopeRoots.map((root) => root.value)));
   const scopePublisherIds = scopeRoots.map((root) => root.value);
+
+  if (allowlistRoots.length > 0 && diffuseurIsRequested && !scopePublisherIds.includes(diffuseurPublisherId)) {
+    scopes.push({ publisherId: diffuseurPublisherId });
+    scopePublisherIds.push(diffuseurPublisherId);
+  }
 
   if (scopes.length === 0) {
     return { where: {}, publisherIds: candidatePublisherIds, scopes, scopePublisherIds };
@@ -178,18 +189,19 @@ export const publisherDiffusionRuleService = {
   /**
    * Construit le where des missions qu'un diffuseur peut diffuser, sous forme
    * d'allowlist : `OR` des scopes, chaque scope = `publisherId` de l'annonceur
-   * `AND` ses critères/exclusions enfants. `publisherIds` restreint optionnellement
+   * `AND` ses critères/exclusions enfants. Le diffuseur est toujours implicitement
+   * autorisé à diffuser ses propres missions. `publisherIds` restreint optionnellement
    * aux annonceurs demandés (param `publisher` de la route).
    */
   async buildMissionDiffuseurCandidateWhere(publisherId: string, publisherIds?: string[]): Promise<Prisma.MissionWhereInput> {
     const rules = await findOrderedRules(publisherId);
-    const { where } = buildAllowlistFilter(rules, publisherIds);
+    const { where } = buildAllowlistFilter(rules, publisherId, publisherIds);
     return where;
   },
 
   async buildMissionDiffuseurCandidateFilter(publisherId: string, publisherIds?: string[]): Promise<MissionDiffuseurCandidateFilter> {
     const rules = await findOrderedRules(publisherId);
-    return buildAllowlistFilter(rules, publisherIds);
+    return buildAllowlistFilter(rules, publisherId, publisherIds);
   },
 
   async canPublisherAccessMission({ publisherId, missionId }: { publisherId: string; missionId: string }): Promise<boolean> {
@@ -198,7 +210,7 @@ export const publisherDiffusionRuleService = {
       return true;
     }
 
-    const { where: diffusionRuleWhere } = buildAllowlistFilter(rules);
+    const { where: diffusionRuleWhere } = buildAllowlistFilter(rules, publisherId);
     if (Object.keys(diffusionRuleWhere).length === 0) {
       return false;
     }


### PR DESCRIPTION
## Description

Un widget dont le diffuseur demande ses propres missions (ex. widget JVA avec `publishers = [JVA]`) renvoyait 0 mission : `buildAllowlistFilter` retournait un where impossible (`id IN []`) car le diffuseur ne figure pas dans sa propre allowlist de diffusion rules.

**Changements** :
- Le diffuseur est désormais implicitement autorisé à diffuser ses propres missions : bypass du filtre impossible quand il fait partie des annonceurs demandés, et ajout d'un scope implicite `{ publisherId: diffuseur }` en `OR` des scopes de l'allowlist
- L'autorité de l'allowlist est préservée pour les tiers : un annonceur hors allowlist reste exclu
- Corrige aussi `canPublisherAccessMission` (un diffuseur se voyait refuser l'accès à sa propre mission, utilisé par `v0/mission` et `v2/activity`)
- Le scope implicite n'est pas ajouté à `filter.publisherIds` (liste des annonceurs explicitement configurés) pour ne pas impacter les feeds XML par annonceur (job grimpio)

## Liens utiles

- 📝 Ticket Notion : [aqui !](https://app.notion.com/p/jeveuxaider/L-aper-u-dans-le-tableau-de-bord-des-widgets-semble-cass-39072a322d508074a4e1e17251c9be1e?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Vérification locale** : `GET /iframe/690de5ec230a450839dc9e14/search` (widget « LP - Bénévolat jeunes 16 18 ans ») renvoie 1764 missions contre 0 avant le fix ; `/aggs` renvoie bien les agrégations.

**Tests** : 608/608 tests unitaires passent, dont 4 nouveaux cas de régression (diffuseur seul, diffuseur + annonceur de l'allowlist, annonceur hors allowlist, scope explicite du diffuseur avec critères).

**Point d'attention** : le variant SQL brut (`buildMissionPublisherDiffusionRuleSql`, utilisé par les exports XML) conserve l'ancienne sémantique sans scope implicite — même classe de problème si un diffuseur-annonceur y passe un jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)