### PR TITLE
fix(app): add tab scroll buttons for rgaa 13.10

### DIFF
--- a/app/src/components/Tabs.jsx
+++ b/app/src/components/Tabs.jsx
@@ -1,4 +1,5 @@
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { RiArrowLeftSLine, RiArrowRightSLine } from "react-icons/ri";
 import { Link, useNavigate } from "react-router-dom";
 
 const TAB_VARIANTS = {
@@ -46,12 +47,28 @@ export const Tab = ({ tab, panelId, isFocusable, onKeyDown, setRef, variant = "p
 const Tabs = ({ tabs, ariaLabel, panelId, className = "", variant = "primary", tabClassName = "" }) => {
   const navigate = useNavigate();
   const tabRefs = useRef([]);
+  const listRef = useRef(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
   const activeTabIndex = tabs.findIndex((tab) => tab.isActive);
   const focusableTabIndex = activeTabIndex === -1 ? 0 : activeTabIndex;
+
+  useEffect(() => {
+    const checkOverflow = () => {
+      const list = listRef.current;
+      setIsOverflowing(list ? list.scrollWidth > list.clientWidth + 1 : false);
+    };
+    checkOverflow();
+    window.addEventListener("resize", checkOverflow);
+    return () => window.removeEventListener("resize", checkOverflow);
+  }, [tabs]);
 
   if (!tabs?.length) {
     return null;
   }
+
+  const handleScroll = (direction) => {
+    listRef.current?.scrollBy({ left: direction * 150, behavior: "smooth" });
+  };
 
   const focusTab = (index) => {
     const tab = tabRefs.current[index];
@@ -104,21 +121,34 @@ const Tabs = ({ tabs, ariaLabel, panelId, className = "", variant = "primary", t
   };
 
   return (
-    <div role="tablist" aria-label={ariaLabel} className={`flex flex-nowrap overflow-x-auto overflow-y-hidden ${className}`}>
-      {tabs.map((tab, index) => (
-        <Tab
-          key={tab.key}
-          tab={tab}
-          panelId={panelId}
-          isFocusable={index === focusableTabIndex}
-          setRef={(node) => {
-            tabRefs.current[index] = node;
-          }}
-          onKeyDown={(event) => handleTabKeyDown(event, index, tab)}
-          variant={variant}
-          className={tabClassName}
-        />
-      ))}
+    <div className="flex items-center">
+      {/* RGAA 13.10 : alternative au swipe quand les onglets débordent */}
+      {isOverflowing && (
+        <button type="button" className="focus shrink-0 p-1 hover:bg-gray-100" aria-label="Faire défiler les onglets vers la gauche" onClick={() => handleScroll(-1)}>
+          <RiArrowLeftSLine className="text-xl" aria-hidden="true" />
+        </button>
+      )}
+      <div role="tablist" aria-label={ariaLabel} ref={listRef} className={`flex flex-nowrap overflow-x-auto overflow-y-hidden ${className}`}>
+        {tabs.map((tab, index) => (
+          <Tab
+            key={tab.key}
+            tab={tab}
+            panelId={panelId}
+            isFocusable={index === focusableTabIndex}
+            setRef={(node) => {
+              tabRefs.current[index] = node;
+            }}
+            onKeyDown={(event) => handleTabKeyDown(event, index, tab)}
+            variant={variant}
+            className={tabClassName}
+          />
+        ))}
+      </div>
+      {isOverflowing && (
+        <button type="button" className="focus shrink-0 p-1 hover:bg-gray-100" aria-label="Faire défiler les onglets vers la droite" onClick={() => handleScroll(1)}>
+          <RiArrowRightSLine className="text-xl" aria-hidden="true" />
+        </button>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Description

Corrige le critère RGAA 13.10 (alternative en geste simple aux gestes complexes) suite au retour d'audit : en version mobile, les onglets (Flux API / Widgets / Campagnes / Modération sur `/broadcast`) nécessitent de swiper horizontalement pour atteindre les onglets masqués.

**Changement** (`components/Tabs.jsx`, composant partagé) :

- Quand la barre d'onglets déborde de son conteneur, deux boutons chevrons apparaissent de part et d'autre et font défiler la liste (150 px par clic, défilement fluide) — l'alternative en geste simple demandée par l'audit
- Quand tout tient à l'écran (desktop), les boutons ne sont pas rendus : aucun changement visuel ; la détection se recalcule au redimensionnement et quand les onglets changent
- Les boutons sont hors du `role="tablist"` (qui ne doit contenir que des tabs), avec `aria-label` explicites et focus visible (utilitaire `focus`)
- La navigation clavier existante (flèches gauche/droite entre onglets) est inchangée

Le composant étant partagé, le correctif couvre aussi les barres d'onglets de `/performance`, `/my-missions` et des panneaux internes (Évolution, etc.).

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/13-10-39e72a322d5080d4b454e520dd6226d5?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Simplicité assumée : les boutons ne se grisent pas en butée de défilement (`scrollBy` y est simplement sans effet).
- À vérifier à la review en largeur mobile (~320 px) sur `/broadcast` : les chevrons apparaissent et permettent d'atteindre « Modération » sans swipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)