### PR TITLE
fix(plateform): RGAA 10.8 (hidden content)

### DIFF
--- a/plateform/app/components/layout/newsletter.tsx
+++ b/plateform/app/components/layout/newsletter.tsx
@@ -45,10 +45,10 @@ export default function Newsletter({
     <section className="bg-blue-france-950 relative">
       <img src={TraceSvg} alt="" aria-hidden="true" className="absolute top-20 left-0 w-1/5" />
       <div className="fr-container py-6! md:py-12! px-6! flex flex-col md:flex-row gap-4 md:gap-2 items-center justify-center">
-        <div className="flex-1 z-10" aria-hidden="true">
+        <div className="flex-1 z-10">
           {/* SVG illustration à venir */}
           <div className="flex items-center justify-center gap-4">
-            <img src={MailSendSvg} alt="" className="hidden md:block rotate-12" />
+            <img src={MailSendSvg} alt="" aria-hidden="true" className="hidden md:block rotate-12" />
 
             <div className="flex-1 max-w-md">
               <h2 className="fr-h2 fr-mb-2w">{title}</h2>


### PR DESCRIPTION
## Description

Correction du critère RGAA 10.8 (contenus cachés correctement gérés) sur la section newsletter de la plateforme.

Dans `plateform/app/components/layout/newsletter.tsx`, un `aria-hidden="true"` posé sur le bloc englobant masquait aux technologies d'assistance le titre `<h2>` « Inscris-toi à la newsletter » et son sous-titre. L'attribut est déplacé sur la seule illustration décorative (`<img src={MailSendSvg}>`), sur le même modèle que le `TraceSvg` voisin.

Les autres occurrences de `aria-hidden` dans `plateform/app` ont été passées en revue : aucune autre ne masque de contenu informatif.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/10-8-Contenus-cach-s-correctement-g-r-s-3a072a322d5080c2af57c3d3a54f7189?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Changement purement accessibilité, sans impact visuel. Vérifiable avec un lecteur d'écran : le titre et le sous-titre de la section newsletter sont de nouveau annoncés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)