### PR TITLE
fix(plateform): RGAA 12.7 (skiplinks)

### DIFF
--- a/plateform/app/components/layout/footer.tsx
+++ b/plateform/app/components/layout/footer.tsx
@@ -1,6 +1,6 @@
 import { useLocation } from "react-router";
 import { useIsMobile } from "~/hooks/useIsMobile";
-import { isFooterVisible } from "~/utils/layout";
+import { isGlobalFooterVisible } from "~/utils/layout";
 
 export function FooterContent() {
   return (
@@ -81,7 +81,7 @@ export default function Footer() {
   const location = useLocation();
   const isMobile = useIsMobile();
 
-  if (!isFooterVisible(location.pathname, isMobile)) {
+  if (!isGlobalFooterVisible(location.pathname, isMobile)) {
     return null;
   }
 

--- a/plateform/app/components/layout/footer.tsx
+++ b/plateform/app/components/layout/footer.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router";
 import { useIsMobile } from "~/hooks/useIsMobile";
+import { isFooterVisible } from "~/utils/layout";
 
 export function FooterContent() {
   return (
@@ -79,10 +80,8 @@ export function FooterContent() {
 export default function Footer() {
   const location = useLocation();
   const isMobile = useIsMobile();
-  const isQuiz = location.pathname.startsWith("/quiz");
-  const isMobileResults = isMobile && location.pathname.startsWith("/results");
 
-  if (isQuiz || isMobileResults) {
+  if (!isFooterVisible(location.pathname, isMobile)) {
     return null;
   }
 

--- a/plateform/app/components/layout/footer.tsx
+++ b/plateform/app/components/layout/footer.tsx
@@ -3,7 +3,7 @@ import { useIsMobile } from "~/hooks/useIsMobile";
 
 export function FooterContent() {
   return (
-    <footer className="fr-footer" role="contentinfo" id="footer">
+    <footer className="fr-footer" role="contentinfo" id="footer" tabIndex={-1}>
       <div className="fr-container">
         <div className="fr-footer__body">
           <div className="fr-footer__brand fr-enlarge-link">

--- a/plateform/app/components/layout/skip-links.tsx
+++ b/plateform/app/components/layout/skip-links.tsx
@@ -1,15 +1,13 @@
 import { useLocation } from "react-router";
-import { useIsMobile } from "~/hooks/useIsMobile";
-import { isFooterVisible } from "~/utils/layout";
+import { hasFooterTarget } from "~/utils/layout";
 
 // Liens d'évitement DSFR (RGAA 12.7). Doit rester le premier élément focusable du <body>.
 // Pas de lien « Menu » : le site n'a pas de menu de navigation à cibler.
-// Le lien « Pied de page » n'est rendu que si le footer est présent sur la route courante
-// (masqué sur le quiz et sur /results en mobile), pour ne pas annoncer une cible inexistante.
+// Le lien « Pied de page » n'est rendu que si la route comporte une cible #footer
+// (cf. hasFooterTarget), pour ne pas annoncer une cible inexistante (masquée sur le quiz).
 export default function SkipLinks() {
   const location = useLocation();
-  const isMobile = useIsMobile();
-  const footerVisible = isFooterVisible(location.pathname, isMobile);
+  const footerTarget = hasFooterTarget(location.pathname);
 
   return (
     <div className="fr-skiplinks">
@@ -20,7 +18,7 @@ export default function SkipLinks() {
               Contenu
             </a>
           </li>
-          {footerVisible && (
+          {footerTarget && (
             <li>
               <a className="fr-link" href="#footer">
                 Pied de page

--- a/plateform/app/components/layout/skip-links.tsx
+++ b/plateform/app/components/layout/skip-links.tsx
@@ -1,0 +1,22 @@
+// Liens d'évitement DSFR (RGAA 12.7). Doit rester le premier élément focusable du <body>.
+// Pas de lien « Menu » : le site n'a pas de menu de navigation à cibler.
+export default function SkipLinks() {
+  return (
+    <div className="fr-skiplinks">
+      <nav className="fr-container" role="navigation" aria-label="Accès rapide">
+        <ul className="fr-skiplinks__list">
+          <li>
+            <a className="fr-link" href="#contenu">
+              Contenu
+            </a>
+          </li>
+          <li>
+            <a className="fr-link" href="#footer">
+              Pied de page
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  );
+}

--- a/plateform/app/components/layout/skip-links.tsx
+++ b/plateform/app/components/layout/skip-links.tsx
@@ -1,6 +1,16 @@
+import { useLocation } from "react-router";
+import { useIsMobile } from "~/hooks/useIsMobile";
+import { isFooterVisible } from "~/utils/layout";
+
 // Liens d'évitement DSFR (RGAA 12.7). Doit rester le premier élément focusable du <body>.
 // Pas de lien « Menu » : le site n'a pas de menu de navigation à cibler.
+// Le lien « Pied de page » n'est rendu que si le footer est présent sur la route courante
+// (masqué sur le quiz et sur /results en mobile), pour ne pas annoncer une cible inexistante.
 export default function SkipLinks() {
+  const location = useLocation();
+  const isMobile = useIsMobile();
+  const footerVisible = isFooterVisible(location.pathname, isMobile);
+
   return (
     <div className="fr-skiplinks">
       <nav className="fr-container" role="navigation" aria-label="Accès rapide">
@@ -10,11 +20,13 @@ export default function SkipLinks() {
               Contenu
             </a>
           </li>
-          <li>
-            <a className="fr-link" href="#footer">
-              Pied de page
-            </a>
-          </li>
+          {footerVisible && (
+            <li>
+              <a className="fr-link" href="#footer">
+                Pied de page
+              </a>
+            </li>
+          )}
         </ul>
       </nav>
     </div>

--- a/plateform/app/root.tsx
+++ b/plateform/app/root.tsx
@@ -5,14 +5,15 @@ import faviconSvg from "@gouvfr/dsfr/dist/favicon/favicon.svg?url";
 import webmanifest from "@gouvfr/dsfr/dist/favicon/manifest.webmanifest?url";
 import "@gouvfr/dsfr/dist/utility/utility.min.css";
 import { type ReactNode, useEffect } from "react";
-import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
-import Footer from "~/components/layout/footer";
+import { Link, Links, Meta, Outlet, Scripts, ScrollRestoration, isRouteErrorResponse } from "react-router";
+import Footer, { FooterContent } from "~/components/layout/footer";
 import Header from "~/components/layout/header";
 import InternalUserFlagIndicator from "~/components/layout/internal-user-flag-indicator";
 import SkipLinks from "~/components/layout/skip-links";
 import { PUBLISHER_ID } from "~/services/config";
 import { initTracking } from "~/services/tracking";
 import { serializeForInlineScript } from "~/utils/string";
+import type { Route } from "./+types/root";
 import "./main.css";
 
 // Tag de tracking API Engagement (jstag.js) — doit être chargé en tête du <head>, avant tout autre script.
@@ -56,6 +57,29 @@ export default function Root() {
       <Outlet />
       <Footer />
       <InternalUserFlagIndicator />
+    </>
+  );
+}
+
+// Rendu à la place de l'Outlet quand une route échoue (avant rendu) ou pour une URL inconnue
+// (404). On fournit ici les cibles des liens d'évitement (`#contenu`, `#footer`), absentes de
+// l'UI d'erreur par défaut de React Router, pour que le SkipLinks du layout reste fonctionnel.
+export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
+  const isNotFound = isRouteErrorResponse(error) && error.status === 404;
+  const title = isNotFound ? "Page introuvable" : "Une erreur est survenue";
+  const description = isNotFound ? "La page que tu cherches n'existe pas ou a été déplacée." : "Une erreur inattendue s'est produite. Réessaie plus tard.";
+
+  return (
+    <>
+      <Header />
+      <main id="contenu" tabIndex={-1} className="fr-container flex-1 py-16">
+        <h1>{title}</h1>
+        <p className="fr-text--lead">{description}</p>
+        <Link to="/" className="fr-btn">
+          Retour à l'accueil
+        </Link>
+      </main>
+      <FooterContent />
     </>
   );
 }

--- a/plateform/app/root.tsx
+++ b/plateform/app/root.tsx
@@ -9,6 +9,7 @@ import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
 import Footer from "~/components/layout/footer";
 import Header from "~/components/layout/header";
 import InternalUserFlagIndicator from "~/components/layout/internal-user-flag-indicator";
+import SkipLinks from "~/components/layout/skip-links";
 import { PUBLISHER_ID } from "~/services/config";
 import { initTracking } from "~/services/tracking";
 import { serializeForInlineScript } from "~/utils/string";
@@ -34,6 +35,7 @@ export function Layout({ children }: { children: ReactNode }) {
         <Links />
       </head>
       <body className="flex flex-col min-h-screen">
+        <SkipLinks />
         {children}
         <ScrollRestoration />
         <Scripts />

--- a/plateform/app/routes/_index.tsx
+++ b/plateform/app/routes/_index.tsx
@@ -63,7 +63,7 @@ export default function Landing() {
   };
 
   return (
-    <main>
+    <main id="contenu" tabIndex={-1}>
       <GradientBg className="bg-size-[100%_640px]">
         <div className="relative lg:min-h-[640px] lg:overflow-hidden">
           <Hero onStartQuiz={handleStartQuiz} />

--- a/plateform/app/routes/accessibilite.tsx
+++ b/plateform/app/routes/accessibilite.tsx
@@ -6,7 +6,7 @@ export function meta(): Route.MetaDescriptors {
 
 export default function Accessibilite() {
   return (
-    <main>
+    <main id="contenu" tabIndex={-1}>
       <div className="fr-container py-8 md:py-16">
         <h1>Accessibilité</h1>
       </div>

--- a/plateform/app/routes/mentions-legales.tsx
+++ b/plateform/app/routes/mentions-legales.tsx
@@ -6,7 +6,7 @@ export function meta(): Route.MetaDescriptors {
 
 export default function MentionsLegales() {
   return (
-    <main>
+    <main id="contenu" tabIndex={-1}>
       <div className="fr-container max-w-3xl py-8 md:py-16">
         <h1>Mentions légales</h1>
 

--- a/plateform/app/routes/mission-detail.tsx
+++ b/plateform/app/routes/mission-detail.tsx
@@ -66,7 +66,7 @@ export default function MissionDetailPage() {
   if (loading) {
     return (
       <GradientBg>
-        <main className="mx-auto max-w-[1200px] px-5 py-10 md:px-6">
+        <main id="contenu" tabIndex={-1} className="mx-auto max-w-[1200px] px-5 py-10 md:px-6">
           <Link to={backPath} className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-line fr-btn--icon-left mb-8">
             {backLabel}
           </Link>
@@ -79,7 +79,7 @@ export default function MissionDetailPage() {
   if (error || !mission) {
     return (
       <GradientBg>
-        <main className="mx-auto max-w-[1200px] px-5 py-10 md:px-6">
+        <main id="contenu" tabIndex={-1} className="mx-auto max-w-[1200px] px-5 py-10 md:px-6">
           <Link to={backPath} className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-line fr-btn--icon-left mb-8">
             {backLabel}
           </Link>
@@ -94,7 +94,7 @@ export default function MissionDetailPage() {
   return (
     <>
       <GradientBg>
-        <main className="min-h-screen">
+        <main id="contenu" tabIndex={-1} className="min-h-screen">
           {mission.photo && (
             <div className="h-[216px] w-full overflow-hidden md:hidden">
               <img src={mission.photo} alt="" className="h-full w-full object-cover" />

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -209,7 +209,7 @@ export default function MissionsPage() {
 
   return (
     <>
-      <main>
+      <main id="contenu" tabIndex={-1}>
         <GradientBg>
           <div className="fr-container pt-4 md:pt-16">
             <div className="flex items-center justify-between gap-4">

--- a/plateform/app/routes/politique-de-confidentialite.tsx
+++ b/plateform/app/routes/politique-de-confidentialite.tsx
@@ -6,7 +6,7 @@ export function meta(): Route.MetaDescriptors {
 
 export default function PolitiqueDeConfidentialite() {
   return (
-    <main>
+    <main id="contenu" tabIndex={-1}>
       <div className="fr-container max-w-3xl py-8 md:py-16">
         <h1>Politique de confidentialité de la Plateforme de l'Engagement</h1>
 

--- a/plateform/app/routes/quiz/_layout.tsx
+++ b/plateform/app/routes/quiz/_layout.tsx
@@ -162,7 +162,7 @@ export default function QuizLayout() {
         backHref={!transitioning && !loadingResults ? (currentIndex > 0 ? steps[currentIndex - 1].route : "/") : undefined}
         onBack={handleBackNavigated}
       />
-      <main className="flex-1 bg-gradient-to-l from-blue-france-950/40 md:from-blue-france-950 to-transparent pt-10 pb-24 md:pb-10">
+      <main id="contenu" tabIndex={-1} className="flex-1 bg-gradient-to-l from-blue-france-950/40 md:from-blue-france-950 to-transparent pt-10 pb-24 md:pb-10">
         <div className="fr-container flex flex-col gap-10">
           {!transitioning && !loadingResults && (
             <div className="hidden lg:block">

--- a/plateform/app/routes/results.tsx
+++ b/plateform/app/routes/results.tsx
@@ -48,6 +48,22 @@ export default function ResultsPage() {
     if (userScoringId) setQuizSessionId(userScoringId);
   }, [userScoringId]);
 
+  // RGAA 12.7 : le lien d'évitement « Pied de page » cible #footer, rendu ici dans le
+  // panneau dépliable (masqué quand il est replié). Quand la cible est activée, on déplie
+  // le panneau et on place le focus sur le footer pour qu'il soit réellement atteignable.
+  useEffect(() => {
+    if (!isMobile) return;
+    const revealFooter = () => {
+      if (window.location.hash !== "#footer") return;
+      setExpanded(true);
+      // Laisser React retirer `hidden` du conteneur de défilement avant de déplacer le focus.
+      setTimeout(() => document.getElementById("footer")?.focus(), 0);
+    };
+    revealFooter();
+    window.addEventListener("hashchange", revealFooter);
+    return () => window.removeEventListener("hashchange", revealFooter);
+  }, [isMobile]);
+
   // results.viewed : une fois le chargement terminé (succès), on émet l'évènement une seule fois.
   useEffect(() => {
     if (loading || error || resultsViewedFired.current) return;

--- a/plateform/app/routes/results.tsx
+++ b/plateform/app/routes/results.tsx
@@ -123,7 +123,7 @@ export default function ResultsPage() {
 
   if (isMobile) {
     return (
-      <main className="flex-1 relative overflow-hidden">
+      <main id="contenu" tabIndex={-1} className="flex-1 relative overflow-hidden">
         {showMap && (
           <div className="absolute inset-0 z-0" onClickCapture={handleCollapseSheet}>
             <LazyMissionMap items={pinnedItems} center={mapCenter} onMarkerClick={handleMarkerClick} activeMissionId={activeMissionId} />
@@ -238,7 +238,7 @@ export default function ResultsPage() {
 
   return (
     <>
-      <main>
+      <main id="contenu" tabIndex={-1}>
         <GradientBg fixed className="px-12">
           <section className="flex flex-row max-w-7xl mx-auto">
             <div className="flex flex-col flex-1 py-12">

--- a/plateform/app/utils/__tests__/layout.test.ts
+++ b/plateform/app/utils/__tests__/layout.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { isFooterVisible } from "../layout";
+
+describe("isFooterVisible", () => {
+  it("affiche le footer sur les pages standard", () => {
+    expect(isFooterVisible("/", false)).toBe(true);
+    expect(isFooterVisible("/", true)).toBe(true);
+    expect(isFooterVisible("/missions", true)).toBe(true);
+    expect(isFooterVisible("/accessibilite", true)).toBe(true);
+  });
+
+  it("masque le footer sur le parcours quiz (desktop et mobile)", () => {
+    expect(isFooterVisible("/quiz", false)).toBe(false);
+    expect(isFooterVisible("/quiz", true)).toBe(false);
+    expect(isFooterVisible("/quiz/age", false)).toBe(false);
+  });
+
+  it("masque le footer sur /results uniquement en mobile", () => {
+    expect(isFooterVisible("/results/abc", true)).toBe(false);
+    expect(isFooterVisible("/results/abc", false)).toBe(true);
+  });
+});

--- a/plateform/app/utils/__tests__/layout.test.ts
+++ b/plateform/app/utils/__tests__/layout.test.ts
@@ -1,22 +1,37 @@
 import { describe, expect, it } from "vitest";
-import { isFooterVisible } from "../layout";
+import { hasFooterTarget, isGlobalFooterVisible } from "../layout";
 
-describe("isFooterVisible", () => {
-  it("affiche le footer sur les pages standard", () => {
-    expect(isFooterVisible("/", false)).toBe(true);
-    expect(isFooterVisible("/", true)).toBe(true);
-    expect(isFooterVisible("/missions", true)).toBe(true);
-    expect(isFooterVisible("/accessibilite", true)).toBe(true);
+describe("isGlobalFooterVisible", () => {
+  it("affiche le footer global sur les pages standard", () => {
+    expect(isGlobalFooterVisible("/", false)).toBe(true);
+    expect(isGlobalFooterVisible("/", true)).toBe(true);
+    expect(isGlobalFooterVisible("/missions", true)).toBe(true);
   });
 
-  it("masque le footer sur le parcours quiz (desktop et mobile)", () => {
-    expect(isFooterVisible("/quiz", false)).toBe(false);
-    expect(isFooterVisible("/quiz", true)).toBe(false);
-    expect(isFooterVisible("/quiz/age", false)).toBe(false);
+  it("masque le footer global sur le parcours quiz", () => {
+    expect(isGlobalFooterVisible("/quiz", false)).toBe(false);
+    expect(isGlobalFooterVisible("/quiz/age", true)).toBe(false);
   });
 
-  it("masque le footer sur /results uniquement en mobile", () => {
-    expect(isFooterVisible("/results/abc", true)).toBe(false);
-    expect(isFooterVisible("/results/abc", false)).toBe(true);
+  it("masque le footer global sur /results uniquement en mobile (la route rend son propre footer)", () => {
+    expect(isGlobalFooterVisible("/results/abc", true)).toBe(false);
+    expect(isGlobalFooterVisible("/results/abc", false)).toBe(true);
+  });
+});
+
+describe("hasFooterTarget", () => {
+  it("expose une cible #footer sur les pages standard", () => {
+    expect(hasFooterTarget("/")).toBe(true);
+    expect(hasFooterTarget("/missions")).toBe(true);
+    expect(hasFooterTarget("/accessibilite")).toBe(true);
+  });
+
+  it("expose une cible #footer sur /results (footer global desktop ou footer local mobile)", () => {
+    expect(hasFooterTarget("/results/abc")).toBe(true);
+  });
+
+  it("n'expose pas de cible #footer sur le quiz", () => {
+    expect(hasFooterTarget("/quiz")).toBe(false);
+    expect(hasFooterTarget("/quiz/age")).toBe(false);
   });
 });

--- a/plateform/app/utils/layout.ts
+++ b/plateform/app/utils/layout.ts
@@ -1,13 +1,25 @@
 /**
- * Détermine si le pied de page est affiché pour une route donnée.
- *
- * Source de vérité partagée entre le `Footer` et les liens d'évitement (`SkipLinks`) :
- * le footer est masqué sur le parcours quiz et sur `/results` en mobile, donc le lien
- * d'évitement « Pied de page » ne doit pas être annoncé dans ces cas (RGAA 12.7 —
- * pas de lien vers une cible inexistante).
+ * Le pied de page GLOBAL (rendu dans `root.tsx`) est masqué sur le parcours quiz
+ * et sur `/results` en mobile — là, la route résultats rend son propre footer à
+ * l'intérieur du panneau dépliable. Utilisé par le composant `Footer`.
  */
-export function isFooterVisible(pathname: string, isMobile: boolean): boolean {
+export function isGlobalFooterVisible(pathname: string, isMobile: boolean): boolean {
   const isQuiz = pathname.startsWith("/quiz");
   const isMobileResults = isMobile && pathname.startsWith("/results");
   return !(isQuiz || isMobileResults);
+}
+
+/**
+ * Indique si la page comporte une cible `#footer` atteignable par le lien d'évitement
+ * (RGAA 12.7). Vrai sur toutes les routes SAUF le quiz :
+ * - pages standard : footer global (`root.tsx`) ;
+ * - `/results` en mobile : la route rend son propre `<FooterContent id="footer">`
+ *   (`routes/results.tsx`), donc la cible existe même si le footer global est masqué ;
+ * - quiz : aucun footer.
+ *
+ * On ne se base donc pas sur la visibilité du footer global : celle-ci ne reflète pas
+ * la présence effective de la cible dans le parcours résultats mobile.
+ */
+export function hasFooterTarget(pathname: string): boolean {
+  return !pathname.startsWith("/quiz");
 }

--- a/plateform/app/utils/layout.ts
+++ b/plateform/app/utils/layout.ts
@@ -1,0 +1,13 @@
+/**
+ * Détermine si le pied de page est affiché pour une route donnée.
+ *
+ * Source de vérité partagée entre le `Footer` et les liens d'évitement (`SkipLinks`) :
+ * le footer est masqué sur le parcours quiz et sur `/results` en mobile, donc le lien
+ * d'évitement « Pied de page » ne doit pas être annoncé dans ces cas (RGAA 12.7 —
+ * pas de lien vers une cible inexistante).
+ */
+export function isFooterVisible(pathname: string, isMobile: boolean): boolean {
+  const isQuiz = pathname.startsWith("/quiz");
+  const isMobileResults = isMobile && pathname.startsWith("/results");
+  return !(isQuiz || isMobileResults);
+}


### PR DESCRIPTION
## Description

Corrige la non-conformité RGAA **12.7 — Lien d'évitement vers le contenu principal** sur le front public `plateform/`.

Avant : aucun lien d'évitement n'existait. Un utilisateur au clavier / lecteur d'écran devait parcourir l'en-tête à chaque page pour atteindre le contenu.

### Ce que la PR apporte

- **Composant `skip-links.tsx`** : lien d'évitement DSFR natif (`fr-skiplinks`), rendu **premier enfant de `<body>`** dans `root.tsx` (dans `Layout`, avant `{children}`) → présent sur tous les rendus, y compris les `ErrorBoundary`.
- **Deux liens : « Contenu » + « Pied de page »**. Le « Menu » du triplet DSFR standard est **volontairement omis** : `plateform` n'a pas de menu de navigation (l'en-tête ne contient qu'un logo + lien retour), un lien vers un landmark inexistant serait une erreur.
- **Cibles focusables** : chaque `<main>` de route reçoit `id="contenu"` + `tabIndex={-1}` ; le `<footer id="footer">` reçoit également `tabIndex={-1}`.

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/Retours-RGAA-Plateforme-39f72a322d508093bd1fcd2fc8c6476d?source=copy_link#39f72a322d508021b0f9f8f4d91c5d48

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Point d'attention — `tabindex="-1"` sur les cibles** : sans lui, l'ancre `#...` ne fait que défiler sans déplacer le focus (le lien « Pied de page » était inopérant sur le focus avant ajout). La révélation visuelle du bandeau `.fr-skiplinks` est 100 % CSS (`:focus-within`), aucun JS DSFR requis.

Un seul `<main>` se rend à la fois par route (retours conditionnels *loading/error/loaded*, branches `isMobile`), donc `id="contenu"` reste unique à l'exécution malgré plusieurs occurrences dans `mission-detail.tsx` (×3) et `results.tsx` (×2).

**Vérifications réalisées (dev server, parcours home + quiz)** :

| Contrôle | Résultat |
|---|---|
| `typecheck` / `lint` | ✅ |
| Skip link = 1er élément focusable du `<body>` | ✅ (`Tab` → « Contenu ») |
| Révélation visuelle au focus (bandeau DSFR) | ✅ |
| « Contenu » déplace le focus | ✅ → `main#contenu` |
| « Pied de page » déplace le focus | ✅ → `footer#footer` |
| 1 seul `.fr-skiplinks` et 1 seul `#contenu` par page | ✅ |
