### PR TITLE
fix(plateform): RGAA 7.5 (status messages)

### DIFF
--- a/plateform/app/components/layout/newsletter.tsx
+++ b/plateform/app/components/layout/newsletter.tsx
@@ -59,7 +59,7 @@ export default function Newsletter({
 
         <div className="flex-1 w-full md:w-auto">
           {success ? (
-            <div className="fr-alert fr-alert--success max-w-md">
+            <div role="status" className="fr-alert fr-alert--success max-w-md">
               <p>Ton inscription est bien prise en compte. À très vite dans ta boîte mail !</p>
             </div>
           ) : (
@@ -81,7 +81,7 @@ export default function Newsletter({
                 />
                 <p className="fr-hint-text fr-mt-1w">Champ obligatoire</p>
                 {error && (
-                  <div className="fr-messages-group" id="newsletter-email-error" aria-live="assertive">
+                  <div className="fr-messages-group" id="newsletter-email-error" role="alert">
                     <p className="fr-message fr-message--error">{error}</p>
                   </div>
                 )}

--- a/plateform/app/components/mission-detail/email-mission-details-modal.tsx
+++ b/plateform/app/components/mission-detail/email-mission-details-modal.tsx
@@ -82,7 +82,7 @@ export default function EmailMissionModal({ missionId, publisherId, userScoringI
 
       <Modal open={open} onClose={handleClose} title="Reçois ta mission par email" titleIcon="fr-icon-mail-line">
         {success ? (
-          <div className="fr-alert fr-alert--success">
+          <div role="status" className="fr-alert fr-alert--success">
             <p>La mission a bien été envoyée ! Vérifie ta boîte mail.</p>
           </div>
         ) : (
@@ -109,7 +109,7 @@ export default function EmailMissionModal({ missionId, publisherId, userScoringI
                 placeholder="nom@email.fr"
               />
               {error && (
-                <div className="fr-messages-group" id={`${emailId}-error`} aria-live="assertive">
+                <div className="fr-messages-group" id={`${emailId}-error`} role="alert">
                   <p className="fr-message fr-message--error">{error}</p>
                 </div>
               )}

--- a/plateform/app/components/results/email-missions-modal.tsx
+++ b/plateform/app/components/results/email-missions-modal.tsx
@@ -74,7 +74,7 @@ export default function EmailMissionsModal({ userScoringId, open: controlledOpen
       <Modal open={open} onClose={handleClose} title="Reçois tes missions par email" beforeTitle={<MailIllustration className="mx-auto mb-6 h-[100px]" />} className="">
         {success ? (
           <div className="flex flex-col items-center gap-4 py-4 text-center">
-            <div className="fr-alert fr-alert--success w-full">
+            <div role="status" className="fr-alert fr-alert--success w-full">
               <p>Tes missions ont bien été envoyées ! Vérifie ta boîte mail.</p>
             </div>
             <button type="button" onClick={handleClose} className="fr-btn fr-btn--secondary w-full! justify-center!">
@@ -106,7 +106,7 @@ export default function EmailMissionsModal({ userScoringId, open: controlledOpen
                   placeholder="nom@email.fr"
                 />
                 {error && (
-                  <div className="fr-messages-group" id={`${emailId}-error`} aria-live="assertive">
+                  <div className="fr-messages-group" id={`${emailId}-error`} role="alert">
                     <p className="fr-message fr-message--error">{error}</p>
                   </div>
                 )}

--- a/plateform/app/components/results/other-missions.tsx
+++ b/plateform/app/components/results/other-missions.tsx
@@ -32,7 +32,9 @@ export default function OtherMissions({
       <h2 className="fr-h5 mb-4!">Il y a d'autres missions qui peuvent te plaire</h2>
 
       {pageLoading ? (
-        <p className="text-mention-grey py-8 text-sm">Chargement…</p>
+        <p role="status" className="text-mention-grey py-8 text-sm">
+          Chargement…
+        </p>
       ) : (
         <div className={gridClassName}>
           {items.map((item, index) => {

--- a/plateform/app/routes/mission-detail.tsx
+++ b/plateform/app/routes/mission-detail.tsx
@@ -70,7 +70,9 @@ export default function MissionDetailPage() {
           <Link to={backPath} className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-line fr-btn--icon-left mb-8">
             {backLabel}
           </Link>
-          <p className="text-mention-grey text-sm">Chargement…</p>
+          <p role="status" className="text-mention-grey text-sm">
+            Chargement…
+          </p>
         </main>
       </GradientBg>
     );
@@ -83,7 +85,7 @@ export default function MissionDetailPage() {
           <Link to={backPath} className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-line fr-btn--icon-left mb-8">
             {backLabel}
           </Link>
-          <div className="fr-alert fr-alert--error">
+          <div role="alert" className="fr-alert fr-alert--error">
             <p>{error ?? "Mission introuvable."}</p>
           </div>
         </main>

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -216,7 +216,7 @@ export default function MissionsPage() {
               <h1 className="fr-h1 m-0!">Trouve ta mission</h1>
               <MissionFiltersTrigger filters={filterDefs} onChange={handleFilterChange} />
             </div>
-            <p className="fr-text--lead hidden md:block">
+            <p role="status" className="fr-text--lead hidden md:block">
               {loading && total === 0 ? "Chargement…" : `${total.toLocaleString("fr-FR")} mission${total > 1 ? "s" : ""} disponible${total > 1 ? "s" : ""}`}
             </p>
             <MissionFiltersBar filters={filterDefs} onChange={handleFilterChange} />
@@ -224,15 +224,19 @@ export default function MissionsPage() {
 
           <div className="fr-container my-4 md:my-8">
             {error && (
-              <div className="fr-alert fr-alert--error fr-mb-4w">
+              <div role="alert" className="fr-alert fr-alert--error fr-mb-4w">
                 <p>Erreur lors du chargement des missions : {error}</p>
               </div>
             )}
 
-            {loading && items.length === 0 && <p className="fr-text--sm">Chargement des missions…</p>}
+            {loading && items.length === 0 && (
+              <p role="status" className="fr-text--sm">
+                Chargement des missions…
+              </p>
+            )}
 
             {!loading && !error && items.length === 0 && (
-              <div className="fr-alert fr-alert--info">
+              <div role="status" className="fr-alert fr-alert--info">
                 <p>Aucune mission ne correspond à ces filtres.</p>
               </div>
             )}

--- a/plateform/app/routes/results.tsx
+++ b/plateform/app/routes/results.tsx
@@ -197,7 +197,11 @@ export default function ResultsPage() {
           className={`absolute inset-x-0 bottom-0 z-[1000] flex flex-col rounded-t-3xl bg-background shadow-2xl transition-[top] duration-300 ${expanded ? "top-12" : "top-[calc(100%-5rem)]"} ${selectedMission ? "hidden" : ""}`}
         >
           <div className={`flex flex-col gap-2 px-6 py-4 ${expanded ? "items-start!" : "items-center! justify-center! h-full"}`} onClick={handleToggleSheet}>
-            {!loading && error && <p className="fr-error-text m-0! text-center!">{error}</p>}
+            {!loading && error && (
+              <p role="alert" className="fr-error-text m-0! text-center!">
+                {error}
+              </p>
+            )}
             {!loading && !error && (
               <h2 className={`m-0! ${expanded ? "text-center!" : ""}`}>
                 <Highlight>


### PR DESCRIPTION
## Description

Correction du critère **RGAA 7.5 — Messages de statut restitués** sur `plateform` : les messages dynamiques (chargement, succès, erreur, résultats de filtrage) n'étaient pas annoncés aux lecteurs d'écran.

**Changements** :

- `routes/missions.tsx` : `role="status"` sur le compteur « X missions disponibles » (annonce du nombre de résultats après filtrage), sur le message de chargement et sur l'alerte « Aucune mission » ; `role="alert"` sur l'erreur de chargement.
- `components/layout/newsletter.tsx` : `role="status"` sur l'alerte de succès ; erreur du champ email en `role="alert"`.
- `components/results/email-missions-modal.tsx` : `role="status"` sur l'alerte de succès ; erreur du champ email en `role="alert"`.

En complément des 3 fichiers relevés par l'audit, le même problème a été corrigé sur 4 autres occurrences trouvées dans l'app :

- `components/mission-detail/email-mission-details-modal.tsx` : succès en `role="status"`, erreur en `role="alert"`.
- `routes/mission-detail.tsx` : chargement en `role="status"`, erreur/mission introuvable en `role="alert"`.
- `components/results/other-missions.tsx` : chargement de la pagination en `role="status"`.
- `routes/results.tsx` : erreur de la bottom sheet mobile en `role="alert"`.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/7-5-Messages-de-statut-restitu-s-3a072a322d50804e99cdfb580aea8a15?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Sur les erreurs de formulaire, `aria-live="assertive"` est remplacé par `role="alert"` (et non cumulé) : `role="alert"` implique `aria-live="assertive"` + `aria-atomic="true"`, et il est restitué de façon fiable même quand le conteneur est inséré dynamiquement dans le DOM (rendu conditionnel `{error && ...}`), là où un simple `aria-live` sur un élément fraîchement monté ne l'est pas toujours.
- Les erreurs de validation du quiz (`radio-group`, `radio-group-rich`, `checkbox-group-rich`) sont volontairement laissées en `aria-live="polite"` pour ne pas toucher au fix RGAA 11.10 (#1288).
- Changement d'attributs uniquement, aucun impact visuel : validation via `typecheck` + `lint`. Vérification manuelle possible avec VoiceOver sur `/missions` (annonce du total après filtrage) et sur les formulaires newsletter / envoi par email (succès et erreur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)