### PR TITLE
fix(plateform): RGAA 8.5 (page titles)

### DIFF
--- a/plateform/app/root.tsx
+++ b/plateform/app/root.tsx
@@ -21,6 +21,14 @@ const apiEngagementTag = PUBLISHER_ID
   ? `(function(i,s,o,g,r,a,m){i["ApiEngagementObject"]=r;(i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments);}),(i[r].l=1*new Date());(a=s.createElement(o)),(m=s.getElementsByTagName(o)[0]);a.async=1;a.src=g;m.parentNode.insertBefore(a,m);})(window,document,"script","https://app.api-engagement.beta.gouv.fr/jstag.js","apieng");apieng("config",${serializeForInlineScript(PUBLISHER_ID)});`
   : null;
 
+// RGAA 8.5 : sert de titre aux pages d'erreur (404 notamment, où seule la route racine matche
+// et où aucun autre meta() ne fournit de <title>) et de secours pour toute route sans meta().
+export function meta({ error }: Route.MetaArgs): Route.MetaDescriptors {
+  if (!error) return [{ title: "API Engagement" }];
+  const isNotFound = isRouteErrorResponse(error) && error.status === 404;
+  return [{ title: isNotFound ? "Page introuvable — API Engagement" : "Une erreur est survenue — API Engagement" }];
+}
+
 export function Layout({ children }: { children: ReactNode }) {
   return (
     <html lang="fr" data-fr-scheme="system" suppressHydrationWarning>

--- a/plateform/app/routes/mission-detail.tsx
+++ b/plateform/app/routes/mission-detail.tsx
@@ -1,6 +1,11 @@
 import type { MissionDetailResponse } from "@engagement/dto";
 import { useEffect, useRef, useState } from "react";
 import { Link, useLocation, useParams, useSearchParams } from "react-router";
+import type { Route } from "./+types/mission-detail";
+
+export function meta(): Route.MetaDescriptors {
+  return [{ title: "Détail de la mission — API Engagement" }];
+}
 
 export async function clientLoader({ params }: { params: { userScoringId?: string } }) {
   return { backHref: params.userScoringId ? `/results/${params.userScoringId}` : "/missions" };
@@ -44,6 +49,12 @@ export default function MissionDetailPage() {
   useEffect(() => {
     if (userScoringId) setQuizSessionId(userScoringId);
   }, [userScoringId]);
+
+  // RGAA 8.5/8.6 : la mission est chargée côté client, meta() ne peut donner qu'un titre générique.
+  // On le remplace par le titre de la mission dès qu'elle est disponible.
+  useEffect(() => {
+    if (mission?.title) document.title = `${mission.title} — API Engagement`;
+  }, [mission]);
 
   // mission_detail.viewed : une fois la fiche chargée, émis une seule fois par mission.
   useEffect(() => {

--- a/plateform/app/routes/mission-detail.tsx
+++ b/plateform/app/routes/mission-detail.tsx
@@ -4,7 +4,7 @@ import { Link, useLocation, useParams, useSearchParams } from "react-router";
 import type { Route } from "./+types/mission-detail";
 
 export function meta(): Route.MetaDescriptors {
-  return [{ title: "Détail de la mission — API Engagement" }];
+  return [{ title: "Détail de la mission — Trouve ta mission" }];
 }
 
 export async function clientLoader({ params }: { params: { userScoringId?: string } }) {

--- a/plateform/app/routes/results.tsx
+++ b/plateform/app/routes/results.tsx
@@ -20,6 +20,11 @@ import { setQuizSessionId } from "~/services/tracking";
 import { trackResultsViewed } from "~/services/tracking/events";
 import { useQuizStore } from "~/stores/quiz";
 import { evalCondition } from "~/utils/conditions";
+import type { Route } from "./+types/results";
+
+export function meta(): Route.MetaDescriptors {
+  return [{ title: "Tes missions recommandées — API Engagement" }];
+}
 
 export async function clientLoader() {
   return { backHref: null };


### PR DESCRIPTION
## Description

Correction du critère RGAA 8.5 / 8.6 (titre de page présent et pertinent) : trois pages étaient rendues sans `<title>` propre.

**Changements** :

- `routes/results.tsx` : ajout d'un `meta()` → « Tes missions recommandées — API Engagement »
- `routes/mission-detail.tsx` : ajout d'un `meta()` de repli (« Détail de la mission — API Engagement ») puis mise à jour de `document.title` avec le titre de la mission dès qu'elle est chargée (la mission est fetchée côté client, `meta()` ne peut pas la connaître)
- `root.tsx` : ajout d'un `meta()` racine — la page 404 était rendue **sans aucune balise `<title>`** (seule la route racine matche sur une URL inconnue). Titres : « Page introuvable — API Engagement » (404), « Une erreur est survenue — API Engagement » (autres erreurs), « API Engagement » en secours. Le `meta()` le plus profond gagnant toujours, les pages existantes ne sont pas affectées.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/8-5-8-6-Titre-de-page-pr-sent-et-pertinent-3a072a322d50800380dcff95230afc84?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Vérifié en SSR (serveur dev) : toutes les pages (`/`, `/missions`, `/missions/:id`, `/results/:id`, pages légales, 404) rendent désormais un `<title>` unique ; la mise à jour dynamique du titre sur la fiche mission est côté client, à vérifier en navigation réelle.
- Point restant hors périmètre de cette PR : les 16 steps du quiz partagent tous le titre « Quiz Engagement » hérité de `quiz/_layout.tsx` — pertinence (8.6) discutable, à traiter séparément si souhaité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)