### PR TITLE
fix(app): wrap tracking doc link to avoid overflow for rgaa 10.11

### DIFF
--- a/app/src/scenes/settings/TrackingAnnounce.jsx
+++ b/app/src/scenes/settings/TrackingAnnounce.jsx
@@ -27,7 +27,7 @@ const TrackingAnnounce = () => {
     <div className="space-y-12 p-4 sm:p-12">
       <title>API Engagement - Tracking des événements - Paramètres</title>
       <div className="border-grey-border space-y-8 border p-4 sm:p-8">
-        <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-wrap items-start justify-between gap-4">
           <h2 className="text-2xl font-bold">Tracking des événements</h2>
           <a
             href="https://doc.api-engagement.beta.gouv.fr/annoncer-des-missions/tracking-des-candidatures/rajout-de-la-balise-et-des-commandes-de-tracking-par-le-tag"


### PR DESCRIPTION
## Description

Corrige un reliquat du critère RGAA 10.11 (présentation sans défilement horizontal à 320 px de large) signalé par l'audit : sur la page Paramètres > Tracking des événements (mode annonceur), le lien « Ouvrir la documentation » sortait de son conteneur et créait un scroll horizontal.

**Changement** (`TrackingAnnounce.jsx`, 1 ligne) :

- Ajout de `flex-wrap` sur l'en-tête de la carte : le conteneur était en `flex justify-between` sans retour à la ligne possible, et le lien porte `shrink-0` (pour ne pas couper son texte) — à 320 px il débordait donc du cadre. Avec `flex-wrap`, le lien passe sous le titre sur petit écran ; sur desktop, rien ne change (titre à gauche, lien à droite).

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/10-11-39e72a322d508095ab95d4d0133d8b14?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Même famille de cause que les correctifs 10.11 de la campagne précédente (`flex-wrap` manquant sur le fieldset des champs de dates du `DateRangePicker`).
- La page miroir côté diffuseur (`TrackingBroadcast.jsx`) n'est pas concernée : son lien est dans une rangée « lien + bouton Copier » qui tient à 320 px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)