### PR TITLE
fix(plateform): RGAA 9.1 (headings hierarchy)

### DIFF
--- a/plateform/app/components/landing/hero.tsx
+++ b/plateform/app/components/landing/hero.tsx
@@ -8,7 +8,7 @@ export default function Hero({ onStartQuiz }: HeroProps) {
   return (
     <section className="fr-container pt-4! lg:pt-16!">
       <div className="relative z-10 w-full lg:max-w-md lg:min-w-[320px] xl:max-w-xl">
-        <h4 className="fr-h4">Tu veux te rendre utile ?</h4>
+        <p className="fr-h4">Tu veux te rendre utile ?</p>
         <h1 className="text-4xl! md:text-5xl! lg:text-6xl! xl:text-7xl! text-title-grey">
           À chacun
           <br /> sa façon d'<Highlight>agir</Highlight>

--- a/plateform/app/components/landing/pro-space.tsx
+++ b/plateform/app/components/landing/pro-space.tsx
@@ -46,7 +46,7 @@ export default function ProSpace() {
           {BENEFITS.map((benefit) => (
             <div key={benefit.title} className="flex flex-col items-center md:items-start gap-2">
               <div className="bg-yellow-tournesol-925 flex size-12 items-center justify-center rounded-full text-2xl">{benefit.icon}</div>
-              <h5 className="fr-h5 fr-mb-0 text-default-grey text-center md:text-left">{benefit.title}</h5>
+              <h3 className="fr-h5 fr-mb-0 text-default-grey text-center md:text-left">{benefit.title}</h3>
               <p className="fr-text--lead text-default-grey fr-mb-0 text-center md:text-left">{benefit.body}</p>
             </div>
           ))}

--- a/plateform/app/components/quiz/checkbox-group-rich.tsx
+++ b/plateform/app/components/quiz/checkbox-group-rich.tsx
@@ -26,8 +26,8 @@ export default function CheckboxGroupRich({ title, subtitle, onChange, options, 
       role="group"
       aria-describedby={error ? "checkbox-group-rich-legend checkbox-group-rich-messages" : "checkbox-group-rich-legend"}
     >
-      <legend className="fr-h1 mb-10! ml-2!" id="checkbox-group-rich-legend">
-        {title}
+      <legend className="mb-10! ml-2!" id="checkbox-group-rich-legend">
+        <h1 className="fr-h1 mb-0!">{title}</h1>
         {subtitle && <span className="fr-text--lead font-normal block mt-4! mb-0!">{subtitle}</span>}
       </legend>
       <div className="fr-fieldset__content grid grid-cols-1 md:grid-cols-2 max-w-4xl! mx-0! gap-x-6 gap-y-4!">

--- a/plateform/app/components/quiz/label.tsx
+++ b/plateform/app/components/quiz/label.tsx
@@ -9,9 +9,9 @@ type Props = {
 export default function Label({ subtitle, children, htmlFor }: Props) {
   return (
     <div className="flex flex-col gap-4">
-      <label className="fr-h1 mb-0!" htmlFor={htmlFor}>
-        {children}
-      </label>
+      <h1 className="fr-h1 mb-0!">
+        <label htmlFor={htmlFor}>{children}</label>
+      </h1>
       {subtitle && <p className="fr-text--lead mb-0!">{subtitle}</p>}
     </div>
   );

--- a/plateform/app/components/quiz/radio-group-rich.tsx
+++ b/plateform/app/components/quiz/radio-group-rich.tsx
@@ -20,8 +20,8 @@ export default function RadioGroupRich({ title, subtitle, onChange, options, sel
       role="group"
       aria-describedby={error ? "radio-group-rich-legend radio-group-rich-messages" : "radio-group-rich-legend"}
     >
-      <legend className="fr-h1 mb-10! ml-2!" id="radio-group-rich-legend">
-        {title}
+      <legend className="mb-10! ml-2!" id="radio-group-rich-legend">
+        <h1 className="fr-h1 mb-0!">{title}</h1>
         {subtitle && <span className="fr-text--lead font-normal block mt-4! mb-0!">{subtitle}</span>}
       </legend>
       <div className="fr-fieldset__content grid grid-cols-1 md:grid-cols-2 max-w-4xl! mx-0! gap-x-6 gap-y-4!">

--- a/plateform/app/components/quiz/radio-group.tsx
+++ b/plateform/app/components/quiz/radio-group.tsx
@@ -20,8 +20,8 @@ export default function RadioGroup({ title, subtitle, onChange, options, selecte
       role="group"
       aria-describedby={error ? "radio-group-legend radio-group-messages" : "radio-group-legend"}
     >
-      <legend className="fr-h1 mb-10! ml-2!" id="radio-group-legend">
-        {title}
+      <legend className="mb-10! ml-2!" id="radio-group-legend">
+        <h1 className="fr-h1 mb-0!">{title}</h1>
         {subtitle && <span className="fr-text--lead font-normal block mt-4! mb-0!">{subtitle}</span>}
       </legend>
       <div className="fr-fieldset__content flex flex-col gap-4 max-w-sm! mx-0! ml-2!">

--- a/plateform/app/components/results/pinned-missions.tsx
+++ b/plateform/app/components/results/pinned-missions.tsx
@@ -24,6 +24,8 @@ export default function PinnedMissions({ items, loading, error, userScoringId, s
       )}
       {!loading && !error && items.length > 0 && (
         <>
+          {/* RGAA 9.1 : titre de section masqué — les cartes mission sont des <h3>, le h1 « X missions pour toi » est le seul titre visible au-dessus. */}
+          <h2 className="fr-sr-only">Les missions sélectionnées pour toi</h2>
           <div className="grid grid-cols-1 gap-6 pb-6 md:grid-cols-2 md:px-4">
             {items.map((item, index) => (
               <div

--- a/plateform/app/routes/results.tsx
+++ b/plateform/app/routes/results.tsx
@@ -199,7 +199,7 @@ export default function ResultsPage() {
           <div className={`flex flex-col gap-2 px-6 py-4 ${expanded ? "items-start!" : "items-center! justify-center! h-full"}`} onClick={handleToggleSheet}>
             {!loading && error && <p className="fr-error-text m-0! text-center!">{error}</p>}
             {!loading && !error && (
-              <h2 className={`m-0! ${expanded ? "text-center!" : ""}`}>
+              <h1 className={`fr-h2 m-0! ${expanded ? "text-center!" : ""}`}>
                 <button
                   type="button"
                   aria-expanded={expanded}
@@ -216,7 +216,7 @@ export default function ResultsPage() {
                   </Highlight>
                   pour toi
                 </button>
-              </h2>
+              </h1>
             )}
 
             {expanded && (
@@ -270,14 +270,14 @@ export default function ResultsPage() {
             <div className="flex flex-col flex-1 py-12">
               <div className="flex gap-2 mb-6 flex-row items-center justify-between gap-4 px-6">
                 {!loading && !error && (
-                  <h2 className="m-0!">
+                  <h1 className="fr-h2 m-0!">
                     <Highlight>
                       <span className="text-blue-france-sun">
                         {pinnedItems.length} mission{pinnedItems.length > 1 ? "s" : ""}
                       </span>
                     </Highlight>
                     pour toi
-                  </h2>
+                  </h1>
                 )}
 
                 <Link to={changeAnswersHref} className="fr-link fr-link--sm shrink-0">


### PR DESCRIPTION
## Description

Corrige la hiérarchie des titres (critère RGAA 9.1) sur la plateforme : un seul `<h1>` par page, sans saut de niveau, sans changement visuel.

**Changements** :

- **Landing** (`hero.tsx`) : l'accroche « Tu veux te rendre utile ? » passe de `<h4>` à `<p className="fr-h4">` (elle précédait le `<h1>`).
- **Landing** (`pro-space.tsx`) : les titres de bénéfices passent de `<h5>` à `<h3 className="fr-h5">` (saut `h2 → h5` supprimé).
- **Quiz** (`label.tsx`, `radio-group.tsx`, `radio-group-rich.tsx`, `checkbox-group-rich.tsx`) : chaque step expose désormais un vrai `<h1>` de document. Le `<h1>` est placé dans la `<legend>` des fieldsets (autorisé par la spec HTML, conserve le nom accessible du groupe), et le `<label>` est placé dans le `<h1>` pour le composant `Label` (l'inverse serait invalide, l'association `htmlFor` est conservée).
- **Résultats** (`results.tsx`) : « X missions pour toi » passe de `<h2>` à `<h1 className="fr-h2">` sur mobile et desktop (classe `fr-h2` pour garder la taille actuelle, notamment dans la barre repliée du panneau mobile).
- **Résultats** (`pinned-missions.tsx`) : ajout d'un `<h2 className="fr-sr-only">` au-dessus des missions épinglées — leurs cartes sont des `<h3>` et passaient directement sous le `h1`.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/9-1-Hi-rarchie-des-titres-3a072a322d508091b204edc85222cb2b?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Changement purement markup : `typecheck` et `lint` passent, pas de logique modifiée (pas de tests unitaires à ajouter).
- Vérification visuelle recommandée : `/` (accroche + section pro), un step de chaque type de quiz (âge, motivation, thématiques) et `/results/:id` en mobile et desktop.
- Hors périmètre, connus mais non traités : en cas d'erreur de chargement sur `/results/:id`, l'alerte DSFR expose un `<h3>` seul (le `h1` n'est pas rendu) ; sur mobile, quand une mission est sélectionnée depuis la carte, le panneau contenant le `h1` passe en `display:none` et la carte flottante (`h3`) devient le seul titre exposé — états transitoires d'interaction.