### PR TITLE
fix(app): visible linked form error messages for rgaa 11.10

### DIFF
--- a/app/src/scenes/account/index.jsx
+++ b/app/src/scenes/account/index.jsx
@@ -56,7 +56,7 @@ const Account = () => {
       <title>API Engagement - Mon compte</title>
       <h1 className="text-4xl font-bold">Mon compte</h1>
 
-      <form onSubmit={handleSubmit} className="bg-white p-4 shadow-lg sm:p-12">
+      <form onSubmit={handleSubmit} noValidate className="bg-white p-4 shadow-lg sm:p-12">
         <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
           <h2 className="text-3xl font-bold">Vos informations</h2>
           <button

--- a/app/src/scenes/auth/ForgotPassword.jsx
+++ b/app/src/scenes/auth/ForgotPassword.jsx
@@ -15,7 +15,7 @@ const Forgot = () => {
     e.preventDefault();
     const errors = {};
     if (!isValidEmail(values.email)) {
-      errors.email = true;
+      errors.email = "Le format de l'adresse e-mail n'est pas valide. Exemple de format valide : jane.doe@gmail.com.";
     }
     setErrors(errors);
     if (Object.keys(errors).length > 0) return;
@@ -45,15 +45,17 @@ const Forgot = () => {
         id="email"
         value={values.email}
         onChange={(e) => setValues({ ...values, email: e.target.value })}
+        aria-invalid={errors.email ? true : undefined}
+        aria-describedby={errors.email ? "email-error" : undefined}
       />
       {errors.email && (
-        <div className="text-error flex items-center text-sm">
+        <p id="email-error" className="text-error flex items-center text-sm" aria-live="polite">
           <RiErrorWarningFill className="mr-2" aria-hidden="true" />
-          Adresse email invalide
-        </div>
+          {errors.email}
+        </p>
       )}
 
-      <button type="submit" className="primary-btn mt-6 w-full" disabled={errors.email || loading || done}>
+      <button type="submit" className="primary-btn mt-6 w-full" disabled={loading || done}>
         {loading ? "Chargement..." : "Réinitialisez votre mot de passe"}
       </button>
 

--- a/app/src/scenes/auth/ResetPassword.jsx
+++ b/app/src/scenes/auth/ResetPassword.jsx
@@ -141,12 +141,14 @@ const ResetPasswordForm = ({ user, token }) => {
             setErrors({ ...errors, password: null });
           }}
           autoComplete="new-password"
+          aria-invalid={errors.password ? true : undefined}
+          aria-describedby={errors.password ? "password-error" : undefined}
         />
         {errors.password && (
-          <div className="text-error flex items-center text-sm">
+          <p id="password-error" className="text-error flex items-center text-sm" aria-live="polite">
             <RiErrorWarningFill className="mr-2" aria-hidden="true" />
             {errors.password}
-          </div>
+          </p>
         )}
       </div>
       <div className="mt-2 flex flex-col gap-2">
@@ -196,22 +198,24 @@ const ResetPasswordForm = ({ user, token }) => {
             setValues({ ...values, confirmPassword: e.target.value });
             setErrors({ ...errors, confirmPassword: null });
           }}
+          aria-invalid={errors.confirmPassword ? true : undefined}
+          aria-describedby={errors.confirmPassword ? "confirm-password-error" : undefined}
         />
         {errors.confirmPassword && (
-          <div className="text-error flex items-center text-sm">
+          <p id="confirm-password-error" className="text-error flex items-center text-sm" aria-live="polite">
             <RiErrorWarningFill className="mr-2" aria-hidden="true" />
             {errors.confirmPassword}
-          </div>
+          </p>
         )}
       </div>
 
       {errors.expired && (
-        <div className="text-error flex items-center text-sm">
+        <p className="text-error flex items-center text-sm" aria-live="polite">
           <RiErrorWarningFill className="mr-2" aria-hidden="true" />
           <Link to="/forgot-password" className="underline">
             Réinitialisation expirée
           </Link>
-        </div>
+        </p>
       )}
 
       {!success ? (

--- a/app/src/scenes/auth/Signup.jsx
+++ b/app/src/scenes/auth/Signup.jsx
@@ -141,12 +141,14 @@ const SignupForm = ({ user, token }) => {
           name="firstname"
           value={values.firstname}
           onChange={handleChange}
+          aria-invalid={submitted && errors.firstname ? true : undefined}
+          aria-describedby={submitted && errors.firstname ? "firstname-error" : undefined}
         />
         {submitted && errors.firstname && (
-          <div className="text-error flex items-center text-sm">
+          <p id="firstname-error" className="text-error flex items-center text-sm" aria-live="polite">
             <RiErrorWarningFill className="mr-2" aria-hidden="true" />
             {errors.firstname}
-          </div>
+          </p>
         )}
       </div>
       <div className="flex flex-col">
@@ -159,12 +161,14 @@ const SignupForm = ({ user, token }) => {
           name="lastname"
           value={values.lastname}
           onChange={handleChange}
+          aria-invalid={submitted && errors.lastname ? true : undefined}
+          aria-describedby={submitted && errors.lastname ? "lastname-error" : undefined}
         />
         {submitted && errors.lastname && (
-          <div className="text-error flex items-center text-sm">
+          <p id="lastname-error" className="text-error flex items-center text-sm" aria-live="polite">
             <RiErrorWarningFill className="mr-2" aria-hidden="true" />
             {errors.lastname}
-          </div>
+          </p>
         )}
       </div>
       <div className="flex flex-col">
@@ -184,12 +188,14 @@ const SignupForm = ({ user, token }) => {
           type={show ? "text" : "password"}
           value={values.password}
           onChange={handleChange}
+          aria-invalid={submitted && errors.password ? true : undefined}
+          aria-describedby={submitted && errors.password ? "password-error" : undefined}
         />
         {submitted && errors.password && (
-          <div className="text-error flex items-center text-sm">
+          <p id="password-error" className="text-error flex items-center text-sm" aria-live="polite">
             <RiErrorWarningFill className="mr-2" aria-hidden="true" />
             {errors.password}
-          </div>
+          </p>
         )}
       </div>
       <div className="mt-1 flex flex-col gap-2">
@@ -236,12 +242,14 @@ const SignupForm = ({ user, token }) => {
           type={showConfirm ? "text" : "password"}
           value={values.confirmPassword}
           onChange={handleChange}
+          aria-invalid={submitted && errors.confirmPassword ? true : undefined}
+          aria-describedby={submitted && errors.confirmPassword ? "confirm-password-error" : undefined}
         />
         {submitted && errors.confirmPassword && (
-          <div className="text-error flex items-center text-sm">
+          <p id="confirm-password-error" className="text-error flex items-center text-sm" aria-live="polite">
             <RiErrorWarningFill className="mr-2" aria-hidden="true" />
             {errors.confirmPassword}
-          </div>
+          </p>
         )}
       </div>
       <button type="submit" className="primary-btn mt-6 w-full" disabled={loading}>

--- a/app/src/scenes/broadcast/moderation/components/MissionItem.jsx
+++ b/app/src/scenes/broadcast/moderation/components/MissionItem.jsx
@@ -2,7 +2,7 @@ import { toast } from "@/services/toast";
 import { Menu, Transition } from "@headlessui/react";
 import { Fragment, useEffect, useId, useState } from "react";
 import { BsDot } from "react-icons/bs";
-import { RiCalendarEventFill, RiCheckboxCircleFill, RiCloseCircleFill, RiMapPin2Fill, RiMoreFill, RiPencilFill, RiTimeLine } from "react-icons/ri";
+import { RiCalendarEventFill, RiCheckboxCircleFill, RiCloseCircleFill, RiErrorWarningFill, RiMapPin2Fill, RiMoreFill, RiPencilFill, RiTimeLine } from "react-icons/ri";
 import { useSearchParams } from "react-router-dom";
 
 import Modal from "@/components/Modal";
@@ -250,13 +250,19 @@ const UpdateNoteModal = ({ open, onChange, onClose, data }) => {
   const { publisher } = useStore();
   const noteId = useId();
   const [note, setNote] = useState(data.note || "");
+  const [error, setError] = useState("");
 
   useEffect(() => {
     setNote(data.note || "");
+    setError("");
   }, [data]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (note.trim() === "") {
+      setError("Le champ Note est obligatoire.");
+      return;
+    }
     try {
       const res = await api.put(`/moderation/${data.id}`, { note, moderatorId: publisher.id });
       if (!res.ok) {
@@ -272,16 +278,36 @@ const UpdateNoteModal = ({ open, onChange, onClose, data }) => {
 
   return (
     <Modal open={open} onClose={onClose} title="Modifier la note" className="w-[90vw] max-w-3xl">
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit} noValidate>
         <div className="flex items-center justify-center">
           <div className="flex w-full flex-col justify-center gap-4">
             <div className="flex flex-col gap-1">
               <label htmlFor={noteId} className="text-sm">
-                Note
+                Note<span className="text-error ml-1">*</span>
               </label>
-              <textarea id={noteId} className="input" rows={4} name="note" value={note} onChange={(e) => setNote(e.target.value)} required />
+              <textarea
+                id={noteId}
+                className="input"
+                rows={4}
+                name="note"
+                value={note}
+                onChange={(e) => {
+                  setNote(e.target.value);
+                  setError("");
+                }}
+                required
+                aria-required="true"
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? `${noteId}-error` : undefined}
+              />
+              {error && (
+                <p id={`${noteId}-error`} className="text-error flex items-center text-sm" aria-live="polite">
+                  <RiErrorWarningFill className="mr-2" aria-hidden="true" />
+                  {error}
+                </p>
+              )}
               <div className="mt-6 flex justify-end">
-                <button className="primary-btn w-full" type="submit">
+                <button className="primary-btn w-full" type="submit" disabled={!note.trim() || error}>
                   Enregistrer
                 </button>
               </div>


### PR DESCRIPTION
## Description

Corrige le critère RGAA 11.10 (contrôle de saisie pertinent) sur les formulaires du back-office, suite au retour d'audit : les messages d'erreur doivent être visibles, dans une balise `<p>` liée au champ par `aria-describedby`, et contenir l'intitulé du champ — au lieu de la bulle de validation native du navigateur.

**Changements** (pattern aligné sur `Login.jsx`, déjà conforme) :

- `account/index.jsx` (Mon compte) : ajout de `noValidate` — c'était la « régression » constatée : les messages custom conformes existaient déjà mais la bulle native du navigateur interceptait la soumission avant leur affichage
- `auth/ForgotPassword.jsx` : message converti en `<p id>` lié (`aria-describedby` + `aria-invalid`), wording aligné sur Login (« Le format de l'adresse e-mail n'est pas valide… ») ; correction au passage d'un bug bloquant : le bouton restait désactivé définitivement après une première erreur (les erreurs ne sont recalculées qu'à la soumission)
- `auth/ResetPassword.jsx` : erreurs mot de passe / confirmation converties en `<p id>` liés + `aria-invalid` ; erreur globale « Réinitialisation expirée » en `<p>`
- `auth/Signup.jsx` : les 4 blocs d'erreur (prénom, nom, mot de passe, confirmation) convertis en `<p id>` liés + `aria-invalid`
- `MissionItem.jsx` (modale « Modifier la note », /broadcast/moderation) : seul formulaire reposant uniquement sur la bulle native — `noValidate` + validation custom (« Le champ Note est obligatoire. ») en `<p>` lié, astérisque sur le label et bouton désactivé tant que la note est vide (même pattern que la modale de modération en masse)

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/11-10-39e72a322d5080d59543d4417d142545?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Déjà conformes, non touchés : `Login.jsx` (le modèle : `noValidate` + `<p id>` liés), `MissionTab.jsx`, `user/Create·Edit` (via `LabelledInput`), et la modale de modération en masse (`Header.jsx`) dont le bouton est désactivé tant que le formulaire est invalide.
- `MissionItem.jsx` est aussi modifié par la PR #1279 (critère 10.7) mais sur des zones disjointes (menu d'actions vs modale note) — pas de conflit attendu entre les deux PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)