### PR TITLE
fix(api): add moderator access control on moderation search routes

### DIFF
--- a/api/src/controllers/moderation.ts
+++ b/api/src/controllers/moderation.ts
@@ -71,6 +71,14 @@ router.post("/search", passport.authenticate("user", { session: false }), async 
     if (!moderator) {
       return res.status(404).send({ ok: false, code: NOT_FOUND });
     }
+    if (!moderator.moderator) {
+      return res.status(403).send({ ok: false, code: FORBIDDEN });
+    }
+
+    const userPublisherIds = req.user.publishers.map((publisherId: string) => publisherId.toString());
+    if (req.user.role !== "admin" && !userPublisherIds.includes(moderator.id)) {
+      return res.status(403).send({ ok: false, code: FORBIDDEN });
+    }
 
     const filters: ModerationFilters = {
       moderatorId: moderator.id,
@@ -111,6 +119,14 @@ router.post("/aggs", passport.authenticate("user", { session: false }), async (r
     if (!moderator) {
       return res.status(404).send({ ok: false, code: NOT_FOUND });
     }
+    if (!moderator.moderator) {
+      return res.status(403).send({ ok: false, code: FORBIDDEN });
+    }
+
+    const userPublisherIds = req.user.publishers.map((publisherId: string) => publisherId.toString());
+    if (req.user.role !== "admin" && !userPublisherIds.includes(moderator.id)) {
+      return res.status(403).send({ ok: false, code: FORBIDDEN });
+    }
 
     const filters: ModerationFilters = {
       moderatorId: moderator.id,
@@ -143,6 +159,14 @@ router.post("/search-history", passport.authenticate("user", { session: false })
     const moderator = await publisherService.findOnePublisherById(body.data.moderatorId);
     if (!moderator) {
       return res.status(404).send({ ok: false, code: NOT_FOUND });
+    }
+    if (!moderator.moderator) {
+      return res.status(403).send({ ok: false, code: FORBIDDEN });
+    }
+
+    const userPublisherIds = req.user.publishers.map((publisherId: string) => publisherId.toString());
+    if (req.user.role !== "admin" && !userPublisherIds.includes(moderator.id)) {
+      return res.status(403).send({ ok: false, code: FORBIDDEN });
     }
 
     const result = await missionModerationStatusService.aggregateByOrganization({

--- a/api/tests/integration/api/endpoints/moderation.test.ts
+++ b/api/tests/integration/api/endpoints/moderation.test.ts
@@ -47,6 +47,22 @@ describe("Moderation API endpoints (integration test)", () => {
       expect(res.status).toBe(400);
     });
 
+    it("should return 403 when the moderatorId is not a moderator", async () => {
+      const nonModerator = await createTestPublisher({ moderator: false });
+
+      const res = await request(app).post("/moderation/search").set("Authorization", `jwt ${adminToken}`).send({ moderatorId: nonModerator.id });
+
+      expect(res.status).toBe(403);
+    });
+
+    it("should return 403 when user does not have access to the moderator publisher", async () => {
+      const { token } = await createTestUser({ role: "user", publishers: [partner.id] });
+
+      const res = await request(app).post("/moderation/search").set("Authorization", `jwt ${token}`).send({ moderatorId: jva.id });
+
+      expect(res.status).toBe(403);
+    });
+
     it("should return empty results when there are no moderation records for this moderator", async () => {
       const otherPublisher = await createTestPublisher({ moderator: true });
 
@@ -155,6 +171,22 @@ describe("Moderation API endpoints (integration test)", () => {
       expect(res.status).toBe(401);
     });
 
+    it("should return 403 when the moderatorId is not a moderator", async () => {
+      const nonModerator = await createTestPublisher({ moderator: false });
+
+      const res = await request(app).post("/moderation/aggs").set("Authorization", `jwt ${adminToken}`).send({ moderatorId: nonModerator.id });
+
+      expect(res.status).toBe(403);
+    });
+
+    it("should return 403 when user does not have access to the moderator publisher", async () => {
+      const { token } = await createTestUser({ role: "user", publishers: [partner.id] });
+
+      const res = await request(app).post("/moderation/aggs").set("Authorization", `jwt ${token}`).send({ moderatorId: jva.id });
+
+      expect(res.status).toBe(403);
+    });
+
     it("should return aggregations with correct keys", async () => {
       await createMissionWithModeration({ publisherId: partner.id, moderationStatus: "REFUSED", moderationComment: "CONTENT_INSUFFICIENT" });
       await createMissionWithModeration({ publisherId: partner.id, moderationStatus: "PENDING" });
@@ -194,6 +226,40 @@ describe("Moderation API endpoints (integration test)", () => {
       const commentsAgg = res.body.data.comments;
       expect(commentsAgg).toHaveLength(1);
       expect(commentsAgg[0].key).toBe("CONTENT_INSUFFICIENT");
+    });
+  });
+
+  // ─── POST /moderation/search-history ──────────────────────────────────────
+
+  describe("POST /moderation/search-history", () => {
+    it("should return 401 when unauthenticated", async () => {
+      const res = await request(app).post("/moderation/search-history").send({ moderatorId: jva.id });
+      expect(res.status).toBe(401);
+    });
+
+    it("should return 403 when the moderatorId is not a moderator", async () => {
+      const nonModerator = await createTestPublisher({ moderator: false });
+
+      const res = await request(app).post("/moderation/search-history").set("Authorization", `jwt ${adminToken}`).send({ moderatorId: nonModerator.id });
+
+      expect(res.status).toBe(403);
+    });
+
+    it("should return 403 when user does not have access to the moderator publisher", async () => {
+      const { token } = await createTestUser({ role: "user", publishers: [partner.id] });
+
+      const res = await request(app).post("/moderation/search-history").set("Authorization", `jwt ${token}`).send({ moderatorId: jva.id });
+
+      expect(res.status).toBe(403);
+    });
+
+    it("allows a user attached to the moderator publisher", async () => {
+      const { token } = await createTestUser({ role: "user", publishers: [jva.id] });
+
+      const res = await request(app).post("/moderation/search-history").set("Authorization", `jwt ${token}`).send({ moderatorId: jva.id });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Description

Corrige une faille de contrôle d'accès (broken access control / IDOR) sur les routes `POST /moderation/search`, `POST /moderation/aggs` et `POST /moderation/search-history`.

Ces routes résolvaient le `moderatorId` du body et vérifiaient seulement que le publisher existait : tout utilisateur authentifié pouvait récupérer la file de modération de n'importe quel modérateur (titres, descriptions, commentaires/notes internes de modération, RNA/SIREN, historique des événements).

**Changements** :
- Ajout sur les trois routes du même garde-fou que les routes sœurs (`GET /:id`, `PUT /:id`, `PUT /many`) :
  - `!moderator.moderator` → 403 `FORBIDDEN`
  - `req.user.role !== "admin" && !userPublisherIds.includes(moderator.id)` → 403 `FORBIDDEN`
- Tests d'intégration ajoutés : cas 403 (publisher non modérateur, utilisateur non rattaché) sur `/search` et `/aggs`, et couverture complète de `/search-history` (401, 403, cas passant)

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/POST-moderation-event-search-aucun-contr-le-de-propri-t-38072a322d5080ecbbaee1359a63e5ad?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Points d'attention** :
- Le schéma zod de `/search` et `/aggs` a un défaut `moderatorId = JEVEUXAIDER` : un non-admin non rattaché à JVA qui omet le champ reçoit désormais 403 au lieu de la file complète de modération JVA.
- Le 404 pour un `moderatorId` inconnu est conservé (cohérent avec `GET /:id`).
- Piste de refactor séparée : les six routes du controller partagent maintenant le même bloc résolution + vérification du modérateur, factorisable en middleware d'autorisation (sur le modèle de `authorizeStatsSearch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)