### PR TITLE
fix(app): remove redundant radiogroup role for rgaa 11.5

### DIFF
--- a/app/src/components/DateRangePicker.jsx
+++ b/app/src/components/DateRangePicker.jsx
@@ -62,7 +62,7 @@ const DateRangePicker = ({ value, onChange }) => {
     <div className="flex flex-wrap gap-4 sm:items-center">
       <fieldset className="m-0 border-0 p-0">
         <legend className="sr-only">Période</legend>
-        <div className="border-grey-border flex flex-col items-stretch gap-2 rounded-sm border sm:w-fit sm:flex-row sm:items-center sm:gap-x-2" role="radiogroup">
+        <div className="border-grey-border flex flex-col items-stretch gap-2 rounded-sm border sm:w-fit sm:flex-row sm:items-center sm:gap-x-2">
           {RANGES.map((range, i) => {
             const isSelected = selectedIndex === i;
             return (


### PR DESCRIPTION
## Description

Corrige le critère RGAA 11.5 (regroupement des champs de même nature) sur le sélecteur de période de `/performance`, suite au retour d'audit : le conteneur des boutons radio (raccourcis « 7 jours / 30 jours / 6 mois / 12 mois / Total ») cumulait un `role="radiogroup"` avec le `<fieldset>` englobant — double emploi, les deux ayant la même fonction de regroupement.

**Changement** (`DateRangePicker.jsx`, 1 ligne) :

- Suppression du `role="radiogroup"` sur le conteneur ; le regroupement reste assuré par le `<fieldset>` et sa `<legend>` « Période ». Les `role="radio"`, `aria-checked`, la navigation aux flèches et le tabindex tournant sont inchangés.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/11-5-39e72a322d50808a90c3e4b215a2f52f?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Le composant étant partagé, le correctif couvre `/performance` (modes diffuseur et annonceur), l'onglet « Moyens de diffusion » et les pages admin-stats.
- Balayage du même défaut sur le reste de l'app : c'était l'unique `role="radiogroup"` ; le `role="group"` de `SettingsModal.jsx` n'a pas de fieldset autour (pas de double emploi), et les autres fieldsets (`RealTime.jsx`, `widget/Settings.jsx`) contiennent des `<input type="radio">` natifs sans rôle ARIA ajouté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)