### PR TITLE
fix(app): announce count status messages for rgaa 7.5

### DIFF
--- a/app/src/scenes/broadcast/Widgets.jsx
+++ b/app/src/scenes/broadcast/Widgets.jsx
@@ -76,85 +76,84 @@ const Widgets = () => {
         )}
       </div>
 
+      <div className="flex flex-col items-center justify-between lg:flex-row">
+        {/* La zone de statut doit rester montée en permanence : une zone live re-insérée dans le DOM n'est pas restituée par les lecteurs d'écran (RGAA 7.5) */}
+        <p className="text-lg font-semibold" role="status" aria-live="polite" aria-atomic="true">
+          {loading ? "" : data.length > 1 ? `${data.length} widgets` : `${data.length} widget`}
+        </p>
+        {user.role === "admin" && (
+          <div className="flex items-center">
+            <Toggle
+              id="toggle-show-inactive-widgets"
+              aria-label="Afficher les widgets désactivés"
+              value={!filters.active}
+              onChange={(checked) => setFilters({ ...filters, active: !checked, page: 1 })}
+            />
+            <label className="ml-2" htmlFor="toggle-show-inactive-widgets">
+              Afficher les widgets désactivés
+            </label>
+          </div>
+        )}
+      </div>
+
       {loading ? (
         <div className="flex h-full items-center justify-center">
           <Loader />
         </div>
       ) : (
-        <>
-          <div className="flex flex-col items-center justify-between lg:flex-row">
-            <p className="text-lg font-semibold" role="status" aria-live="polite" aria-atomic="true">
-              {data.length > 1 ? `${data.length} widgets` : `${data.length} widget`}
-            </p>
-            {user.role === "admin" && (
-              <div className="flex items-center">
-                <Toggle
-                  id="toggle-show-inactive-widgets"
-                  aria-label="Afficher les widgets désactivés"
-                  value={!filters.active}
-                  onChange={(checked) => setFilters({ ...filters, active: !checked, page: 1 })}
-                />
-                <label className="ml-2" htmlFor="toggle-show-inactive-widgets">
-                  Afficher les widgets désactivés
-                </label>
-              </div>
-            )}
-          </div>
-
-          <Table
-            caption="Liste des widgets"
-            header={TABLE_HEADER}
-            pagination
-            page={filters.page}
-            pageSize={filters.pageSize}
-            onPageChange={(page) => setFilters({ ...filters, page })}
-            total={data.length}
-            auto
-          >
-            {data.slice((filters.page - 1) * filters.pageSize, filters.page * filters.pageSize).map((item, i) => (
-              <tr key={i} className={`${i % 2 === 0 ? "bg-table-even" : "bg-table-odd"} table-row`}>
+        <Table
+          caption="Liste des widgets"
+          header={TABLE_HEADER}
+          pagination
+          page={filters.page}
+          pageSize={filters.pageSize}
+          onPageChange={(page) => setFilters({ ...filters, page })}
+          total={data.length}
+          auto
+        >
+          {data.slice((filters.page - 1) * filters.pageSize, filters.page * filters.pageSize).map((item, i) => (
+            <tr key={i} className={`${i % 2 === 0 ? "bg-table-even" : "bg-table-odd"} table-row`}>
+              <td className="px-4">
+                <Link to={`/broadcast/widget/${item.id}`} className="text-blue-france truncate">
+                  {item.name}
+                </Link>
+              </td>
+              <td className={`px-4 ${!item.active ? "opacity-50" : "opacity-100"}`}>
+                {item.publishers
+                  .slice(0, 3)
+                  .map((p) => p.name)
+                  .join(", ")}
+                {item.publishers.length > 3 ? ` +${item.publishers.length - 3}` : ""}
+              </td>
+              <td className={`${!item.active ? "opacity-50" : "opacity-100"} px-4`}>{new Date(item.createdAt).toLocaleDateString("fr")}</td>
+              <td className="mt-3 flex gap-2 px-4 text-lg">
+                <Link className="secondary-btn flex items-center" to={`/broadcast/widget/${item.id}`}>
+                  <RiEditFill className="text-lg" role="img" aria-label="Modifier le widget" />
+                </Link>
+                <a
+                  className="secondary-btn flex items-center"
+                  href={`${item.type === "volontariat" ? VOLONTARIAT_URL : BENEVOLAT_URL}?widget=${item.id}&notrack=true`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <RiEyeFill className="text-lg" role="img" aria-label="Voir le widget" />
+                </a>
+                <Link className="secondary-btn flex items-center" to={`/settings/real-time?sourceId=${item.id}&sourceType=widget`}>
+                  <RiPulseLine className="text-lg" role="img" aria-label={`Voir les événements en direct du widget ${item.name || ""}`.trim()} />
+                </Link>
+              </td>
+              {user.role === "admin" && (
                 <td className="px-4">
-                  <Link to={`/broadcast/widget/${item.id}`} className="text-blue-france truncate">
-                    {item.name}
-                  </Link>
+                  <Toggle
+                    aria-label={`${item.active ? "Désactiver" : "Activer"} le widget ${item.name || ""}`.trim()}
+                    value={item.active}
+                    onChange={(v) => handleActivate(v, item)}
+                  />
                 </td>
-                <td className={`px-4 ${!item.active ? "opacity-50" : "opacity-100"}`}>
-                  {item.publishers
-                    .slice(0, 3)
-                    .map((p) => p.name)
-                    .join(", ")}
-                  {item.publishers.length > 3 ? ` +${item.publishers.length - 3}` : ""}
-                </td>
-                <td className={`${!item.active ? "opacity-50" : "opacity-100"} px-4`}>{new Date(item.createdAt).toLocaleDateString("fr")}</td>
-                <td className="mt-3 flex gap-2 px-4 text-lg">
-                  <Link className="secondary-btn flex items-center" to={`/broadcast/widget/${item.id}`}>
-                    <RiEditFill className="text-lg" role="img" aria-label="Modifier le widget" />
-                  </Link>
-                  <a
-                    className="secondary-btn flex items-center"
-                    href={`${item.type === "volontariat" ? VOLONTARIAT_URL : BENEVOLAT_URL}?widget=${item.id}&notrack=true`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <RiEyeFill className="text-lg" role="img" aria-label="Voir le widget" />
-                  </a>
-                  <Link className="secondary-btn flex items-center" to={`/settings/real-time?sourceId=${item.id}&sourceType=widget`}>
-                    <RiPulseLine className="text-lg" role="img" aria-label={`Voir les événements en direct du widget ${item.name || ""}`.trim()} />
-                  </Link>
-                </td>
-                {user.role === "admin" && (
-                  <td className="px-4">
-                    <Toggle
-                      aria-label={`${item.active ? "Désactiver" : "Activer"} le widget ${item.name || ""}`.trim()}
-                      value={item.active}
-                      onChange={(v) => handleActivate(v, item)}
-                    />
-                  </td>
-                )}
-              </tr>
-            ))}
-          </Table>
-        </>
+              )}
+            </tr>
+          ))}
+        </Table>
       )}
     </div>
   );

--- a/app/src/scenes/broadcast/moderation/components/Header.jsx
+++ b/app/src/scenes/broadcast/moderation/components/Header.jsx
@@ -39,7 +39,7 @@ const Header = ({ total, data, size, sort, selected, onSize, onSort, onSelect, o
               </button>
             </div>
           ) : (
-            <h2 role="status" className="text-xl font-semibold">
+            <h2 role="status" aria-live="polite" aria-atomic="true" className="text-xl font-semibold">
               {total.toLocaleString("fr")} missions diffusables
             </h2>
           )}
@@ -57,7 +57,7 @@ const Header = ({ total, data, size, sort, selected, onSize, onSort, onSelect, o
 
   return (
     <div className="mx-4 flex flex-wrap items-center justify-between gap-4 py-4 sm:mx-12">
-      <h2 role="status" className="text-xl font-semibold">
+      <h2 role="status" aria-live="polite" aria-atomic="true" className="text-xl font-semibold">
         {total.toLocaleString("fr")} missions diffusables
       </h2>
 

--- a/app/src/scenes/my-missions/Flux.jsx
+++ b/app/src/scenes/my-missions/Flux.jsx
@@ -195,7 +195,9 @@ const Flux = ({ moderated }) => {
       <div className="flex flex-col gap-6">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="min-w-0 flex-1 space-y-2">
-            <h2 className="text-2xl font-bold">{total.toLocaleString("fr")} missions partagées</h2>
+            <h2 role="status" aria-live="polite" aria-atomic="true" className="text-2xl font-bold">
+              {total.toLocaleString("fr")} missions partagées
+            </h2>
             <div className="flex flex-wrap items-center gap-2">
               <p className="text-text-mention text-base">Dernière synchronisation le {lastImport ? new Date(lastImport.startedAt).toLocaleDateString("fr") : "N/A"}</p>
               {lastImport && new Date(lastImport.startedAt) > new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() - 1) ? (


### PR DESCRIPTION
## Description

Corrige le critère RGAA 7.5 (restitution des messages de statut par les technologies d'assistance) sur `/broadcast/moderation` (missions diffusables), `/my-missions` et `/broadcast/widgets`, suite aux retours d'audit : seul le nombre était restitué (« 22 » au lieu de « 22 missions diffusables »), et le compteur des widgets n'était pas restitué du tout.

**Changements** :

- `broadcast/moderation/components/Header.jsx` : ajout de `aria-live="polite" aria-atomic="true"` sur les deux `<h2 role="status">` « missions diffusables » — sans `aria-atomic`, React ne met à jour que le nœud texte du nombre et les lecteurs d'écran ne restituent que ce nœud (« 22 » seul)
- `my-missions/Flux.jsx` : le compteur « X missions partagées » devient une zone de statut (`role="status" aria-live="polite" aria-atomic="true"`)
- `broadcast/Widgets.jsx` : la zone de statut « X widgets » est sortie du ternaire `loading` pour rester montée en permanence — une zone live re-insérée dans le DOM n'est jamais restituée (hypothèse de l'auditrice confirmée) ; seul son contenu change désormais. Bonus : le toggle « Afficher les widgets désactivés » ne perd plus le focus clavier pendant le rechargement

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/7-5-39e72a322d5080fab4afd69ccaa46417?source=copy_link)
- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/7-5-39e72a322d50804b8bc5ca68773e63ed?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Historique : ces deux commits avaient été poussés par erreur directement sur `staging` (mauvais upstream de branche), puis revertés (`5fc5622a`) pour repasser par une review. Cette PR les réintroduit proprement.
- Remarques de l'audit sur le calendrier du datepicker : `react-datepicker` 9.1.0 rend déjà une structure ARIA complète (`role="table"` > `row` > `columnheader`/`gridcell`), et l'auditrice valide les champs dates comme alternative accessible (« donc OK ») — pas d'action code.
- `/broadcast/campaigns` (`Campaigns.jsx`) présente le même défaut de zone live démontée pendant le chargement — à traiter si l'audit le remonte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)