### PR TITLE
feat(api): end implicit diffusion bypass

### DIFF
--- a/api/scripts/backfill-diffusion-scope-roots.ts
+++ b/api/scripts/backfill-diffusion-scope-roots.ts
@@ -1,0 +1,283 @@
+import dotenv from "dotenv";
+import fs from "fs";
+import path from "path";
+
+const SCRIPT_NAME = "BackfillDiffusionScopeRoots";
+
+type Options = {
+  apply: boolean;
+  envPath?: string;
+  json: boolean;
+  apiAllowlists: Map<string, string[]>;
+};
+
+type AuditReason = "api_without_roots" | "diffuser_without_roots" | "rules_without_allowlist" | "widget_missing_roots";
+
+type AuditRow = {
+  diffuserId: string;
+  diffuserName: string;
+  reasons: AuditReason[];
+  existingRoots: string[];
+  rootsToCreate: string[];
+  blockers: string[];
+};
+
+const parseOptions = (argv: string[]): Options => {
+  const options: Options = { apply: false, json: false, apiAllowlists: new Map() };
+  const args = [...argv];
+
+  while (args.length) {
+    const arg = args.shift();
+    switch (arg) {
+      case "--apply":
+        options.apply = true;
+        break;
+      case "--dry-run":
+        options.apply = false;
+        break;
+      case "--env":
+        options.envPath = args.shift();
+        break;
+      case "--json":
+        options.json = true;
+        break;
+      case "--api-allowlist": {
+        const value = args.shift() ?? fail("Missing value after --api-allowlist");
+        const [diffuserId, publisherList] = value.split(":");
+        const publisherIds =
+          publisherList
+            ?.split(",")
+            .map((id) => id.trim())
+            .filter(Boolean) ?? [];
+        if (!diffuserId || publisherIds.length === 0) {
+          fail(`Invalid --api-allowlist value "${value}". Expected diffuserId:publisherId1,publisherId2`);
+        }
+        options.apiAllowlists.set(diffuserId.trim(), publisherIds);
+        break;
+      }
+      default:
+        fail(`Unexpected argument: ${arg}`);
+    }
+  }
+
+  return options;
+};
+
+const fail = (message: string): never => {
+  console.error(`[${SCRIPT_NAME}] ${message}`);
+  console.error(
+    `Usage: npx ts-node scripts/backfill-diffusion-scope-roots.ts [--env <path>] [--dry-run|--apply] [--json] [--api-allowlist diffuserId:publisherId1,publisherId2]...`
+  );
+  process.exit(1);
+};
+
+const loadEnvironment = (envPath?: string) => {
+  if (!envPath) {
+    dotenv.config({ quiet: true });
+    return;
+  }
+
+  const candidate = path.isAbsolute(envPath) ? envPath : path.resolve(process.cwd(), envPath);
+  if (!fs.existsSync(candidate)) {
+    fail(`Env file not found: ${candidate}`);
+  }
+  console.error(`[${SCRIPT_NAME}] Loading environment variables from ${candidate}`);
+  dotenv.config({ path: candidate, override: true, quiet: true });
+};
+
+const addReason = (reasons: Set<AuditReason>, reason: AuditReason) => {
+  reasons.add(reason);
+};
+
+const addDesiredRoots = (map: Map<string, Set<string>>, diffuserId: string, publisherIds: string[]) => {
+  const roots = map.get(diffuserId) ?? new Set<string>();
+  for (const publisherId of publisherIds) {
+    roots.add(publisherId);
+  }
+  map.set(diffuserId, roots);
+};
+
+const options = parseOptions(process.argv.slice(2));
+loadEnvironment(options.envPath);
+
+async function main() {
+  const { prisma } = await import("@/db/postgres");
+  const { publisherDiffusionRuleService, DIFFUSION_SCOPE_ROOT_CRITERIA } = await import("@/services/publisher-diffusion-rule");
+
+  const [diffusers, rules, activeWidgets] = await Promise.all([
+    prisma.publisher.findMany({
+      where: {
+        deletedAt: null,
+        OR: [{ hasApiRights: true }, { hasWidgetRights: true }, { hasCampaignRights: true }],
+      },
+      select: { id: true, name: true, hasApiRights: true, hasWidgetRights: true, hasCampaignRights: true },
+      orderBy: { name: "asc" },
+    }),
+    prisma.publisherDiffusionRule.findMany({
+      select: { publisherId: true, combinedWithId: true, field: true, operator: true, value: true },
+    }),
+    prisma.widget.findMany({
+      where: { active: true, deletedAt: null },
+      select: {
+        id: true,
+        name: true,
+        fromPublisherId: true,
+        widgetPublishers: { select: { publisherId: true } },
+      },
+      orderBy: { name: "asc" },
+    }),
+  ]);
+
+  const widgetFromPublisherIds = Array.from(new Set(activeWidgets.map((widget) => widget.fromPublisherId)));
+  const widgetFromPublishers = await prisma.publisher.findMany({
+    where: { id: { in: widgetFromPublisherIds } },
+    select: { id: true, name: true, hasApiRights: true, hasWidgetRights: true, hasCampaignRights: true },
+  });
+  const diffusersById = new Map([...diffusers, ...widgetFromPublishers].map((diffuser) => [diffuser.id, diffuser]));
+  const rulesByPublisherId = new Map<string, typeof rules>();
+  const rootsByPublisherId = new Map<string, string[]>();
+  const desiredRootsByPublisherId = new Map<string, Set<string>>();
+  const reasonsByPublisherId = new Map<string, Set<AuditReason>>();
+  const blockersByPublisherId = new Map<string, string[]>();
+
+  const reasonsFor = (publisherId: string) => {
+    const reasons = reasonsByPublisherId.get(publisherId) ?? new Set<AuditReason>();
+    reasonsByPublisherId.set(publisherId, reasons);
+    return reasons;
+  };
+  const blockersFor = (publisherId: string) => {
+    const blockers = blockersByPublisherId.get(publisherId) ?? [];
+    blockersByPublisherId.set(publisherId, blockers);
+    return blockers;
+  };
+
+  for (const rule of rules) {
+    const publisherRules = rulesByPublisherId.get(rule.publisherId) ?? [];
+    publisherRules.push(rule);
+    rulesByPublisherId.set(rule.publisherId, publisherRules);
+
+    if (
+      rule.combinedWithId === DIFFUSION_SCOPE_ROOT_CRITERIA.combinedWithId &&
+      rule.field === DIFFUSION_SCOPE_ROOT_CRITERIA.field &&
+      rule.operator === DIFFUSION_SCOPE_ROOT_CRITERIA.operator
+    ) {
+      const roots = rootsByPublisherId.get(rule.publisherId) ?? [];
+      roots.push(rule.value);
+      rootsByPublisherId.set(rule.publisherId, roots);
+    }
+  }
+
+  for (const widget of activeWidgets) {
+    const widgetPublisherIds = widget.widgetPublishers.map((publisher) => publisher.publisherId);
+    if (!widgetPublisherIds.length) {
+      addReason(reasonsFor(widget.fromPublisherId), "widget_missing_roots");
+      blockersFor(widget.fromPublisherId).push(`Widget ${widget.id} (${widget.name}) has no widget_publisher allowlist`);
+      continue;
+    }
+    addReason(reasonsFor(widget.fromPublisherId), "widget_missing_roots");
+    addDesiredRoots(desiredRootsByPublisherId, widget.fromPublisherId, widgetPublisherIds);
+  }
+
+  for (const [diffuserId, publisherIds] of options.apiAllowlists) {
+    addDesiredRoots(desiredRootsByPublisherId, diffuserId, publisherIds);
+  }
+
+  for (const diffuser of diffusers) {
+    const rulesForDiffuser = rulesByPublisherId.get(diffuser.id) ?? [];
+    const rootsForDiffuser = rootsByPublisherId.get(diffuser.id) ?? [];
+    const hasRoots = rootsForDiffuser.length > 0;
+
+    if (rulesForDiffuser.length > 0 && !hasRoots) {
+      addReason(reasonsFor(diffuser.id), "rules_without_allowlist");
+      addDesiredRoots(desiredRootsByPublisherId, diffuser.id, [diffuser.id]);
+    }
+
+    if (!hasRoots) {
+      addReason(reasonsFor(diffuser.id), diffuser.hasApiRights ? "api_without_roots" : "diffuser_without_roots");
+
+      if (diffuser.hasApiRights && !options.apiAllowlists.has(diffuser.id)) {
+        blockersFor(diffuser.id).push("API diffuser without explicit --api-allowlist");
+      }
+
+      if (!diffuser.hasApiRights && !desiredRootsByPublisherId.has(diffuser.id)) {
+        addDesiredRoots(desiredRootsByPublisherId, diffuser.id, [diffuser.id]);
+      }
+    }
+  }
+
+  const auditRows: AuditRow[] = Array.from(reasonsByPublisherId.entries())
+    .map(([diffuserId, reasons]) => {
+      const diffuser = diffusersById.get(diffuserId);
+      const existingRoots = Array.from(new Set(rootsByPublisherId.get(diffuserId) ?? [])).sort();
+      const desiredRoots = Array.from(desiredRootsByPublisherId.get(diffuserId) ?? []).sort();
+      const existing = new Set(existingRoots);
+      const rootsToCreate = desiredRoots.filter((publisherId) => !existing.has(publisherId));
+
+      return {
+        diffuserId,
+        diffuserName: diffuser?.name ?? "Unknown publisher",
+        reasons: Array.from(reasons).sort(),
+        existingRoots,
+        rootsToCreate,
+        blockers: blockersByPublisherId.get(diffuserId) ?? [],
+      };
+    })
+    .filter((row) => row.rootsToCreate.length > 0 || row.blockers.length > 0)
+    .sort((left, right) => left.diffuserName.localeCompare(right.diffuserName));
+
+  const blockerCount = auditRows.reduce((sum, row) => sum + row.blockers.length, 0);
+  const rootsToCreateCount = auditRows.reduce((sum, row) => sum + row.rootsToCreate.length, 0);
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          mode: options.apply ? "apply" : "dry-run",
+          generatedAt: new Date().toISOString(),
+          summary: { diffusers: auditRows.length, rootsToCreate: rootsToCreateCount, blockers: blockerCount },
+          diffusers: auditRows,
+        },
+        null,
+        2
+      )
+    );
+  } else {
+    console.log(`[${SCRIPT_NAME}] Mode: ${options.apply ? "apply" : "dry-run"}`);
+    console.log(`[${SCRIPT_NAME}] Diffusers to review: ${auditRows.length}`);
+    console.log(`[${SCRIPT_NAME}] Roots to create: ${rootsToCreateCount}`);
+    console.log(`[${SCRIPT_NAME}] Blockers: ${blockerCount}`);
+    for (const row of auditRows) {
+      console.log(`\n- ${row.diffuserName} (${row.diffuserId})`);
+      console.log(`  reasons: ${row.reasons.join(", ")}`);
+      console.log(`  existing roots: ${row.existingRoots.length}`);
+      console.log(`  roots to create: ${row.rootsToCreate.join(", ") || "none"}`);
+      for (const blocker of row.blockers) {
+        console.log(`  blocker: ${blocker}`);
+      }
+    }
+  }
+
+  if (!options.apply) {
+    return;
+  }
+  if (blockerCount > 0) {
+    throw new Error(`Refusing to apply with ${blockerCount} blocker(s). Fix the audit input and rerun.`);
+  }
+
+  for (const row of auditRows) {
+    for (const annonceurPublisherId of row.rootsToCreate) {
+      await publisherDiffusionRuleService.findOrCreateScopeRoot(row.diffuserId, annonceurPublisherId);
+      console.log(`[${SCRIPT_NAME}] Created scope root ${row.diffuserId} -> ${annonceurPublisherId}`);
+    }
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(`[${SCRIPT_NAME}] Failed`, error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    const { prisma } = await import("@/db/postgres");
+    await prisma.$disconnect();
+  });

--- a/api/scripts/backfill-diffusion-scope-roots.ts
+++ b/api/scripts/backfill-diffusion-scope-roots.ts
@@ -11,7 +11,7 @@ type Options = {
   apiAllowlists: Map<string, string[]>;
 };
 
-type AuditReason = "api_without_roots" | "diffuser_without_roots" | "rules_without_allowlist" | "widget_missing_roots";
+type AuditReason = "api_without_roots";
 
 type AuditRow = {
   diffuserId: string;
@@ -85,10 +85,6 @@ const loadEnvironment = (envPath?: string) => {
   dotenv.config({ path: candidate, override: true, quiet: true });
 };
 
-const addReason = (reasons: Set<AuditReason>, reason: AuditReason) => {
-  reasons.add(reason);
-};
-
 const addDesiredRoots = (map: Map<string, Set<string>>, diffuserId: string, publisherIds: string[]) => {
   const roots = map.get(diffuserId) ?? new Set<string>();
   for (const publisherId of publisherIds) {
@@ -104,58 +100,24 @@ async function main() {
   const { prisma } = await import("@/db/postgres");
   const { publisherDiffusionRuleService, DIFFUSION_SCOPE_ROOT_CRITERIA } = await import("@/services/publisher-diffusion-rule");
 
-  const [diffusers, rules, activeWidgets] = await Promise.all([
+  const [apiDiffusers, rules] = await Promise.all([
     prisma.publisher.findMany({
       where: {
         deletedAt: null,
-        OR: [{ hasApiRights: true }, { hasWidgetRights: true }, { hasCampaignRights: true }],
+        hasApiRights: true,
       },
-      select: { id: true, name: true, hasApiRights: true, hasWidgetRights: true, hasCampaignRights: true },
+      select: { id: true, name: true },
       orderBy: { name: "asc" },
     }),
     prisma.publisherDiffusionRule.findMany({
       select: { publisherId: true, combinedWithId: true, field: true, operator: true, value: true },
     }),
-    prisma.widget.findMany({
-      where: { active: true, deletedAt: null },
-      select: {
-        id: true,
-        name: true,
-        fromPublisherId: true,
-        widgetPublishers: { select: { publisherId: true } },
-      },
-      orderBy: { name: "asc" },
-    }),
   ]);
 
-  const widgetFromPublisherIds = Array.from(new Set(activeWidgets.map((widget) => widget.fromPublisherId)));
-  const widgetFromPublishers = await prisma.publisher.findMany({
-    where: { id: { in: widgetFromPublisherIds } },
-    select: { id: true, name: true, hasApiRights: true, hasWidgetRights: true, hasCampaignRights: true },
-  });
-  const diffusersById = new Map([...diffusers, ...widgetFromPublishers].map((diffuser) => [diffuser.id, diffuser]));
-  const rulesByPublisherId = new Map<string, typeof rules>();
   const rootsByPublisherId = new Map<string, string[]>();
   const desiredRootsByPublisherId = new Map<string, Set<string>>();
-  const reasonsByPublisherId = new Map<string, Set<AuditReason>>();
-  const blockersByPublisherId = new Map<string, string[]>();
-
-  const reasonsFor = (publisherId: string) => {
-    const reasons = reasonsByPublisherId.get(publisherId) ?? new Set<AuditReason>();
-    reasonsByPublisherId.set(publisherId, reasons);
-    return reasons;
-  };
-  const blockersFor = (publisherId: string) => {
-    const blockers = blockersByPublisherId.get(publisherId) ?? [];
-    blockersByPublisherId.set(publisherId, blockers);
-    return blockers;
-  };
 
   for (const rule of rules) {
-    const publisherRules = rulesByPublisherId.get(rule.publisherId) ?? [];
-    publisherRules.push(rule);
-    rulesByPublisherId.set(rule.publisherId, publisherRules);
-
     if (
       rule.combinedWithId === DIFFUSION_SCOPE_ROOT_CRITERIA.combinedWithId &&
       rule.field === DIFFUSION_SCOPE_ROOT_CRITERIA.field &&
@@ -167,59 +129,26 @@ async function main() {
     }
   }
 
-  for (const widget of activeWidgets) {
-    const widgetPublisherIds = widget.widgetPublishers.map((publisher) => publisher.publisherId);
-    if (!widgetPublisherIds.length) {
-      addReason(reasonsFor(widget.fromPublisherId), "widget_missing_roots");
-      blockersFor(widget.fromPublisherId).push(`Widget ${widget.id} (${widget.name}) has no widget_publisher allowlist`);
-      continue;
-    }
-    addReason(reasonsFor(widget.fromPublisherId), "widget_missing_roots");
-    addDesiredRoots(desiredRootsByPublisherId, widget.fromPublisherId, widgetPublisherIds);
-  }
-
   for (const [diffuserId, publisherIds] of options.apiAllowlists) {
     addDesiredRoots(desiredRootsByPublisherId, diffuserId, publisherIds);
   }
 
-  for (const diffuser of diffusers) {
-    const rulesForDiffuser = rulesByPublisherId.get(diffuser.id) ?? [];
-    const rootsForDiffuser = rootsByPublisherId.get(diffuser.id) ?? [];
-    const hasRoots = rootsForDiffuser.length > 0;
-
-    if (rulesForDiffuser.length > 0 && !hasRoots) {
-      addReason(reasonsFor(diffuser.id), "rules_without_allowlist");
-      addDesiredRoots(desiredRootsByPublisherId, diffuser.id, [diffuser.id]);
-    }
-
-    if (!hasRoots) {
-      addReason(reasonsFor(diffuser.id), diffuser.hasApiRights ? "api_without_roots" : "diffuser_without_roots");
-
-      if (diffuser.hasApiRights && !options.apiAllowlists.has(diffuser.id)) {
-        blockersFor(diffuser.id).push("API diffuser without explicit --api-allowlist");
-      }
-
-      if (!diffuser.hasApiRights && !desiredRootsByPublisherId.has(diffuser.id)) {
-        addDesiredRoots(desiredRootsByPublisherId, diffuser.id, [diffuser.id]);
-      }
-    }
-  }
-
-  const auditRows: AuditRow[] = Array.from(reasonsByPublisherId.entries())
-    .map(([diffuserId, reasons]) => {
-      const diffuser = diffusersById.get(diffuserId);
-      const existingRoots = Array.from(new Set(rootsByPublisherId.get(diffuserId) ?? [])).sort();
-      const desiredRoots = Array.from(desiredRootsByPublisherId.get(diffuserId) ?? []).sort();
+  const auditRows: AuditRow[] = apiDiffusers
+    .filter((diffuser) => (rootsByPublisherId.get(diffuser.id) ?? []).length === 0)
+    .map((diffuser) => {
+      const existingRoots = Array.from(new Set(rootsByPublisherId.get(diffuser.id) ?? [])).sort();
+      const desiredRoots = Array.from(desiredRootsByPublisherId.get(diffuser.id) ?? []).sort();
       const existing = new Set(existingRoots);
       const rootsToCreate = desiredRoots.filter((publisherId) => !existing.has(publisherId));
+      const blockers = options.apiAllowlists.has(diffuser.id) ? [] : ["API diffuser without explicit --api-allowlist"];
 
       return {
-        diffuserId,
-        diffuserName: diffuser?.name ?? "Unknown publisher",
-        reasons: Array.from(reasons).sort(),
+        diffuserId: diffuser.id,
+        diffuserName: diffuser.name,
+        reasons: ["api_without_roots"] satisfies AuditReason[],
         existingRoots,
         rootsToCreate,
-        blockers: blockersByPublisherId.get(diffuserId) ?? [],
+        blockers,
       };
     })
     .filter((row) => row.rootsToCreate.length > 0 || row.blockers.length > 0)

--- a/api/src/services/publisher.ts
+++ b/api/src/services/publisher.ts
@@ -143,11 +143,11 @@ export const publisherService = (() => {
       key: (publisherId) => publisherId,
     });
 
-  const resolveExplicitDiffusionPartnerIds = (publisherId: string, rightsEnabled: boolean, partnerIds: string[]): string[] => {
-    if (!rightsEnabled) {
-      return [];
+  const resolveExplicitDiffusionPartnerIds = (publisherId: string, hasApiRights: boolean, partnerIds: string[]): string[] => {
+    if (partnerIds.length) {
+      return partnerIds;
     }
-    return partnerIds.length ? partnerIds : [publisherId];
+    return hasApiRights ? [publisherId] : [];
   };
 
   const ensureDiffusionPartnersExist = async (tx: Prisma.TransactionClient, partnerIds: string[]): Promise<void> => {
@@ -251,6 +251,7 @@ export const publisherService = (() => {
   const createPublisher = async (input: PublisherCreateInput): Promise<PublisherRecord> => {
     const normalizedPartnerIds = normalizeDiffusionPartnerIds(input.publishers);
     const rightsEnabled = Boolean(input.hasApiRights || input.hasWidgetRights || input.hasCampaignRights);
+    const hasApiRights = input.hasApiRights ?? false;
     const id = input.id ?? (await generateUniquePublisherId());
 
     const data: Prisma.PublisherCreateInput = {
@@ -287,8 +288,8 @@ export const publisherService = (() => {
 
     const created = await prisma.$transaction(async (tx) => {
       const publisher = await tx.publisher.create({ data, include: defaultInclude });
-      if (rightsEnabled) {
-        await syncDiffusionScopeRoots(tx, publisher.id, resolveExplicitDiffusionPartnerIds(publisher.id, rightsEnabled, normalizedPartnerIds));
+      if (rightsEnabled && (normalizedPartnerIds.length || hasApiRights)) {
+        await syncDiffusionScopeRoots(tx, publisher.id, resolveExplicitDiffusionPartnerIds(publisher.id, hasApiRights, normalizedPartnerIds));
       }
       return publisher;
     });
@@ -496,8 +497,7 @@ export const publisherService = (() => {
       data.deletedAt = patch.deletedAt ?? null;
     }
 
-    const rightsWereEnabled = existing.hasApiRights || existing.hasWidgetRights || existing.hasCampaignRights;
-    const shouldSyncDiffusions = !rightsEnabled || patch.publishers !== undefined || (!rightsWereEnabled && rightsEnabled);
+    const shouldSyncDiffusions = !rightsEnabled || patch.publishers !== undefined || (!existing.hasApiRights && effectiveRights.hasApiRights);
 
     const updated = await prisma.$transaction(async (tx) => {
       const publisher = await tx.publisher.update({
@@ -506,7 +506,7 @@ export const publisherService = (() => {
       });
 
       if (shouldSyncDiffusions) {
-        await syncDiffusionScopeRoots(tx, id, resolveExplicitDiffusionPartnerIds(id, rightsEnabled, normalizedPartnerIds ?? []));
+        await syncDiffusionScopeRoots(tx, id, resolveExplicitDiffusionPartnerIds(id, effectiveRights.hasApiRights, normalizedPartnerIds ?? []));
       }
 
       return publisher;

--- a/api/src/services/publisher.ts
+++ b/api/src/services/publisher.ts
@@ -497,7 +497,8 @@ export const publisherService = (() => {
       data.deletedAt = patch.deletedAt ?? null;
     }
 
-    const shouldSyncDiffusions = !rightsEnabled || patch.publishers !== undefined || (!existing.hasApiRights && effectiveRights.hasApiRights);
+    const shouldSyncExplicitDiffusions = !rightsEnabled || patch.publishers !== undefined;
+    const shouldBootstrapApiDiffusionRoots = !existing.hasApiRights && effectiveRights.hasApiRights && patch.publishers === undefined;
 
     const updated = await prisma.$transaction(async (tx) => {
       const publisher = await tx.publisher.update({
@@ -505,8 +506,13 @@ export const publisherService = (() => {
         data,
       });
 
-      if (shouldSyncDiffusions) {
+      if (shouldSyncExplicitDiffusions) {
         await syncDiffusionScopeRoots(tx, id, resolveExplicitDiffusionPartnerIds(id, effectiveRights.hasApiRights, normalizedPartnerIds ?? []));
+      } else if (shouldBootstrapApiDiffusionRoots) {
+        const existingRoots = await publisherDiffusionRuleService.findRules({ publisherId: id, ...DIFFUSION_SCOPE_ROOT_CRITERIA }, tx);
+        if (existingRoots.length === 0) {
+          await syncDiffusionScopeRoots(tx, id, [id]);
+        }
       }
 
       return publisher;

--- a/api/src/services/publisher.ts
+++ b/api/src/services/publisher.ts
@@ -143,13 +143,6 @@ export const publisherService = (() => {
       key: (publisherId) => publisherId,
     });
 
-  const resolveExplicitDiffusionPartnerIds = (publisherId: string, hasApiRights: boolean, partnerIds: string[]): string[] => {
-    if (partnerIds.length) {
-      return partnerIds;
-    }
-    return hasApiRights ? [publisherId] : [];
-  };
-
   const ensureDiffusionPartnersExist = async (tx: Prisma.TransactionClient, partnerIds: string[]): Promise<void> => {
     const uniqueIds = Array.from(new Set(partnerIds));
     if (!uniqueIds.length) {
@@ -252,6 +245,7 @@ export const publisherService = (() => {
     const normalizedPartnerIds = normalizeDiffusionPartnerIds(input.publishers);
     const rightsEnabled = Boolean(input.hasApiRights || input.hasWidgetRights || input.hasCampaignRights);
     const hasApiRights = input.hasApiRights ?? false;
+    const shouldBootstrapApiDiffusionRoots = hasApiRights && input.publishers === undefined;
     const id = input.id ?? (await generateUniquePublisherId());
 
     const data: Prisma.PublisherCreateInput = {
@@ -288,8 +282,8 @@ export const publisherService = (() => {
 
     const created = await prisma.$transaction(async (tx) => {
       const publisher = await tx.publisher.create({ data, include: defaultInclude });
-      if (rightsEnabled && (normalizedPartnerIds.length || hasApiRights)) {
-        await syncDiffusionScopeRoots(tx, publisher.id, resolveExplicitDiffusionPartnerIds(publisher.id, hasApiRights, normalizedPartnerIds));
+      if (rightsEnabled && (normalizedPartnerIds.length || shouldBootstrapApiDiffusionRoots)) {
+        await syncDiffusionScopeRoots(tx, publisher.id, normalizedPartnerIds.length ? normalizedPartnerIds : [publisher.id]);
       }
       return publisher;
     });
@@ -507,7 +501,7 @@ export const publisherService = (() => {
       });
 
       if (shouldSyncExplicitDiffusions) {
-        await syncDiffusionScopeRoots(tx, id, resolveExplicitDiffusionPartnerIds(id, effectiveRights.hasApiRights, normalizedPartnerIds ?? []));
+        await syncDiffusionScopeRoots(tx, id, normalizedPartnerIds ?? []);
       } else if (shouldBootstrapApiDiffusionRoots) {
         const existingRoots = await publisherDiffusionRuleService.findRules({ publisherId: id, ...DIFFUSION_SCOPE_ROOT_CRITERIA }, tx);
         if (existingRoots.length === 0) {

--- a/api/src/services/publisher.ts
+++ b/api/src/services/publisher.ts
@@ -143,6 +143,13 @@ export const publisherService = (() => {
       key: (publisherId) => publisherId,
     });
 
+  const resolveExplicitDiffusionPartnerIds = (publisherId: string, rightsEnabled: boolean, partnerIds: string[]): string[] => {
+    if (!rightsEnabled) {
+      return [];
+    }
+    return partnerIds.length ? partnerIds : [publisherId];
+  };
+
   const ensureDiffusionPartnersExist = async (tx: Prisma.TransactionClient, partnerIds: string[]): Promise<void> => {
     const uniqueIds = Array.from(new Set(partnerIds));
     if (!uniqueIds.length) {
@@ -280,8 +287,8 @@ export const publisherService = (() => {
 
     const created = await prisma.$transaction(async (tx) => {
       const publisher = await tx.publisher.create({ data, include: defaultInclude });
-      if (rightsEnabled && normalizedPartnerIds.length) {
-        await syncDiffusionScopeRoots(tx, publisher.id, normalizedPartnerIds);
+      if (rightsEnabled) {
+        await syncDiffusionScopeRoots(tx, publisher.id, resolveExplicitDiffusionPartnerIds(publisher.id, rightsEnabled, normalizedPartnerIds));
       }
       return publisher;
     });
@@ -489,7 +496,8 @@ export const publisherService = (() => {
       data.deletedAt = patch.deletedAt ?? null;
     }
 
-    const shouldClearDiffusions = patch.publishers === null || !rightsEnabled;
+    const rightsWereEnabled = existing.hasApiRights || existing.hasWidgetRights || existing.hasCampaignRights;
+    const shouldSyncDiffusions = !rightsEnabled || patch.publishers !== undefined || (!rightsWereEnabled && rightsEnabled);
 
     const updated = await prisma.$transaction(async (tx) => {
       const publisher = await tx.publisher.update({
@@ -497,10 +505,8 @@ export const publisherService = (() => {
         data,
       });
 
-      if (shouldClearDiffusions) {
-        await syncDiffusionScopeRoots(tx, id, []);
-      } else if (normalizedPartnerIds) {
-        await syncDiffusionScopeRoots(tx, id, normalizedPartnerIds);
+      if (shouldSyncDiffusions) {
+        await syncDiffusionScopeRoots(tx, id, resolveExplicitDiffusionPartnerIds(id, rightsEnabled, normalizedPartnerIds ?? []));
       }
 
       return publisher;

--- a/api/tests/integration/services/publisher.test.ts
+++ b/api/tests/integration/services/publisher.test.ts
@@ -69,6 +69,22 @@ describe("publisherService diffusion sync", () => {
     expect(updated.publishers[0].publisherId).toBe(diffuseur.id);
   });
 
+  it("keeps existing partner scope roots when API rights are enabled without explicit publishers", async () => {
+    const annonceur = await createTestPublisher({ name: "Existing annonceur" });
+    const diffuseur = await createTestPublisher({
+      name: "Widget diffuseur promoted to API",
+      hasApiRights: false,
+      hasWidgetRights: true,
+      hasCampaignRights: true,
+      publishers: [{ publisherId: annonceur.id }],
+    });
+
+    const updated = await publisherService.updatePublisher(diffuseur.id, { hasApiRights: true });
+
+    expect(updated.publishers.map((publisher) => publisher.publisherId)).toEqual([annonceur.id]);
+    expect((await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, ...DIFFUSION_SCOPE_ROOT_CRITERIA })).map((root) => root.value)).toEqual([annonceur.id]);
+  });
+
   it("rolls back publisher update when scope root synchronization fails", async () => {
     const diffuseur = await createTestPublisher({ name: "Diffuseur before rollback" });
     const initialRoots = await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, ...DIFFUSION_SCOPE_ROOT_CRITERIA });

--- a/api/tests/integration/services/publisher.test.ts
+++ b/api/tests/integration/services/publisher.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from "vitest";
 
 import { publisherService } from "@/services/publisher";
-import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
+import publisherDiffusionRuleService, { DIFFUSION_SCOPE_ROOT_CRITERIA } from "@/services/publisher-diffusion-rule";
 
 import { createTestPublisher } from "../../fixtures";
 
 describe("publisherService diffusion sync", () => {
+  it("creates a self scope root when a diffuser is created without explicit publishers", async () => {
+    const diffuseur = await createTestPublisher({ name: "Diffuseur self scope", publishers: [] });
+
+    const roots = await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, ...DIFFUSION_SCOPE_ROOT_CRITERIA });
+
+    expect(diffuseur.publishers).toHaveLength(1);
+    expect(diffuseur.publishers[0].publisherId).toBe(diffuseur.id);
+    expect(roots.map((root) => root.value)).toEqual([diffuseur.id]);
+  });
+
   it("rolls back publisher creation when scope root synchronization fails", async () => {
     await expect(
       publisherService.createPublisher({
@@ -18,18 +28,37 @@ describe("publisherService diffusion sync", () => {
     await expect(publisherService.findOnePublisherByName("Diffuseur rollback create")).resolves.toBeNull();
   });
 
-  it("clears all scope roots when publishers is null", async () => {
+  it("keeps an explicit self scope root when publishers is null and rights stay enabled", async () => {
     const annonceur = await createTestPublisher({ name: "Annonceur" });
     const diffuseur = await createTestPublisher({ name: "Diffuseur", publishers: [{ publisherId: annonceur.id }] });
 
     const updated = await publisherService.updatePublisher(diffuseur.id, { publishers: null });
 
-    expect(updated.publishers).toHaveLength(0);
+    expect(updated.publishers).toHaveLength(1);
+    expect(updated.publishers[0].publisherId).toBe(diffuseur.id);
+    expect((await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, ...DIFFUSION_SCOPE_ROOT_CRITERIA })).map((root) => root.value)).toEqual([diffuseur.id]);
+  });
+
+  it("creates a self scope root when rights are enabled without explicit publishers", async () => {
+    const diffuseur = await createTestPublisher({
+      name: "Diffuseur rights disabled",
+      hasApiRights: false,
+      hasWidgetRights: false,
+      hasCampaignRights: false,
+      publishers: [],
+    });
+
     expect(await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, combinedWithId: null })).toHaveLength(0);
+
+    const updated = await publisherService.updatePublisher(diffuseur.id, { hasApiRights: true });
+
+    expect(updated.publishers).toHaveLength(1);
+    expect(updated.publishers[0].publisherId).toBe(diffuseur.id);
   });
 
   it("rolls back publisher update when scope root synchronization fails", async () => {
     const diffuseur = await createTestPublisher({ name: "Diffuseur before rollback" });
+    const initialRoots = await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, ...DIFFUSION_SCOPE_ROOT_CRITERIA });
 
     await expect(
       publisherService.updatePublisher(diffuseur.id, {
@@ -40,6 +69,6 @@ describe("publisherService diffusion sync", () => {
 
     const persisted = await publisherService.findOnePublisherById(diffuseur.id);
     expect(persisted?.name).toBe("Diffuseur before rollback");
-    expect(await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id })).toHaveLength(0);
+    expect(await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, ...DIFFUSION_SCOPE_ROOT_CRITERIA })).toEqual(initialRoots);
   });
 });

--- a/api/tests/integration/services/publisher.test.ts
+++ b/api/tests/integration/services/publisher.test.ts
@@ -6,14 +6,27 @@ import publisherDiffusionRuleService, { DIFFUSION_SCOPE_ROOT_CRITERIA } from "@/
 import { createTestPublisher } from "../../fixtures";
 
 describe("publisherService diffusion sync", () => {
-  it("creates a self scope root when a diffuser is created without explicit publishers", async () => {
-    const diffuseur = await createTestPublisher({ name: "Diffuseur self scope", publishers: [] });
+  it("creates a self scope root when an API diffuser is created without explicit publishers", async () => {
+    const diffuseur = await createTestPublisher({ name: "API diffuseur self scope", hasApiRights: true, publishers: [] });
 
     const roots = await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, ...DIFFUSION_SCOPE_ROOT_CRITERIA });
 
     expect(diffuseur.publishers).toHaveLength(1);
     expect(diffuseur.publishers[0].publisherId).toBe(diffuseur.id);
     expect(roots.map((root) => root.value)).toEqual([diffuseur.id]);
+  });
+
+  it("does not create a self scope root for a widget-only diffuser without explicit publishers", async () => {
+    const diffuseur = await createTestPublisher({
+      name: "Widget-only diffuseur without scope",
+      hasApiRights: false,
+      hasWidgetRights: true,
+      hasCampaignRights: false,
+      publishers: [],
+    });
+
+    expect(diffuseur.publishers).toHaveLength(0);
+    expect(await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, ...DIFFUSION_SCOPE_ROOT_CRITERIA })).toHaveLength(0);
   });
 
   it("rolls back publisher creation when scope root synchronization fails", async () => {
@@ -28,7 +41,7 @@ describe("publisherService diffusion sync", () => {
     await expect(publisherService.findOnePublisherByName("Diffuseur rollback create")).resolves.toBeNull();
   });
 
-  it("keeps an explicit self scope root when publishers is null and rights stay enabled", async () => {
+  it("keeps an explicit self scope root when publishers is null and API rights stay enabled", async () => {
     const annonceur = await createTestPublisher({ name: "Annonceur" });
     const diffuseur = await createTestPublisher({ name: "Diffuseur", publishers: [{ publisherId: annonceur.id }] });
 
@@ -39,7 +52,7 @@ describe("publisherService diffusion sync", () => {
     expect((await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, ...DIFFUSION_SCOPE_ROOT_CRITERIA })).map((root) => root.value)).toEqual([diffuseur.id]);
   });
 
-  it("creates a self scope root when rights are enabled without explicit publishers", async () => {
+  it("creates a self scope root when API rights are enabled without explicit publishers", async () => {
     const diffuseur = await createTestPublisher({
       name: "Diffuseur rights disabled",
       hasApiRights: false,

--- a/api/tests/integration/services/publisher.test.ts
+++ b/api/tests/integration/services/publisher.test.ts
@@ -7,13 +7,20 @@ import { createTestPublisher } from "../../fixtures";
 
 describe("publisherService diffusion sync", () => {
   it("creates a self scope root when an API diffuser is created without explicit publishers", async () => {
-    const diffuseur = await createTestPublisher({ name: "API diffuseur self scope", hasApiRights: true, publishers: [] });
+    const diffuseur = await publisherService.createPublisher({ name: "API diffuseur self scope", hasApiRights: true });
 
     const roots = await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, ...DIFFUSION_SCOPE_ROOT_CRITERIA });
 
     expect(diffuseur.publishers).toHaveLength(1);
     expect(diffuseur.publishers[0].publisherId).toBe(diffuseur.id);
     expect(roots.map((root) => root.value)).toEqual([diffuseur.id]);
+  });
+
+  it("does not create a self scope root when an API diffuser is created with an explicit empty publishers list", async () => {
+    const diffuseur = await createTestPublisher({ name: "API diffuseur empty scope", hasApiRights: true, publishers: [] });
+
+    expect(diffuseur.publishers).toHaveLength(0);
+    expect(await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, ...DIFFUSION_SCOPE_ROOT_CRITERIA })).toHaveLength(0);
   });
 
   it("does not create a self scope root for a widget-only diffuser without explicit publishers", async () => {
@@ -41,15 +48,14 @@ describe("publisherService diffusion sync", () => {
     await expect(publisherService.findOnePublisherByName("Diffuseur rollback create")).resolves.toBeNull();
   });
 
-  it("keeps an explicit self scope root when publishers is null and API rights stay enabled", async () => {
+  it("clears all scope roots when publishers is null", async () => {
     const annonceur = await createTestPublisher({ name: "Annonceur" });
     const diffuseur = await createTestPublisher({ name: "Diffuseur", publishers: [{ publisherId: annonceur.id }] });
 
     const updated = await publisherService.updatePublisher(diffuseur.id, { publishers: null });
 
-    expect(updated.publishers).toHaveLength(1);
-    expect(updated.publishers[0].publisherId).toBe(diffuseur.id);
-    expect((await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, ...DIFFUSION_SCOPE_ROOT_CRITERIA })).map((root) => root.value)).toEqual([diffuseur.id]);
+    expect(updated.publishers).toHaveLength(0);
+    expect(await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, combinedWithId: null })).toHaveLength(0);
   });
 
   it("creates a self scope root when API rights are enabled without explicit publishers", async () => {


### PR DESCRIPTION
## Description

Cette PR prépare la PR 0 du plan de table matérialisée de diffusion côté API uniquement : elle supprime la création de nouveaux diffuseurs API avec bypass implicite et ajoute un script d'audit/backfill des scope roots API existants.

Changements principaux :

- un publisher avec droits API et sans partenaires explicites reçoit désormais un scope root self explicite ;
- vider `publishers` sur un publisher qui garde les droits API revient à un scope self, pas à zéro règle ;
- activer les droits API sur un publisher sans `publishers` crée aussi le scope self ;
- les publishers widget-only ne reçoivent pas de self-root automatique ; la diffusion widget reste portée par `widgetRules` + `widget.publishers` ;
- ajout de `scripts/backfill-diffusion-scope-roots.ts` en dry-run par défaut, avec `--apply` bloquant si des diffuseurs API n'ont pas de `--api-allowlist` explicite.

## Liens utiles

- 📝 Ticket Notion : à compléter
- Plan : `docs/diffusion-table-materialisee.md`

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

Validations locales :

- `npx eslint --no-ignore scripts/backfill-diffusion-scope-roots.ts src/services/publisher.ts tests/integration/services/publisher.test.ts` : OK
- `npx tsc --noEmit -p tsconfig.build.json` : OK
- `npx ts-node scripts/backfill-diffusion-scope-roots.ts --dry-run --json` : OK, résumé local du 17/07/2026 : 6 diffuseurs API à revoir, 0 root à créer sans allowlist, 6 bloqueurs avant `--apply`

Non validé :

- `npm run test:integration -- tests/integration/services/publisher.test.ts` ne démarre pas localement car `node_modules` ne contient pas le binding optionnel `@rolldown/binding-darwin-x64` requis par Vitest/Rolldown.

Mode opératoire attendu avant `--apply` en staging/prod :

1. lancer le dry-run avec `--json` ;
2. fournir les allowlists des diffuseurs API via `--api-allowlist diffuseurId:annonceurId1,annonceurId2` ;
3. relancer avec `--apply`.