### PR TITLE
fix(plateform): RGAA 1.2 (decorative images)

### DIFF
--- a/plateform/app/components/layout/newsletter.tsx
+++ b/plateform/app/components/layout/newsletter.tsx
@@ -43,7 +43,7 @@ export default function Newsletter({
 
   return (
     <section className="bg-blue-france-950 relative">
-      <img src={TraceSvg} alt="Trace" className="absolute top-20 left-0 w-1/5" />
+      <img src={TraceSvg} alt="" aria-hidden="true" className="absolute top-20 left-0 w-1/5" />
       <div className="fr-container py-6! md:py-12! px-6! flex flex-col md:flex-row gap-4 md:gap-2 items-center justify-center">
         <div className="flex-1 z-10" aria-hidden="true">
           {/* SVG illustration à venir */}

--- a/plateform/app/components/layout/partners.tsx
+++ b/plateform/app/components/layout/partners.tsx
@@ -48,7 +48,7 @@ export default function Partners({ style = "default" }: { style?: "default" | "c
           {PARTNERS.map((partner) => (
             <div key={partner.name} className={`flex items-start gap-2 ${style === "compact" ? "flex-1" : "gap-4"}`}>
               <div className="flex items-center justify-center bg-white rounded-sm p-1">
-                <img src={partner.logo} className="size-10 shrink-0 rounded object-contain" aria-hidden="true" />
+                <img src={partner.logo} alt="" className="size-10 shrink-0 rounded object-contain" aria-hidden="true" />
               </div>
               <div className="flex-1">
                 <p className="fr-mb-0 font-bold">

--- a/plateform/app/components/quiz/mission-card.tsx
+++ b/plateform/app/components/quiz/mission-card.tsx
@@ -20,7 +20,7 @@ export default function MissionCard({ imageSrc, category = "Solidarité", title,
       <div className="flex flex-col gap-2">
         <p className="fr-text font-bold mb-0!">{title}</p>
         <div className="fr-text--xs flex items-center gap-2 m-0!">
-          <img src={AscLogo} className="block w-8" aria-hidden="true" />
+          <img src={AscLogo} alt="" className="block w-8" aria-hidden="true" />
           <span>Service Civique</span>
         </div>
       </div>


### PR DESCRIPTION
## Description

Correction du critère RGAA 1.2 (images de décoration correctement ignorées) sur la plateforme.

**Changements** :
- `newsletter.tsx` : l'image décorative `trace.svg` avait `alt="Trace"` et était annoncée inutilement par les lecteurs d'écran → `alt=""` + `aria-hidden="true"` (constat de l'audit)
- `partners.tsx` et `quiz/mission-card.tsx` : ajout de `alt=""` sur deux images décoratives qui n'avaient que `aria-hidden="true"` (déjà conformes au 1.2, mais `<img>` sans `alt` est du HTML invalide — critère 8.2 — et incohérent avec le reste du site)

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/1-2-Image-de-d-coration-correctement-ignor-e-3a072a322d5080e99d66f773156569b2?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Changement purement accessibilité, sans impact visuel ni logique. `typecheck` et `lint` passent sur `plateform`. Les images concernées sont bien décoratives : l'information (nom du partenaire, « Service Civique ») est présente en texte adjacent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)