### PR TITLE
feat(analytics): link mission clicks to backend ranking

### DIFF
--- a/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
+++ b/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
@@ -43,10 +43,11 @@ models:
   - name: int_tracking_mission_click
     description: >
       Chaque clic mission enrichi (rang, section, distance, publisher), une ligne par événement `mission.clicked`.
-      Réconcilié avec le backend via `quiz_session_id` = `matching_engine_result.user_scoring_id` et le pont
-      `mission_scoring` (`results[i].missionScoringId` = `mission_scoring.id` -> `mission_id`) : expose le rang
-      attribué par le moteur de matching à la mission cliquée. `mission_score` reste un placeholder (le score
-      total de classement n'est pas persisté dans `results`). Utilisateurs internes exclus.
+      Réconcilié avec le backend via `quiz_session_id` = `user_scoring_id` et le pont `mission_scoring`
+      (`results[i].missionScoringId` = `mission_scoring.id` -> `mission_id`) : expose le rang attribué à la
+      mission cliquée par le run de matching actif au moment du clic (dernier `created_at` <= `clicked_at`).
+      `mission_score` reste un placeholder (le score total de classement n'est pas persisté dans `results`).
+      Utilisateurs internes exclus.
     columns:
       - name: event_uuid
         tests:
@@ -58,8 +59,8 @@ models:
           - not_null
       - name: backend_rank
         description: >
-          Rang de la mission dans le dernier run de matching de la session (position dans `results`).
-          Null si le clic n'a pas pu être rattaché au backend.
+          Rang de la mission dans le run de matching actif au moment du clic (dernier `created_at` <=
+          `clicked_at`), position dans `results`. Null si le clic n'a pas pu être rattaché au backend.
       - name: matching_engine_version
         description: Version du moteur de matching du run rattaché (nullable si non rattaché).
       - name: matched_to_backend

--- a/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
+++ b/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
@@ -64,8 +64,6 @@ models:
         description: Version du moteur de matching du run rattaché (nullable si non rattaché).
       - name: matched_to_backend
         description: Vrai si le clic a été rattaché à une mission du résultat de matching de la session.
-        tests:
-          - not_null
 
   - name: int_tracking_quiz_backend
     description: >

--- a/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
+++ b/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
@@ -43,13 +43,27 @@ models:
   - name: int_tracking_mission_click
     description: >
       Chaque clic mission enrichi (rang, section, distance, publisher), une ligne par événement `mission.clicked`.
-      `mission_score` reste à alimenter depuis le backend. Utilisateurs internes exclus.
+      Réconcilié avec le backend via `quiz_session_id` = `matching_engine_result.user_scoring_id` et le pont
+      `mission_scoring` (`results[i].missionScoringId` = `mission_scoring.id` -> `mission_id`) : expose le rang
+      attribué par le moteur de matching à la mission cliquée. `mission_score` reste un placeholder (le score
+      total de classement n'est pas persisté dans `results`). Utilisateurs internes exclus.
     columns:
       - name: event_uuid
         tests:
           - not_null
           - unique
       - name: mission_id
+        description: Identifiant de la mission cliquée (text ; formats mixtes ObjectId Mongo / UUID).
+        tests:
+          - not_null
+      - name: backend_rank
+        description: >
+          Rang de la mission dans le dernier run de matching de la session (position dans `results`).
+          Null si le clic n'a pas pu être rattaché au backend.
+      - name: matching_engine_version
+        description: Version du moteur de matching du run rattaché (nullable si non rattaché).
+      - name: matched_to_backend
+        description: Vrai si le clic a été rattaché à une mission du résultat de matching de la session.
         tests:
           - not_null
 

--- a/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_mission_click.sql
+++ b/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_mission_click.sql
@@ -21,28 +21,72 @@ with clicks as (
     entry_page,
     is_internal_user
   from {{ ref('stg_tracking__mission_clicked') }}
+),
+
+-- Un seul run de matching par session (le plus récent).
+latest_result as (
+  select distinct on (user_scoring_id)
+    user_scoring_id,
+    matching_engine_version,
+    results
+  from {{ ref('matching_engine_result') }}
+  where results is not null
+  order by user_scoring_id asc, created_at desc
+),
+
+-- Déplie le classement backend : rang (ordinality) et scoring de mission.
+backend_ranked as (
+  select
+    lr.user_scoring_id,
+    lr.matching_engine_version,
+    t.ord as backend_rank,
+    t.elem ->> 'missionScoringId' as mission_scoring_id
+  from latest_result as lr
+  cross join
+    lateral jsonb_array_elements(lr.results)
+    with ordinality as t (elem, ord)
+),
+
+-- Pont vers mission_id via mission_scoring. Une ligne par (session,
+-- mission), meilleur rang gardé pour éviter le fan-out (unicité event_uuid).
+backend_missions as (
+  select distinct on (br.user_scoring_id, ms.mission_id)
+    br.user_scoring_id,
+    ms.mission_id,
+    br.backend_rank,
+    br.matching_engine_version
+  from backend_ranked as br
+  inner join {{ ref('mission_scoring') }} as ms on br.mission_scoring_id = ms.id
+  order by br.user_scoring_id asc, ms.mission_id asc, br.backend_rank asc
 )
 
 select
-  event_uuid,
-  clicked_at,
-  session_date,
-  distinct_id,
-  quiz_session_id,
-  quiz_attempt_id,
-  utm_source,
-  utm_campaign,
-  utm_medium,
-  mission_id,
-  publisher_id,
-  publisher_name,
-  section,
-  rank,
-  mission_domain,
-  mission_type,
-  opens_external,
-  distance_km,
-  entry_page,
-  null::numeric as mission_score
-from clicks
-where {{ exclude_internal_users() }}
+  c.event_uuid,
+  c.clicked_at,
+  c.session_date,
+  c.distinct_id,
+  c.quiz_session_id,
+  c.quiz_attempt_id,
+  c.utm_source,
+  c.utm_campaign,
+  c.utm_medium,
+  c.mission_id,
+  c.publisher_id,
+  c.publisher_name,
+  c.section,
+  c.rank,
+  c.mission_domain,
+  c.mission_type,
+  c.opens_external,
+  c.distance_km,
+  c.entry_page,
+  bm.backend_rank,
+  bm.matching_engine_version,
+  null::numeric as mission_score,
+  bm.mission_id is not null as matched_to_backend
+from clicks as c
+left join backend_missions as bm
+  on
+    c.quiz_session_id = bm.user_scoring_id
+    and c.mission_id = bm.mission_id
+where {{ exclude_internal_users('c.is_internal_user') }}

--- a/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_mission_click.sql
+++ b/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_mission_click.sql
@@ -23,41 +23,39 @@ with clicks as (
   from {{ ref('stg_tracking__mission_clicked') }}
 ),
 
--- Un seul run de matching par session (le plus récent).
-latest_result as (
-  select distinct on (user_scoring_id)
-    user_scoring_id,
-    matching_engine_version,
-    results
-  from {{ ref('matching_engine_result') }}
-  where results is not null
-  order by user_scoring_id asc, created_at desc
-),
-
--- Déplie le classement backend : rang (ordinality) et scoring de mission.
-backend_ranked as (
+-- Rattache chaque clic au résultat de matching actif au moment du clic :
+-- le dernier run de la session dont created_at <= clicked_at, puis le rang de
+-- la mission cliquée dans ce run (via le pont mission_scoring).
+click_backend as (
   select
-    lr.user_scoring_id,
-    lr.matching_engine_version,
-    t.ord as backend_rank,
-    t.elem ->> 'missionScoringId' as mission_scoring_id
-  from latest_result as lr
+    c.event_uuid,
+    active_result.matching_engine_version,
+    ranked.backend_rank
+  from clicks as c
   cross join
-    lateral jsonb_array_elements(lr.results)
-    with ordinality as t (elem, ord)
-),
-
--- Pont vers mission_id via mission_scoring. Une ligne par (session,
--- mission), meilleur rang gardé pour éviter le fan-out (unicité event_uuid).
-backend_missions as (
-  select distinct on (br.user_scoring_id, ms.mission_id)
-    br.user_scoring_id,
-    ms.mission_id,
-    br.backend_rank,
-    br.matching_engine_version
-  from backend_ranked as br
-  inner join {{ ref('mission_scoring') }} as ms on br.mission_scoring_id = ms.id
-  order by br.user_scoring_id asc, ms.mission_id asc, br.backend_rank asc
+    lateral (
+      select
+        mer.matching_engine_version,
+        mer.results
+      from {{ ref('stg_matching_engine_result') }} as mer
+      where
+        mer.user_scoring_id = c.quiz_session_id
+        and mer.results is not null
+        and mer.created_at <= c.clicked_at
+      order by mer.created_at desc
+      limit 1
+    ) as active_result
+  cross join
+    lateral (
+      select min(t.ord) as backend_rank
+      from
+        jsonb_array_elements(active_result.results)
+        with ordinality as t (elem, ord)
+      inner join {{ ref('stg_mission_scoring') }} as ms
+        on ms.id = t.elem ->> 'missionScoringId'
+      where ms.mission_id = c.mission_id
+    ) as ranked
+  where ranked.backend_rank is not null
 )
 
 select
@@ -80,13 +78,10 @@ select
   c.opens_external,
   c.distance_km,
   c.entry_page,
-  bm.backend_rank,
-  bm.matching_engine_version,
+  cb.backend_rank,
+  cb.matching_engine_version,
   null::numeric as mission_score,
-  bm.mission_id is not null as matched_to_backend
+  cb.event_uuid is not null as matched_to_backend
 from clicks as c
-left join backend_missions as bm
-  on
-    c.quiz_session_id = bm.user_scoring_id
-    and c.mission_id = bm.mission_id
+left join click_backend as cb on c.event_uuid = cb.event_uuid
 where {{ exclude_internal_users('c.is_internal_user') }}

--- a/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_quiz_backend.sql
+++ b/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_quiz_backend.sql
@@ -14,7 +14,7 @@ latest_result as (
     user_scoring_id,
     matching_engine_version,
     results
-  from {{ ref('matching_engine_result') }}
+  from {{ ref('stg_matching_engine_result') }}
   where results is not null
   order by user_scoring_id asc, created_at desc
 ),

--- a/analytics/dbt/analytics/models/marts/tracking/__models.yml
+++ b/analytics/dbt/analytics/models/marts/tracking/__models.yml
@@ -15,8 +15,10 @@ models:
 
   - name: tracking_mission_click
     description: >
-      Fait clic mission (grain événement) pour les breakdowns rang / score / distance / section / publisher,
-      enrichi du statut et de la tranche d'âge de la session.
+      Fait clic mission (grain événement) pour les breakdowns rang / distance / section / publisher,
+      enrichi du statut et de la tranche d'âge de la session. Réconcilié avec le moteur de matching :
+      `backend_rank`, `matching_engine_version` et `matched_to_backend` permettent d'analyser le CTR par rang.
+      `mission_score` reste un placeholder (non alimenté).
     columns:
       - name: event_uuid
         tests:

--- a/analytics/dbt/analytics/models/marts/tracking/tracking_mission_click.sql
+++ b/analytics/dbt/analytics/models/marts/tracking/tracking_mission_click.sql
@@ -31,7 +31,10 @@ select
   c.opens_external,
   c.distance_km,
   c.entry_page,
+  c.backend_rank,
+  c.matching_engine_version,
   c.mission_score,
+  c.matched_to_backend,
   s.statut,
   s.age_bracket
 from clicks as c

--- a/analytics/dbt/analytics/tests/assert_mission_click_matched_has_backend_rank.sql
+++ b/analytics/dbt/analytics/tests/assert_mission_click_matched_has_backend_rank.sql
@@ -1,0 +1,10 @@
+-- Un clic rattaché au backend doit toujours porter un rang et une version.
+-- Le test échoue s'il remonte des lignes (invariant de la jointure violé).
+select
+  event_uuid,
+  quiz_session_id,
+  mission_id
+from {{ ref('int_tracking_mission_click') }}
+where
+  matched_to_backend
+  and (backend_rank is null or matching_engine_version is null)


### PR DESCRIPTION
## Description

Rattache chaque clic mission du tracking front au classement produit par le moteur de matching backend. Le modèle `int_tracking_mission_click` (et le mart `tracking_mission_click`) expose désormais, pour chaque clic rattachable à une session quiz, le rang et la version d'algo attribués par le backend, plus un flag de rattachement.

Jointure : `tracking_mission_click.quiz_session_id = matching_engine_result.user_scoring_id` (niveau session), puis pont via `mission_scoring` (`results[].missionScoringId = mission_scoring.id → mission_id`), car le JSON `results` ne porte pas le `mission_id` mais un `missionScoringId`.

Nouvelles colonnes :
- `backend_rank` : rang de la mission dans le dernier run de matching de la session.
- `matching_engine_version` : version d'algo du run rattaché.
- `matched_to_backend` : flag de rattachement (garde-fou de couverture).

`mission_score` est laissé en placeholder : le score total de classement n'est pas persisté dans `results` (seuls les `taxonomyScores` par thème le sont). Le détail par taxonomie fera l'objet d'une PR dédiée.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/Cr-ation-des-mod-les-dbt-pour-le-tracking-front-de-la-plateforme-39172a322d50802991b1f678d7863a11)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement (dbt build + tests + validation Metabase sur staging)
- [x] Tests unitaires ajoutés/modifiés si nécessaire (tests dbt : cohérence du rattachement (matched → backend_rank non null), unicité event_uuid conservée)
- [x] Respect des standards de code (SQLFluff OK ; pas d'ESLint sur du SQL)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Grain inchangé (un clic = une ligne). La dédup `distinct on (session, mission)` garantit l'unicité `event_uuid` malgré la jointure.
- On ne retient que le dernier run de matching par session (`distinct on user_scoring_id order by created_at desc`), plusieurs versions/reruns étant possibles.
- `mission_id` conservé en `text` (formats mixtes ObjectId Mongo / UUID) : ne pas caster en `uuid`.
- Observé sur staging : un clic récent peut ressortir `matched_to_backend = false` par simple lag d'export du `matching_engine_result` / `mission_scoring`, ce n'est pas un défaut du modèle.
- Prérequis : la vue `int_tracking_quiz_backend` doit exister sur staging pour rebuild les marts dépendants (`tracking_quiz_session`, `tracking_scoring_kpi_daily`).
