### PR TITLE
fix(plateform): RGAA 11.10 (form error)

### DIFF
--- a/plateform/app/components/layout/newsletter.tsx
+++ b/plateform/app/components/layout/newsletter.tsx
@@ -64,16 +64,27 @@ export default function Newsletter({
             </div>
           ) : (
             <form onSubmit={handleSubmit} className="max-w-md">
-              {error && (
-                <div className="fr-alert fr-alert--error fr-mb-2w">
-                  <p>{error}</p>
-                </div>
-              )}
-              <div className="fr-input-group fr-mb-2w">
+              <div className={`fr-input-group fr-mb-2w ${error ? "fr-input-group--error" : ""}`}>
                 <label className="fr-label sr-only" htmlFor="newsletter-email">
                   Adresse email
                 </label>
-                <input id="newsletter-email" name="email" type="email" required className="fr-input bg-background!" placeholder="nom@email.fr" />
+                <input
+                  id="newsletter-email"
+                  name="email"
+                  type="email"
+                  required
+                  aria-required="true"
+                  aria-invalid={error ? true : undefined}
+                  aria-describedby={error ? "newsletter-email-error" : undefined}
+                  className="fr-input bg-background!"
+                  placeholder="nom@email.fr"
+                />
+                <p className="fr-hint-text fr-mt-1w">Champ obligatoire</p>
+                {error && (
+                  <div className="fr-messages-group" id="newsletter-email-error" aria-live="assertive">
+                    <p className="fr-message fr-message--error">{error}</p>
+                  </div>
+                )}
               </div>
               <button type="submit" disabled={loading} className="fr-btn w-full! md:w-auto! justify-center! md:justify-start!">
                 {loading ? "Inscription en cours…" : ctaText}

--- a/plateform/app/components/mission-detail/email-mission-details-modal.tsx
+++ b/plateform/app/components/mission-detail/email-mission-details-modal.tsx
@@ -89,17 +89,30 @@ export default function EmailMissionModal({ missionId, publisherId, userScoringI
           <form onSubmit={handleSubmit}>
             <p className="fr-mb-2w">On t'envoie ta mission pour que tu puisses la retrouver facilement.</p>
 
-            {error && (
-              <div className="fr-alert fr-alert--error fr-mb-2w">
-                <p>{error}</p>
-              </div>
-            )}
+            <p className="fr-hint-text fr-mb-2w">
+              Les champs marqués d'un <span aria-hidden="true">*</span> sont obligatoires.
+            </p>
 
-            <div className="fr-input-group fr-mb-2w">
+            <div className={`fr-input-group fr-mb-2w ${error ? "fr-input-group--error" : ""}`}>
               <label className="fr-label" htmlFor={emailId}>
-                Adresse email
+                Adresse email <span aria-hidden="true">*</span>
               </label>
-              <input id={emailId} name="email" type="email" required className="fr-input" placeholder="nom@email.fr" />
+              <input
+                id={emailId}
+                name="email"
+                type="email"
+                required
+                aria-required="true"
+                aria-invalid={error ? true : undefined}
+                aria-describedby={error ? `${emailId}-error` : undefined}
+                className="fr-input"
+                placeholder="nom@email.fr"
+              />
+              {error && (
+                <div className="fr-messages-group" id={`${emailId}-error`} aria-live="assertive">
+                  <p className="fr-message fr-message--error">{error}</p>
+                </div>
+              )}
             </div>
 
             {userScoringId && (

--- a/plateform/app/components/quiz/checkbox-group-rich.tsx
+++ b/plateform/app/components/quiz/checkbox-group-rich.tsx
@@ -24,7 +24,7 @@ export default function CheckboxGroupRich({ title, subtitle, onChange, options, 
       className={`fr-fieldset block! ${error ? "fr-fieldset--error" : ""}`}
       id="checkbox-group-rich"
       role="group"
-      aria-describedby={`checkbox-group-rich-legend ${error && "checkbox-group-rich-messages"}`}
+      aria-describedby={error ? "checkbox-group-rich-legend checkbox-group-rich-messages" : "checkbox-group-rich-legend"}
     >
       <legend className="fr-h1 mb-10! ml-2!" id="checkbox-group-rich-legend">
         {title}
@@ -42,6 +42,7 @@ export default function CheckboxGroupRich({ title, subtitle, onChange, options, 
                 onChange={() => toggle(o.value)}
                 checked={!o.disabled && selected.includes(o.value)}
                 disabled={o.disabled}
+                aria-invalid={error ? true : undefined}
               />
               <label
                 className={`fr-label text-base before:size-4! after:absolute after:inset-0 after:right-[-5.5rem] after:content-[''] ${o.disabled ? "cursor-not-allowed!" : ""}`}

--- a/plateform/app/components/quiz/radio-group-rich.tsx
+++ b/plateform/app/components/quiz/radio-group-rich.tsx
@@ -18,7 +18,7 @@ export default function RadioGroupRich({ title, subtitle, onChange, options, sel
       className={`fr-fieldset block! ${error ? "fr-fieldset--error" : ""}`}
       id="radio-group-rich"
       role="group"
-      aria-describedby={`radio-group-rich-legend ${error && "radio-group-rich-messages"}`}
+      aria-describedby={error ? "radio-group-rich-legend radio-group-rich-messages" : "radio-group-rich-legend"}
     >
       <legend className="fr-h1 mb-10! ml-2!" id="radio-group-rich-legend">
         {title}
@@ -36,6 +36,7 @@ export default function RadioGroupRich({ title, subtitle, onChange, options, sel
                 onChange={() => onChange(o.value)}
                 checked={!o.disabled && selected === o.value}
                 disabled={o.disabled}
+                aria-invalid={error ? true : undefined}
               />
               <label className={`fr-label text-base ${o.disabled ? "cursor-not-allowed!" : ""}`} htmlFor={`radio-group-rich-${o.value}`}>
                 {o.label}

--- a/plateform/app/components/quiz/radio-group.tsx
+++ b/plateform/app/components/quiz/radio-group.tsx
@@ -18,7 +18,7 @@ export default function RadioGroup({ title, subtitle, onChange, options, selecte
       className={`fr-fieldset block! ${error ? "fr-fieldset--error" : ""}`}
       id="radio-group"
       role="group"
-      aria-describedby={`radio-group-legend ${error && "radio-group-messages"}`}
+      aria-describedby={error ? "radio-group-legend radio-group-messages" : "radio-group-legend"}
     >
       <legend className="fr-h1 mb-10! ml-2!" id="radio-group-legend">
         {title}
@@ -39,6 +39,7 @@ export default function RadioGroup({ title, subtitle, onChange, options, selecte
                 onChange={() => onChange(o.value)}
                 checked={!o.disabled && selected === o.value}
                 disabled={o.disabled}
+                aria-invalid={error ? true : undefined}
               />
               <label className={`fr-label text-sm w-full ${o.disabled ? "cursor-not-allowed!" : ""}`} htmlFor={`radio-group-${o.value}`}>
                 {o.label}

--- a/plateform/app/components/results/email-missions-modal.tsx
+++ b/plateform/app/components/results/email-missions-modal.tsx
@@ -86,17 +86,30 @@ export default function EmailMissionsModal({ userScoringId, open: controlledOpen
             <p className="fr-text--lead fr-mb-2w">On t'envoie ta sélection de 5 missions pour que tu puisses les retrouver facilement.</p>
 
             <form onSubmit={handleSubmit}>
-              {error && (
-                <div className="fr-alert fr-alert--error fr-mb-2w">
-                  <p>{error}</p>
-                </div>
-              )}
+              <p className="fr-hint-text fr-mb-2w">
+                Les champs marqués d'un <span aria-hidden="true">*</span> sont obligatoires.
+              </p>
 
-              <div className="fr-input-group fr-mb-2w">
+              <div className={`fr-input-group fr-mb-2w ${error ? "fr-input-group--error" : ""}`}>
                 <label className="fr-label" htmlFor={emailId}>
-                  Adresse email
+                  Adresse email <span aria-hidden="true">*</span>
                 </label>
-                <input id={emailId} name="email" type="email" required className="fr-input" placeholder="nom@email.fr" />
+                <input
+                  id={emailId}
+                  name="email"
+                  type="email"
+                  required
+                  aria-required="true"
+                  aria-invalid={error ? true : undefined}
+                  aria-describedby={error ? `${emailId}-error` : undefined}
+                  className="fr-input"
+                  placeholder="nom@email.fr"
+                />
+                {error && (
+                  <div className="fr-messages-group" id={`${emailId}-error`} aria-live="assertive">
+                    <p className="fr-message fr-message--error">{error}</p>
+                  </div>
+                )}
               </div>
 
               <div className="fr-checkbox-group fr-mb-2w">

--- a/plateform/app/routes/quiz/_layout.tsx
+++ b/plateform/app/routes/quiz/_layout.tsx
@@ -170,7 +170,7 @@ export default function QuizLayout() {
             </div>
           )}
           {scoringError && !loadingResults && (
-            <div className="fr-alert fr-alert--error">
+            <div className="fr-alert fr-alert--error" role="alert">
               <p>{scoringError}</p>
             </div>
           )}


### PR DESCRIPTION
## Description

Corrige deux non-conformités RGAA 4.1.2 sur les formulaires du front public `plateform/` :

- **Critère 11.10** — les champs email obligatoires n'avaient aucune indication perceptible ni `aria-required`.
- **Critère 11.11** — les messages d'erreur étaient rendus dans un `fr-alert` détaché du champ (pas d'`aria-describedby`, pas d'`aria-invalid`, alerte non annoncée) : un lecteur d'écran n'associait pas l'erreur au champ fautif.

### Changements

- **Champs email obligatoires** (`newsletter.tsx`, `email-missions-modal.tsx`, `email-mission-details-modal.tsx`) : ajout d'un marqueur requis (astérisque + légende « Les champs marqués d'un * sont obligatoires ») et de `aria-required="true"`. Le libellé masqué de la newsletter (`sr-only`) reçoit une mention visible « Champ obligatoire ».
- **Liaison des erreurs** : passage du `fr-alert` détaché à l'état d'erreur DSFR relié au champ — `fr-input-group--error` sur le groupe, message sous l'input en `fr-message--error` dans un `fr-messages-group` (`aria-live="assertive"`), `aria-invalid` + `aria-describedby` sur l'input.
- **Groupes du quiz** (`radio-group.tsx`, `radio-group-rich.tsx`, `checkbox-group-rich.tsx`) : ajout de `aria-invalid` sur les inputs en erreur et correction d'un `aria-describedby` qui référençait un id inexistant (`"…-legend undefined"`) hors état d'erreur.
- **Alerte de scoring du quiz** (`quiz/_layout.tsx`) : ajout de `role="alert"` pour que l'échec de sauvegarde soit annoncé (erreur sans champ associé).

On reste en DSFR vanilla (classes `fr-*`), sans introduire `@codegouvfr/react-dsfr` ni nouvelle validation client : l'erreur reliée reste l'erreur de soumission existante.

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/Retours-RGAA-Plateforme-39f72a322d508093bd1fcd2fc8c6476d?source=copy_link#39f72a322d50800e9313d4c513f8f227

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire _(changement visuel/ARIA : `typecheck` + vérification manuelle du DOM)_
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Vérifications réalisées (`npm --workspace=plateform run typecheck` + `lint` OK) :

- **Newsletter** : `aria-required="true"`, mention requise visible.
- **Modale email (détail mission / résultats)** : libellé « Adresse email * », légende visible, attributs de liaison correctement absents hors erreur.
- **Groupe quiz** : hors erreur `aria-describedby="radio-group-rich-legend"` (plus de `undefined`) ; après « Continuer » sans sélection → `fr-fieldset--error`, tous les inputs `aria-invalid="true"`, message annoncé.
- Aucune erreur console.

Point d'attention reviewer : l'état d'erreur relié au champ réutilise le message de soumission générique existant (ex. « Une erreur est survenue »). Pas de refonte visuelle, uniquement des ajouts d'attributs ARIA et de l'indication requise.
