### PR TITLE
fix(plateform): RGAA 11.11 (error message suggestions)

### DIFF
--- a/plateform/app/components/layout/newsletter.tsx
+++ b/plateform/app/components/layout/newsletter.tsx
@@ -34,8 +34,12 @@ export default function Newsletter({
     try {
       await subscribeNewsletter({ email, distinctId });
       setSuccess(true);
-    } catch {
-      setError("Une erreur est survenue. Merci de réessayer.");
+    } catch (err) {
+      if (err instanceof Error && err.message === "INVALID_BODY") {
+        setError("Le format de l'adresse email n'est pas valide. Le format attendu est : nom@email.fr");
+      } else {
+        setError("Une erreur est survenue. Merci de réessayer.");
+      }
     } finally {
       setLoading(false);
     }

--- a/plateform/app/components/mission-detail/email-mission-details-modal.tsx
+++ b/plateform/app/components/mission-detail/email-mission-details-modal.tsx
@@ -67,8 +67,12 @@ export default function EmailMissionModal({ missionId, publisherId, userScoringI
         });
         setSuccess(true);
       }
-    } catch {
-      setError("Une erreur est survenue. Merci de réessayer.");
+    } catch (err) {
+      if (err instanceof Error && err.message === "INVALID_BODY") {
+        setError("Le format de l'adresse email n'est pas valide. Le format attendu est : nom@email.fr");
+      } else {
+        setError("Une erreur est survenue. Merci de réessayer.");
+      }
     } finally {
       setSubmitting(false);
     }

--- a/plateform/app/components/results/email-missions-modal.tsx
+++ b/plateform/app/components/results/email-missions-modal.tsx
@@ -56,8 +56,12 @@ export default function EmailMissionsModal({ userScoringId, open: controlledOpen
         trackEmailMissionsSent({ hasAlertOptIn: missionAlertEnabled });
         setSuccess(true);
       }
-    } catch {
-      setError("Une erreur est survenue. Merci de réessayer.");
+    } catch (err) {
+      if (err instanceof Error && err.message === "INVALID_BODY") {
+        setError("Le format de l'adresse email n'est pas valide. Le format attendu est : nom@email.fr");
+      } else {
+        setError("Une erreur est survenue. Merci de réessayer.");
+      }
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
## Description

Correction du critère RGAA 11.11 (suggestions de correction des erreurs de saisie) sur les formulaires email de `plateform`.

Les trois formulaires email (newsletter, envoi des 5 missions, envoi d'une mission) affichaient un message générique (« Une erreur est survenue. Merci de réessayer. ») quelle que soit la cause, sans indiquer le type de donnée attendu ni d'exemple en cas d'échec de validation.

**Changements** :

- Quand le backend rejette l'email (`400 INVALID_BODY`, validation `zod.email()` plus stricte que celle du navigateur — ex. `nom@email` sans TLD), le message affiché précise désormais le format attendu et un exemple : « Le format de l'adresse email n'est pas valide. Le format attendu est : nom@email.fr »
- Le message générique est conservé uniquement pour les erreurs techniques (réseau, 5xx), qui ne sont pas des erreurs de saisie
- Le message reste relié au champ via `aria-describedby` / `aria-invalid` / `role="alert"` (mis en place dans les PR RGAA précédentes)

Fichiers concernés :

- `plateform/app/components/layout/newsletter.tsx`
- `plateform/app/components/results/email-missions-modal.tsx`
- `plateform/app/components/mission-detail/email-mission-details-modal.tsx` (non cité dans le constat d'audit mais même pattern)

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/11-11-Suggestions-de-correction-3a072a322d5080b28722d53e480c66f6?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Pour tester manuellement : saisir `nom@email` (sans TLD) dans un des trois formulaires — le navigateur laisse passer, le backend rejette, et le message précis s'affiche relié au champ.
- Les autres messages d'erreur de l'app ont été passés en revue : ils sont soit hors périmètre 11.11 (erreurs de chargement, error boundary), soit déjà clairs sur l'action corrective.
- Validation effectuée : `typecheck` + `lint` sur le workspace `plateform`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)