### PR TITLE
fix(app): visible focus on moderation actions menu for rgaa 10.7

### DIFF
--- a/app/src/scenes/broadcast/moderation/components/MissionItem.jsx
+++ b/app/src/scenes/broadcast/moderation/components/MissionItem.jsx
@@ -1,6 +1,5 @@
 import { toast } from "@/services/toast";
-import { Menu, Transition } from "@headlessui/react";
-import { Fragment, useEffect, useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { BsDot } from "react-icons/bs";
 import { RiCalendarEventFill, RiCheckboxCircleFill, RiCloseCircleFill, RiMapPin2Fill, RiMoreFill, RiPencilFill, RiTimeLine } from "react-icons/ri";
 import { useSearchParams } from "react-router-dom";
@@ -173,74 +172,104 @@ const MissionItem = ({ data, history, selected, onChange, onSelect, onFilter, on
 const MissionActionsMenu = ({ data, onFilter, onChange }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
+  const [show, setShow] = useState(false);
+  const [position, setPosition] = useState({ top: 0, right: 0 });
+  const ref = useRef(null);
+  const buttonRef = useRef(null);
+
+  useEffect(() => {
+    const handleClick = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        setShow(false);
+      }
+    };
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
+  }, []);
+
+  useEffect(() => {
+    if (!show) {
+      return;
+    }
+    const handleClose = () => setShow(false);
+    window.addEventListener("scroll", handleClose, true);
+    window.addEventListener("resize", handleClose);
+    return () => {
+      window.removeEventListener("scroll", handleClose, true);
+      window.removeEventListener("resize", handleClose);
+    };
+  }, [show]);
+
+  const handleToggle = () => {
+    if (!show && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setPosition({ top: rect.bottom + 8, right: window.innerWidth - rect.right });
+    }
+    setShow(!show);
+  };
+
+  const handleFocusOut = (e) => {
+    if (ref.current && !ref.current.contains(e.relatedTarget)) {
+      setShow(false);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === "Escape") {
+      setShow(false);
+      buttonRef.current?.focus();
+    }
+  };
 
   const handleMissionClick = () => {
     const newSearchParams = new URLSearchParams(searchParams);
     newSearchParams.set("mission", data.id);
     setSearchParams(newSearchParams);
+    setShow(false);
+  };
+
+  const handleOpenNote = () => {
+    setShow(false);
+    setIsModalOpen(true);
+  };
+
+  const handleFilterOrganization = () => {
+    setShow(false);
+    onFilter(data.missionPublisherOrganizationId);
   };
 
   return (
     <>
-      <Menu as="div" className="relative h-full text-left">
-        <Menu.Button className="secondary-btn shadow-border-black text-black" aria-label="Plus d'actions">
-          <span className="font-semibold">
-            <RiMoreFill aria-hidden="true" />
-          </span>
-        </Menu.Button>
-        <Transition
-          as={Fragment}
-          enter="transition ease-out duration-100"
-          enterFrom="transform opacity-0 scale-95"
-          enterTo="transform opacity-100 scale-100"
-          leave="transition ease-in duration-75"
-          leaveFrom="transform opacity-100 scale-100"
-          leaveTo="transform opacity-0 scale-95"
-        >
-          <Menu.Items as="div" className="border-grey-border absolute right-0 z-30 mt-2 w-64 origin-top-right border bg-white text-black focus:outline-none">
-            <Menu.Item>
-              <button onClick={handleMissionClick} className="text-blue-france flex w-full cursor-pointer items-center border-none p-3 text-left text-sm hover:bg-gray-950">
+      <div className="relative h-full text-left" ref={ref} onBlur={handleFocusOut} onKeyDown={handleKeyDown}>
+        <button ref={buttonRef} type="button" className="secondary-btn shadow-border-black text-black" aria-label="Plus d'actions" aria-expanded={show} onClick={handleToggle}>
+          <RiMoreFill aria-hidden="true" />
+        </button>
+        {/* fixed + position calculée : les conteneurs overflow-x-auto du tableau clippent tout panneau en absolute (et un panneau resté dans le DOM y crée du scroll) */}
+        <div className={`border-grey-border fixed z-30 w-64 border bg-white shadow-lg ${show ? "" : "hidden"}`} style={{ top: position.top, right: position.right }}>
+          <ul className="m-0 flex list-none flex-col p-0">
+            <li>
+              <button type="button" className="nav-link text-left" onClick={handleMissionClick}>
                 Aperçu de la mission
               </button>
-            </Menu.Item>
-            <Menu.Item>
-              <a
-                href={data.missionApplicationUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-france flex w-full cursor-pointer items-center border-none p-3 text-left text-sm hover:bg-gray-950"
-              >
+            </li>
+            <li>
+              <a href={data.missionApplicationUrl} target="_blank" rel="noopener noreferrer" className="nav-link" onClick={() => setShow(false)}>
                 Lien de la mission
               </a>
-            </Menu.Item>
-            <Menu.Item>
-              {data.note ? (
-                <button
-                  className="text-blue-france flex w-full cursor-pointer items-center border-none p-3 text-left text-sm hover:bg-gray-950"
-                  onClick={() => setIsModalOpen(true)}
-                >
-                  Modifier la note
-                </button>
-              ) : (
-                <button
-                  className="text-blue-france flex w-full cursor-pointer items-center border-none p-3 text-left text-sm hover:bg-gray-950"
-                  onClick={() => setIsModalOpen(true)}
-                >
-                  Ajouter une note interne
-                </button>
-              )}
-            </Menu.Item>
-            <Menu.Item>
-              <button
-                className="text-blue-france flex w-full cursor-pointer items-center border-none p-3 text-left text-sm hover:bg-gray-950"
-                onClick={() => onFilter(data.missionPublisherOrganizationId)}
-              >
+            </li>
+            <li>
+              <button type="button" className="nav-link text-left" onClick={handleOpenNote}>
+                {data.note ? "Modifier la note" : "Ajouter une note interne"}
+              </button>
+            </li>
+            <li>
+              <button type="button" className="nav-link text-left" onClick={handleFilterOrganization}>
                 Filtrer les missions de l'organisation
               </button>
-            </Menu.Item>
-          </Menu.Items>
-        </Transition>
-      </Menu>
+            </li>
+          </ul>
+        </div>
+      </div>
       <UpdateNoteModal open={isModalOpen} onClose={() => setIsModalOpen(false)} onChange={onChange} data={data} />
     </>
   );


### PR DESCRIPTION
## Description

Corrige le critère RGAA 10.7 (visibilité de la prise de focus) sur le menu d'actions des missions de la page de modération (`/broadcast/moderation`), suite au retour d'audit : les items du menu Headless UI ne montraient aucun focus visible (conteneur en `focus:outline-none`, focus « virtuel » `data-active` jamais stylé, seuls les états `hover` l'étaient).

**Changements** (`MissionActionsMenu` dans `MissionItem.jsx`) :

- Menu réécrit en natif sur le modèle du menu compte de l'en-tête (`AccountMenu` de `Header.jsx`), déjà validé par l'audit : bouton avec `aria-expanded` + liste d'items en classe `nav-link`, qui inclut l'utilitaire `focus` global (outline visible et contrasté ≥ 3:1)
- Clavier : Tab circule entre les items, Échap referme et rend le focus au bouton, clic extérieur et perte de focus referment ; le menu se ferme à l'activation d'un item
- Le panneau est positionné en `fixed` (calculé depuis le bouton à l'ouverture) pour s'afficher par-dessus le tableau : les conteneurs `overflow-x-auto` de la page et du composant `Table` clippent tout panneau en `absolute`. Il se referme au scroll/redimensionnement pour ne jamais flotter à une position périmée
- Suppression de la dépendance à l'ancienne API `Menu`/`Transition` de Headless UI dans ce fichier

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/10-7-39e72a322d5080f296b6dce3d2b9cd68?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Nuances visuelles assumées : items en texte noir (style `nav-link`, cohérent avec le menu compte) au lieu de bleu, padding un peu plus grand, plus d'animation d'ouverture.
- Les 4 actions sont inchangées : aperçu de la mission, lien externe, note interne, filtre par organisation.
- À vérifier à la review : ouverture du menu près du bas de page et comportement au scroll pendant qu'il est ouvert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)