### PR TITLE
fix(app): relevant chart description table headers for rgaa 1.7

### DIFF
--- a/app/src/components/AnalyticsViz.jsx
+++ b/app/src/components/AnalyticsViz.jsx
@@ -33,6 +33,8 @@ const AnalyticsViz = ({
   chartDescription,
   chartDescriptionMode = "none",
   chartDescriptionId,
+  chartNameLabel,
+  chartValueLabel,
 }) => {
   const generatedId = useId();
   const analyticsProvider = useAnalyticsProvider();
@@ -264,7 +266,7 @@ const AnalyticsViz = ({
                 <thead className="text-text-mention text-left text-[10px] uppercase">
                   <tr>
                     <th className="px-2">Légende</th>
-                    <th className="px-2 text-right">Valeur</th>
+                    <th className="px-2 text-right">{chartValueLabel || "Valeur"}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -302,6 +304,8 @@ const AnalyticsViz = ({
             nameKey={chartNameKey}
             nameFormatter={chartNameFormatter}
             valueFormatter={chartValueFormatter}
+            nameLabel={chartNameLabel}
+            valueLabel={chartValueLabel}
           />
         )}
       </figure>
@@ -325,6 +329,8 @@ const AnalyticsViz = ({
           nameKey={chartNameKey}
           nameFormatter={chartNameFormatter}
           valueFormatter={chartValueFormatter}
+          nameLabel={chartNameLabel}
+          valueLabel={chartValueLabel}
         />
       </figure>
     );
@@ -348,6 +354,7 @@ const AnalyticsViz = ({
           stackedKeys={stackedKeys}
           seriesLabelMap={chartProps?.seriesLabelMap}
           nameFormatter={chartNameFormatter}
+          nameLabel={chartNameLabel}
         />
       </figure>
     );

--- a/app/src/components/ChartDetailsTable.jsx
+++ b/app/src/components/ChartDetailsTable.jsx
@@ -14,6 +14,8 @@ const ChartDetailsTable = ({
   className = "",
   nameFormatter,
   valueFormatter,
+  nameLabel,
+  valueLabel,
 }) => {
   if (mode === "none" || mode === "external" || !id || !data.length) {
     return (
@@ -38,7 +40,7 @@ const ChartDetailsTable = ({
         <caption className={mode === "sr-only" ? "" : "mb-2 text-left font-semibold"}>{captionText}</caption>
         <thead className="text-text-mention text-left text-[10px] uppercase">
           <tr>
-            <th className="px-2 py-1">Catégorie</th>
+            <th className="px-2 py-1">{nameLabel || "Catégorie"}</th>
             {stackedKeys.map((key) => (
               <th key={key} className="px-2 py-1 text-right">
                 {getChartSeriesLabel(key, seriesLabelMap)}
@@ -74,8 +76,8 @@ const ChartDetailsTable = ({
       <caption className={mode === "sr-only" ? "" : "mb-2 text-left font-semibold"}>{captionText}</caption>
       <thead className="text-text-mention text-left text-[10px] uppercase">
         <tr>
-          <th className="px-2 py-1">Libellé</th>
-          <th className="px-2 py-1 text-right">Valeur</th>
+          <th className="px-2 py-1">{nameLabel || "Libellé"}</th>
+          <th className="px-2 py-1 text-right">{valueLabel || "Valeur"}</th>
         </tr>
       </thead>
       <tbody>

--- a/app/src/scenes/performance/AnalyticsCard.jsx
+++ b/app/src/scenes/performance/AnalyticsCard.jsx
@@ -21,6 +21,8 @@ const AnalyticsCard = ({
   chartDescription,
   chartDescriptionMode,
   chartDescriptionId,
+  chartNameLabel,
+  chartValueLabel,
 }) => {
   if (!cardId) {
     return null;
@@ -58,6 +60,8 @@ const AnalyticsCard = ({
       chartDescription={chartDescription}
       chartDescriptionMode={chartDescriptionMode}
       chartDescriptionId={chartDescriptionId}
+      chartNameLabel={chartNameLabel}
+      chartValueLabel={chartValueLabel}
     />
   );
 

--- a/app/src/scenes/performance/GlobalAnnounce.jsx
+++ b/app/src/scenes/performance/GlobalAnnounce.jsx
@@ -312,6 +312,7 @@ const Evolution = ({ filters }) => {
                 type="stacked"
                 data={histogram}
                 stackedKeys={keys}
+                nameLabel="Période"
               />
             </figure>
           )}

--- a/app/src/scenes/performance/GlobalBroadcast.jsx
+++ b/app/src/scenes/performance/GlobalBroadcast.jsx
@@ -441,6 +441,7 @@ const Evolution = ({ filters }) => {
                 type="stacked"
                 data={histogram}
                 stackedKeys={keys}
+                nameLabel="Période"
               />
             </figure>
           )}

--- a/app/src/scenes/public-stats/components/SomeNumbers.jsx
+++ b/app/src/scenes/public-stats/components/SomeNumbers.jsx
@@ -182,6 +182,8 @@ const SomeNumbers = ({ filters, onFiltersChange }) => {
               chartTitle={`Évolution mensuelle des organisations actives en ${filters.year}`}
               chartDescription="Nombre d'organisations actives par mois sur l'année sélectionnée."
               chartDescriptionMode="sr-only"
+              chartNameLabel="Mois"
+              chartValueLabel="Nombre d'organisations actives"
               adapterOptions={{ labelColumn: "month_start", valueColumn: "organizations" }}
               chartProps={{
                 dataKey: "value",
@@ -217,6 +219,8 @@ const SomeNumbers = ({ filters, onFiltersChange }) => {
               chartTitle={`Évolution mensuelle des missions partagées en ${filters.year}`}
               chartDescription="Nombre de missions partagées par mois sur l'année sélectionnée."
               chartDescriptionMode="sr-only"
+              chartNameLabel="Mois"
+              chartValueLabel="Nombre de missions partagées"
               adapterOptions={{ labelColumn: "month_start", valueColumn: "missions" }}
               chartProps={{
                 dataKey: "value",
@@ -242,6 +246,8 @@ const SomeNumbers = ({ filters, onFiltersChange }) => {
               chartTitle={`Évolution mensuelle des redirections en ${filters.year}`}
               chartDescription="Nombre de redirections par mois sur l'année sélectionnée."
               chartDescriptionMode="sr-only"
+              chartNameLabel="Mois"
+              chartValueLabel="Nombre de redirections"
               adapterOptions={{ labelColumn: "month_start", valueColumn: "redirection_count" }}
               chartProps={{
                 dataKey: "value",
@@ -266,6 +272,8 @@ const SomeNumbers = ({ filters, onFiltersChange }) => {
               chartTitle={`Évolution mensuelle des candidatures en ${filters.year}`}
               chartDescription="Nombre de candidatures par mois sur l'année sélectionnée."
               chartDescriptionMode="sr-only"
+              chartNameLabel="Mois"
+              chartValueLabel="Nombre de candidatures"
               adapterOptions={{ labelColumn: "month_start", valueColumn: "candidature_count" }}
               chartProps={{
                 dataKey: "value",


### PR DESCRIPTION
## Description

Corrige le critère RGAA 1.7 (pertinence de la description détaillée des images porteuses d'information) sur les pages `/public-stats` et `/performance` (modes diffuseur et annonceur), suite au retour d'audit : l'en-tête générique « Valeur » des tableaux de description n'est pas pertinent.

**Changements** :

- `ChartDetailsTable` : nouvelles props optionnelles `nameLabel` / `valueLabel` (les libellés génériques « Libellé » / « Catégorie » / « Valeur » restent les valeurs par défaut, aucune régression sur les autres pages)
- `AnalyticsViz` / `AnalyticsCard` : propagation via `chartNameLabel` / `chartValueLabel` (utilisées aussi pour l'en-tête « Valeur » de la table-légende des camemberts)
- `/public-stats` (`SomeNumbers`) : les 4 tableaux de description passent de « Libellé / Valeur » à « Mois / Nombre d'organisations actives », « Mois / Nombre de missions partagées », « Mois / Nombre de redirections », « Mois / Nombre de candidatures »
- `/performance` diffuseur (`GlobalBroadcast`) et annonceur (`GlobalAnnounce`) : dans les tableaux de description des histogrammes « Évolution », l'en-tête générique « Catégorie » devient « Période » (la colonne contient des dates ou des mois)

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/1-7-39e72a322d5080e0ac08c2db557f784a?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Les tableaux empilés de `/performance` n'ont pas d'en-tête « Valeur » : leurs colonnes portent déjà les noms des partenaires + « Total », seul l'en-tête « Catégorie » était générique.
- Cette branche part du `staging` à jour et est indépendante de la PR #1273 (critère 1.6). Les deux PR touchent des lignes adjacentes dans `SomeNumbers`, `GlobalBroadcast` et `GlobalAnnounce` : la deuxième mergée pourra avoir un conflit trivial à résoudre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)