### PR TITLE
fix(plateform): respect prefers-reduced-motion (RGAA 13.8)

### DIFF
--- a/plateform/app/components/landing/how-it-works.tsx
+++ b/plateform/app/components/landing/how-it-works.tsx
@@ -7,6 +7,7 @@ import FirefighterSvg from "@gouvfr/dsfr/dist/artwork/pictograms/institutions/fi
 import MoneySvg from "@gouvfr/dsfr/dist/artwork/pictograms/institutions/money.svg?url";
 import LocationFranceSvg from "@gouvfr/dsfr/dist/artwork/pictograms/map/location-france.svg?url";
 import LongTraceSvg from "~/assets/svg/long-trace.svg";
+import { getScrollBehavior } from "~/utils/motion";
 
 import Highlight from "../ui/highlight";
 
@@ -69,7 +70,7 @@ export default function HowItWorks({ onStartQuiz }: { onStartQuiz: () => void })
   const handleScroll = (direction: "left" | "right") => {
     if (!scrollRef.current) return;
     const offset = direction === "left" ? -300 : 300;
-    scrollRef.current.scrollBy({ left: offset, behavior: "smooth" });
+    scrollRef.current.scrollBy({ left: offset, behavior: getScrollBehavior() });
   };
 
   return (

--- a/plateform/app/components/landing/mission-examples.tsx
+++ b/plateform/app/components/landing/mission-examples.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router";
 
 import { trackMissionClickedFromBrowse } from "~/services/tracking/events";
+import { getScrollBehavior } from "~/utils/motion";
 
 type Props = {
   missions: MissionBrowse[];
@@ -28,7 +29,7 @@ export default function MissionExamples({ missions, className }: Props) {
   const handleScroll = (direction: "left" | "right") => {
     if (!scrollRef.current) return;
     const offset = direction === "left" ? -380 : 380;
-    scrollRef.current.scrollBy({ left: offset, behavior: "smooth" });
+    scrollRef.current.scrollBy({ left: offset, behavior: getScrollBehavior() });
   };
 
   if (!missions?.length) return null;

--- a/plateform/app/components/landing/testimonials.tsx
+++ b/plateform/app/components/landing/testimonials.tsx
@@ -6,6 +6,8 @@ import SpvLogo from "~/assets/images/spv-logo.png";
 
 import Highlight from "../ui/highlight";
 
+import { getScrollBehavior } from "~/utils/motion";
+
 type Testimonial = {
   id: string;
   image: string;
@@ -79,7 +81,7 @@ export default function Testimonials({ onStartQuiz }: { onStartQuiz: () => void 
   const handleScroll = (direction: "left" | "right") => {
     if (!scrollRef.current) return;
     const offset = direction === "left" ? -352 : 352;
-    scrollRef.current.scrollBy({ left: offset, behavior: "smooth" });
+    scrollRef.current.scrollBy({ left: offset, behavior: getScrollBehavior() });
   };
 
   return (

--- a/plateform/app/components/mission-detail/similar-missions.tsx
+++ b/plateform/app/components/mission-detail/similar-missions.tsx
@@ -4,6 +4,7 @@ import type { MissionMatchItem } from "@engagement/dto";
 import MatchMissionCard from "~/components/missions/match-mission-card";
 import Highlight from "~/components/ui/highlight";
 import { fetchMatches } from "~/services/matching";
+import { getScrollBehavior } from "~/utils/motion";
 
 interface Props {
   userScoringId: string;
@@ -23,7 +24,7 @@ export default function SimilarMissions({ userScoringId, currentMissionId }: Pro
   if (items.length === 0) return null;
 
   const scrollBy = (direction: -1 | 1) => {
-    scrollRef.current?.scrollBy({ left: direction * 300, behavior: "smooth" });
+    scrollRef.current?.scrollBy({ left: direction * 300, behavior: getScrollBehavior() });
   };
 
   return (

--- a/plateform/app/main.css
+++ b/plateform/app/main.css
@@ -219,6 +219,21 @@
   animation: slide-down-fade 200ms ease-out forwards;
 }
 
+/* RGAA 13.8 — neutralise animations et transitions quand l'utilisateur préfère
+   les mouvements réduits. Durées quasi nulles plutôt que `animation: none` afin
+   que les événements `animationend` continuent de se déclencher (`results.tsx`
+   s'appuie sur `onAnimationEnd`). */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 .mission-map__emoji-marker {
   align-items: center;
   background: rgb(246 246 255 / 92%);

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -12,6 +12,7 @@ import GradientBg from "~/components/ui/gradient-bg";
 import Pagination from "~/components/ui/pagination";
 import { browseMissions } from "~/services/mission-browse";
 import { trackMissionClickedFromBrowse, trackMissionsFilterApplied, trackPageViewed } from "~/services/tracking/events";
+import { getScrollBehavior } from "~/utils/motion";
 import type { MissionDetailNavState, MissionsFilterType } from "~/services/tracking/types";
 import type { Route } from "./+types/missions";
 
@@ -204,7 +205,7 @@ export default function MissionsPage() {
       else params.set("page", String(newPage));
       return params;
     });
-    window.scrollTo({ top: 0, behavior: "smooth" });
+    window.scrollTo({ top: 0, behavior: getScrollBehavior() });
   };
 
   return (

--- a/plateform/app/utils/motion.ts
+++ b/plateform/app/utils/motion.ts
@@ -1,0 +1,8 @@
+/**
+ * Comportement de défilement respectant `prefers-reduced-motion` (RGAA 13.8).
+ * Un `behavior: "smooth"` explicite passé à `scrollBy`/`scrollTo` ignore la
+ * propriété CSS `scroll-behavior` : la préférence doit être vérifiée côté JS.
+ */
+export function getScrollBehavior(): "auto" | "smooth" {
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth";
+}


### PR DESCRIPTION
## Description

Corrige le critère RGAA 13.8 (contenus en mouvement) : les animations, transitions et défilements lissés respectent désormais la préférence utilisateur `prefers-reduced-motion`.

**Changements** :
- `main.css` : bloc `@media (prefers-reduced-motion: reduce)` global qui neutralise animations et transitions (durées quasi nulles plutôt que `animation: none`, afin que les callbacks `onAnimationEnd` de `results.tsx` continuent de se déclencher) et force `scroll-behavior: auto`.
- Nouveau helper `app/utils/motion.ts` (`getScrollBehavior()`) : un `behavior: "smooth"` explicite passé à `scrollBy`/`scrollTo` ignore la propriété CSS `scroll-behavior`, la préférence doit donc être vérifiée côté JS via `matchMedia`.
- Utilisation du helper sur les 5 appels concernés : carrousels de la landing (`how-it-works`, `testimonials`, `mission-examples`), carrousel des missions similaires (`similar-missions`) et remontée en haut de page à la pagination (`missions.tsx`).

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/13-8-Contenus-en-mouvement-prefers-reduced-motion-3a072a322d50801e82c9ee54d5039fa2?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Pour tester : activer « Réduire les animations » (macOS : Réglages → Accessibilité → Affichage, ou DevTools Chrome : Rendering → Emulate CSS media feature `prefers-reduced-motion`), puis vérifier que les carrousels sautent d'un cran sans glissement et que les steps du quiz / l'écran de chargement apparaissent sans fondu.
- `npm --workspace=plateform run typecheck` et `lint` passent ; pas de test unitaire ajouté (changement purement visuel, aucune logique quiz/mapping touchée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)