### PR TITLE
fix(api): add rate limit quotas in enrichment sentry error

### DIFF
--- a/api/src/jobs/update-mission-enrichment/handler.ts
+++ b/api/src/jobs/update-mission-enrichment/handler.ts
@@ -4,6 +4,7 @@ import { BaseHandler } from "@/jobs/base/handler";
 import { JobResult } from "@/jobs/types";
 import { missionEnrichmentService } from "@/services/mission-enrichment";
 import { JOB_ENRICH_SLEEP_MS } from "@/services/mission-enrichment/config";
+import { MissionEnrichmentRateLimitError } from "@/services/mission-enrichment/errors";
 import { CURRENT_PROMPT_VERSION } from "@/services/mission-enrichment/prompts";
 import { setTimeout as sleep } from "timers/promises";
 
@@ -76,9 +77,10 @@ export class UpdateMissionEnrichmentHandler implements BaseHandler<UpdateMission
           console.log(`${LOG_PREFIX} [${processed}/${missions.length}] enriched ${mission.id}`);
         } catch (error) {
           failed++;
-          console.error(`${LOG_PREFIX} failed to enrich ${mission.id}`, error);
+          const rateLimitDetails = error instanceof MissionEnrichmentRateLimitError ? error.details : undefined;
+          console.error(`${LOG_PREFIX} failed to enrich ${mission.id}`, error, rateLimitDetails ?? {});
           if ((error as { name?: string })?.name !== "AI_NoObjectGeneratedError") {
-            captureException(error, { extra: { missionId: mission.id } });
+            captureException(error, { extra: { missionId: mission.id, ...(rateLimitDetails ? { rateLimit: rateLimitDetails } : {}) } });
           }
         }
 

--- a/api/src/services/ai/providers/albert/__tests__/index.test.ts
+++ b/api/src/services/ai/providers/albert/__tests__/index.test.ts
@@ -141,6 +141,28 @@ describe("AlbertProvider", () => {
     } satisfies Partial<APICallError>);
   });
 
+  it("attaches the parsed limit detail to APICallError.data on a 429 rate limit", async () => {
+    process.env.ALBERT_API_KEY = "test-key";
+    process.env.ALBERT_BASE_URL = "https://albert.test";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response('{"detail":"2460000 input tokens per day exceeded (remaining: 0)."}', {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        })
+      )
+    );
+
+    const { AlbertProvider } = await importAlbert();
+
+    await expect(new AlbertProvider().languageModel("mistral-test").doGenerate(baseOptions)).rejects.toMatchObject({
+      statusCode: 429,
+      isRetryable: true,
+      data: { detail: "2460000 input tokens per day exceeded (remaining: 0)." },
+    } satisfies Partial<APICallError>);
+  });
+
   it("throws a non-retryable APICallError when Albert returns no content", async () => {
     process.env.ALBERT_API_KEY = "test-key";
     process.env.ALBERT_BASE_URL = "https://albert.test";

--- a/api/src/services/ai/providers/albert/language-model.ts
+++ b/api/src/services/ai/providers/albert/language-model.ts
@@ -4,7 +4,7 @@ import { APICallError, UnsupportedFunctionalityError } from "@ai-sdk/provider";
 import { ALBERT_BASE_URL } from "@/config";
 
 import type { AlbertChatCompletion } from "./types";
-import { buildResponseFormat, getAlbertApiKey, headersToRecord, mapFinishReason, mapUsage, toAlbertMessages } from "./utils";
+import { buildResponseFormat, getAlbertApiKey, headersToRecord, mapFinishReason, mapUsage, parseAlbertErrorDetail, toAlbertMessages } from "./utils";
 
 export const createAlbertLanguageModel = (modelId: string): LanguageModelV3 => ({
   specificationVersion: "v3",
@@ -58,6 +58,7 @@ export const createAlbertLanguageModel = (modelId: string): LanguageModelV3 => (
       });
     }
     if (!response.ok) {
+      const detail = parseAlbertErrorDetail(responseBody);
       throw new APICallError({
         message: `Albert API error ${response.status}: ${responseBody}`,
         url,
@@ -65,6 +66,7 @@ export const createAlbertLanguageModel = (modelId: string): LanguageModelV3 => (
         statusCode: response.status,
         responseHeaders: headersToRecord(response.headers),
         responseBody,
+        data: detail ? { detail } : undefined,
         isRetryable: response.status === 429 || response.status >= 500,
       });
     }

--- a/api/src/services/ai/providers/albert/utils.ts
+++ b/api/src/services/ai/providers/albert/utils.ts
@@ -1,11 +1,4 @@
-import type {
-  JSONObject,
-  JSONSchema7,
-  LanguageModelV3CallOptions,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3Message,
-  LanguageModelV3Usage,
-} from "@ai-sdk/provider";
+import type { JSONObject, JSONSchema7, LanguageModelV3CallOptions, LanguageModelV3GenerateResult, LanguageModelV3Message, LanguageModelV3Usage } from "@ai-sdk/provider";
 import { LoadAPIKeyError, UnsupportedFunctionalityError } from "@ai-sdk/provider";
 
 import { ALBERT_API_KEY } from "@/config";
@@ -94,6 +87,17 @@ export const mapUsage = (usage: AlbertChatCompletion["usage"]): LanguageModelV3U
 });
 
 export const headersToRecord = (headers: Headers): Record<string, string> => Object.fromEntries(headers.entries());
+
+// Albert renvoie la limite atteinte dans le corps JSON (`{"detail":"… input tokens per day exceeded …"}`)
+// et non dans les headers ; on extrait ce message pour l'exposer sur `APICallError.data` (payload parsé).
+export const parseAlbertErrorDetail = (responseBody: string): string | undefined => {
+  try {
+    const parsed = JSON.parse(responseBody) as { detail?: unknown };
+    return typeof parsed.detail === "string" && parsed.detail.trim() ? parsed.detail.trim() : undefined;
+  } catch {
+    return undefined; // corps non-JSON (ex. page HTML d'un proxy) : rien à extraire
+  }
+};
 
 export const getAlbertApiKey = (): string => {
   if (!ALBERT_API_KEY) {

--- a/api/src/services/mission-enrichment/errors.ts
+++ b/api/src/services/mission-enrichment/errors.ts
@@ -2,6 +2,7 @@ export type RateLimitDetails = {
   provider?: string; // ex. "albert", "mistral.chat"
   statusCode?: number; // 429
   retryAfter?: string; // header retry-after si présent
+  detail?: string; // message de limite extrait du corps (Albert renvoie `{"detail":"… tokens per day exceeded …"}`)
   rateLimitHeaders?: Record<string, string>; // sous-ensemble filtré des headers de rate-limit (highlights lisibles)
   responseHeaders?: Record<string, string>; // headers complets (pour découvrir le nommage exact côté provider)
   responseBody?: string; // corps tronqué (le provider y met souvent le message de limite)
@@ -22,6 +23,9 @@ export const buildRateLimitMessage = (details?: RateLimitDetails): string => {
   }
   if (details.retryAfter) {
     parts.push(`retry-after=${details.retryAfter}`);
+  }
+  if (details.detail) {
+    parts.push(details.detail);
   }
   for (const [key, value] of Object.entries(details.rateLimitHeaders ?? {})) {
     if (key === "retry-after") {

--- a/api/src/services/mission-enrichment/errors.ts
+++ b/api/src/services/mission-enrichment/errors.ts
@@ -1,6 +1,44 @@
+export type RateLimitDetails = {
+  provider?: string; // ex. "albert", "mistral.chat"
+  statusCode?: number; // 429
+  retryAfter?: string; // header retry-after si présent
+  rateLimitHeaders?: Record<string, string>; // sous-ensemble filtré des headers de rate-limit (highlights lisibles)
+  responseHeaders?: Record<string, string>; // headers complets (pour découvrir le nommage exact côté provider)
+  responseBody?: string; // corps tronqué (le provider y met souvent le message de limite)
+};
+
+/** Construit un message lisible résumant la limite atteinte. Sans détails → message historique. */
+export const buildRateLimitMessage = (details?: RateLimitDetails): string => {
+  if (!details) {
+    return "Rate limit reached";
+  }
+
+  const parts: string[] = [];
+  if (details.provider) {
+    parts.push(`provider=${details.provider}`);
+  }
+  if (details.statusCode != null) {
+    parts.push(`status=${details.statusCode}`);
+  }
+  if (details.retryAfter) {
+    parts.push(`retry-after=${details.retryAfter}`);
+  }
+  for (const [key, value] of Object.entries(details.rateLimitHeaders ?? {})) {
+    if (key === "retry-after") {
+      continue; // déjà affiché ci-dessus
+    }
+    parts.push(`${key}=${value}`);
+  }
+
+  return parts.length ? `Rate limit reached [${parts.join(", ")}]` : "Rate limit reached";
+};
+
 export class MissionEnrichmentRateLimitError extends Error {
-  constructor() {
-    super("Rate limit reached");
+  readonly details?: RateLimitDetails;
+
+  constructor(details?: RateLimitDetails) {
+    super(buildRateLimitMessage(details));
     this.name = "MissionEnrichmentRateLimitError";
+    this.details = details;
   }
 }

--- a/api/src/services/mission-enrichment/providers/__tests__/llm.test.ts
+++ b/api/src/services/mission-enrichment/providers/__tests__/llm.test.ts
@@ -79,4 +79,23 @@ describe("llmMissionEnrichmentProvider — rate limit detection", () => {
     expect(message).toContain("retry-after=12");
     expect(message).toContain("x-ratelimit-remaining-requests=0");
   });
+
+  it("extracts the limit from Albert's JSON body when no rate-limit header is present", async () => {
+    generateObjectMock.mockRejectedValue(
+      makeApiCallError(429, {
+        responseHeaders: { "content-type": "application/json", server: "nginx/1.29.3" },
+        responseBody: '{"detail":"2460000 input tokens per day exceeded (remaining: 0)."}',
+      })
+    );
+    const inputWithProvider = { ...input, promptVersion: { ...promptVersion, MODEL: { provider: "albert" } } };
+
+    const error = await llmMissionEnrichmentProvider.generate(inputWithProvider).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(MissionEnrichmentRateLimitError);
+    const { details, message } = error as MissionEnrichmentRateLimitError;
+    expect(details?.detail).toBe("2460000 input tokens per day exceeded (remaining: 0).");
+    expect(details?.rateLimitHeaders).toBeUndefined();
+    expect(message).toContain("provider=albert");
+    expect(message).toContain("2460000 input tokens per day exceeded (remaining: 0).");
+  });
 });

--- a/api/src/services/mission-enrichment/providers/__tests__/llm.test.ts
+++ b/api/src/services/mission-enrichment/providers/__tests__/llm.test.ts
@@ -20,7 +20,7 @@ const generateObjectMock = generateObject as ReturnType<typeof vi.fn>;
 const promptVersion = { MODEL: {}, ENRICHMENT_SCHEMA: {}, TEMPERATURE: 0, buildSystemPrompt: () => "", buildUserMessage: () => "" };
 const input = { systemPrompt: "sys", userMessage: "usr", promptVersion } as any;
 
-const makeApiCallError = (statusCode: number) => Object.assign(new Error("api error"), { name: "AI_APICallError", statusCode });
+const makeApiCallError = (statusCode: number, extra: Record<string, unknown> = {}) => Object.assign(new Error("api error"), { name: "AI_APICallError", statusCode, ...extra });
 const makeRetryError = (lastError: unknown) => Object.assign(new Error("retry error"), { name: "AI_RetryError", lastError });
 
 describe("llmMissionEnrichmentProvider — rate limit detection", () => {
@@ -46,5 +46,37 @@ describe("llmMissionEnrichmentProvider — rate limit detection", () => {
     generateObjectMock.mockRejectedValue(makeRetryError(makeApiCallError(503)));
 
     await expect(llmMissionEnrichmentProvider.generate(input)).rejects.toSatisfy((e: unknown) => (e as { name?: string }).name === "AI_RetryError");
+  });
+
+  it("surfaces rate-limit details (provider, retry-after, rate-limit headers, body) on the thrown error", async () => {
+    generateObjectMock.mockRejectedValue(
+      makeApiCallError(429, {
+        responseHeaders: {
+          "Retry-After": "12",
+          "X-RateLimit-Remaining-Requests": "0",
+          "content-type": "application/json",
+        },
+        responseBody: "Rate limit exceeded: 60 requests per minute",
+      })
+    );
+    const inputWithProvider = { ...input, promptVersion: { ...promptVersion, MODEL: { provider: "albert" } } };
+
+    const error = await llmMissionEnrichmentProvider.generate(inputWithProvider).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(MissionEnrichmentRateLimitError);
+    const { details, message } = error as MissionEnrichmentRateLimitError;
+    expect(details).toMatchObject({
+      provider: "albert",
+      statusCode: 429,
+      retryAfter: "12",
+      rateLimitHeaders: { "retry-after": "12", "x-ratelimit-remaining-requests": "0" },
+      responseBody: "Rate limit exceeded: 60 requests per minute",
+    });
+    // le content-type est conservé dans responseHeaders mais exclu du sous-ensemble rate-limit
+    expect(details?.rateLimitHeaders).not.toHaveProperty("content-type");
+    expect(details?.responseHeaders).toHaveProperty("content-type", "application/json");
+    expect(message).toContain("provider=albert");
+    expect(message).toContain("retry-after=12");
+    expect(message).toContain("x-ratelimit-remaining-requests=0");
   });
 });

--- a/api/src/services/mission-enrichment/providers/__tests__/llm.test.ts
+++ b/api/src/services/mission-enrichment/providers/__tests__/llm.test.ts
@@ -80,11 +80,11 @@ describe("llmMissionEnrichmentProvider — rate limit detection", () => {
     expect(message).toContain("x-ratelimit-remaining-requests=0");
   });
 
-  it("extracts the limit from Albert's JSON body when no rate-limit header is present", async () => {
+  it("surfaces the provider-parsed limit detail (APICallError.data.detail) when no rate-limit header is present", async () => {
     generateObjectMock.mockRejectedValue(
       makeApiCallError(429, {
         responseHeaders: { "content-type": "application/json", server: "nginx/1.29.3" },
-        responseBody: '{"detail":"2460000 input tokens per day exceeded (remaining: 0)."}',
+        data: { detail: "2460000 input tokens per day exceeded (remaining: 0)." },
       })
     );
     const inputWithProvider = { ...input, promptVersion: { ...promptVersion, MODEL: { provider: "albert" } } };

--- a/api/src/services/mission-enrichment/providers/llm.ts
+++ b/api/src/services/mission-enrichment/providers/llm.ts
@@ -15,27 +15,10 @@ const isRateLimitHeader = (key: string): boolean => {
   return normalized.includes("ratelimit") || normalized.includes("retryafter");
 };
 
-// Albert ne renvoie pas de headers x-ratelimit-* : la limite atteinte est dans le corps JSON, ex.
-// `{"detail":"2460000 input tokens per day exceeded (remaining: 0)."}`. On en extrait le message.
-const extractBodyDetail = (responseBody?: string): string | undefined => {
-  if (!responseBody) {
-    return undefined;
-  }
-  try {
-    const parsed = JSON.parse(responseBody) as { detail?: unknown; message?: unknown; error?: unknown };
-    const errorMessage = typeof parsed.error === "object" && parsed.error !== null ? (parsed.error as { message?: unknown }).message : parsed.error;
-    const candidate = [parsed.detail, parsed.message, errorMessage].find((value) => typeof value === "string" && value.trim());
-    return candidate ? (candidate as string).trim() : undefined;
-  } catch {
-    // corps non-JSON : rien à extraire, responseBody reste disponible tel quel dans les détails
-    return undefined;
-  }
-};
-
 // Extrait de l'APICallError 429 les infos utiles au diagnostic (quelle limite, chez quel provider).
 // L'APICallError porte déjà responseHeaders/responseBody/statusCode ; on les propage sans nouvel appel.
 export const extractRateLimitDetails = (rootError: unknown, provider?: string): RateLimitDetails => {
-  const err = (rootError ?? {}) as { statusCode?: number; responseHeaders?: Record<string, string>; responseBody?: string };
+  const err = (rootError ?? {}) as { statusCode?: number; responseHeaders?: Record<string, string>; responseBody?: string; data?: { detail?: string } };
   const responseHeaders = err.responseHeaders;
 
   const normalizedHeaders: Record<string, string> = {};
@@ -54,7 +37,8 @@ export const extractRateLimitDetails = (rootError: unknown, provider?: string): 
     provider,
     statusCode: err.statusCode,
     retryAfter: normalizedHeaders["retry-after"],
-    detail: extractBodyDetail(responseBody),
+    // `data.detail` est renseigné par les providers qui savent parser leur corps d'erreur (ex. Albert).
+    detail: err.data?.detail,
     rateLimitHeaders: Object.keys(rateLimitHeaders).length ? rateLimitHeaders : undefined,
     responseHeaders: Object.keys(normalizedHeaders).length ? normalizedHeaders : undefined,
     responseBody: responseBody ? responseBody.slice(0, RESPONSE_BODY_MAX_LENGTH) : undefined,

--- a/api/src/services/mission-enrichment/providers/llm.ts
+++ b/api/src/services/mission-enrichment/providers/llm.ts
@@ -15,6 +15,23 @@ const isRateLimitHeader = (key: string): boolean => {
   return normalized.includes("ratelimit") || normalized.includes("retryafter");
 };
 
+// Albert ne renvoie pas de headers x-ratelimit-* : la limite atteinte est dans le corps JSON, ex.
+// `{"detail":"2460000 input tokens per day exceeded (remaining: 0)."}`. On en extrait le message.
+const extractBodyDetail = (responseBody?: string): string | undefined => {
+  if (!responseBody) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(responseBody) as { detail?: unknown; message?: unknown; error?: unknown };
+    const errorMessage = typeof parsed.error === "object" && parsed.error !== null ? (parsed.error as { message?: unknown }).message : parsed.error;
+    const candidate = [parsed.detail, parsed.message, errorMessage].find((value) => typeof value === "string" && value.trim());
+    return candidate ? (candidate as string).trim() : undefined;
+  } catch {
+    // corps non-JSON : rien à extraire, responseBody reste disponible tel quel dans les détails
+    return undefined;
+  }
+};
+
 // Extrait de l'APICallError 429 les infos utiles au diagnostic (quelle limite, chez quel provider).
 // L'APICallError porte déjà responseHeaders/responseBody/statusCode ; on les propage sans nouvel appel.
 export const extractRateLimitDetails = (rootError: unknown, provider?: string): RateLimitDetails => {
@@ -37,6 +54,7 @@ export const extractRateLimitDetails = (rootError: unknown, provider?: string): 
     provider,
     statusCode: err.statusCode,
     retryAfter: normalizedHeaders["retry-after"],
+    detail: extractBodyDetail(responseBody),
     rateLimitHeaders: Object.keys(rateLimitHeaders).length ? rateLimitHeaders : undefined,
     responseHeaders: Object.keys(normalizedHeaders).length ? normalizedHeaders : undefined,
     responseBody: responseBody ? responseBody.slice(0, RESPONSE_BODY_MAX_LENGTH) : undefined,

--- a/api/src/services/mission-enrichment/providers/llm.ts
+++ b/api/src/services/mission-enrichment/providers/llm.ts
@@ -1,9 +1,47 @@
 import { LLM_MAX_RETRIES, LLM_NO_OBJECT_MAX_RETRIES } from "@/services/mission-enrichment/config";
+import type { RateLimitDetails } from "@/services/mission-enrichment/errors";
 import { MissionEnrichmentRateLimitError } from "@/services/mission-enrichment/errors";
 import type { MissionEnrichmentProvider, MissionEnrichmentProviderInput, MissionEnrichmentProviderResult } from "@/services/mission-enrichment/providers/types";
 import { generateObject } from "ai";
 
 const LOG_PREFIX = "[mission-enrichment]";
+
+const RESPONSE_BODY_MAX_LENGTH = 500;
+
+// Repère les headers portant l'info de rate-limit (retry-after, x-ratelimit-*, ratelimitbysize-*, …).
+// On normalise en retirant les séparateurs pour couvrir les variantes de nommage entre providers.
+const isRateLimitHeader = (key: string): boolean => {
+  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return normalized.includes("ratelimit") || normalized.includes("retryafter");
+};
+
+// Extrait de l'APICallError 429 les infos utiles au diagnostic (quelle limite, chez quel provider).
+// L'APICallError porte déjà responseHeaders/responseBody/statusCode ; on les propage sans nouvel appel.
+export const extractRateLimitDetails = (rootError: unknown, provider?: string): RateLimitDetails => {
+  const err = (rootError ?? {}) as { statusCode?: number; responseHeaders?: Record<string, string>; responseBody?: string };
+  const responseHeaders = err.responseHeaders;
+
+  const normalizedHeaders: Record<string, string> = {};
+  const rateLimitHeaders: Record<string, string> = {};
+  for (const [key, value] of Object.entries(responseHeaders ?? {})) {
+    const lowerKey = key.toLowerCase();
+    normalizedHeaders[lowerKey] = value;
+    if (isRateLimitHeader(lowerKey)) {
+      rateLimitHeaders[lowerKey] = value;
+    }
+  }
+
+  const responseBody = err.responseBody;
+
+  return {
+    provider,
+    statusCode: err.statusCode,
+    retryAfter: normalizedHeaders["retry-after"],
+    rateLimitHeaders: Object.keys(rateLimitHeaders).length ? rateLimitHeaders : undefined,
+    responseHeaders: Object.keys(normalizedHeaders).length ? normalizedHeaders : undefined,
+    responseBody: responseBody ? responseBody.slice(0, RESPONSE_BODY_MAX_LENGTH) : undefined,
+  };
+};
 
 export const llmMissionEnrichmentProvider: MissionEnrichmentProvider = {
   async generate({ systemPrompt, userMessage, promptVersion }: MissionEnrichmentProviderInput): Promise<MissionEnrichmentProviderResult> {
@@ -25,7 +63,8 @@ export const llmMissionEnrichmentProvider: MissionEnrichmentProvider = {
         const rootError = (error as { name?: string })?.name === "AI_RetryError" ? (error as { lastError?: unknown })?.lastError : error;
         const isRateLimit = (rootError as { name?: string })?.name === "AI_APICallError" && (rootError as { statusCode?: number })?.statusCode === 429;
         if (isRateLimit) {
-          throw new MissionEnrichmentRateLimitError();
+          const provider = (promptVersion.MODEL as { provider?: string })?.provider;
+          throw new MissionEnrichmentRateLimitError(extractRateLimitDetails(rootError, provider));
         }
         const isNoObject = (error as { name?: string })?.name === "AI_NoObjectGeneratedError";
         if (isNoObject && attempt < LLM_NO_OBJECT_MAX_RETRIES) {

--- a/api/src/worker/handlers/mission-enrichment.ts
+++ b/api/src/worker/handlers/mission-enrichment.ts
@@ -8,7 +8,7 @@ export const handleMissionEnrichment = async (payload: { missionId: string; forc
     await missionEnrichmentService.enrich(payload.missionId, { force: payload.force });
   } catch (error) {
     if (error instanceof MissionEnrichmentRateLimitError) {
-      console.warn(`[mission.enrichment] rate limit missionId=${payload.missionId} — will be retried`);
+      console.warn(`[mission.enrichment] rate limit missionId=${payload.missionId} — will be retried — ${error.message}`, error.details ?? {});
       throw new WorkerRetryableError(`rate_limit missionId=${payload.missionId}`);
     }
     if ((error as { name?: string })?.name === "AI_NoObjectGeneratedError") {


### PR DESCRIPTION
## Description

Ajoute le détail de la limite atteinte aux `MissionEnrichmentRateLimitError` (enrichissement de mission).

Jusqu'ici, un rate limit remontait une erreur **sans contexte** (`"Rate limit reached"`) : impossible de savoir quelle limite était atteinte (requêtes/minute ? tokens/minute ?) ni chez quel provider. L'information existait pourtant déjà au moment du 429 mais était jetée : le provider Albert (custom) attache tous les headers de réponse + le corps sur l'`APICallError`, et le provider Mistral (`@ai-sdk`) expose les mêmes champs — mais `providers/llm.ts` levait une erreur vide.

Cette PR propage ces infos (provider, `statusCode`, `retry-after`, headers `x-ratelimit-*`, corps) jusqu'aux logs et à Sentry, sans aucun appel réseau supplémentaire.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- **Constat côté Albert** : contrairement à un endpoint OpenAI classique, Albert ne renvoie **aucun** header `retry-after` / `x-ratelimit-*` — la limite atteinte est uniquement dans le corps JSON, ex. `{"detail":"2460000 input tokens per day exceeded (remaining: 0)."}`. Ce parsing (spécifique à Albert) vit donc dans le provider Albert, qui l'expose sur `APICallError.data.detail` ; la couche générique se contente de lire ce champ. On continue par ailleurs à logguer l'intégralité des `responseHeaders` (non sensibles sur un 429) et à gérer le cas headers pour les providers qui, eux, exposent `x-ratelimit-*` (ex. Mistral).
- **Note** : le quota observé est un quota **journalier** (`… per day exceeded`), pas par minute — le retry SQS ne débloquera pas avant le reset du jour. Hors périmètre de cette PR (qui ne fait qu'exposer l'info), mais à garder en tête pour une éventuelle stratégie de backoff.
- Tests : `llm.test.ts` étendu (les 4 tests existants restent verts + 1 nouveau test asserant `details` provider/retry-after/headers/body). Vérifié en local : `vitest` (10/10), `npm run lint`, `tsc` OK.
- Aucun appel réseau ajouté : on ne fait que propager ce que l'`APICallError` transporte déjà.
