### PR TITLE
fix(app): move main menu inside banner header for rgaa 9.2

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -5,7 +5,6 @@ import { ToastContainer } from "react-toastify";
 import Footer from "@/components/Footer";
 import Header from "@/components/Header";
 import Loader from "@/components/Loader";
-import Nav from "@/components/Nav";
 import Account from "@/scenes/account";
 import AdminAccounts from "@/scenes/admin-account";
 import AdminMissions from "@/scenes/admin-mission";
@@ -236,7 +235,6 @@ const ProtectedLayout = () => {
         </div>
       )}
       <Header />
-      <Nav />
 
       <main id="main-content" role="main" tabIndex={-1} className="mx-auto mb-14 w-full max-w-[1200px] flex-1 px-0 pt-14 sm:w-4/5 sm:px-4">
         <Outlet />
@@ -280,7 +278,6 @@ const PublisherSyncLayout = () => {
 };
 
 const PublicLayout = () => {
-  const { user } = useStore();
   const location = useLocation();
 
   useEffect(() => {
@@ -292,7 +289,6 @@ const PublicLayout = () => {
   return (
     <div className="bg-global-background flex min-h-screen w-full flex-col">
       <Header />
-      {user ? <Nav /> : ""}
       <main id="main-content" role="main" tabIndex={-1}>
         <Outlet />
       </main>

--- a/app/src/components/Header.jsx
+++ b/app/src/components/Header.jsx
@@ -5,6 +5,7 @@ import { Link, useLocation } from "react-router-dom";
 
 import LogoSvg from "@/assets/svg/logo.svg?react";
 
+import Nav from "@/components/Nav";
 import { WARNINGS } from "@/constants";
 import api from "@/services/api";
 import { captureError } from "@/services/error";
@@ -17,45 +18,48 @@ import marianneBanner from "@/assets/svg/marianne-banner.svg";
 const Header = () => {
   const { user } = useStore();
   return (
-    <header role="banner" className="border-b-grey-border flex w-full justify-center border-b bg-white">
-      <div className="flex w-full max-w-7xl flex-wrap items-center justify-between gap-4 px-4 py-1 sm:py-3">
-        <Link className="hover:bg-gray-975 flex items-center gap-4 p-2 sm:p-4" to={user ? "/" : "/login"}>
-          <div className="flex h-24 items-center justify-center">
-            <div className="flex flex-col items-start">
-              <img src={marianneBanner} alt="" aria-hidden="true" className="mb-1 w-10" />
-              <p className="text-xs leading-3 font-bold text-black uppercase">
-                République
-                <br />
-                française
-              </p>
-              <img src={deviseSrc} alt="" aria-hidden="true" className="mt-1 h-7" />
+    <header role="banner" className="w-full bg-white">
+      <div className="border-b-grey-border flex w-full justify-center border-b">
+        <div className="flex w-full max-w-7xl flex-wrap items-center justify-between gap-4 px-4 py-1 sm:py-3">
+          <Link className="hover:bg-gray-975 flex items-center gap-4 p-2 sm:p-4" to={user ? "/" : "/login"}>
+            <div className="flex h-24 items-center justify-center">
+              <div className="flex flex-col items-start">
+                <img src={marianneBanner} alt="" aria-hidden="true" className="mb-1 w-10" />
+                <p className="text-xs leading-3 font-bold text-black uppercase">
+                  République
+                  <br />
+                  française
+                </p>
+                <img src={deviseSrc} alt="" aria-hidden="true" className="mt-1 h-7" />
+              </div>
             </div>
-          </div>
-          <LogoSvg alt="" className="hidden w-8 sm:block" aria-hidden="true" />
-          <div className="hidden sm:block">
-            <p className="text-xl font-bold">API Engagement</p>
-            <p className="text-sm">Plateforme de partage de missions de bénévolat et de volontariat</p>
-          </div>
-        </Link>
-        <nav role="navigation" aria-label="Navigation d'en-tête" className="text-blue-france relative flex items-center gap-3 text-sm">
-          <a href="https://doc.api-engagement.beta.gouv.fr/" target="_blank" className="text-blue-france flex items-center" aria-label="Documentation">
-            <RiBookletLine className="mr-2" aria-hidden="true" />
-            <span className="hidden sm:block">Documentation</span>
-          </a>
+            <LogoSvg alt="" className="hidden w-8 sm:block" aria-hidden="true" />
+            <div className="hidden sm:block">
+              <p className="text-xl font-bold">API Engagement</p>
+              <p className="text-sm">Plateforme de partage de missions de bénévolat et de volontariat</p>
+            </div>
+          </Link>
+          <nav role="navigation" aria-label="Navigation d'en-tête" className="text-blue-france relative flex items-center gap-3 text-sm">
+            <a href="https://doc.api-engagement.beta.gouv.fr/" target="_blank" className="text-blue-france flex items-center" aria-label="Documentation">
+              <RiBookletLine className="mr-2" aria-hidden="true" />
+              <span className="hidden sm:block">Documentation</span>
+            </a>
 
-          {!user ? (
-            <Link to="/login" className="tertiary-btn flex items-center">
-              <RiUserLine className="mr-2" aria-hidden="true" />
-              Connexion
-            </Link>
-          ) : (
-            <>
-              {user.role === "admin" ? <AdminNotificationMenu /> : <NotificationMenu />}
-              <AccountMenu />
-            </>
-          )}
-        </nav>
+            {!user ? (
+              <Link to="/login" className="tertiary-btn flex items-center">
+                <RiUserLine className="mr-2" aria-hidden="true" />
+                Connexion
+              </Link>
+            ) : (
+              <>
+                {user.role === "admin" ? <AdminNotificationMenu /> : <NotificationMenu />}
+                <AccountMenu />
+              </>
+            )}
+          </nav>
+        </div>
       </div>
+      {user ? <Nav /> : null}
     </header>
   );
 };


### PR DESCRIPTION
## Description

Corrige le critère RGAA 9.2 (cohérence de la structure du document) : le menu principal (Performance / Diffuser des missions / Vos missions / Paramètres…) était rendu en dehors du `<header role="banner">`, en élément frère dans les layouts. Il est désormais à l'intérieur de la balise, sur toutes les pages qui l'affichent.

**Changements** :

- `Header.jsx` : le `<header role="banner">` englobe maintenant deux rangées — la rangée logo/Marianne + navigation d'en-tête (bordure basse et centrage conservés), puis `<Nav />` rendu quand l'utilisateur est connecté
- `App.jsx` : `<Nav />` retiré de `ProtectedLayout` et `PublicLayout` (la condition « connecté » de `PublicLayout` est reprise à l'identique dans `Header` via le store) ; import `Nav` et destructuration `user` devenus inutiles supprimés

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/9-2-39e72a322d50800880cde533c31b2215?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Comportement préservé partout : pages d'auth = header sans menu (comme avant), `/public-stats` non connecté = sans menu / connecté = avec menu (comme avant), pages protégées = header + menu.
- Le rendu visuel est inchangé (même empilement : rangée bordée puis barre de menu avec son ombre) — vérification rapide dans le navigateur conseillée à la review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)