### PR TITLE
fix(api): strip password hash and tokens from user responses

### DIFF
--- a/api/src/controllers/user.ts
+++ b/api/src/controllers/user.ts
@@ -42,7 +42,7 @@ router.post("/search", passport.authenticate("admin", { session: false }), async
     };
 
     const users = await userService.findUsers(filters);
-    return res.status(200).send({ ok: true, data: users });
+    return res.status(200).send({ ok: true, data: users.map((user) => userService.toPublicUser(user)) });
   } catch (error) {
     next(error);
   }
@@ -70,7 +70,7 @@ router.get("/refresh", passport.authenticate("user", { session: false }), async 
     });
 
     if (user.publishers.length === 0) {
-      return res.send({ ok: true, data: { token, user, publisher: null } });
+      return res.send({ ok: true, data: { token, user: userService.toPublicUser(user), publisher: null } });
     }
 
     let publisher = null;
@@ -81,7 +81,7 @@ router.get("/refresh", passport.authenticate("user", { session: false }), async 
       publisher = await publisherService.findOnePublisherById(user.publishers[0]);
     }
 
-    return res.send({ ok: true, data: { token, user, publisher } });
+    return res.send({ ok: true, data: { token, user: userService.toPublicUser(user), publisher } });
   } catch (error) {
     next(error);
   }
@@ -104,7 +104,7 @@ router.get("/:id", passport.authenticate("user", { session: false }), async (req
     }
 
     const data = await userService.findUserById(params.data.id, { includeDeleted: true });
-    return res.status(200).send({ ok: true, data });
+    return res.status(200).send({ ok: true, data: data ? userService.toPublicUser(data) : null });
   } catch (error) {
     next(error);
   }
@@ -143,7 +143,7 @@ router.get("/loginas/:id", passport.authenticate("admin", { session: false }), a
         publisherId: publisher.id,
       },
     });
-    return res.status(200).send({ ok: true, data: { user, publisher, token } });
+    return res.status(200).send({ ok: true, data: { user: userService.toPublicUser(user), publisher, token } });
   } catch (error) {
     next(error);
   }
@@ -191,7 +191,7 @@ router.post("/invite", passport.authenticate("admin", { session: false }), async
       },
     });
 
-    return res.status(200).send({ ok: true, data: user });
+    return res.status(200).send({ ok: true, data: userService.toPublicUser(user) });
   } catch (error) {
     next(error);
   }
@@ -218,7 +218,7 @@ router.post("/verify-token", async (req: UserRequest, res: Response, next: NextF
       return res.status(403).send({ ok: false, code: REQUEST_EXPIRED, message: `Token expired` });
     }
 
-    return res.status(200).send({ ok: true, data: user });
+    return res.status(200).send({ ok: true, data: userService.toPublicUser(user) });
   } catch (error) {
     next(error);
   }
@@ -246,7 +246,7 @@ router.post("/verify-reset-password-token", async (req: UserRequest, res: Respon
       return res.status(403).send({ ok: false, code: REQUEST_EXPIRED, message: `Token expired` });
     }
 
-    return res.status(200).send({ ok: true, data: user });
+    return res.status(200).send({ ok: true, data: userService.toPublicUser(user) });
   } catch (error) {
     next(error);
   }
@@ -327,7 +327,7 @@ router.post("/login", async (req: UserRequest, res: Response, next: NextFunction
         await loginHistoryService.recordLogin(user.id, now);
 
         const token = jwt.sign({ _id: updatedUser.id }, SECRET, { expiresIn: AUTH_TOKEN_EXPIRATION });
-        return res.status(200).send({ ok: true, data: { user: updatedUser, publisher, token } });
+        return res.status(200).send({ ok: true, data: { user: userService.toPublicUser(updatedUser), publisher, token } });
       },
       delay > 0 ? delay : 0
     );
@@ -388,7 +388,7 @@ router.put("/", passport.authenticate("user", { session: false }), async (req: U
       lastname: body.data.lastname ?? null,
     });
 
-    res.status(200).send({ ok: true, data: updated });
+    res.status(200).send({ ok: true, data: userService.toPublicUser(updated) });
   } catch (error) {
     next(error);
   }
@@ -577,7 +577,7 @@ router.put("/:id", passport.authenticate("admin", { session: false }), async (re
 
     const updated = Object.keys(patch).length ? await userService.updateUser(user.id, patch) : user;
 
-    res.status(200).send({ ok: true, data: updated });
+    res.status(200).send({ ok: true, data: userService.toPublicUser(updated) });
   } catch (error) {
     next(error);
   }

--- a/api/src/services/user.ts
+++ b/api/src/services/user.ts
@@ -2,7 +2,7 @@ import bcrypt from "bcryptjs";
 
 import { Prisma } from "@/db/core";
 import { userRepository } from "@/repositories/user";
-import type { UserCreateInput, UserFindParams, UserRecord, UserUpdatePatch } from "@/types/user";
+import type { PublicUserRecord, UserCreateInput, UserFindParams, UserRecord, UserUpdatePatch } from "@/types/user";
 
 const SALT_ROUNDS = 10;
 
@@ -159,6 +159,15 @@ const buildUpdateData = async (patch: UserUpdatePatch): Promise<Prisma.UserUpdat
 };
 
 export const userService = {
+  /**
+   * Retire les champs sensibles (`password`, `invitationToken`, `forgotPasswordToken`, `forgotPasswordExpiresAt`)
+   * d'un record : à utiliser pour toute réponse HTTP contenant un user.
+   */
+  toPublicUser(user: UserRecord): PublicUserRecord {
+    const { password, invitationToken, forgotPasswordToken, forgotPasswordExpiresAt, ...publicUser } = user;
+    return publicUser;
+  },
+
   async findUsers(params: UserFindParams = {}): Promise<UserRecord[]> {
     const users = (await userRepository.findMany({
       where: buildWhere(params),

--- a/api/src/types/user.ts
+++ b/api/src/types/user.ts
@@ -20,6 +20,8 @@ export interface UserRecord {
   updatedAt: Date;
 }
 
+export type PublicUserRecord = Omit<UserRecord, "password" | "invitationToken" | "forgotPasswordToken" | "forgotPasswordExpiresAt">;
+
 export interface UserFindParams {
   email?: string;
   publisherId?: string;

--- a/api/tests/integration/api/endpoints/user.test.ts
+++ b/api/tests/integration/api/endpoints/user.test.ts
@@ -157,4 +157,77 @@ describe("Dashboard user controller", () => {
       expect(res.body.code).toBe("INVALID_PASSWORD");
     });
   });
+
+  describe("sensitive user fields", () => {
+    const SENSITIVE_FIELDS = ["password", "invitationToken", "forgotPasswordToken", "forgotPasswordExpiresAt"];
+
+    const expectPublicUser = (user: Record<string, unknown>) => {
+      expect(user.email).toBeTruthy();
+      for (const field of SENSITIVE_FIELDS) {
+        expect(user).not.toHaveProperty(field);
+      }
+    };
+
+    it("strips sensitive fields from POST /user/search results, admin included", async () => {
+      const { token: adminToken } = await createTestUser({ role: "admin" });
+      await createTestUser({
+        password: "SuperSecret123!",
+        invitationToken: "secret-invitation-token",
+        forgotPasswordToken: "secret-forgot-token",
+        forgotPasswordExpiresAt: new Date(Date.now() + 1000 * 60),
+      });
+
+      const res = await request(app)
+        .post("/user/search")
+        .set({ Authorization: `jwt ${adminToken}` })
+        .send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBeGreaterThan(0);
+      res.body.data.forEach(expectPublicUser);
+    });
+
+    it("strips sensitive fields from POST /user/login and GET /user/refresh", async () => {
+      const { user } = await createTestUser({ password: "SuperSecret123!", publishers: [publisherId] });
+
+      const login = await request(app).post("/user/login").send({ email: user.email, password: "SuperSecret123!" });
+      expect(login.status).toBe(200);
+      expectPublicUser(login.body.data.user);
+
+      const refresh = await request(app)
+        .get("/user/refresh")
+        .set({ Authorization: `jwt ${login.body.data.token}` });
+      expect(refresh.status).toBe(200);
+      expectPublicUser(refresh.body.data.user);
+    });
+
+    it("strips sensitive fields from GET /user/:id and GET /user/loginas/:id", async () => {
+      const { token: adminToken } = await createTestUser({ role: "admin" });
+      const { user: targetUser } = await createTestUser({ password: "SuperSecret123!", publishers: [publisherId] });
+
+      const getOne = await request(app)
+        .get(`/user/${targetUser.id}`)
+        .set({ Authorization: `jwt ${adminToken}` });
+      expect(getOne.status).toBe(200);
+      expectPublicUser(getOne.body.data);
+
+      const loginas = await request(app)
+        .get(`/user/loginas/${targetUser.id}`)
+        .set({ Authorization: `jwt ${adminToken}` });
+      expect(loginas.status).toBe(200);
+      expectPublicUser(loginas.body.data.user);
+    });
+
+    it("does not echo tokens back from POST /user/verify-token", async () => {
+      await createTestUser({
+        invitationToken: "invitation-token-verify",
+        invitationExpiresAt: new Date(Date.now() + 1000 * 60 * 60),
+      });
+
+      const res = await request(app).post("/user/verify-token").send({ token: "invitation-token-verify" });
+
+      expect(res.status).toBe(200);
+      expectPublicUser(res.body.data);
+    });
+  });
 });


### PR DESCRIPTION
## Description

Correction d'une faille d'exposition de données sensibles : le hash bcrypt du mot de passe, `invitationToken`, `forgotPasswordToken` et `forgotPasswordExpiresAt` étaient renvoyés dans toutes les réponses user de l'API (search, refresh, get, loginas, invite, verify-token, login, updates). Le hash permettait un cracking offline, et les tokens exposés constituaient une primitive directe de prise de compte.

**Changements** :

- Nouveau type `PublicUserRecord` (`Omit` des 4 champs sensibles) dans `types/user.ts`
- Sérialiseur `userService.toPublicUser` qui retire ces champs, sur le même pattern que `toPublicPublisher`
- Toutes les réponses HTTP de `controllers/user.ts` (11 points de sortie) passent par le sérialiseur
- Le record interne conserve le hash : `comparePassword`, le `req.user` de passport et le flux d'email d'invitation ne sont pas impactés

Aucun changement front nécessaire : `app/src` ne lit jamais ces champs dans les réponses API.

## Liens utiles

- 📝 [Ticket Notion](https://app.notion.com/p/jeveuxaider/Exposition-des-hashes-de-mot-de-passe-sur-les-endpoints-user-39972a322d5080bb8940ffde1a5513ea?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Nouveau bloc de tests d'intégration `sensitive user fields` dans `user.test.ts` : vérifie l'absence des 4 champs sur search (admin inclus), login, refresh, get by id, loginas et verify-token (13/13 tests verts).
- Hors périmètre de cette PR, repérés au passage : `PUT /user/:id/reset-password` génère un mot de passe en clair via `Math.random()` (faible), et `GET /user/:id` renvoie 200 avec `data: null` pour un user inexistant (comportement conservé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)