### PR TITLE
feat(api): use geo weight for remote missions in matching

### DIFF
--- a/api/src/repositories/mission-matching-result.ts
+++ b/api/src/repositories/mission-matching-result.ts
@@ -24,7 +24,9 @@ export type MissionMatchingEmailMission = {
 const buildMissionMatchingResultItemsFromScoringIds = (missionScoringIds: string[]): MissionMatchingResultItem[] =>
   missionScoringIds.map((missionScoringId) => ({ missionScoringId, missionAddressId: null, taxonomyScores: {} }));
 
-const findMissionsByMatchingResultItems = async (items: MissionMatchingResultItem[]): Promise<MissionMatchingEmailMission[]> => {
+// ignoreRemoteAddress : quand la version du snapshot ignore l'adresse des missions remote=full,
+// on neutralise aussi le fallback ville ici pour ne pas la ré-exposer dans les emails.
+const findMissionsByMatchingResultItems = async (items: MissionMatchingResultItem[], ignoreRemoteAddress = false): Promise<MissionMatchingEmailMission[]> => {
   if (items.length === 0) {
     return [];
   }
@@ -39,6 +41,7 @@ const findMissionsByMatchingResultItems = async (items: MissionMatchingResultIte
         select: {
           id: true,
           title: true,
+          remote: true,
           duration: true,
           startAt: true,
           endAt: true,
@@ -59,8 +62,10 @@ const findMissionsByMatchingResultItems = async (items: MissionMatchingResultIte
 
   return missionScorings.map((missionScoring) => {
     const item = itemsByMissionScoringId.get(missionScoring.id);
+    const isFullRemoteAddressIgnored = ignoreRemoteAddress && missionScoring.mission.remote === "full";
     const matchedAddress = item?.missionAddressId ? missionScoring.mission.addresses.find((address) => address.id === item.missionAddressId) : null;
     const fallbackAddress = missionScoring.mission.addresses[0] ?? null;
+    const city = isFullRemoteAddressIgnored ? null : (matchedAddress?.city ?? fallbackAddress?.city ?? null);
 
     return {
       missionScoringId: missionScoring.id,
@@ -77,7 +82,7 @@ const findMissionsByMatchingResultItems = async (items: MissionMatchingResultIte
         publisherLogo: missionScoring.mission.publisher?.logo ?? null,
         publisherName: missionScoring.mission.publisher?.name ?? null,
         publisherOrganizationName: missionScoring.mission.publisherOrganization?.name ?? null,
-        city: matchedAddress?.city ?? fallbackAddress?.city ?? null,
+        city,
       },
     };
   });

--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -492,6 +492,8 @@ describe("matchingEngineService", () => {
       expect(result.version).toBe("m3");
       expect(rankingSql).toContain("WHEN m.\"remote\"::text = 'full' THEN CAST(");
       expect(rankingSql).toContain('JOIN "mission" m');
+      expect(rankingSql).toContain("remote_full_candidates AS (");
+      expect(rankingSql).toContain("FROM remote_full_candidates rfc");
       expect(rankingValues).toContain(1);
     });
 
@@ -515,6 +517,7 @@ describe("matchingEngineService", () => {
       const rankingSql = getSqlText(prismaMock.$queryRaw.mock.calls[1][0]);
       expect(result.version).toBe("m2");
       expect(rankingSql).not.toContain('m."remote"::text');
+      expect(rankingSql).not.toContain("remote_full_candidates");
     });
 
     it("returns a geo score of 1 for a remote=full mission ranked with m3", async () => {

--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -494,7 +494,8 @@ describe("matchingEngineService", () => {
       expect(rankingSql).toContain('JOIN "mission" m');
       expect(rankingSql).toContain("remote_full_candidates AS (");
       expect(rankingSql).toContain("FROM remote_full_candidates rfc");
-      expect(rankingValues).toContain(1);
+      expect(rankingSql).toContain('WHEN m."remote"::text = \'full\' THEN NULL ELSE gs."distance_km" END');
+      expect(rankingValues).toContain(0.9);
     });
 
     it("does not inject the remote=full branch for the m2 version (non-regression)", async () => {

--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -469,5 +469,90 @@ describe("matchingEngineService", () => {
       ]);
       expect(missionMatchingResultRepositoryMock.createForUserScoringVersion).not.toHaveBeenCalled();
     });
+
+    it("injects the remote=full geo score branch and value for the m3 version", async () => {
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            id: "user-scoring-m3",
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      missionMatchingResultRepositoryMock.createForUserScoringVersion.mockResolvedValue({
+        id: "mission-matching-result-m3",
+      });
+
+      const result = await matchingEngineService.rankMissionsByUserScoring({
+        userScoringId: "user-scoring-m3",
+        version: "m3",
+      });
+
+      const rankingSql = getSqlText(prismaMock.$queryRaw.mock.calls[1][0]);
+      const rankingValues = getSqlValues(prismaMock.$queryRaw.mock.calls[1][0]);
+      expect(result.version).toBe("m3");
+      expect(rankingSql).toContain("WHEN m.\"remote\"::text = 'full' THEN CAST(");
+      expect(rankingSql).toContain('JOIN "mission" m');
+      expect(rankingValues).toContain(1);
+    });
+
+    it("does not inject the remote=full branch for the m2 version (non-regression)", async () => {
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            id: "user-scoring-m2",
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      missionMatchingResultRepositoryMock.createForUserScoringVersion.mockResolvedValue({
+        id: "mission-matching-result-m2",
+      });
+
+      const result = await matchingEngineService.rankMissionsByUserScoring({
+        userScoringId: "user-scoring-m2",
+        version: "m2",
+      });
+
+      const rankingSql = getSqlText(prismaMock.$queryRaw.mock.calls[1][0]);
+      expect(result.version).toBe("m2");
+      expect(rankingSql).not.toContain('m."remote"::text');
+    });
+
+    it("returns a geo score of 1 for a remote=full mission ranked with m3", async () => {
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            id: "user-scoring-m3-remote",
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            mission_id: "mission-remote-full",
+            mission_scoring_id: "mission-scoring-remote-full",
+            total_score: 0.9,
+            taxonomy_score: 0.8,
+            geo_score: 1,
+            distance_km: null,
+            closest_address_id: null,
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            mission_scoring_id: "mission-scoring-remote-full",
+            taxonomy_key: "domaine",
+            taxonomy_score: 0.8,
+          },
+        ]);
+      missionMatchingResultRepositoryMock.createForUserScoringVersion.mockResolvedValue({
+        id: "mission-matching-result-m3-remote",
+      });
+
+      const result = await matchingEngineService.rankMissionsByUserScoring({
+        userScoringId: "user-scoring-m3-remote",
+        version: "m3",
+      });
+
+      expect(result.items[0].geoScore).toBe(1);
+      expect(result.items[0].distanceKm).toBeNull();
+    });
   });
 });

--- a/api/src/services/matching-engine/config.ts
+++ b/api/src/services/matching-engine/config.ts
@@ -49,7 +49,7 @@ export const MATCHING_ENGINE_VERSIONS = {
       tranche_age: 1,
     } satisfies MatchingEngineTaxonomyWeights,
     geoWeight: 0.3,
-    remoteFullGeoScore: 1.0,
+    remoteFullGeoScore: 0.9,
   },
 } as const satisfies Record<MatchingEngineVersion, MatchingEngineVersionConfig>;
 

--- a/api/src/services/matching-engine/config.ts
+++ b/api/src/services/matching-engine/config.ts
@@ -5,7 +5,7 @@ export const MATCHING_ENGINE_TAXONOMIES = [...ENRICHABLE_TAXONOMIES, ...GATE_TAX
 
 export const MATCHING_ENGINE_TOP_RESULTS_LIMIT = 20;
 
-export const CURRENT_MATCHING_ENGINE_VERSION: MatchingEngineVersion = "m2";
+export const CURRENT_MATCHING_ENGINE_VERSION: MatchingEngineVersion = "m3";
 
 export const MATCHING_ENGINE_VERSIONS = {
   m1: {
@@ -20,6 +20,7 @@ export const MATCHING_ENGINE_VERSIONS = {
       tranche_age: 1,
     } satisfies MatchingEngineTaxonomyWeights,
     geoWeight: 0.7,
+    remoteFullGeoScore: null,
   },
   m2: {
     taxonomyWeights: {
@@ -33,6 +34,22 @@ export const MATCHING_ENGINE_VERSIONS = {
       tranche_age: 1,
     } satisfies MatchingEngineTaxonomyWeights,
     geoWeight: 0.3,
+    remoteFullGeoScore: null,
+  },
+  m3: {
+    // Identique à m2, mais les missions remote=full sont considérées comme naturellement proches.
+    taxonomyWeights: {
+      domaine: 1,
+      secteur_activite: 1,
+      type_mission: 1,
+      competence_rome: 1,
+      region_internationale: 1,
+      engagement_intent: 1,
+      formation_onisep: 1,
+      tranche_age: 1,
+    } satisfies MatchingEngineTaxonomyWeights,
+    geoWeight: 0.3,
+    remoteFullGeoScore: 1.0,
   },
 } as const satisfies Record<MatchingEngineVersion, MatchingEngineVersionConfig>;
 

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -120,6 +120,24 @@ const buildRanking = (params: {
       CAST(NULL AS double precision) AS "distance_km"
     FROM remote_full_candidates rfc`;
 
+  // Une mission remote=full ignore toute adresse : on nullifie distance/closest_* pour ne pas polluer
+  // l'affichage ni avgDistanceKmTop5, y compris quand elle a une adresse géocodée.
+  const rankedGeoColumnsSql = !remoteFullActive
+    ? Prisma.sql`
+      gs."distance_km",
+      gs."closest_lat",
+      gs."closest_lon",
+      gs."closest_address_id",
+      gs."closest_city",
+      gs."closest_address"`
+    : Prisma.sql`
+      CASE WHEN m."remote"::text = 'full' THEN NULL ELSE gs."distance_km" END AS "distance_km",
+      CASE WHEN m."remote"::text = 'full' THEN NULL ELSE gs."closest_lat" END AS "closest_lat",
+      CASE WHEN m."remote"::text = 'full' THEN NULL ELSE gs."closest_lon" END AS "closest_lon",
+      CASE WHEN m."remote"::text = 'full' THEN NULL ELSE gs."closest_address_id" END AS "closest_address_id",
+      CASE WHEN m."remote"::text = 'full' THEN NULL ELSE gs."closest_city" END AS "closest_city",
+      CASE WHEN m."remote"::text = 'full' THEN NULL ELSE gs."closest_address" END AS "closest_address"`;
+
   return Prisma.sql`
   WITH taxonomy_weights ("taxonomy_key", "taxonomy_weight") AS (
     VALUES ${buildTaxonomyWeightsValuesSql(params.taxonomyWeights)}
@@ -442,13 +460,7 @@ const buildRanking = (params: {
             ELSE EXP(-LN(2) * gs."distance_km" / NULLIF(CAST(${params.geoHalfDecayKm} AS double precision), 0.0))
           END
         ELSE NULL
-      END AS "geo_score",
-      gs."distance_km",
-      gs."closest_lat",
-      gs."closest_lon",
-      gs."closest_address_id",
-      gs."closest_city",
-      gs."closest_address"
+      END AS "geo_score",${rankedGeoColumnsSql}
     FROM candidate_missions cm
     CROSS JOIN weighted_user_totals ut
     JOIN "mission" m

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -88,8 +88,37 @@ const buildRanking = (params: {
   offset: number;
 }) => {
   // Missions remote=full : proximité naturelle (score géo forcé), uniquement si la version l'active.
-  const remoteFullGeoScoreSql =
-    params.remoteFullGeoScore == null ? Prisma.empty : Prisma.sql`WHEN m."remote"::text = 'full' THEN CAST(${params.remoteFullGeoScore} AS double precision)`;
+  const remoteFullActive = params.remoteFullGeoScore != null;
+  const remoteFullGeoScoreSql = !remoteFullActive ? Prisma.empty : Prisma.sql`WHEN m."remote"::text = 'full' THEN CAST(${params.remoteFullGeoScore} AS double precision)`;
+
+  // Quand le boost remote est actif et que l'utilisateur est géolocalisé, les missions remote=full éligibles
+  // doivent entrer dans le pool candidat même sans match taxonomie ni adresse proche : elles sont "partout".
+  const remoteFullCandidatesCteSql = !remoteFullActive
+    ? Prisma.empty
+    : Prisma.sql`
+  remote_full_candidates AS (
+    SELECT
+      ems."mission_id",
+      ems."mission_scoring_id"
+    FROM eligible_mission_scorings ems
+    JOIN "mission" m
+      ON m."id" = ems."mission_id"
+     AND m."remote"::text = 'full'
+    LEFT JOIN taxonomy_scores ts
+      ON ts."mission_scoring_id" = ems."mission_scoring_id"
+    WHERE EXISTS (SELECT 1 FROM user_geo)
+    ORDER BY COALESCE(ts."weighted_sum", 0) DESC, ems."mission_id" ASC
+    LIMIT ${params.geoCandidateLimit}
+  ),`;
+  const remoteFullCandidatesUnionSql = !remoteFullActive
+    ? Prisma.empty
+    : Prisma.sql`
+    UNION ALL
+    SELECT
+      rfc."mission_id",
+      rfc."mission_scoring_id",
+      CAST(NULL AS double precision) AS "distance_km"
+    FROM remote_full_candidates rfc`;
 
   return Prisma.sql`
   WITH taxonomy_weights ("taxonomy_key", "taxonomy_weight") AS (
@@ -322,7 +351,7 @@ const buildRanking = (params: {
       AND NOT EXISTS (SELECT 1 FROM user_geo)
     ORDER BY ems."mission_id" ASC
     LIMIT ${params.offset + params.limit}
-  ),
+  ),${remoteFullCandidatesCteSql}
   candidate_mission_rows AS (
     SELECT
       tc."mission_id",
@@ -346,7 +375,7 @@ const buildRanking = (params: {
       fc."mission_id",
       fc."mission_scoring_id",
       CAST(NULL AS double precision) AS "distance_km"
-    FROM fallback_candidates fc
+    FROM fallback_candidates fc${remoteFullCandidatesUnionSql}
   ),
   candidate_missions AS (
     SELECT

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -81,11 +81,17 @@ const buildRanking = (params: {
   geoWeight: number;
   geoHalfDecayKm: number;
   missingGeoScore: number;
+  remoteFullGeoScore: number | null;
   taxonomyCandidateLimit: number;
   geoCandidateLimit: number;
   limit: number;
   offset: number;
-}) => Prisma.sql`
+}) => {
+  // Missions remote=full : proximité naturelle (score géo forcé), uniquement si la version l'active.
+  const remoteFullGeoScoreSql =
+    params.remoteFullGeoScore == null ? Prisma.empty : Prisma.sql`WHEN m."remote"::text = 'full' THEN CAST(${params.remoteFullGeoScore} AS double precision)`;
+
+  return Prisma.sql`
   WITH taxonomy_weights ("taxonomy_key", "taxonomy_weight") AS (
     VALUES ${buildTaxonomyWeightsValuesSql(params.taxonomyWeights)}
   ),
@@ -402,6 +408,7 @@ const buildRanking = (params: {
       CASE
         WHEN EXISTS (SELECT 1 FROM user_geo) THEN
           CASE
+            ${remoteFullGeoScoreSql}
             WHEN gs."distance_km" IS NULL THEN CAST(${params.missingGeoScore} AS double precision)
             ELSE EXP(-LN(2) * gs."distance_km" / NULLIF(CAST(${params.geoHalfDecayKm} AS double precision), 0.0))
           END
@@ -415,6 +422,8 @@ const buildRanking = (params: {
       gs."closest_address"
     FROM candidate_missions cm
     CROSS JOIN weighted_user_totals ut
+    JOIN "mission" m
+      ON m."id" = cm."mission_id"
     LEFT JOIN taxonomy_scores ts
       ON ts."mission_scoring_id" = cm."mission_scoring_id"
     LEFT JOIN geo_scores gs
@@ -448,6 +457,7 @@ const buildRanking = (params: {
   LIMIT ${params.limit}
   OFFSET ${params.offset}
 `;
+};
 
 const buildPublisherRuleSql = async (publisherId?: string): Promise<Prisma.Sql> => {
   if (!publisherId) {
@@ -546,6 +556,7 @@ export const matchingEngineService = {
     const geoWeight = input.geoWeight ?? versionConfig.geoWeight;
     const geoHalfDecayKm = input.geoHalfDecayKm ?? 20;
     const missingGeoScore = input.missingGeoScore ?? 0.1;
+    const remoteFullGeoScore = input.remoteFullGeoScore !== undefined ? input.remoteFullGeoScore : versionConfig.remoteFullGeoScore;
     const taxonomyCandidateLimit = getTaxonomyCandidateLimit({ limit: rankingLimit, offset });
     const geoCandidateLimit = getGeoCandidateLimit({ limit: rankingLimit, offset });
 
@@ -561,6 +572,7 @@ export const matchingEngineService = {
         geoWeight,
         geoHalfDecayKm,
         missingGeoScore,
+        remoteFullGeoScore,
         taxonomyCandidateLimit,
         geoCandidateLimit,
         limit: rankingLimit,

--- a/api/src/services/matching-engine/types.ts
+++ b/api/src/services/matching-engine/types.ts
@@ -4,11 +4,13 @@ export type MatchingEngineTaxonomy = EnrichableTaxonomyKey | GateTaxonomyKey;
 
 export type MatchingEngineTaxonomyWeights = Record<MatchingEngineTaxonomy, number>;
 
-export type MatchingEngineVersion = "m1" | "m2";
+export type MatchingEngineVersion = "m1" | "m2" | "m3";
 
 export type MatchingEngineVersionConfig = {
   taxonomyWeights: MatchingEngineTaxonomyWeights;
   geoWeight: number;
+  // Score géo forcé pour les missions remote=full (proximité naturelle). null = pas de traitement spécial.
+  remoteFullGeoScore: number | null;
 };
 
 export type RankMissionsByUserScoringInput = {
@@ -21,6 +23,7 @@ export type RankMissionsByUserScoringInput = {
   geoWeight?: number;
   geoHalfDecayKm?: number;
   missingGeoScore?: number;
+  remoteFullGeoScore?: number | null;
 };
 
 export type MatchMissionItem = {

--- a/api/src/services/mission-email/index.ts
+++ b/api/src/services/mission-email/index.ts
@@ -3,7 +3,7 @@ import { missionMatchingResultRepository } from "@/repositories/mission-matching
 import { userScoringRepository } from "@/repositories/user-scoring";
 import type { MissionContent } from "@/services/brevo";
 import { buildMissionContentHtml, sendTemplate, TEMPLATE_IDS } from "@/services/brevo";
-import { CURRENT_MATCHING_ENGINE_VERSION } from "@/services/matching-engine/config";
+import { CURRENT_MATCHING_ENGINE_VERSION, MATCHING_ENGINE_VERSIONS } from "@/services/matching-engine/config";
 import type { MissionMatchingResultItem } from "@/services/matching-engine/types";
 import { missionService } from "@/services/mission";
 import { subscribeToNewsletter } from "@/services/newsletter";
@@ -127,7 +127,9 @@ const buildMissionMatchingEmailParams = async (userScoringId: string, publisherI
     return null;
   }
 
-  const missions = await missionMatchingResultRepository.findMissionsByMatchingResultItems(matchingItems);
+  // La version courante ignore-t-elle l'adresse des missions remote=full ? (aligné sur le moteur / l'API)
+  const ignoreRemoteAddress = MATCHING_ENGINE_VERSIONS[CURRENT_MATCHING_ENGINE_VERSION].remoteFullGeoScore != null;
+  const missions = await missionMatchingResultRepository.findMissionsByMatchingResultItems(matchingItems, ignoreRemoteAddress);
   const missionsByScoringId = new Map(missions.map((item) => [item.missionScoringId, item]));
   const orderedMissions = matchingItems.map((item) => missionsByScoringId.get(item.missionScoringId)).filter((item): item is NonNullable<typeof item> => Boolean(item));
 

--- a/api/src/services/mission-match/index.ts
+++ b/api/src/services/mission-match/index.ts
@@ -2,6 +2,7 @@ import type { MissionMatchResponse } from "@engagement/dto";
 
 import { prisma } from "@/db/postgres";
 import { matchingEngineService } from "@/services/matching-engine";
+import { MATCHING_ENGINE_VERSIONS } from "@/services/matching-engine/config";
 import type { MatchingEngineVersion } from "@/services/matching-engine/types";
 import { buildMissionIndex, buildValuesIndex, missionMatchMissionSelect, missionMatchScoringValueSelect, toMissionMatchItem } from "./transformers";
 
@@ -37,11 +38,13 @@ export const missionMatchService = {
 
     const missionIndex = buildMissionIndex(missionRows);
     const valuesIndex = buildValuesIndex(scoringValueRows);
+    // La version active ignore-t-elle l'adresse des missions remote=full ? (aligné sur le moteur)
+    const ignoreRemoteAddress = MATCHING_ENGINE_VERSIONS[result.version].remoteFullGeoScore != null;
 
     return {
       tookMs: result.tookMs,
       engineVersion: result.version,
-      items: result.items.map((item) => toMissionMatchItem(item, missionIndex, valuesIndex, input.publisherId)),
+      items: result.items.map((item) => toMissionMatchItem(item, missionIndex, valuesIndex, input.publisherId, ignoreRemoteAddress)),
       total: result.total,
       avgDistanceKmTop5: result.avgDistanceKmTop5,
     };

--- a/api/src/services/mission-match/transformers.ts
+++ b/api/src/services/mission-match/transformers.ts
@@ -131,11 +131,14 @@ export const toMissionMatchItem = (
   item: MatchMissionItem,
   missionIndex: Record<string, MissionIndexEntry>,
   valuesIndex: Record<string, MissionMatchValue[]>,
-  publisherId: string
+  publisherId: string,
+  // Quand le moteur ignore l'adresse des missions remote=full, on neutralise aussi le fallback ville.
+  ignoreRemoteAddress = false
 ): MissionMatchItem => {
   const mission = missionIndex[item.missionId];
   const photo = mission?.domainLogo ?? mission?.organizationLogo ?? mission?.publisherDefaultMissionLogo ?? mission?.publisherLogo ?? null;
   const hasCompensation = mission?.compensationAmount != null || mission?.compensationAmountMax != null;
+  const isFullRemoteAddressIgnored = ignoreRemoteAddress && mission?.remote === "full";
 
   return {
     mission: {
@@ -155,7 +158,7 @@ export const toMissionMatchItem = (
         publisherLogo: mission?.publisherLogo ?? null,
       },
       location: {
-        city: item.closestCity ?? mission?.city ?? null,
+        city: item.closestCity ?? (isFullRemoteAddressIgnored ? null : mission?.city) ?? null,
         closestLat: item.closestLat,
         closestLon: item.closestLon,
         closestAddress: item.closestAddress,

--- a/api/tests/integration/api/mission-match.test.ts
+++ b/api/tests/integration/api/mission-match.test.ts
@@ -20,6 +20,38 @@ const createUserScoring = async (): Promise<string> => {
   return response.body.data.id;
 };
 
+// Utilisateur géolocalisé (Paris) : active la branche géo du moteur.
+const createGeoUserScoring = async (): Promise<string> => {
+  const response = await withApiKey(request(app).post("/user-scoring")).send({
+    answers: [
+      { taxonomy: "domaine", value: "social_solidarite" },
+      { taxonomy: "location", params: { lat: 48.8566, lon: 2.3522 } },
+    ],
+  });
+
+  expect(response.status).toBe(201);
+  return response.body.data.id;
+};
+
+// Mission remote=full sans adresse et sans recouvrement taxonomie avec l'utilisateur :
+// elle n'entre ni dans les candidats taxonomie ni géo → cas ciblé par remote_full_candidates.
+const createRemoteFullMissionWithoutMatch = async () => {
+  const mission = await createTestMission({
+    publisherId,
+    title: "Mission full remote",
+    domain: "solidarite",
+    remote: "full",
+    addresses: [],
+  });
+  const enrichment = await createTestMissionEnrichment({ missionId: mission.id });
+  await createTestMissionScoring({
+    missionId: mission.id,
+    missionEnrichmentId: enrichment.id,
+    values: [{ taxonomyKey: "domaine", valueKey: "sport", score: 1 }],
+  });
+  return mission;
+};
+
 const createRankableMission = async () => {
   const mission = await createTestMission({
     publisherId,
@@ -92,5 +124,35 @@ describe("GET /missions/match", () => {
     expect(response.body.ok).toBe(true);
     expect(response.body.data.engineVersion).toBe("m3");
     expect(response.body.data.items).toHaveLength(1);
+  });
+
+  it("ranks an eligible full-remote mission without taxonomy match nor address for a geolocated user (m3)", async () => {
+    const mission = await createRemoteFullMissionWithoutMatch();
+    const userScoringId = await createGeoUserScoring();
+
+    const response = await withApiKey(request(app).get("/missions/match")).query({
+      userScoringId,
+      engineVersion: "m3",
+    });
+
+    expect(response.status).toBe(200);
+    const item = response.body.data.items.find((entry: { mission: { id: string } }) => entry.mission.id === mission.id);
+    expect(item).toBeDefined();
+    expect(item.match.geoScore).toBe(1);
+    expect(item.mission.location.distanceKm).toBeNull();
+  });
+
+  it("does not surface the same full-remote mission under m2 (candidate pool gap it fixes)", async () => {
+    const mission = await createRemoteFullMissionWithoutMatch();
+    const userScoringId = await createGeoUserScoring();
+
+    const response = await withApiKey(request(app).get("/missions/match")).query({
+      userScoringId,
+      engineVersion: "m2",
+    });
+
+    expect(response.status).toBe(200);
+    const item = response.body.data.items.find((entry: { mission: { id: string } }) => entry.mission.id === mission.id);
+    expect(item).toBeUndefined();
   });
 });

--- a/api/tests/integration/api/mission-match.test.ts
+++ b/api/tests/integration/api/mission-match.test.ts
@@ -52,6 +52,37 @@ const createRemoteFullMissionWithoutMatch = async () => {
   return mission;
 };
 
+// Mission remote=full AVEC une adresse géocodée proche : sous m3, la distance doit tout de même être
+// ignorée (nullifiée) pour ne pas fausser l'affichage ni avgDistanceKmTop5.
+const createRemoteFullMissionWithAddress = async () => {
+  const mission = await createTestMission({
+    publisherId,
+    title: "Mission full remote géolocalisée",
+    domain: "solidarite",
+    remote: "full",
+    addresses: [
+      {
+        street: "1 rue de Test",
+        postalCode: "75001",
+        departmentCode: "75",
+        departmentName: "Paris",
+        city: "Paris",
+        region: "Ile-de-France",
+        country: "France",
+        location: { lat: 48.8566, lon: 2.3522 },
+        geolocStatus: "FOUND",
+      },
+    ],
+  });
+  const enrichment = await createTestMissionEnrichment({ missionId: mission.id });
+  await createTestMissionScoring({
+    missionId: mission.id,
+    missionEnrichmentId: enrichment.id,
+    values: [{ taxonomyKey: "domaine", valueKey: "social_solidarite", score: 1 }],
+  });
+  return mission;
+};
+
 const createRankableMission = async () => {
   const mission = await createTestMission({
     publisherId,
@@ -138,7 +169,7 @@ describe("GET /missions/match", () => {
     expect(response.status).toBe(200);
     const item = response.body.data.items.find((entry: { mission: { id: string } }) => entry.mission.id === mission.id);
     expect(item).toBeDefined();
-    expect(item.match.geoScore).toBe(1);
+    expect(item.match.geoScore).toBe(0.9);
     expect(item.mission.location.distanceKm).toBeNull();
   });
 
@@ -154,5 +185,25 @@ describe("GET /missions/match", () => {
     expect(response.status).toBe(200);
     const item = response.body.data.items.find((entry: { mission: { id: string } }) => entry.mission.id === mission.id);
     expect(item).toBeUndefined();
+  });
+
+  it("ignores the geocoded address of a full-remote mission under m3 (no distance leaked)", async () => {
+    const mission = await createRemoteFullMissionWithAddress();
+    const userScoringId = await createGeoUserScoring();
+
+    const response = await withApiKey(request(app).get("/missions/match")).query({
+      userScoringId,
+      engineVersion: "m3",
+    });
+
+    expect(response.status).toBe(200);
+    const item = response.body.data.items.find((entry: { mission: { id: string } }) => entry.mission.id === mission.id);
+    expect(item).toBeDefined();
+    expect(item.match.geoScore).toBe(0.9);
+    expect(item.mission.location.distanceKm).toBeNull();
+    expect(item.mission.location.closestLat).toBeNull();
+    expect(item.mission.location.closestLon).toBeNull();
+    expect(item.mission.location.addressId).toBeNull();
+    expect(response.body.data.avgDistanceKmTop5).toBeNull();
   });
 });

--- a/api/tests/integration/api/mission-match.test.ts
+++ b/api/tests/integration/api/mission-match.test.ts
@@ -57,7 +57,7 @@ describe("GET /missions/match", () => {
   it("rejects an unknown engine version", async () => {
     const response = await withApiKey(request(app).get("/missions/match")).query({
       userScoringId: "00000000-0000-0000-0000-000000000000",
-      engineVersion: "m3",
+      engineVersion: "m99",
     });
 
     expect(response.status).toBe(400);
@@ -90,7 +90,7 @@ describe("GET /missions/match", () => {
 
     expect(response.status).toBe(200);
     expect(response.body.ok).toBe(true);
-    expect(response.body.data.engineVersion).toBe("m2");
+    expect(response.body.data.engineVersion).toBe("m3");
     expect(response.body.data.items).toHaveLength(1);
   });
 });

--- a/api/tests/integration/api/mission-match.test.ts
+++ b/api/tests/integration/api/mission-match.test.ts
@@ -204,6 +204,8 @@ describe("GET /missions/match", () => {
     expect(item.mission.location.closestLat).toBeNull();
     expect(item.mission.location.closestLon).toBeNull();
     expect(item.mission.location.addressId).toBeNull();
+    // Le fallback city (mission.addresses[0].city) doit aussi être neutralisé pour une full-remote.
+    expect(item.mission.location.city).toBeNull();
     expect(response.body.data.avgDistanceKmTop5).toBeNull();
   });
 });


### PR DESCRIPTION
## Description

Les missions **remote** étaient pénalisées par le moteur de matching. Le score géographique repose sur la distance haversine minimale entre l'utilisateur et les adresses géocodées de la mission (`geo_score = 1.0` à 0 km, `0.5` à 20 km). Or une mission `remote=full` n'a pas d'adresse : elle tombait dans la branche « pas de distance » et se voyait attribuer `missingGeoScore = 0.1`, soit un score **plus bas qu'une mission physique même lointaine** (une mission à 60 km garde un score > 0.1).

Cette PR introduit une nouvelle version du moteur, **`m3`**, qui considère une mission `remote=full` comme **naturellement proche** (`geo_score = 1.0`), en ignorant toute adresse éventuelle. `m3` devient la version active (`CURRENT_MATCHING_ENGINE_VERSION`).

### Détails techniques

- Nouvelle version `m3` : mêmes `taxonomyWeights` et `geoWeight` (0.3) que `m2`, plus un nouveau paramètre `remoteFullGeoScore`.
- Le comportement remote est porté par la config de version via `remoteFullGeoScore: number | null` :
  - `m1`/`m2` → `null` : **aucun changement**, le SQL généré est strictement identique à avant (non-régression).
  - `m3` → `1.0` : injecte une branche `WHEN m."remote"::text = 'full' THEN 1.0` en tête du calcul du `geo_score`.
- Le champ `mission.remote` (`no` | `possible` | `full`) est désormais exploité par le moteur (jointure `mission` ajoutée dans la CTE de ranking).
- **Inclusion dans le pool candidat** : quand le boost est actif et que l'utilisateur est géolocalisé, une CTE `remote_full_candidates` injecte les missions `remote=full` éligibles dans le pool. Sans ça, une mission full-remote sans adresse **et** sans recouvrement taxonomie n'atteignait jamais l'étape de scoring (ni candidat taxonomie, ni candidat géo) et ne bénéficiait donc pas du `geo_score = 1.0` annoncé.
- Les missions `remote=possible` (partiel) **ne sont pas modifiées** dans cette PR (voir points d'attention).
- `distance_km` reste `NULL` pour les full-remote → elles restent exclues de `avgDistanceKmTop5` ; le `geoScore` renvoyé vaut `1.0`.

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Points d'attention pour le reviewer :**

- **Promotion de version** : `CURRENT_MATCHING_ENGINE_VERSION` passe de `m2` à `m3`. `mission-email` lit le snapshot persisté pour la version courante — s'assurer que le flux qui persiste les résultats (offset 0) tourne bien en `m3` au déploiement, sinon l'email ne trouvera pas de résultats. `m2` reste disponible en fallback via `?engineVersion=m2`.
- **Missions `remote=possible`** : hors périmètre ici. À cadrer avec une analyse du stock (part des `possible` ayant une adresse géocodée) → approche « plancher géo » si adresse, sinon traitement comme `full`.
- **Tests** :
  - Unitaires (SQL généré) : injection de la branche remote + de la CTE `remote_full_candidates` en `m3`, non-régression `m2` (aucune des deux), `geoScore=1` / `distanceKm=null`.
  - Intégration (Postgres) : une mission `remote=full` sans adresse ni match taxonomie, pour un utilisateur géolocalisé, **remonte avec `geoScore=1` en `m3`** alors qu'elle est **absente en `m2`** — ce qui valide la correction du trou dans le pool candidat.
