### PR TITLE
fix(app): visible labels on public stats filters for rgaa 11.1

### DIFF
--- a/app/src/scenes/public-stats/components/Distribution.jsx
+++ b/app/src/scenes/public-stats/components/Distribution.jsx
@@ -53,50 +53,56 @@ const Distribution = ({ filters, onFiltersChange }) => {
         </div>
 
         <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <label htmlFor="distribution-year" className="sr-only">
-              Année
-            </label>
-            <select
-              id="distribution-year"
-              className="input w-full sm:w-48"
-              value={filters.year}
-              onChange={(e) => onFiltersChange({ ...filters, year: parseInt(e.target.value, 10) })}
-            >
-              <option value={2020}>2020</option>
-              <option value={2021}>2021</option>
-              <option value={2022}>2022</option>
-              <option value={2023}>2023</option>
-              <option value={2024}>2024</option>
-              <option value={2025}>2025</option>
-              <option value={2026}>2026</option>
-            </select>
-            <label htmlFor="distribution-department" className="sr-only">
-              Département
-            </label>
-            <select
-              id="distribution-department"
-              className="input w-full sm:w-48"
-              value={departmentCode}
-              onChange={(e) => onFiltersChange({ ...filters, department: e.target.value })}
-            >
-              <option value="">Départements</option>
-              {Object.entries(DEPARTMENT_NAMES)
-                .sort((a, b) => a[0].localeCompare(b[0], "fr", { numeric: true }))
-                .map(([code, value]) => (
-                  <option key={value[0]} value={code}>
-                    {code} - {value[0]}
-                  </option>
-                ))}
-            </select>
-            <label htmlFor="distribution-mission-type" className="sr-only">
-              Type de mission
-            </label>
-            <select id="distribution-mission-type" className="input w-48" value={filters.type} onChange={(e) => onFiltersChange({ ...filters, type: e.target.value })}>
-              <option value="">Type de mission</option>
-              <option value="benevolat">Bénévolat</option>
-              <option value="volontariat">Volontariat</option>
-            </select>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <div className="flex flex-col gap-1">
+              <label htmlFor="distribution-year" className="text-sm">
+                Année
+              </label>
+              <select
+                id="distribution-year"
+                className="input w-full sm:w-48"
+                value={filters.year}
+                onChange={(e) => onFiltersChange({ ...filters, year: parseInt(e.target.value, 10) })}
+              >
+                <option value={2020}>2020</option>
+                <option value={2021}>2021</option>
+                <option value={2022}>2022</option>
+                <option value={2023}>2023</option>
+                <option value={2024}>2024</option>
+                <option value={2025}>2025</option>
+                <option value={2026}>2026</option>
+              </select>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label htmlFor="distribution-department" className="text-sm">
+                Département
+              </label>
+              <select
+                id="distribution-department"
+                className="input w-full sm:w-48"
+                value={departmentCode}
+                onChange={(e) => onFiltersChange({ ...filters, department: e.target.value })}
+              >
+                <option value="">Tous les départements</option>
+                {Object.entries(DEPARTMENT_NAMES)
+                  .sort((a, b) => a[0].localeCompare(b[0], "fr", { numeric: true }))
+                  .map(([code, value]) => (
+                    <option key={value[0]} value={code}>
+                      {code} - {value[0]}
+                    </option>
+                  ))}
+              </select>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label htmlFor="distribution-mission-type" className="text-sm">
+                Type de mission
+              </label>
+              <select id="distribution-mission-type" className="input w-48" value={filters.type} onChange={(e) => onFiltersChange({ ...filters, type: e.target.value })}>
+                <option value="">Tous les types</option>
+                <option value="benevolat">Bénévolat</option>
+                <option value="volontariat">Volontariat</option>
+              </select>
+            </div>
           </div>
         </div>
       </div>

--- a/app/src/scenes/public-stats/components/SomeNumbers.jsx
+++ b/app/src/scenes/public-stats/components/SomeNumbers.jsx
@@ -110,45 +110,51 @@ const SomeNumbers = ({ filters, onFiltersChange }) => {
         </div>
 
         <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <label htmlFor="numbers-year" className="sr-only">
-              Année
-            </label>
-            <select id="numbers-year" className="input w-full sm:w-48" value={filters.year} onChange={(e) => onFiltersChange({ ...filters, year: parseInt(e.target.value, 10) })}>
-              <option value={2020}>2020</option>
-              <option value={2021}>2021</option>
-              <option value={2022}>2022</option>
-              <option value={2023}>2023</option>
-              <option value={2024}>2024</option>
-              <option value={2025}>2025</option>
-              <option value={2026}>2026</option>
-            </select>
-            <label htmlFor="numbers-department" className="sr-only">
-              Département
-            </label>
-            <select
-              id="numbers-department"
-              className="input w-full sm:w-48"
-              value={filters.department}
-              onChange={(e) => onFiltersChange({ ...filters, department: e.target.value })}
-            >
-              <option value="">Départements</option>
-              {Object.entries(DEPARTMENT_NAMES)
-                .sort((a, b) => a[0].localeCompare(b[0], "fr", { numeric: true }))
-                .map(([code, value]) => (
-                  <option key={value[0]} value={code}>
-                    {code} - {value[0]}
-                  </option>
-                ))}
-            </select>
-            <label htmlFor="numbers-mission-type" className="sr-only">
-              Type de mission
-            </label>
-            <select id="numbers-mission-type" className="input w-full sm:w-48" value={filters.type} onChange={(e) => onFiltersChange({ ...filters, type: e.target.value })}>
-              <option value="">Type de mission</option>
-              <option value="benevolat">Bénévolat</option>
-              <option value="volontariat">Volontariat</option>
-            </select>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <div className="flex flex-col gap-1">
+              <label htmlFor="numbers-year" className="text-sm">
+                Année
+              </label>
+              <select id="numbers-year" className="input w-full sm:w-48" value={filters.year} onChange={(e) => onFiltersChange({ ...filters, year: parseInt(e.target.value, 10) })}>
+                <option value={2020}>2020</option>
+                <option value={2021}>2021</option>
+                <option value={2022}>2022</option>
+                <option value={2023}>2023</option>
+                <option value={2024}>2024</option>
+                <option value={2025}>2025</option>
+                <option value={2026}>2026</option>
+              </select>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label htmlFor="numbers-department" className="text-sm">
+                Département
+              </label>
+              <select
+                id="numbers-department"
+                className="input w-full sm:w-48"
+                value={filters.department}
+                onChange={(e) => onFiltersChange({ ...filters, department: e.target.value })}
+              >
+                <option value="">Tous les départements</option>
+                {Object.entries(DEPARTMENT_NAMES)
+                  .sort((a, b) => a[0].localeCompare(b[0], "fr", { numeric: true }))
+                  .map(([code, value]) => (
+                    <option key={value[0]} value={code}>
+                      {code} - {value[0]}
+                    </option>
+                  ))}
+              </select>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label htmlFor="numbers-mission-type" className="text-sm">
+                Type de mission
+              </label>
+              <select id="numbers-mission-type" className="input w-full sm:w-48" value={filters.type} onChange={(e) => onFiltersChange({ ...filters, type: e.target.value })}>
+                <option value="">Tous les types</option>
+                <option value="benevolat">Bénévolat</option>
+                <option value="volontariat">Volontariat</option>
+              </select>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

Corrige le critère RGAA 11.1 (présence d'étiquettes pour les champs de formulaire) sur la page `/public-stats`, suite au retour d'audit : les étiquettes des listes déroulantes de filtres étaient masquées en `sr-only`, et l'auditrice recommande des étiquettes toujours visibles, conformément à la [liste déroulante du DSFR](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/liste-deroulante/demonstration-de-la-liste-deroulante).

**Changements** :

- Les 6 selects de filtres (Année, Département, Type de mission — dans les sections « En quelques chiffres » (`SomeNumbers.jsx`) et « Répartition des missions » (`Distribution.jsx`)) ont désormais leur étiquette **visible au-dessus du champ** : chaque paire label + select est dans une colonne, label en `text-sm` comme les autres formulaires de l'app, rangée alignée en `sm:items-end`
- Options vides renommées pour ne pas répéter le libellé du label devenu visible : « Départements » → « Tous les départements », « Type de mission » → « Tous les types »

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/11-1-39e72a322d508091bb5de68b65299359?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Changement visuel assumé : les labels apparaissent au-dessus des filtres, à droite des titres de section — à vérifier à l'œil à la review (desktop et mobile).
- Le select Année n'a pas d'option vide (une année est toujours sélectionnée), rien à renommer pour lui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)