### PR TITLE
feat(api,plateform): add remote and local mission support

### DIFF
--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -252,8 +252,8 @@ components:
         remote:
           type: string
           nullable: true
-          enum: [no, possible, full, null]
-          description: "Disponibilité en distanciel. Valeurs possibles : `no` (présentiel uniquement), `possible` (distanciel possible), `full` (100% distanciel)"
+          enum: [no, possible, full, local, null]
+          description: "Modalité de réalisation. Valeurs possibles : `no` (présentiel uniquement), `possible` (distanciel possible), `full` (100% distanciel), `local` (sur site, à proximité)"
           example: "no"
         schedule:
           type: string
@@ -988,8 +988,8 @@ paths:
                   example: ["300412", "300361"]
                 remote:
                   type: string
-                  enum: [no, possible, full]
-                  description: "Disponibilité en distanciel. Valeurs possibles : `no` (présentiel uniquement), `possible` (distanciel possible), `full` (100% distanciel)"
+                  enum: [no, possible, full, local]
+                  description: "Modalité de réalisation. Valeurs possibles : `no` (présentiel uniquement), `possible` (distanciel possible), `full` (100% distanciel), `local` (sur site, à proximité)"
                   example: "no"
                 schedule:
                   type: string
@@ -1260,8 +1260,8 @@ paths:
                   example: ["300412", "300361"]
                 remote:
                   type: string
-                  enum: [no, possible, full]
-                  description: "Disponibilité en distanciel. Valeurs possibles : `no` (présentiel uniquement), `possible` (distanciel possible), `full` (100% distanciel)"
+                  enum: [no, possible, full, local]
+                  description: "Modalité de réalisation. Valeurs possibles : `no` (présentiel uniquement), `possible` (distanciel possible), `full` (100% distanciel), `local` (sur site, à proximité)"
                   example: "no"
                 schedule:
                   type: string
@@ -1722,7 +1722,7 @@ paths:
               - type: array
                 items:
                   type: string
-          description: "Modalité de télétravail : no, possible, full"
+          description: "Modalité de réalisation : no, possible, full, local"
         - name: lat
           in: query
           schema:

--- a/api/docs/openapi.yaml
+++ b/api/docs/openapi.yaml
@@ -253,7 +253,7 @@ components:
           type: string
           nullable: true
           enum: [no, possible, full, local, null]
-          description: "Modalité de réalisation. Valeurs possibles : `no` (présentiel uniquement), `possible` (distanciel possible), `full` (100% distanciel), `local` (sur site, à proximité)"
+          description: "Politique de télétravail. Valeurs possibles : `no` (présentiel uniquement), `possible` (distanciel possible), `full` (100% distanciel), `local` (sur site, à proximité)"
           example: "no"
         schedule:
           type: string
@@ -989,7 +989,7 @@ paths:
                 remote:
                   type: string
                   enum: [no, possible, full, local]
-                  description: "Modalité de réalisation. Valeurs possibles : `no` (présentiel uniquement), `possible` (distanciel possible), `full` (100% distanciel), `local` (sur site, à proximité)"
+                  description: "Politique de télétravail. Valeurs possibles : `no` (présentiel uniquement), `possible` (distanciel possible), `full` (100% distanciel), `local` (sur site, à proximité)"
                   example: "no"
                 schedule:
                   type: string
@@ -1261,7 +1261,7 @@ paths:
                 remote:
                   type: string
                   enum: [no, possible, full, local]
-                  description: "Modalité de réalisation. Valeurs possibles : `no` (présentiel uniquement), `possible` (distanciel possible), `full` (100% distanciel), `local` (sur site, à proximité)"
+                  description: "Politique de télétravail. Valeurs possibles : `no` (présentiel uniquement), `possible` (distanciel possible), `full` (100% distanciel), `local` (sur site, à proximité)"
                   example: "no"
                 schedule:
                   type: string
@@ -1722,7 +1722,7 @@ paths:
               - type: array
                 items:
                   type: string
-          description: "Modalité de réalisation : no, possible, full, local"
+          description: "Politique de télétravail : no, possible, full, local"
         - name: lat
           in: query
           schema:

--- a/api/prisma/migrations/20260715120000_add_mission_remote_local/migration.sql
+++ b/api/prisma/migrations/20260715120000_add_mission_remote_local/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."MissionRemote" ADD VALUE 'local';

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -63,6 +63,7 @@ enum MissionRemote {
   no
   possible
   full
+  local
 }
 
 enum MissionPlacesStatus {

--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -185,10 +185,10 @@ const resolveRemoteFilter = (remoteValues?: string[], widgetType?: string): Arra
     return ["full", "possible"];
   }
   if (remoteValues?.includes("no") && !remoteValues.includes("yes")) {
-    return ["no"];
+    return ["no", "local"];
   }
   if (!remoteValues && widgetType === "volontariat") {
-    return ["no"];
+    return ["no", "local"];
   }
 };
 

--- a/api/src/jobs/grimpio/__tests__/transformers.test.ts
+++ b/api/src/jobs/grimpio/__tests__/transformers.test.ts
@@ -119,6 +119,9 @@ describe("missionToGrimpioJobJVA", () => {
 
     job = missionToGrimpioJobJVA({ ...baseMission, remote: "no", publisherId: PUBLISHER_IDS.JEVEUXAIDER } as MissionRecord);
     expect(job.remoteJob).toBe("none");
+
+    job = missionToGrimpioJobJVA({ ...baseMission, remote: "local", publisherId: PUBLISHER_IDS.JEVEUXAIDER } as MissionRecord);
+    expect(job.remoteJob).toBe("none");
   });
 
   it("should use JVA logo", () => {
@@ -170,6 +173,9 @@ describe("missionToGrimpioJobASC", () => {
     expect(job.remoteJob).toBe("partial");
 
     job = missionToGrimpioJobASC({ ...baseMission, remote: "no", publisherId: PUBLISHER_IDS.SERVICE_CIVIQUE } as MissionRecord);
+    expect(job.remoteJob).toBe("none");
+
+    job = missionToGrimpioJobASC({ ...baseMission, remote: "local", publisherId: PUBLISHER_IDS.SERVICE_CIVIQUE } as MissionRecord);
     expect(job.remoteJob).toBe("none");
   });
 

--- a/api/src/jobs/import-missions/types.ts
+++ b/api/src/jobs/import-missions/types.ts
@@ -55,7 +55,7 @@ export interface MissionXML {
   softSkills: { value: string[] | string } | string;
   romeSkills: { value: string[] | string } | string;
   requirements: { value: string[] | string } | string;
-  remote: "no" | "possible" | "full";
+  remote: "no" | "possible" | "full" | "local";
   reducedMobilityAccessible: string;
   closeToTransport: string;
   openToMinors: string;

--- a/api/src/jobs/import-missions/utils/__tests__/mission.test.ts
+++ b/api/src/jobs/import-missions/utils/__tests__/mission.test.ts
@@ -42,6 +42,10 @@ describe("parseRemote", () => {
     expect(parseRemote("remote")).toBe("full");
   });
 
+  it("returns 'local' for 'local'", () => {
+    expect(parseRemote("local")).toBe("local");
+  });
+
   it("returns 'possible' for 'partiel', 'partielle', 'hybride'", () => {
     expect(parseRemote("partiel")).toBe("possible");
     expect(parseRemote("partielle")).toBe("possible");
@@ -54,6 +58,7 @@ describe("parseRemote", () => {
 
   it("is case-insensitive", () => {
     expect(parseRemote("FULL")).toBe("full");
+    expect(parseRemote("LOCAL")).toBe("local");
     expect(parseRemote("Oui")).toBe("possible");
   });
 });

--- a/api/src/jobs/import-missions/utils/__tests__/moderation.test.ts
+++ b/api/src/jobs/import-missions/utils/__tests__/moderation.test.ts
@@ -95,7 +95,7 @@ describe("getModeration", () => {
     (mission as any).remote = "maybe";
     const result = getModeration(mission as MissionRecord);
     expect(result.statusCode).toBe("REFUSED");
-    expect(result.statusComment).toBe("Valeur remote non valide (no, possible ou full)");
+    expect(result.statusComment).toBe("Valeur remote non valide (no, possible, full ou local)");
   });
 
   it("should set status to REFUSED for invalid places", () => {

--- a/api/src/jobs/import-missions/utils/mission.ts
+++ b/api/src/jobs/import-missions/utils/mission.ts
@@ -78,6 +78,9 @@ export const parseRemote = (value: unknown): MissionRecord["remote"] => {
   if (["full", "total", "100", "remote"].includes(normalized)) {
     return "full";
   }
+  if (normalized === "local") {
+    return "local";
+  }
   if (["partiel", "partielle", "hybride"].includes(normalized)) {
     return "possible";
   }

--- a/api/src/jobs/letudiant/__tests__/transformers.test.ts
+++ b/api/src/jobs/letudiant/__tests__/transformers.test.ts
@@ -141,14 +141,26 @@ describe("L'Etudiant Transformers", () => {
       expect(result.localisation).toBe("France");
     });
 
-    it("should consider remote job if no address", () => {
+    it("should not consider no-address jobs remote by default", () => {
       const mission: MissionRecord = {
         ...baseMission,
         addresses: [],
       } as MissionRecord;
       const results = missionToPilotyJobs(mission, mockCompanyId, mockMandatoryData);
       const result = results[0].payload;
-      expect(result.remote_policy_id).toBe(mockMandatoryData.remotePolicies.full);
+      expect(result.remote_policy_id).toBeUndefined();
+    });
+
+    it("should not consider local jobs remote without address", () => {
+      const mission: MissionRecord = {
+        ...baseMission,
+        addresses: [],
+        remote: "local",
+      } as MissionRecord;
+      const results = missionToPilotyJobs(mission, mockCompanyId, mockMandatoryData);
+      const result = results[0].payload;
+      expect(result.localisation).toBe("France");
+      expect(result.remote_policy_id).toBeUndefined();
     });
 
     it("should return an array of jobs for each address", () => {

--- a/api/src/jobs/letudiant/transformers.ts
+++ b/api/src/jobs/letudiant/transformers.ts
@@ -90,7 +90,7 @@ export function missionToPilotyJobs(mission: MissionRecord, companyId: string, m
     const formatted = formatLocalisation([city, department, country]) || "France";
     return [
       {
-        payload: buildJobPayload(true, formatted),
+        payload: buildJobPayload(mission.remote === "full", formatted),
         missionAddressId: null,
       },
     ];

--- a/api/src/jobs/linkedin/__tests__/transformers.test.ts
+++ b/api/src/jobs/linkedin/__tests__/transformers.test.ts
@@ -245,6 +245,8 @@ describe("missionToLinkedinJob", () => {
     expect(job?.workplaceTypes).toBe("Hybrid");
     job = missionToLinkedinJob({ ...baseMission, remote: "no" } as MissionRecord, defaultCompany);
     expect(job?.workplaceTypes).toBe("On-site");
+    job = missionToLinkedinJob({ ...baseMission, remote: "local" } as MissionRecord, defaultCompany);
+    expect(job?.workplaceTypes).toBe("On-site");
   });
 
   it("should not have expirationDate if endAt is not provided", () => {

--- a/api/src/jobs/linkedin/transformers.ts
+++ b/api/src/jobs/linkedin/transformers.ts
@@ -72,7 +72,7 @@ export function missionToLinkedinJob(mission: MissionRecord, defaultCompany: str
     postalCode: (mission.addresses?.length ?? 0) === 0 ? mission.postalCode : undefined,
     listDate: new Date(mission.createdAt).toISOString(),
     industryCodes: LINKEDIN_INDUSTRY_CODE[mission.domain ?? ""] ? [{ industryCode: LINKEDIN_INDUSTRY_CODE[mission.domain ?? ""] }] : undefined,
-    workplaceTypes: mission.remote === "no" ? "On-site" : mission.remote === "full" ? "Remote" : "Hybrid",
+    workplaceTypes: mission.remote === "full" ? "Remote" : mission.remote === "possible" ? "Hybrid" : "On-site",
   } as LinkedInJob;
   if (mission.endAt) {
     job.expirationDate = new Date(mission.endAt).toISOString();

--- a/api/src/jobs/talent/__tests__/transformers.test.ts
+++ b/api/src/jobs/talent/__tests__/transformers.test.ts
@@ -131,6 +131,9 @@ describe("missionToTalentJob", () => {
 
     jobs = missionToTalentJob({ ...baseMission, remote: "no" } as MissionRecord);
     expect(jobs[0].isremote).toBe("no");
+
+    jobs = missionToTalentJob({ ...baseMission, remote: "local" } as MissionRecord);
+    expect(jobs[0].isremote).toBe("no");
   });
 
   it("should not have expirationdate if endAt is not provided", () => {

--- a/api/src/jobs/talent/transformers.ts
+++ b/api/src/jobs/talent/transformers.ts
@@ -24,7 +24,7 @@ export function missionToTalentJob(mission: MissionRecord): TalentJob[] {
     description: mission.descriptionHtml,
     jobtype: "part-time",
     expirationdate: mission.endAt ? new Date(mission.endAt).toISOString() : undefined,
-    isremote: mission.remote === "no" ? "no" : "yes",
+    isremote: mission.remote === "full" || mission.remote === "possible" ? "yes" : "no",
     category: mission.activities.length ? getActivityCategory(mission.activities[0]) : undefined,
     logo: getImageUrl(mission.organizationLogo || ""),
   } as TalentJob;

--- a/api/src/repositories/mission-matching-result.ts
+++ b/api/src/repositories/mission-matching-result.ts
@@ -1,6 +1,7 @@
 import { MissionMatchingResult, Prisma } from "@/db/core";
 import { prisma } from "@/db/postgres";
 import type { MatchingEngineVersion, MissionMatchingResultItem } from "@/services/matching-engine/types";
+import { isAddressNeutralizedRemote } from "@/utils/mission-remote";
 
 export type MissionMatchingEmailMission = {
   missionScoringId: string;
@@ -24,7 +25,7 @@ export type MissionMatchingEmailMission = {
 const buildMissionMatchingResultItemsFromScoringIds = (missionScoringIds: string[]): MissionMatchingResultItem[] =>
   missionScoringIds.map((missionScoringId) => ({ missionScoringId, missionAddressId: null, taxonomyScores: {} }));
 
-// ignoreRemoteAddress : quand la version du snapshot ignore l'adresse des missions remote=full,
+// ignoreRemoteAddress : quand la version du snapshot ignore l'adresse des missions remote=full/local,
 // on neutralise aussi le fallback ville ici pour ne pas la ré-exposer dans les emails.
 const findMissionsByMatchingResultItems = async (items: MissionMatchingResultItem[], ignoreRemoteAddress = false): Promise<MissionMatchingEmailMission[]> => {
   if (items.length === 0) {
@@ -62,10 +63,10 @@ const findMissionsByMatchingResultItems = async (items: MissionMatchingResultIte
 
   return missionScorings.map((missionScoring) => {
     const item = itemsByMissionScoringId.get(missionScoring.id);
-    const isFullRemoteAddressIgnored = ignoreRemoteAddress && missionScoring.mission.remote === "full";
+    const isRemoteAddressIgnored = ignoreRemoteAddress && isAddressNeutralizedRemote(missionScoring.mission.remote);
     const matchedAddress = item?.missionAddressId ? missionScoring.mission.addresses.find((address) => address.id === item.missionAddressId) : null;
     const fallbackAddress = missionScoring.mission.addresses[0] ?? null;
-    const city = isFullRemoteAddressIgnored ? null : (matchedAddress?.city ?? fallbackAddress?.city ?? null);
+    const city = isRemoteAddressIgnored ? null : (matchedAddress?.city ?? fallbackAddress?.city ?? null);
 
     return {
       missionScoringId: missionScoring.id,

--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -470,7 +470,7 @@ describe("matchingEngineService", () => {
       expect(missionMatchingResultRepositoryMock.createForUserScoringVersion).not.toHaveBeenCalled();
     });
 
-    it("injects the remote=full geo score branch and value for the m3 version", async () => {
+    it("injects the forced remote geo score branches and values for the m3 version", async () => {
       prismaMock.$queryRaw
         .mockResolvedValueOnce([
           {
@@ -491,11 +491,14 @@ describe("matchingEngineService", () => {
       const rankingValues = getSqlValues(prismaMock.$queryRaw.mock.calls[1][0]);
       expect(result.version).toBe("m3");
       expect(rankingSql).toContain("WHEN m.\"remote\"::text = 'full' THEN CAST(");
+      expect(rankingSql).toContain("WHEN m.\"remote\"::text = 'local' THEN CAST(");
       expect(rankingSql).toContain('JOIN "mission" m');
-      expect(rankingSql).toContain("remote_full_candidates AS (");
-      expect(rankingSql).toContain("FROM remote_full_candidates rfc");
-      expect(rankingSql).toContain('WHEN m."remote"::text = \'full\' THEN NULL ELSE gs."distance_km" END');
+      expect(rankingSql).toContain("forced_remote_candidates AS (");
+      expect(rankingSql).toContain("m.\"remote\"::text IN ('full', 'local')");
+      expect(rankingSql).toContain("FROM forced_remote_candidates rfc");
+      expect(rankingSql).toContain('WHEN m."remote"::text IN (\'full\', \'local\') THEN NULL ELSE gs."distance_km" END');
       expect(rankingValues).toContain(0.9);
+      expect(rankingValues).toContain(0.7);
     });
 
     it("does not inject the remote=full branch for the m2 version (non-regression)", async () => {
@@ -518,7 +521,7 @@ describe("matchingEngineService", () => {
       const rankingSql = getSqlText(prismaMock.$queryRaw.mock.calls[1][0]);
       expect(result.version).toBe("m2");
       expect(rankingSql).not.toContain('m."remote"::text');
-      expect(rankingSql).not.toContain("remote_full_candidates");
+      expect(rankingSql).not.toContain("forced_remote_candidates");
     });
 
     it("returns a geo score of 1 for a remote=full mission ranked with m3", async () => {
@@ -556,6 +559,44 @@ describe("matchingEngineService", () => {
       });
 
       expect(result.items[0].geoScore).toBe(1);
+      expect(result.items[0].distanceKm).toBeNull();
+    });
+
+    it("returns the configured local geo score for a remote=local mission ranked with m3", async () => {
+      prismaMock.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            id: "user-scoring-m3-local",
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            mission_id: "mission-remote-local",
+            mission_scoring_id: "mission-scoring-remote-local",
+            total_score: 0.77,
+            taxonomy_score: 0.8,
+            geo_score: 0.7,
+            distance_km: null,
+            closest_address_id: null,
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            mission_scoring_id: "mission-scoring-remote-local",
+            taxonomy_key: "domaine",
+            taxonomy_score: 0.8,
+          },
+        ]);
+      missionMatchingResultRepositoryMock.createForUserScoringVersion.mockResolvedValue({
+        id: "mission-matching-result-m3-local",
+      });
+
+      const result = await matchingEngineService.rankMissionsByUserScoring({
+        userScoringId: "user-scoring-m3-local",
+        version: "m3",
+      });
+
+      expect(result.items[0].geoScore).toBe(0.7);
       expect(result.items[0].distanceKm).toBeNull();
     });
   });

--- a/api/src/services/matching-engine/config.ts
+++ b/api/src/services/matching-engine/config.ts
@@ -21,6 +21,7 @@ export const MATCHING_ENGINE_VERSIONS = {
     } satisfies MatchingEngineTaxonomyWeights,
     geoWeight: 0.7,
     remoteFullGeoScore: null,
+    remoteLocalGeoScore: null,
   },
   m2: {
     taxonomyWeights: {
@@ -35,9 +36,10 @@ export const MATCHING_ENGINE_VERSIONS = {
     } satisfies MatchingEngineTaxonomyWeights,
     geoWeight: 0.3,
     remoteFullGeoScore: null,
+    remoteLocalGeoScore: null,
   },
   m3: {
-    // Identique à m2, mais les missions remote=full sont considérées comme naturellement proches.
+    // Identique à m2, mais les missions remote=full/local sont considérées comme naturellement proches.
     taxonomyWeights: {
       domaine: 1,
       secteur_activite: 1,
@@ -50,6 +52,7 @@ export const MATCHING_ENGINE_VERSIONS = {
     } satisfies MatchingEngineTaxonomyWeights,
     geoWeight: 0.3,
     remoteFullGeoScore: 0.9,
+    remoteLocalGeoScore: 0.7,
   },
 } as const satisfies Record<MatchingEngineVersion, MatchingEngineVersionConfig>;
 

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -82,35 +82,37 @@ const buildRanking = (params: {
   geoHalfDecayKm: number;
   missingGeoScore: number;
   remoteFullGeoScore: number | null;
+  remoteLocalGeoScore: number | null;
   taxonomyCandidateLimit: number;
   geoCandidateLimit: number;
   limit: number;
   offset: number;
 }) => {
-  // Missions remote=full : proximité naturelle (score géo forcé), uniquement si la version l'active.
-  const remoteFullActive = params.remoteFullGeoScore != null;
-  const remoteFullGeoScoreSql = !remoteFullActive ? Prisma.empty : Prisma.sql`WHEN m."remote"::text = 'full' THEN CAST(${params.remoteFullGeoScore} AS double precision)`;
+  // Missions remote=full/local : proximité naturelle (score géo forcé), uniquement si la version l'active.
+  const forcedRemoteActive = params.remoteFullGeoScore != null || params.remoteLocalGeoScore != null;
+  const remoteFullGeoScoreSql = params.remoteFullGeoScore == null ? Prisma.empty : Prisma.sql`WHEN m."remote"::text = 'full' THEN CAST(${params.remoteFullGeoScore} AS double precision)`;
+  const remoteLocalGeoScoreSql = params.remoteLocalGeoScore == null ? Prisma.empty : Prisma.sql`WHEN m."remote"::text = 'local' THEN CAST(${params.remoteLocalGeoScore} AS double precision)`;
 
-  // Quand le boost remote est actif et que l'utilisateur est géolocalisé, les missions remote=full éligibles
+  // Quand le boost remote est actif et que l'utilisateur est géolocalisé, les missions remote=full/local éligibles
   // doivent entrer dans le pool candidat même sans match taxonomie ni adresse proche : elles sont "partout".
-  const remoteFullCandidatesCteSql = !remoteFullActive
+  const forcedRemoteCandidatesCteSql = !forcedRemoteActive
     ? Prisma.empty
     : Prisma.sql`
-  remote_full_candidates AS (
+  forced_remote_candidates AS (
     SELECT
       ems."mission_id",
       ems."mission_scoring_id"
     FROM eligible_mission_scorings ems
     JOIN "mission" m
       ON m."id" = ems."mission_id"
-     AND m."remote"::text = 'full'
+     AND m."remote"::text IN ('full', 'local')
     LEFT JOIN taxonomy_scores ts
       ON ts."mission_scoring_id" = ems."mission_scoring_id"
     WHERE EXISTS (SELECT 1 FROM user_geo)
     ORDER BY COALESCE(ts."weighted_sum", 0) DESC, ems."mission_id" ASC
     LIMIT ${params.geoCandidateLimit}
   ),`;
-  const remoteFullCandidatesUnionSql = !remoteFullActive
+  const forcedRemoteCandidatesUnionSql = !forcedRemoteActive
     ? Prisma.empty
     : Prisma.sql`
     UNION ALL
@@ -118,11 +120,11 @@ const buildRanking = (params: {
       rfc."mission_id",
       rfc."mission_scoring_id",
       CAST(NULL AS double precision) AS "distance_km"
-    FROM remote_full_candidates rfc`;
+    FROM forced_remote_candidates rfc`;
 
-  // Une mission remote=full ignore toute adresse : on nullifie distance/closest_* pour ne pas polluer
+  // Une mission remote=full/local ignore toute adresse : on nullifie distance/closest_* pour ne pas polluer
   // l'affichage ni avgDistanceKmTop5, y compris quand elle a une adresse géocodée.
-  const rankedGeoColumnsSql = !remoteFullActive
+  const rankedGeoColumnsSql = !forcedRemoteActive
     ? Prisma.sql`
       gs."distance_km",
       gs."closest_lat",
@@ -131,12 +133,12 @@ const buildRanking = (params: {
       gs."closest_city",
       gs."closest_address"`
     : Prisma.sql`
-      CASE WHEN m."remote"::text = 'full' THEN NULL ELSE gs."distance_km" END AS "distance_km",
-      CASE WHEN m."remote"::text = 'full' THEN NULL ELSE gs."closest_lat" END AS "closest_lat",
-      CASE WHEN m."remote"::text = 'full' THEN NULL ELSE gs."closest_lon" END AS "closest_lon",
-      CASE WHEN m."remote"::text = 'full' THEN NULL ELSE gs."closest_address_id" END AS "closest_address_id",
-      CASE WHEN m."remote"::text = 'full' THEN NULL ELSE gs."closest_city" END AS "closest_city",
-      CASE WHEN m."remote"::text = 'full' THEN NULL ELSE gs."closest_address" END AS "closest_address"`;
+      CASE WHEN m."remote"::text IN ('full', 'local') THEN NULL ELSE gs."distance_km" END AS "distance_km",
+      CASE WHEN m."remote"::text IN ('full', 'local') THEN NULL ELSE gs."closest_lat" END AS "closest_lat",
+      CASE WHEN m."remote"::text IN ('full', 'local') THEN NULL ELSE gs."closest_lon" END AS "closest_lon",
+      CASE WHEN m."remote"::text IN ('full', 'local') THEN NULL ELSE gs."closest_address_id" END AS "closest_address_id",
+      CASE WHEN m."remote"::text IN ('full', 'local') THEN NULL ELSE gs."closest_city" END AS "closest_city",
+      CASE WHEN m."remote"::text IN ('full', 'local') THEN NULL ELSE gs."closest_address" END AS "closest_address"`;
 
   return Prisma.sql`
   WITH taxonomy_weights ("taxonomy_key", "taxonomy_weight") AS (
@@ -369,7 +371,7 @@ const buildRanking = (params: {
       AND NOT EXISTS (SELECT 1 FROM user_geo)
     ORDER BY ems."mission_id" ASC
     LIMIT ${params.offset + params.limit}
-  ),${remoteFullCandidatesCteSql}
+  ),${forcedRemoteCandidatesCteSql}
   candidate_mission_rows AS (
     SELECT
       tc."mission_id",
@@ -393,7 +395,7 @@ const buildRanking = (params: {
       fc."mission_id",
       fc."mission_scoring_id",
       CAST(NULL AS double precision) AS "distance_km"
-    FROM fallback_candidates fc${remoteFullCandidatesUnionSql}
+    FROM fallback_candidates fc${forcedRemoteCandidatesUnionSql}
   ),
   candidate_missions AS (
     SELECT
@@ -456,6 +458,7 @@ const buildRanking = (params: {
         WHEN EXISTS (SELECT 1 FROM user_geo) THEN
           CASE
             ${remoteFullGeoScoreSql}
+            ${remoteLocalGeoScoreSql}
             WHEN gs."distance_km" IS NULL THEN CAST(${params.missingGeoScore} AS double precision)
             ELSE EXP(-LN(2) * gs."distance_km" / NULLIF(CAST(${params.geoHalfDecayKm} AS double precision), 0.0))
           END
@@ -598,6 +601,7 @@ export const matchingEngineService = {
     const geoHalfDecayKm = input.geoHalfDecayKm ?? 20;
     const missingGeoScore = input.missingGeoScore ?? 0.1;
     const remoteFullGeoScore = input.remoteFullGeoScore !== undefined ? input.remoteFullGeoScore : versionConfig.remoteFullGeoScore;
+    const remoteLocalGeoScore = input.remoteLocalGeoScore !== undefined ? input.remoteLocalGeoScore : versionConfig.remoteLocalGeoScore;
     const taxonomyCandidateLimit = getTaxonomyCandidateLimit({ limit: rankingLimit, offset });
     const geoCandidateLimit = getGeoCandidateLimit({ limit: rankingLimit, offset });
 
@@ -614,6 +618,7 @@ export const matchingEngineService = {
         geoHalfDecayKm,
         missingGeoScore,
         remoteFullGeoScore,
+        remoteLocalGeoScore,
         taxonomyCandidateLimit,
         geoCandidateLimit,
         limit: rankingLimit,

--- a/api/src/services/matching-engine/types.ts
+++ b/api/src/services/matching-engine/types.ts
@@ -11,6 +11,8 @@ export type MatchingEngineVersionConfig = {
   geoWeight: number;
   // Score géo forcé pour les missions remote=full (proximité naturelle). null = pas de traitement spécial.
   remoteFullGeoScore: number | null;
+  // Score géo forcé pour les missions remote=local (sur site, à proximité). null = pas de traitement spécial.
+  remoteLocalGeoScore: number | null;
 };
 
 export type RankMissionsByUserScoringInput = {
@@ -24,6 +26,7 @@ export type RankMissionsByUserScoringInput = {
   geoHalfDecayKm?: number;
   missingGeoScore?: number;
   remoteFullGeoScore?: number | null;
+  remoteLocalGeoScore?: number | null;
 };
 
 export type MatchMissionItem = {

--- a/api/src/services/mission-browse/transformers.ts
+++ b/api/src/services/mission-browse/transformers.ts
@@ -10,6 +10,7 @@ export const toMissionBrowse = (mission: MissionRecord): MissionBrowse => {
     id: mission.id,
     title: mission.title,
     description: mission.description ?? null,
+    remote: mission.remote ?? null,
     city: mission.city ?? null,
     departmentCode: mission.departmentCode ?? null,
     departmentName: mission.departmentName ?? null,

--- a/api/src/services/mission-email/index.ts
+++ b/api/src/services/mission-email/index.ts
@@ -127,8 +127,10 @@ const buildMissionMatchingEmailParams = async (userScoringId: string, publisherI
     return null;
   }
 
-  // La version courante ignore-t-elle l'adresse des missions remote=full ? (aligné sur le moteur / l'API)
-  const ignoreRemoteAddress = MATCHING_ENGINE_VERSIONS[CURRENT_MATCHING_ENGINE_VERSION].remoteFullGeoScore != null;
+  // La version courante ignore-t-elle l'adresse des missions remote=full/local ? (aligné sur le moteur / l'API)
+  const ignoreRemoteAddress =
+    MATCHING_ENGINE_VERSIONS[CURRENT_MATCHING_ENGINE_VERSION].remoteFullGeoScore != null ||
+    MATCHING_ENGINE_VERSIONS[CURRENT_MATCHING_ENGINE_VERSION].remoteLocalGeoScore != null;
   const missions = await missionMatchingResultRepository.findMissionsByMatchingResultItems(matchingItems, ignoreRemoteAddress);
   const missionsByScoringId = new Map(missions.map((item) => [item.missionScoringId, item]));
   const orderedMissions = matchingItems.map((item) => missionsByScoringId.get(item.missionScoringId)).filter((item): item is NonNullable<typeof item> => Boolean(item));

--- a/api/src/services/mission-enrichment/prompts/builder.ts
+++ b/api/src/services/mission-enrichment/prompts/builder.ts
@@ -58,7 +58,8 @@ export const buildTaxonomyBlock = (taxonomy: TaxonomyForPrompt): string =>
 export const buildMissionBlock = (mission: MissionForPrompt): string => {
   const lines: string[] = [];
 
-  const remoteLabel = mission.remote === "full" ? "Entièrement à distance" : mission.remote === "possible" ? "Présentiel avec option à distance" : "Présentiel";
+  const remoteLabel =
+    mission.remote === "full" ? "Entièrement à distance" : mission.remote === "possible" ? "Présentiel avec option à distance" : mission.remote === "local" ? "Sur site, à proximité" : "Présentiel";
 
   const durationStr = mission.duration ? `${mission.duration} heures` : "non précisée";
   const cleanSchedule = clean(mission.schedule, PROMPT_FIELD_MAX_LENGTH.short);

--- a/api/src/services/mission-match/index.ts
+++ b/api/src/services/mission-match/index.ts
@@ -38,8 +38,8 @@ export const missionMatchService = {
 
     const missionIndex = buildMissionIndex(missionRows);
     const valuesIndex = buildValuesIndex(scoringValueRows);
-    // La version active ignore-t-elle l'adresse des missions remote=full ? (aligné sur le moteur)
-    const ignoreRemoteAddress = MATCHING_ENGINE_VERSIONS[result.version].remoteFullGeoScore != null;
+    // La version active ignore-t-elle l'adresse des missions remote=full/local ? (aligné sur le moteur)
+    const ignoreRemoteAddress = MATCHING_ENGINE_VERSIONS[result.version].remoteFullGeoScore != null || MATCHING_ENGINE_VERSIONS[result.version].remoteLocalGeoScore != null;
 
     return {
       tookMs: result.tookMs,

--- a/api/src/services/mission-match/transformers.ts
+++ b/api/src/services/mission-match/transformers.ts
@@ -4,6 +4,7 @@ import { TAXONOMY } from "@engagement/taxonomy";
 import type { Prisma } from "@/db/core";
 import type { MatchMissionItem } from "@/services/matching-engine/types";
 import { getMissionTrackedApplicationUrl } from "@/utils/mission";
+import { isAddressNeutralizedRemote } from "@/utils/mission-remote";
 
 export const missionMatchMissionSelect = {
   id: true,
@@ -132,13 +133,13 @@ export const toMissionMatchItem = (
   missionIndex: Record<string, MissionIndexEntry>,
   valuesIndex: Record<string, MissionMatchValue[]>,
   publisherId: string,
-  // Quand le moteur ignore l'adresse des missions remote=full, on neutralise aussi le fallback ville.
+  // Quand le moteur ignore l'adresse des missions remote=full/local, on neutralise aussi le fallback ville.
   ignoreRemoteAddress = false
 ): MissionMatchItem => {
   const mission = missionIndex[item.missionId];
   const photo = mission?.domainLogo ?? mission?.organizationLogo ?? mission?.publisherDefaultMissionLogo ?? mission?.publisherLogo ?? null;
   const hasCompensation = mission?.compensationAmount != null || mission?.compensationAmountMax != null;
-  const isFullRemoteAddressIgnored = ignoreRemoteAddress && mission?.remote === "full";
+  const isRemoteAddressIgnored = ignoreRemoteAddress && isAddressNeutralizedRemote(mission?.remote);
 
   return {
     mission: {
@@ -158,7 +159,7 @@ export const toMissionMatchItem = (
         publisherLogo: mission?.publisherLogo ?? null,
       },
       location: {
-        city: item.closestCity ?? (isFullRemoteAddressIgnored ? null : mission?.city) ?? null,
+        city: item.closestCity ?? (isRemoteAddressIgnored ? null : mission?.city) ?? null,
         closestLat: item.closestLat,
         closestLon: item.closestLon,
         closestAddress: item.closestAddress,

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -349,7 +349,7 @@ export const buildWhere = async (filters: MissionSearchFilters): Promise<Prisma.
     const addressWhere: Prisma.MissionWhereInput = {
       addresses: clauses.length === 1 ? { some: clauses[0] } : { some: { OR: clauses } },
     };
-    if (hasGeoFilters(filters) && filters.remote?.includes("local")) {
+    if (hasGeoFilters(filters) && (!filters.remote?.length || filters.remote.includes("local"))) {
       andConditions.push({ OR: [addressWhere, { remote: "local" }] });
     } else {
       Object.assign(where, addressWhere);

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -209,6 +209,7 @@ export const buildWhere = async (filters: MissionSearchFilters): Promise<Prisma.
   const where: Prisma.MissionWhereInput = filters.directFilters ?? {};
 
   const orConditions: Prisma.MissionWhereInput[] = [];
+  const andConditions: Prisma.MissionWhereInput[] = [];
 
   // Restriction par publisher : les diffusion rules du diffuseur (allowlist `OR` de scopes
   // `publisherId === annonceur AND <critères>`) font autorité. À défaut de rules, on retombe
@@ -345,7 +346,14 @@ export const buildWhere = async (filters: MissionSearchFilters): Promise<Prisma.
     if (addressOr.length) {
       clauses.push(...addressOr);
     }
-    where.addresses = clauses.length === 1 ? { some: clauses[0] } : { some: { OR: clauses } };
+    const addressWhere: Prisma.MissionWhereInput = {
+      addresses: clauses.length === 1 ? { some: clauses[0] } : { some: { OR: clauses } },
+    };
+    if (hasGeoFilters(filters) && filters.remote?.includes("local")) {
+      andConditions.push({ OR: [addressWhere, { remote: "local" }] });
+    } else {
+      Object.assign(where, addressWhere);
+    }
   }
 
   if (filters.moderationAcceptedFor) {
@@ -382,6 +390,10 @@ export const buildWhere = async (filters: MissionSearchFilters): Promise<Prisma.
   if (orConditions.length) {
     const existingOr = Array.isArray(where.OR) ? where.OR : where.OR ? [where.OR] : [];
     where.OR = [...existingOr, ...orConditions];
+  }
+  if (andConditions.length) {
+    const existingAnd = Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : [];
+    where.AND = [...existingAnd, ...andConditions];
   }
 
   return where;

--- a/api/src/types/mission.ts
+++ b/api/src/types/mission.ts
@@ -2,7 +2,7 @@ import { Prisma } from "@/db/core";
 import { JobBoardId, MissionJobBoardSyncStatus } from "@/types/mission-job-board";
 
 export type MissionStatusCode = "ACCEPTED" | "REFUSED";
-export type MissionRemote = "no" | "possible" | "full";
+export type MissionRemote = "no" | "possible" | "full" | "local";
 export type MissionPlacesStatus = "ATTRIBUTED_BY_API" | "GIVEN_BY_PARTNER";
 export type MissionCompensationUnit = "hour" | "day" | "month" | "year";
 export type MissionCompensationType = "gross" | "net";

--- a/api/src/utils/mission-moderation.ts
+++ b/api/src/utils/mission-moderation.ts
@@ -34,8 +34,8 @@ export const getModeration = (mission: Partial<MissionRecord> & Record<string, a
     statusComment = "URL de candidature manquant";
   } else if (mission.country && !COUNTRIES.includes(mission.country)) {
     statusComment = `Pays non valide : "${mission.country}"`;
-  } else if (mission.remote && !["no", "possible", "full"].includes(mission.remote)) {
-    statusComment = "Valeur remote non valide (no, possible ou full)";
+  } else if (mission.remote && !["no", "possible", "full", "local"].includes(mission.remote)) {
+    statusComment = "Valeur remote non valide (no, possible, full ou local)";
   } else if (typeof mission.places === "number" && mission.places <= 0) {
     statusComment = "Nombre de places invalide (doit être supérieur à 0)";
   } else if (mission.domain && !DOMAINS.includes(mission.domain)) {

--- a/api/src/utils/mission-remote.ts
+++ b/api/src/utils/mission-remote.ts
@@ -1,0 +1,3 @@
+import type { MissionRemote } from "@/types/mission";
+
+export const isAddressNeutralizedRemote = (remote: MissionRemote | null | undefined): remote is "full" | "local" => remote === "full" || remote === "local";

--- a/api/src/v2/mission/controller.ts
+++ b/api/src/v2/mission/controller.ts
@@ -66,7 +66,7 @@ const missionBaseFields = {
   requirements: zod.array(zod.string()).optional(),
   softSkills: zod.array(zod.string()).optional(),
   romeSkills: zod.array(zod.string()).optional(),
-  remote: zod.enum(["no", "possible", "full"]).optional(),
+  remote: zod.enum(["no", "possible", "full", "local"]).optional(),
   schedule: zod.string().optional(),
   startAt: zod.coerce.date().optional(),
   endAt: zod.coerce.date().optional(),

--- a/api/tests/integration/api/endpoints/iframe/aggs.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/aggs.test.ts
@@ -197,6 +197,48 @@ describe("GET /iframe/:id/aggs", () => {
       expect(france).toBeDefined();
       expect(france.doc_count).toBe(4);
     });
+
+    it("should aggregate local missions without address when filtering on-site missions around a widget location", async () => {
+      const geoWidget = await createTestWidget({
+        fromPublisher: publisher,
+        publishers: [publisher.id],
+        location: { lat: 48.8566, lon: 2.3522 },
+        distance: "25km",
+      });
+      await createTestMission({
+        publisherId: publisher.id,
+        title: "Mission Présentiel Paris",
+        domain: "Environnement",
+        remote: "no",
+        addresses: [
+          {
+            city: "Paris",
+            postalCode: "75001",
+            departmentCode: "75",
+            departmentName: "Paris",
+            country: "FR",
+            location: { lat: 48.8566, lon: 2.3522 },
+          },
+        ],
+      });
+      await createTestMission({
+        publisherId: publisher.id,
+        title: "Mission Locale sans adresse",
+        domain: "Environnement",
+        remote: "local",
+        addresses: [],
+      });
+
+      const response = await request(app).get(`/iframe/${geoWidget.id}/aggs`).query({ remote: "no" }).expect(200);
+
+      const remote = response.body.data.remote;
+      const noRemote = remote.find((r: any) => r.key === "no");
+      const localRemote = remote.find((r: any) => r.key === "local");
+      expect(noRemote).toBeDefined();
+      expect(noRemote.doc_count).toBe(1);
+      expect(localRemote).toBeDefined();
+      expect(localRemote.doc_count).toBe(1);
+    });
   });
 
   describe("Error cases", () => {

--- a/api/tests/integration/api/endpoints/iframe/aggs.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/aggs.test.ts
@@ -239,6 +239,48 @@ describe("GET /iframe/:id/aggs", () => {
       expect(localRemote).toBeDefined();
       expect(localRemote.doc_count).toBe(1);
     });
+
+    it("should aggregate local missions without address around a widget location without remote filter", async () => {
+      const geoWidget = await createTestWidget({
+        fromPublisher: publisher,
+        publishers: [publisher.id],
+        location: { lat: 48.8566, lon: 2.3522 },
+        distance: "25km",
+      });
+      await createTestMission({
+        publisherId: publisher.id,
+        title: "Mission Présentiel Paris",
+        domain: "Environnement",
+        remote: "no",
+        addresses: [
+          {
+            city: "Paris",
+            postalCode: "75001",
+            departmentCode: "75",
+            departmentName: "Paris",
+            country: "FR",
+            location: { lat: 48.8566, lon: 2.3522 },
+          },
+        ],
+      });
+      await createTestMission({
+        publisherId: publisher.id,
+        title: "Mission Locale sans adresse",
+        domain: "Environnement",
+        remote: "local",
+        addresses: [],
+      });
+
+      const response = await request(app).get(`/iframe/${geoWidget.id}/aggs`).expect(200);
+
+      const remote = response.body.data.remote;
+      const noRemote = remote.find((r: any) => r.key === "no");
+      const localRemote = remote.find((r: any) => r.key === "local");
+      expect(noRemote).toBeDefined();
+      expect(noRemote.doc_count).toBe(1);
+      expect(localRemote).toBeDefined();
+      expect(localRemote.doc_count).toBe(1);
+    });
   });
 
   describe("Error cases", () => {

--- a/api/tests/integration/api/endpoints/iframe/aggs.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/aggs.test.ts
@@ -162,6 +162,13 @@ describe("GET /iframe/:id/aggs", () => {
     });
 
     it("should aggregate by remote with correct counts", async () => {
+      await createTestMission({
+        publisherId: publisher.id,
+        title: "Mission Locale",
+        domain: "Environnement",
+        remote: "local",
+      });
+
       const response = await request(app).get(`/iframe/${widget.id}/aggs`).expect(200);
 
       const remote = response.body.data.remote;
@@ -174,6 +181,10 @@ describe("GET /iframe/:id/aggs", () => {
       const fullRemote = remote.find((r: any) => r.key === "full");
       expect(fullRemote).toBeDefined();
       expect(fullRemote.doc_count).toBe(1);
+
+      const localRemote = remote.find((r: any) => r.key === "local");
+      expect(localRemote).toBeDefined();
+      expect(localRemote.doc_count).toBe(1);
     });
 
     it("should aggregate by country with correct counts", async () => {

--- a/api/tests/integration/api/endpoints/iframe/search.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/search.test.ts
@@ -284,6 +284,28 @@ describe("GET /iframe/:id/search", () => {
       const titles = response.body.data.map((mission: MissionRecord) => mission.title);
       expect(titles).toEqual(expect.arrayContaining(["Mission Environnement Paris", "Mission Locale sans adresse"]));
     });
+
+    it("should include local missions without address around a widget location without remote filter", async () => {
+      const geoWidget = await createTestWidget({
+        fromPublisher: publisher,
+        publishers: [publisher.id],
+        location: { lat: 48.8566, lon: 2.3522 },
+        distance: "25km",
+      });
+      await createTestMission({
+        publisherId: publisher.id,
+        title: "Mission Locale sans adresse",
+        domain: "Environnement",
+        remote: "local",
+        addresses: [],
+      });
+
+      const response = await request(app).get(`/iframe/${geoWidget.id}/search`).expect(200);
+
+      expect(response.body.total).toBe(2);
+      const titles = response.body.data.map((mission: MissionRecord) => mission.title);
+      expect(titles).toEqual(expect.arrayContaining(["Mission Environnement Paris", "Mission Locale sans adresse"]));
+    });
   });
 
   describe("Category filters", () => {

--- a/api/tests/integration/api/endpoints/iframe/search.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/search.test.ts
@@ -290,18 +290,34 @@ describe("GET /iframe/:id/search", () => {
 
   describe("Boolean filters", () => {
     it("should filter by remote=yes (full or possible)", async () => {
+      await createTestMission({
+        publisherId: publisher.id,
+        title: "Mission Locale",
+        domain: "Environnement",
+        remote: "local",
+      });
+
       const response = await request(app).get(`/iframe/${widget.id}/search`).query({ remote: "yes" }).expect(200);
 
       expect(response.body.total).toBe(2);
       const remoteValues = response.body.data.map((m: any) => m.remote);
       expect(remoteValues).toEqual(expect.arrayContaining(["full", "possible"]));
+      expect(remoteValues).not.toContain("local");
     });
 
-    it("should filter by remote=no", async () => {
+    it("should filter by remote=no (presentiel or local)", async () => {
+      await createTestMission({
+        publisherId: publisher.id,
+        title: "Mission Locale",
+        domain: "Environnement",
+        remote: "local",
+      });
+
       const response = await request(app).get(`/iframe/${widget.id}/search`).query({ remote: "no" }).expect(200);
 
-      expect(response.body.total).toBe(1);
-      expect(response.body.data[0].remote).toBe("no");
+      expect(response.body.total).toBe(2);
+      const remoteValues = response.body.data.map((m: any) => m.remote);
+      expect(remoteValues).toEqual(expect.arrayContaining(["no", "local"]));
     });
 
     it("should filter by minor=yes (open to minors)", async () => {

--- a/api/tests/integration/api/endpoints/iframe/search.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/search.test.ts
@@ -262,6 +262,28 @@ describe("GET /iframe/:id/search", () => {
 
       expect(response.body.code).toBe("INVALID_QUERY");
     });
+
+    it("should include local missions without address when filtering on-site missions around a widget location", async () => {
+      const geoWidget = await createTestWidget({
+        fromPublisher: publisher,
+        publishers: [publisher.id],
+        location: { lat: 48.8566, lon: 2.3522 },
+        distance: "25km",
+      });
+      await createTestMission({
+        publisherId: publisher.id,
+        title: "Mission Locale sans adresse",
+        domain: "Environnement",
+        remote: "local",
+        addresses: [],
+      });
+
+      const response = await request(app).get(`/iframe/${geoWidget.id}/search`).query({ remote: "no" }).expect(200);
+
+      expect(response.body.total).toBe(2);
+      const titles = response.body.data.map((mission: MissionRecord) => mission.title);
+      expect(titles).toEqual(expect.arrayContaining(["Mission Environnement Paris", "Mission Locale sans adresse"]));
+    });
   });
 
   describe("Category filters", () => {

--- a/api/tests/integration/api/mission-match.test.ts
+++ b/api/tests/integration/api/mission-match.test.ts
@@ -34,13 +34,32 @@ const createGeoUserScoring = async (): Promise<string> => {
 };
 
 // Mission remote=full sans adresse et sans recouvrement taxonomie avec l'utilisateur :
-// elle n'entre ni dans les candidats taxonomie ni géo → cas ciblé par remote_full_candidates.
+// elle n'entre ni dans les candidats taxonomie ni géo → cas ciblé par forced_remote_candidates.
 const createRemoteFullMissionWithoutMatch = async () => {
   const mission = await createTestMission({
     publisherId,
     title: "Mission full remote",
     domain: "solidarite",
     remote: "full",
+    addresses: [],
+  });
+  const enrichment = await createTestMissionEnrichment({ missionId: mission.id });
+  await createTestMissionScoring({
+    missionId: mission.id,
+    missionEnrichmentId: enrichment.id,
+    values: [{ taxonomyKey: "domaine", valueKey: "sport", score: 1 }],
+  });
+  return mission;
+};
+
+// Mission sur site à proximité sans adresse et sans recouvrement taxonomie avec l'utilisateur :
+// elle suit la même injection que full, mais avec un score géo dédié plus faible.
+const createRemoteLocalMissionWithoutMatch = async () => {
+  const mission = await createTestMission({
+    publisherId,
+    title: "Mission locale sans adresse",
+    domain: "solidarite",
+    remote: "local",
     addresses: [],
   });
   const enrichment = await createTestMissionEnrichment({ missionId: mission.id });
@@ -171,6 +190,24 @@ describe("GET /missions/match", () => {
     expect(item).toBeDefined();
     expect(item.match.geoScore).toBe(0.9);
     expect(item.mission.location.distanceKm).toBeNull();
+  });
+
+  it("ranks an eligible local mission without taxonomy match nor address for a geolocated user (m3)", async () => {
+    const mission = await createRemoteLocalMissionWithoutMatch();
+    const userScoringId = await createGeoUserScoring();
+
+    const response = await withApiKey(request(app).get("/missions/match")).query({
+      userScoringId,
+      engineVersion: "m3",
+    });
+
+    expect(response.status).toBe(200);
+    const item = response.body.data.items.find((entry: { mission: { id: string } }) => entry.mission.id === mission.id);
+    expect(item).toBeDefined();
+    expect(item.match.geoScore).toBe(0.7);
+    expect(item.mission.remote).toBe("local");
+    expect(item.mission.location.distanceKm).toBeNull();
+    expect(item.mission.location.city).toBeNull();
   });
 
   it("does not surface the same full-remote mission under m2 (candidate pool gap it fixes)", async () => {

--- a/packages/dto/src/resources/mission-browse.ts
+++ b/packages/dto/src/resources/mission-browse.ts
@@ -18,6 +18,7 @@ export type MissionBrowse = {
   id: string;
   title: string;
   description: string | null;
+  remote: "no" | "possible" | "full" | "local" | null;
   city: string | null;
   departmentCode: string | null;
   departmentName: string | null;
@@ -78,7 +79,7 @@ export type MissionDetailResponse = {
   description: string | null;
   applicationUrl: string;
   photo: string | null;
-  remote: "no" | "possible" | "full" | null;
+  remote: "no" | "possible" | "full" | "local" | null;
   openToMinors: boolean | null;
   reducedMobilityAccessible: boolean | null;
   places: number | null;

--- a/packages/dto/src/resources/mission-match.ts
+++ b/packages/dto/src/resources/mission-match.ts
@@ -21,7 +21,7 @@ export type MissionMatchLocation = {
 export type MissionMatchMission = {
   id: string;
   title: string;
-  remote: "no" | "possible" | "full" | null;
+  remote: "no" | "possible" | "full" | "local" | null;
   schedule: string | null;
   domain: string | null;
   domainOriginal: string | null;

--- a/plateform/app/components/missions/mission-card.tsx
+++ b/plateform/app/components/missions/mission-card.tsx
@@ -20,6 +20,7 @@ export default function MissionCard({ mission, link, onClick }: MissionCardProps
   const domainLabel = getDomainLabel(mission.domain);
   const cardImage = mission.photo ?? mission.organizationLogo ?? mission.domainLogo;
   const compensationLabel = mission.compensation ? formatCompensation(mission.compensation) : null;
+  const locationLabel = mission.remote === "local" ? "Près de chez moi" : mission.city;
 
   const clampStyle = { display: "-webkit-box", WebkitBoxOrient: "vertical" as const, WebkitLineClamp: 3, overflow: "hidden" };
 
@@ -54,7 +55,7 @@ export default function MissionCard({ mission, link, onClick }: MissionCardProps
 
           <div className="fr-card__end flex flex-col gap-2 justify-between mt-3! p-0!">
             <div className="flex flex-col gap-1">
-              {mission.city && <p className="fr-card__detail fr-icon-map-pin-2-line m-0! block! truncate!">{mission.city}</p>}
+              {locationLabel && <p className="fr-card__detail fr-icon-map-pin-2-line m-0! block! truncate!">{locationLabel}</p>}
               {mission.schedule && <p className="fr-card__detail fr-icon-time-line m-0! block! truncate!">{mission.schedule}</p>}
               {mission.organizationName && <p className="fr-card__detail fr-icon-building-line m-0! block! truncate!">{mission.organizationName}</p>}
             </div>

--- a/plateform/app/components/results/mission-map.tsx
+++ b/plateform/app/components/results/mission-map.tsx
@@ -24,6 +24,8 @@ const activeIcon = L.divIcon({
 });
 
 const getAddressLabel = (item: MissionMatchItem): string | null => item.mission.location.closestAddress ?? item.mission.location.city;
+const hasNeutralizedAddress = (item: MissionMatchItem): boolean => item.mission.remote === "full" || item.mission.remote === "local";
+const getFallbackAddressLabel = (item: MissionMatchItem): string => (item.mission.remote === "full" ? "Mission à distance" : "Mission sans adresse précise");
 
 function spreadOverlappingPositions(missions: MapMission[]): MapMission[] {
   const positionCounts = new Map<string, number>();
@@ -74,8 +76,9 @@ export default function MissionMap({ items, center, onMarkerClick, selectionPadd
   const missions = useMemo<MapMission[]>(
     () => {
       const positionedMissions = items.map((item, index) => {
-        const hasPreciseCoordinates = item.mission.remote !== "full" && typeof item.mission.location.closestLat === "number" && typeof item.mission.location.closestLon === "number";
-        const addressLabel = item.mission.remote !== "full" ? getAddressLabel(item) : null;
+        const addressNeutralized = hasNeutralizedAddress(item);
+        const hasPreciseCoordinates = !addressNeutralized && typeof item.mission.location.closestLat === "number" && typeof item.mission.location.closestLon === "number";
+        const addressLabel = !addressNeutralized ? getAddressLabel(item) : null;
         const position: GeoPosition = hasPreciseCoordinates
           ? [item.mission.location.closestLat!, item.mission.location.closestLon!]
           : getNearbyPosition(center, item.mission.id, index);
@@ -84,7 +87,7 @@ export default function MissionMap({ items, center, onMarkerClick, selectionPadd
           item,
           addressLabel,
           position,
-          usesRemoteIcon: item.mission.remote === "full" || (!hasPreciseCoordinates && !addressLabel),
+          usesRemoteIcon: item.mission.remote === "full" || (!hasPreciseCoordinates && !addressLabel && item.mission.remote !== "local"),
         };
       });
 
@@ -122,7 +125,7 @@ export default function MissionMap({ items, center, onMarkerClick, selectionPadd
               {onMissionHover && (
                 <Tooltip direction="top" offset={[0, -8]} opacity={1} className="mission-map__tooltip">
                   <strong className="mission-map__tooltip-title">{item.mission.title}</strong>
-                  <span className="mission-map__tooltip-address">{addressLabel ?? "Mission à distance ou sans adresse précise"}</span>
+                  <span className="mission-map__tooltip-address">{addressLabel ?? getFallbackAddressLabel(item)}</span>
                 </Tooltip>
               )}
               {!onMarkerClick && (
@@ -137,7 +140,7 @@ export default function MissionMap({ items, center, onMarkerClick, selectionPadd
                   {!addressLabel && (
                     <>
                       <br />
-                      Mission à distance ou sans adresse précise
+                      {getFallbackAddressLabel(item)}
                     </>
                   )}
                 </Popup>

--- a/plateform/app/utils/__tests__/mission.test.ts
+++ b/plateform/app/utils/__tests__/mission.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { formatCompensation, formatMissionType, formatStartDate } from "../mission";
+import type { MissionMatchItem } from "@engagement/dto";
+import { formatCompensation, formatMissionType, formatStartDate, matchResultToBrowseMission } from "../mission";
 
 describe("formatStartDate", () => {
   it("retourne null si startAt et duration sont tous les deux null", () => {
@@ -75,5 +76,49 @@ describe("formatMissionType", () => {
 
   it('retourne "Mission" pour un type inconnu', () => {
     expect(formatMissionType("type_inconnu")).toBe("Mission");
+  });
+});
+
+describe("matchResultToBrowseMission", () => {
+  it("conserve la valeur remote local", () => {
+    const item: MissionMatchItem = {
+      mission: {
+        id: "mission-local",
+        title: "Mission près de chez moi",
+        remote: "local",
+        schedule: "Quelques jours par mois",
+        domain: "solidarite",
+        domainOriginal: null,
+        organizationName: "Organisation",
+        publisherId: "publisher",
+        publisherName: "Publisher",
+        media: {
+          photo: null,
+          domainLogo: null,
+          organizationLogo: null,
+          publisherLogo: null,
+        },
+        location: {
+          city: null,
+          closestLat: null,
+          closestLon: null,
+          closestAddress: null,
+          addressId: null,
+          distanceKm: null,
+        },
+        compensation: null,
+        applicationUrl: "https://example.com",
+      },
+      match: {
+        missionScoringId: "mission-scoring",
+        totalScore: 0.8,
+        taxonomyScore: 0.9,
+        geoScore: 0.7,
+        taxonomyScores: {},
+        values: [],
+      },
+    };
+
+    expect(matchResultToBrowseMission(item).remote).toBe("local");
   });
 });

--- a/plateform/app/utils/mission.ts
+++ b/plateform/app/utils/mission.ts
@@ -80,6 +80,7 @@ export function matchResultToBrowseMission(item: MissionMatchItem): MissionBrows
     id: item.mission.id,
     title: item.mission.title,
     description: null,
+    remote: item.mission.remote,
     city: item.mission.location.city,
     departmentCode: null,
     departmentName: null,

--- a/widget/components/CardBenevolat.tsx
+++ b/widget/components/CardBenevolat.tsx
@@ -1,10 +1,10 @@
-import iso from "i18n-iso-countries";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import { RiBuildingFill } from "react-icons/ri";
 
 import { Mission, Widget } from "@/types";
 import { DOMAINS } from "@/config";
+import { getMissionAddressLabel } from "@/utils/missionAddress";
 
 interface CardProps {
   widget: Widget;
@@ -25,13 +25,7 @@ const CardBenevolat = ({ widget, mission, request, focused = false, onKeyDown, o
     if (!mission) {
       return;
     }
-    setAddress(
-      mission.remote === "full"
-        ? "À distance"
-        : mission.addresses?.length && mission.addresses.length > 1
-          ? mission.addresses.map((a) => a.city).join(", ")
-          : `${mission.city} ${mission.country !== "FR" ? `- ${iso.getName(mission.country, "fr")}` : ""}`,
-    );
+    setAddress(getMissionAddressLabel(mission));
     setDomain(DOMAINS[mission.domain] || DOMAINS.autre);
   }, [mission]);
 

--- a/widget/components/CardVolontariat.tsx
+++ b/widget/components/CardVolontariat.tsx
@@ -1,4 +1,3 @@
-import iso from "i18n-iso-countries";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import { RiBuildingFill, RiCalendarEventFill } from "react-icons/ri";
@@ -6,6 +5,7 @@ import { RiBuildingFill, RiCalendarEventFill } from "react-icons/ri";
 import { Mission, Widget } from "@/types";
 import { DOMAINS } from "@/config";
 import LogoSCE from "@/public/images/logo-sce.svg";
+import { getMissionAddressLabel } from "@/utils/missionAddress";
 
 interface CardProps {
   widget: Widget;
@@ -25,13 +25,7 @@ const CardVolontariat = ({ widget, mission, request, focused = false, onKeyDown,
     if (!mission) {
       return;
     }
-    setAddress(
-      mission.remote === "full"
-        ? "À distance"
-        : mission.addresses?.length && mission.addresses.length > 1
-          ? mission.addresses.map((a) => a.city).join(", ")
-          : `${mission.city} ${mission.country !== "FR" ? `- ${iso.getName(mission.country, "fr")}` : ""}`,
-    );
+    setAddress(getMissionAddressLabel(mission));
     setDomain(DOMAINS[mission.domain] || DOMAINS.autre);
   }, [mission]);
 

--- a/widget/components/FiltersBenevolat.tsx
+++ b/widget/components/FiltersBenevolat.tsx
@@ -48,7 +48,7 @@ const FiltersBenevolat = ({ widget, apiUrl, values, total, onChange, show, onSho
         }
 
         const remote = data.remote.filter((b) => b.key === "full" || b.key === "possible");
-        const presentiel = data.remote.filter((b) => b.key === "no");
+        const presentiel = data.remote.filter((b) => b.key === "no" || b.key === "local");
         const newOptions: FilterOptions = {
           organizations: data.organization.map((b) => ({ value: b.key, count: b.doc_count, label: b.label || b.key })),
           domains: data.domain.map((b) => ({ value: b.key, count: b.doc_count, label: DOMAINS[b.key] ? DOMAINS[b.key].label : b.key })),

--- a/widget/types/index.ts
+++ b/widget/types/index.ts
@@ -30,8 +30,8 @@ export interface Mission {
   domain: string;
   domainLogo?: string;
   organizationName: string;
-  city: string;
-  country: string;
+  city: string | null;
+  country: string | null;
   remote?: string;
   places?: number;
   tags?: string[];
@@ -40,7 +40,7 @@ export interface Mission {
 }
 
 export interface Address {
-  city: string;
+  city: string | null;
   location?: {
     lat: number;
     lon: number;

--- a/widget/utils/missionAddress.ts
+++ b/widget/utils/missionAddress.ts
@@ -1,0 +1,27 @@
+import iso from "i18n-iso-countries";
+
+import { Mission } from "@/types";
+
+export const getMissionAddressLabel = (mission: Mission): string => {
+  if (mission.remote === "full") {
+    return "À distance";
+  }
+  if (mission.remote === "local") {
+    return "Près de chez moi";
+  }
+
+  if (mission.addresses && mission.addresses.length > 1) {
+    const cities = mission.addresses.map((address) => address.city).filter(Boolean);
+    if (cities.length) {
+      return cities.join(", ");
+    }
+  }
+
+  const city = mission.city?.trim();
+  if (!city) {
+    return "Lieu non précisé";
+  }
+
+  const countryName = mission.country && mission.country !== "FR" ? iso.getName(mission.country, "fr") : null;
+  return countryName ? `${city} - ${countryName}` : city;
+};


### PR DESCRIPTION
## Description

Cette PR ajoute la nouvelle valeur `remote: "local"` pour représenter les missions **sur site, à proximité** : missions présentielles sans adresse fixe, qui doivent être proposées aux utilisateurs géolocalisés sans être assimilées à du 100% distanciel.

Cela sera utile pour les missions Police / Gendarmerie (scripts de création à venir).

Le changement couvre :
- l'enum Prisma `MissionRemote`, les types API et les DTO partagés ;
- la validation de création/mise à jour de mission et la documentation OpenAPI ;
- le moteur de matching `m3`, avec injection des missions `local` dans le pool géolocalisé et un score dédié `remoteLocalGeoScore = 0.7` ;
- la neutralisation des distances/adresses pour les résultats de matching et les emails ;
- l'affichage Plateform avec le libellé `Près de chez moi` ;
- le widget, où `local` est regroupé avec le présentiel dans le filtre `Sur place` ;
- les exports partenaires, où `local` est traité comme du présentiel.

## Liens utiles

https://app.notion.com/p/jeveuxaider/Cr-er-les-missions-de-la-Gendarmerie-et-de-la-Police-dans-la-PDE-38b72a322d5080a083b8c82cb296e477?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

- `local` est documenté comme une politique de télétravail `sur site, à proximité`.
- Dans les flux sortants partenaires, `local` est volontairement mappé comme du présentiel, pas comme du télétravail.
- Le script de backfill Mongo est hors scope de cette PR : il n'est plus maintenu et ne sera pas adapté pour `remote: "local"`.
