### PR TITLE
fix(api): restrict diffusion rule creation to supported operators

### DIFF
--- a/api/src/v0/diffusion-rule/controller.ts
+++ b/api/src/v0/diffusion-rule/controller.ts
@@ -6,6 +6,7 @@ import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND, RESS
 import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { publisherService } from "@/services/publisher";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
+import { SUPPORTED_CHILD_FIELDS } from "@/services/publisher-diffusion-rule/config";
 import { PublisherRequest } from "@/types/passport";
 import type { PublisherRecord } from "@/types/publisher";
 
@@ -24,13 +25,23 @@ const listQuerySchema = zod
 
 const ALLOWED_RULE_FIELDS = ["publisherOrganization.clientId", "publisherOrganization.parentOrganizations"] as const;
 
-const ruleBodySchema = zod.object({
-  publisherIds: zod.array(zod.string()).min(1),
-  field: zod.enum(ALLOWED_RULE_FIELDS),
-  fieldType: zod.string().optional().nullable(),
-  operator: zod.string().min(1),
-  value: zod.string().min(1),
-});
+// Garde-fou : seuls les opérateurs déclarés dans le registre `SUPPORTED_CHILD_FIELDS` sont acceptés,
+// une règle hors registre casserait le filtrage des missions (match / missions-browse).
+const ruleBodySchema = zod
+  .object({
+    publisherIds: zod.array(zod.string()).min(1),
+    field: zod.enum(ALLOWED_RULE_FIELDS),
+    fieldType: zod.enum(["string"]).optional().nullable(),
+    operator: zod.string().min(1),
+    value: zod.string().min(1),
+  })
+  .refine(
+    (data) => {
+      const config = SUPPORTED_CHILD_FIELDS[data.field];
+      return config.operators.is.includes(data.operator) || config.operators.isNot.includes(data.operator);
+    },
+    { message: "operator not supported for this field" }
+  );
 
 router.get("/", async (req: PublisherRequest, res: Response, next: NextFunction) => {
   try {

--- a/api/tests/integration/api/endpoints/v0/diffusion-rule.test.ts
+++ b/api/tests/integration/api/endpoints/v0/diffusion-rule.test.ts
@@ -193,6 +193,8 @@ describe("DiffusionRule API Integration Tests", () => {
    * POST /v0/diffusion-rule
    * - should return 401 if not authenticated
    * - should return 400 for invalid body
+   * - should return 400 for an unsupported operator on the field
+   * - should return 400 for an unsupported fieldType
    * - should return 403 when none of the publisherIds match the user's diffuseurs
    * - should create rules for allowed diffuseurs only
    * - should default fieldType to "string" when missing
@@ -216,6 +218,28 @@ describe("DiffusionRule API Integration Tests", () => {
 
     it("should return 400 for invalid body", async () => {
       const response = await request(app).post("/v0/diffusion-rule").set("x-api-key", apiKey).send({ publisherIds: [], field: "", operator: "", value: "" });
+      expect(response.status).toBe(400);
+      expect(response.body.ok).toBe(false);
+      expect(response.body.code).toBe("INVALID_BODY");
+    });
+
+    it("should return 400 for an unsupported operator on the field", async () => {
+      const response = await request(app)
+        .post("/v0/diffusion-rule")
+        .set("x-api-key", apiKey)
+        .send({ publisherIds: [diffuseur1.id], field: "publisherOrganization.parentOrganizations", operator: "starts_with", value: "Marine nationale" });
+
+      expect(response.status).toBe(400);
+      expect(response.body.ok).toBe(false);
+      expect(response.body.code).toBe("INVALID_BODY");
+    });
+
+    it("should return 400 for an unsupported fieldType", async () => {
+      const response = await request(app)
+        .post("/v0/diffusion-rule")
+        .set("x-api-key", apiKey)
+        .send({ ...validRule, fieldType: "array", publisherIds: [diffuseur1.id] });
+
       expect(response.status).toBe(400);
       expect(response.body.ok).toBe(false);
       expect(response.body.code).toBe("INVALID_BODY");


### PR DESCRIPTION
## Description

Ajoute un garde-fou sur `POST /v0/diffusion-rule` : il n'est plus possible de créer une diffusion rule non supportée par le moteur de filtrage des missions.

Sans ce garde-fou, une règle avec un opérateur ou un `fieldType` non supporté cassait les endpoints `match` / `missions-browse` (condition Prisma invalide → 500, ex. `starts_with` sur un champ array) ou était silencieusement ignorée (scope de diffusion incorrect + erreur Sentry `unsupported_child_operator` côté filtre de recherche).

**Changements** :
- `operator` est validé contre le registre existant `SUPPORTED_CHILD_FIELDS` (source de vérité des règles supportées par tous les consommateurs : Typesense, chemin Prisma, chemin SQL) :
  - `publisherOrganization.clientId` : `is`, `is_not`
  - `publisherOrganization.parentOrganizations` : `is`, `contains`, `is_not`, `does_not_contain`
- `fieldType` est restreint à `"string"` (seul type valide pour ces deux champs, toujours optionnel avec défaut `"string"`)
- 2 tests d'intégration ajoutés (400 sur opérateur non supporté, 400 sur `fieldType` non supporté)

Aucun usage existant n'est impacté : les règles créées via l'app et `myorganization` utilisent uniquement `is_not` / `does_not_contain`.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/Garde-fou-diffusion-rule-38872a322d5080d7ad18ed0693d7a42d?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Ajouter le support d'un nouveau champ/opérateur ne demandera qu'une entrée dans le registre `SUPPORTED_CHILD_FIELDS` (`api/src/services/publisher-diffusion-rule/config.ts`), sans retoucher le contrôleur.
- Les 22 tests d'intégration de `tests/integration/api/endpoints/v0/diffusion-rule.test.ts` passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)