### PR TITLE
fix(api): matching perf with remote geoWeight

### DIFF
--- a/api/scripts/benchmark-matching-engine.ts
+++ b/api/scripts/benchmark-matching-engine.ts
@@ -15,6 +15,7 @@
  *   --geo-weight N             Poids geo (defaut : moteur)
  *   --geo-half-decay-km N      Demi-vie geo en km (defaut : moteur)
  *   --json                     Sortie JSON au lieu du tableau console
+ *   --explain                  Affiche EXPLAIN (ANALYZE, BUFFERS) du SQL de ranking au lieu de mesurer
  */
 
 import dotenv from "dotenv";
@@ -45,6 +46,7 @@ type BenchmarkOptions = {
   geoWeight?: number;
   geoHalfDecayKm?: number;
   json: boolean;
+  explain: boolean;
 };
 
 type UserScoringCandidate = {
@@ -174,6 +176,7 @@ const parseOptions = (): BenchmarkOptions => ({
   geoWeight: parseNumber("--geo-weight"),
   geoHalfDecayKm: parseNumber("--geo-half-decay-km"),
   json: args.includes("--json"),
+  explain: args.includes("--explain"),
 });
 
 const roundMs = (value: number): number => Number(value.toFixed(2));
@@ -412,6 +415,20 @@ const run = async () => {
     const missingIds = options.userScoringIds.filter((id) => !userScorings.some((userScoring) => userScoring.id === id));
     if (missingIds.length > 0) {
       throw new Error(`user_scoring introuvable ou expire: ${missingIds.join(", ")}`);
+    }
+
+    // Mode diagnostic : affiche le plan EXPLAIN (ANALYZE, BUFFERS) du SQL de ranking par scenario.
+    if (options.explain) {
+      for (const userScoring of userScorings) {
+        for (const limit of options.limits) {
+          for (const offset of options.offsets) {
+            console.log(`\n[${SCRIPT_LABEL}] EXPLAIN userScoringId=${userScoring.id} version=${options.version} limit=${limit} offset=${offset}`);
+            const plan = await matchingEngineService.explainRanking(buildRankingInput(options, userScoring.id, limit, offset));
+            console.log(plan);
+          }
+        }
+      }
+      return;
     }
 
     const results: ScenarioResult[] = [];

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -97,18 +97,41 @@ const buildRanking = (params: {
     ? Prisma.empty
     : Prisma.sql`
   remote_full_candidates AS (
+    -- On priorise les missions remote par score taxonomie (comme l'ordre d'origine) mais sans le
+    -- nested loop O(remote × taxonomy) : le join est piloté DEPUIS taxonomy_scores (→ hash join,
+    -- comme taxonomy_candidates) au lieu d'un LEFT JOIN depuis le côté remote.
     SELECT
-      ems."mission_id",
-      ems."mission_scoring_id"
-    FROM eligible_mission_scorings ems
-    JOIN "mission" m
-      ON m."id" = ems."mission_id"
-     AND m."remote"::text = 'full'
-    WHERE EXISTS (SELECT 1 FROM user_geo)
-    -- Tri déterministe (pas par taxonomie) : joindre taxonomy_scores ici forçait un nested loop
-    -- O(remote × taxonomy) très coûteux. Le classement final (ranked) réordonne de toute façon ces
-    -- candidats par total_score ; ce LIMIT ne sert qu'à borner le pool.
-    ORDER BY ems."mission_id" ASC
+      rc."mission_id",
+      rc."mission_scoring_id"
+    FROM (
+      -- (1) missions remote AVEC score taxonomie, triées par pertinence
+      SELECT
+        ems."mission_id",
+        ems."mission_scoring_id",
+        ts."weighted_sum" AS "weighted_sum"
+      FROM taxonomy_scores ts
+      JOIN eligible_mission_scorings ems
+        ON ems."mission_scoring_id" = ts."mission_scoring_id"
+      JOIN "mission" m
+        ON m."id" = ems."mission_id"
+       AND m."remote"::text = 'full'
+      WHERE EXISTS (SELECT 1 FROM user_geo)
+      UNION ALL
+      -- (2) missions remote SANS score taxonomie (score 0), en complément du pool
+      SELECT
+        ems."mission_id",
+        ems."mission_scoring_id",
+        CAST(0 AS double precision) AS "weighted_sum"
+      FROM eligible_mission_scorings ems
+      JOIN "mission" m
+        ON m."id" = ems."mission_id"
+       AND m."remote"::text = 'full'
+      WHERE EXISTS (SELECT 1 FROM user_geo)
+        AND NOT EXISTS (
+          SELECT 1 FROM taxonomy_scores ts WHERE ts."mission_scoring_id" = ems."mission_scoring_id"
+        )
+    ) rc
+    ORDER BY rc."weighted_sum" DESC, rc."mission_id" ASC
     LIMIT ${params.geoCandidateLimit}
   ),`;
   const remoteFullCandidatesUnionSql = !remoteFullActive

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -104,10 +104,11 @@ const buildRanking = (params: {
     JOIN "mission" m
       ON m."id" = ems."mission_id"
      AND m."remote"::text = 'full'
-    LEFT JOIN taxonomy_scores ts
-      ON ts."mission_scoring_id" = ems."mission_scoring_id"
     WHERE EXISTS (SELECT 1 FROM user_geo)
-    ORDER BY COALESCE(ts."weighted_sum", 0) DESC, ems."mission_id" ASC
+    -- Tri déterministe (pas par taxonomie) : joindre taxonomy_scores ici forçait un nested loop
+    -- O(remote × taxonomy) très coûteux. Le classement final (ranked) réordonne de toute façon ces
+    -- candidats par total_score ; ce LIMIT ne sert qu'à borner le pool.
+    ORDER BY ems."mission_id" ASC
     LIMIT ${params.geoCandidateLimit}
   ),`;
   const remoteFullCandidatesUnionSql = !remoteFullActive
@@ -582,44 +583,62 @@ const buildMissionMatchingResultItems = (params: {
     taxonomyScores: params.taxonomyScoresByMissionScoringId[row.mission_scoring_id] ?? {},
   }));
 
+// Dérive les paramètres de ranking depuis l'input (defaults par version). Partagé entre l'exécution
+// et le debug (explainRanking) pour garantir un SQL identique.
+const resolveRankingParams = (input: RankMissionsByUserScoringInput) => {
+  const version = input.version ?? CURRENT_MATCHING_ENGINE_VERSION;
+  const versionConfig = MATCHING_ENGINE_VERSIONS[version];
+  const limit = Math.max(1, Math.min(500, input.limit ?? 20));
+  const offset = Math.max(0, input.offset ?? 0);
+  // The persisted snapshot is defined as the first page of the ranking.
+  const shouldPersistTopResults = offset === 0;
+  const rankingLimit = shouldPersistTopResults ? Math.max(limit, MATCHING_ENGINE_TOP_RESULTS_LIMIT) : limit;
+
+  return {
+    version,
+    limit,
+    offset,
+    shouldPersistTopResults,
+    rankingLimit,
+    taxonomyWeights: versionConfig.taxonomyWeights,
+    taxonomyWeight: input.taxonomyWeight ?? 0.3,
+    geoWeight: input.geoWeight ?? versionConfig.geoWeight,
+    geoHalfDecayKm: input.geoHalfDecayKm ?? 20,
+    missingGeoScore: input.missingGeoScore ?? 0.1,
+    remoteFullGeoScore: input.remoteFullGeoScore !== undefined ? input.remoteFullGeoScore : versionConfig.remoteFullGeoScore,
+    taxonomyCandidateLimit: getTaxonomyCandidateLimit({ limit: rankingLimit, offset }),
+    geoCandidateLimit: getGeoCandidateLimit({ limit: rankingLimit, offset }),
+  };
+};
+
+const buildRankingSqlForInput = async (input: RankMissionsByUserScoringInput): Promise<Prisma.Sql> => {
+  const params = resolveRankingParams(input);
+  const publisherRuleSql = await buildPublisherRuleSql(input.publisherId);
+
+  return buildRanking({
+    userScoringId: input.userScoringId,
+    publisherRuleSql,
+    taxonomyWeights: params.taxonomyWeights,
+    taxonomyWeight: params.taxonomyWeight,
+    geoWeight: params.geoWeight,
+    geoHalfDecayKm: params.geoHalfDecayKm,
+    missingGeoScore: params.missingGeoScore,
+    remoteFullGeoScore: params.remoteFullGeoScore,
+    taxonomyCandidateLimit: params.taxonomyCandidateLimit,
+    geoCandidateLimit: params.geoCandidateLimit,
+    limit: params.rankingLimit,
+    offset: params.offset,
+  });
+};
+
 export const matchingEngineService = {
   async rankMissionsByUserScoring(input: RankMissionsByUserScoringInput): Promise<RankMissionsByUserScoringResult> {
     const startedAt = Date.now();
-    const version = input.version ?? CURRENT_MATCHING_ENGINE_VERSION;
-    const versionConfig = MATCHING_ENGINE_VERSIONS[version];
-    const taxonomyWeights = versionConfig.taxonomyWeights;
-    const limit = Math.max(1, Math.min(500, input.limit ?? 20));
-    const offset = Math.max(0, input.offset ?? 0);
-    // The persisted snapshot is defined as the first page of the ranking.
-    const shouldPersistTopResults = offset === 0;
-    const rankingLimit = shouldPersistTopResults ? Math.max(limit, MATCHING_ENGINE_TOP_RESULTS_LIMIT) : limit;
-    const taxonomyWeight = input.taxonomyWeight ?? 0.3;
-    const geoWeight = input.geoWeight ?? versionConfig.geoWeight;
-    const geoHalfDecayKm = input.geoHalfDecayKm ?? 20;
-    const missingGeoScore = input.missingGeoScore ?? 0.1;
-    const remoteFullGeoScore = input.remoteFullGeoScore !== undefined ? input.remoteFullGeoScore : versionConfig.remoteFullGeoScore;
-    const taxonomyCandidateLimit = getTaxonomyCandidateLimit({ limit: rankingLimit, offset });
-    const geoCandidateLimit = getGeoCandidateLimit({ limit: rankingLimit, offset });
+    const { version, limit, offset, shouldPersistTopResults } = resolveRankingParams(input);
 
     await assertUserScoringExists(input.userScoringId);
-    const publisherRuleSql = await buildPublisherRuleSql(input.publisherId);
 
-    const rows = await prisma.$queryRaw<DbRankRow[]>(
-      buildRanking({
-        userScoringId: input.userScoringId,
-        publisherRuleSql,
-        taxonomyWeights,
-        taxonomyWeight,
-        geoWeight,
-        geoHalfDecayKm,
-        missingGeoScore,
-        remoteFullGeoScore,
-        taxonomyCandidateLimit,
-        geoCandidateLimit,
-        limit: rankingLimit,
-        offset,
-      })
-    );
+    const rows = await prisma.$queryRaw<DbRankRow[]>(await buildRankingSqlForInput(input));
     const missionScoringIdsForDetails = rows.slice(0, MATCHING_ENGINE_TOP_RESULTS_LIMIT).map((row) => row.mission_scoring_id);
     const taxonomyScoresRows =
       missionScoringIdsForDetails.length > 0
@@ -677,6 +696,16 @@ export const matchingEngineService = {
       total,
       avgDistanceKmTop5,
     };
+  },
+
+  // Debug/diagnostic : renvoie le plan `EXPLAIN (ANALYZE, BUFFERS)` du SQL de ranking pour un input
+  // donné (mêmes paramètres que rankMissionsByUserScoring). Utilisé par scripts/explain-matching-ranking.ts.
+  async explainRanking(input: RankMissionsByUserScoringInput): Promise<string> {
+    await assertUserScoringExists(input.userScoringId);
+    const sql = await buildRankingSqlForInput(input);
+    const rows = await prisma.$queryRaw<Array<Record<string, string>>>(Prisma.sql`EXPLAIN (ANALYZE, BUFFERS) ${sql}`);
+
+    return rows.map((row) => row["QUERY PLAN"]).join("\n");
   },
 };
 


### PR DESCRIPTION
## Description

Corrige la régression de performance de l'endpoint `/match` introduite par la version `m3` du matching engine (commit `98e615c`, PR #1260 « use geo weight for remote missions »).

**Symptôme** : sur les profils **géolocalisés**, `tookMs` explosait (jusqu'à ~6.5 s en prod, +560–650 ms sur staging vs `m2`). Les profils sans géoloc n'étaient pas affectés.

**Cause racine** (identifiée via `EXPLAIN (ANALYZE, BUFFERS)`) : dans `buildRanking`, le CTE `remote_full_candidates` faisait un `LEFT JOIN taxonomy_scores ORDER BY weighted_sum DESC`. Comme `taxonomy_scores` est un CTE **non indexé** dont Postgres sous-estime la cardinalité (161 lignes estimées vs ~11 881 réelles), le planner dégénérait en **nested loop** : `677 missions remote × 11 881 lignes = ~8 M comparaisons`, soit ~1 s à lui seul (`Rows Removed by Join Filter: 8043038` dans le plan).

**Correctif** : réécriture du CTE `remote_full_candidates` pour piloter le join **depuis `taxonomy_scores`** (→ hash join, comme le CTE `taxonomy_candidates` déjà en place) au lieu d'un `LEFT JOIN` depuis le côté remote (→ nested loop). Structure en `UNION ALL` :
1. missions remote **avec** score taxonomie : `FROM taxonomy_scores JOIN eligible_mission_scorings … JOIN mission (remote='full')` ;
2. missions remote **sans** score (complément, score 0) : `NOT EXISTS (taxonomy_scores)` → hash anti join.

Puis `ORDER BY weighted_sum DESC, mission_id ASC LIMIT geoCandidateLimit`. **L'ordre par pertinence taxonomie est préservé** (pas de perte de rappel), et le nested loop disparaît.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [x] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

### Résultats

Benchmark staging (`activeMissionScorings = 22965`), profils géolocalisés, `m3`, `tookMs` moyen :

| Profil / limit | m2 (référence) | m3 avant | m3 après |
|---|---|---|---|
| `89d07…` / 20 | 887 | 1450 | **919** |
| `89d07…` / 500 | 1164 | 1670 | **1157** |
| `031da…` / 20 | 836 | 1391 | **947** |
| `031da…` / 500 | 1057 | 1605 | **~1400** |

`EXPLAIN` : `Execution Time` **1918 ms → ~898 ms** ; le CTE `remote_full_candidates` passe de ~1052 ms (nested loop, 8 M comparaisons) à ~87 ms (hash join + hash anti join). Le temps `m3` repasse au niveau de `m2`.

### Outillage

- Ajout du flag `--explain` au benchmark existant (`scripts/benchmark-matching-engine.ts --explain`) : affiche l'`EXPLAIN (ANALYZE, BUFFERS)` du SQL de ranking au lieu de mesurer (réutilise `--user-scoring-id`, `--version`, `--limits`…).
- Refactor interne : extraction de `resolveRankingParams` + `buildRankingSqlForInput` (dérivation des paramètres partagée entre exécution et diagnostic, hot path inchangé) + méthode `matchingEngineService.explainRanking`.

### Tests

- `matching-engine.test.ts` (12 unit) ✅
- `mission-match.test.ts` (6 intégration) ✅
