### PR TITLE
refactor(api): use materialized mission diffusion

### DIFF
--- a/api/prisma/migrations/20260722120000_add_mission_diffusion_created_at/migration.sql
+++ b/api/prisma/migrations/20260722120000_add_mission_diffusion_created_at/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "mission_diffusion" ADD COLUMN     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- CreateIndex
+CREATE INDEX "mission_diffusion_created_at_idx" ON "mission_diffusion"("created_at");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -439,14 +439,16 @@ model PublisherDiffusionRule {
 // encode l'allowlist explicite ou le scope propre du publisher. Le statut, le soft-delete et la
 // restriction `publisher` restent évalués en lecture (cf. mission-diffusion service).
 model MissionDiffusion {
-  distributionPublisherId String @map("distribution_publisher_id")
-  missionId               String @map("mission_id")
+  distributionPublisherId String   @map("distribution_publisher_id")
+  missionId               String   @map("mission_id")
+  createdAt               DateTime @default(now()) @map("created_at")
 
   distributionPublisher Publisher @relation("MissionDiffusionDistributionPublisher", fields: [distributionPublisherId], references: [id], onDelete: Cascade)
   mission               Mission   @relation("MissionDiffusionMission", fields: [missionId], references: [id], onDelete: Cascade)
 
   @@id([distributionPublisherId, missionId], map: "mission_diffusion_pkey")
   @@index([missionId], map: "mission_diffusion_mission_id_idx")
+  @@index([createdAt], map: "mission_diffusion_created_at_idx")
   @@map("mission_diffusion")
 }
 

--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -225,10 +225,10 @@ const buildMissionFilters = async (widget: WidgetRecord, query: { [key: string]:
     limit: pagination.limit,
   };
 
-  // Compatibilité temporaire des routes iframe historiques : les publishers
-  // sélectionnés uniquement via `widget.publishers` ne sont pas matérialisés
-  // dans le snapshot du diffuseur. Dans un widget hybride, on combine donc le
-  // snapshot pour les roots (et le scope propre) avec ce fallback historique.
+  // Compatibilité temporaire des routes iframe historiques : on combine le
+  // snapshot pour les roots live avec le fallback des publishers widget-only.
+  // Ce compromis local n'essaie pas de couvrir la staleness après suppression
+  // d'une root : ces routes seront remplacées par Typesense.
   // À supprimer avec `iframe/*` lors de la migration vers Typesense.
   if (diffusionRoots.length > 0) {
     if (widget.publishers.length === 0) {

--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -5,6 +5,7 @@ import zod from "zod";
 import { PUBLISHER_IDS } from "@/config";
 import { INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
 import { ipRateLimiter } from "@/middlewares/rate-limit";
+import publisherDiffusionRuleService, { DIFFUSION_SCOPE_ROOT_CRITERIA } from "@/services/publisher-diffusion-rule";
 import publisherOrganizationService from "@/services/publisher-organization";
 import { widgetService } from "@/services/widget";
 import { widgetMissionService } from "@/services/widget-mission";
@@ -211,13 +212,25 @@ const resolveLocationFilters = (widget: WidgetRecord, lon?: number, lat?: number
 };
 
 const buildMissionFilters = async (widget: WidgetRecord, query: { [key: string]: any }, pagination: { skip: number; limit: number }): Promise<MissionSearchFilters> => {
+  const [directFilters, diffusionRoots] = await Promise.all([
+    applyWidgetRules(widget.rules || [], publisherOrganizationService.findIdsMatchingArrayValue),
+    publisherDiffusionRuleService.findRules({ publisherId: widget.fromPublisherId, ...DIFFUSION_SCOPE_ROOT_CRITERIA }),
+  ]);
+
   const filters: MissionSearchFilters = {
-    directFilters: await applyWidgetRules(widget.rules || [], publisherOrganizationService.findIdsMatchingArrayValue),
+    directFilters,
     publisherIds: widget.publishers,
-    diffuseurPublisherId: widget.fromPublisherId,
     skip: pagination.skip,
     limit: pagination.limit,
   };
+
+  // Compatibilité temporaire des routes iframe historiques : sans racine de
+  // diffusion, elles doivent conserver leur fallback sur `widget.publishers`,
+  // car les publishers widget-only ne sont pas tous présents dans le snapshot.
+  // À supprimer avec `iframe/*` lors de la migration vers Typesense.
+  if (diffusionRoots.length > 0) {
+    filters.diffuseurPublisherId = widget.fromPublisherId;
+  }
 
   const domainValues = normalizeToArray(query.domain);
   if (domainValues?.length) {

--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -3,6 +3,7 @@ import { NextFunction, Request, Response, Router } from "express";
 import zod from "zod";
 
 import { PUBLISHER_IDS } from "@/config";
+import { Prisma } from "@/db/core";
 import { INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
 import { ipRateLimiter } from "@/middlewares/rate-limit";
 import publisherDiffusionRuleService, { DIFFUSION_SCOPE_ROOT_CRITERIA } from "@/services/publisher-diffusion-rule";
@@ -224,12 +225,35 @@ const buildMissionFilters = async (widget: WidgetRecord, query: { [key: string]:
     limit: pagination.limit,
   };
 
-  // Compatibilité temporaire des routes iframe historiques : sans racine de
-  // diffusion, elles doivent conserver leur fallback sur `widget.publishers`,
-  // car les publishers widget-only ne sont pas tous présents dans le snapshot.
+  // Compatibilité temporaire des routes iframe historiques : les publishers
+  // sélectionnés uniquement via `widget.publishers` ne sont pas matérialisés
+  // dans le snapshot du diffuseur. Dans un widget hybride, on combine donc le
+  // snapshot pour les roots (et le scope propre) avec ce fallback historique.
   // À supprimer avec `iframe/*` lors de la migration vers Typesense.
   if (diffusionRoots.length > 0) {
-    filters.diffuseurPublisherId = widget.fromPublisherId;
+    if (widget.publishers.length === 0) {
+      filters.diffuseurPublisherId = widget.fromPublisherId;
+    } else {
+      const snapshotPublisherIds = new Set([...diffusionRoots.map((root) => root.value), widget.fromPublisherId]);
+      const publishersWithSnapshot = widget.publishers.filter((publisherId) => snapshotPublisherIds.has(publisherId));
+      const publishersWithFallback = widget.publishers.filter((publisherId) => !snapshotPublisherIds.has(publisherId));
+      const accessConditions: Prisma.MissionWhereInput[] = [];
+
+      if (publishersWithSnapshot.length > 0) {
+        accessConditions.push({
+          publisherId: { in: publishersWithSnapshot },
+          missionDiffusions: { some: { distributionPublisherId: widget.fromPublisherId } },
+        });
+      }
+      if (publishersWithFallback.length > 0) {
+        accessConditions.push({ publisherId: { in: publishersWithFallback } });
+      }
+
+      filters.directFilters = {
+        AND: [directFilters, accessConditions.length === 1 ? accessConditions[0] : { OR: accessConditions }],
+      };
+      filters.publisherIds = [];
+    }
   }
 
   const domainValues = normalizeToArray(query.domain);

--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -252,7 +252,7 @@ const buildMissionFilters = async (widget: WidgetRecord, query: { [key: string]:
       filters.directFilters = {
         AND: [directFilters, accessConditions.length === 1 ? accessConditions[0] : { OR: accessConditions }],
       };
-      filters.publisherIds = [];
+      filters.publisherIds = undefined;
     }
   }
 

--- a/api/src/services/__tests__/mission.test.ts
+++ b/api/src/services/__tests__/mission.test.ts
@@ -18,19 +18,19 @@ import { buildWhere, missionService } from "@/services/mission";
 
 describe("buildWhere diffusion publisher filter", () => {
   it("uses the whole diffusion snapshot when publisherIds is undefined", async () => {
-    const where = await buildWhere({ diffuseurPublisherId: "diffuseur-1" });
+    const where = await buildWhere({ diffuseurPublisherId: "diffuseur-1", skip: 0, limit: 10 });
 
     expect(where.AND).toEqual([{ missionDiffusions: { some: { distributionPublisherId: "diffuseur-1" } } }]);
   });
 
   it("builds an impossible condition when publisherIds is explicitly empty", async () => {
-    const where = await buildWhere({ diffuseurPublisherId: "diffuseur-1", publisherIds: [] });
+    const where = await buildWhere({ diffuseurPublisherId: "diffuseur-1", publisherIds: [], skip: 0, limit: 10 });
 
     expect(where.AND).toEqual([{ id: { in: [] } }]);
   });
 
   it("intersects the diffusion snapshot with explicit publisherIds", async () => {
-    const where = await buildWhere({ diffuseurPublisherId: "diffuseur-1", publisherIds: ["publisher-1"] });
+    const where = await buildWhere({ diffuseurPublisherId: "diffuseur-1", publisherIds: ["publisher-1"], skip: 0, limit: 10 });
 
     expect(where.AND).toEqual([
       {

--- a/api/src/services/__tests__/mission.test.ts
+++ b/api/src/services/__tests__/mission.test.ts
@@ -14,7 +14,31 @@ vi.mock("@/error", () => ({
   captureException: captureExceptionMock,
 }));
 
-import { missionService } from "@/services/mission";
+import { buildWhere, missionService } from "@/services/mission";
+
+describe("buildWhere diffusion publisher filter", () => {
+  it("uses the whole diffusion snapshot when publisherIds is undefined", async () => {
+    const where = await buildWhere({ diffuseurPublisherId: "diffuseur-1" });
+
+    expect(where.AND).toEqual([{ missionDiffusions: { some: { distributionPublisherId: "diffuseur-1" } } }]);
+  });
+
+  it("builds an impossible condition when publisherIds is explicitly empty", async () => {
+    const where = await buildWhere({ diffuseurPublisherId: "diffuseur-1", publisherIds: [] });
+
+    expect(where.AND).toEqual([{ id: { in: [] } }]);
+  });
+
+  it("intersects the diffusion snapshot with explicit publisherIds", async () => {
+    const where = await buildWhere({ diffuseurPublisherId: "diffuseur-1", publisherIds: ["publisher-1"] });
+
+    expect(where.AND).toEqual([
+      {
+        AND: [{ missionDiffusions: { some: { distributionPublisherId: "diffuseur-1" } } }, { publisherId: { in: ["publisher-1"] } }],
+      },
+    ]);
+  });
+});
 
 describe("missionService.enqueueMissionProcessing", () => {
   beforeEach(() => {

--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -6,18 +6,10 @@ vi.mock("@/repositories/mission-matching-result", () => ({
   },
 }));
 
-vi.mock("@/services/publisher-diffusion-rule", () => ({
-  default: {
-    buildMissionPublisherDiffusionRuleSql: vi.fn(),
-  },
-}));
-
-import { Prisma } from "@/db/core";
 import { prisma } from "@/db/postgres";
 import { missionMatchingResultRepository } from "@/repositories/mission-matching-result";
 import { matchingEngineService } from "@/services/matching-engine";
 import { CURRENT_MATCHING_ENGINE_VERSION } from "@/services/matching-engine/config";
-import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 
 const prismaMock = prisma as unknown as {
   $queryRaw: ReturnType<typeof vi.fn>;
@@ -25,10 +17,6 @@ const prismaMock = prisma as unknown as {
 
 const missionMatchingResultRepositoryMock = missionMatchingResultRepository as unknown as {
   createForUserScoringVersion: ReturnType<typeof vi.fn>;
-};
-
-const publisherDiffusionRuleServiceMock = publisherDiffusionRuleService as unknown as {
-  buildMissionPublisherDiffusionRuleSql: ReturnType<typeof vi.fn>;
 };
 
 const getSqlText = (query: unknown): string => {
@@ -59,7 +47,6 @@ describe("matchingEngineService", () => {
   beforeEach(() => {
     prismaMock.$queryRaw.mockReset();
     missionMatchingResultRepositoryMock.createForUserScoringVersion.mockReset();
-    publisherDiffusionRuleServiceMock.buildMissionPublisherDiffusionRuleSql.mockReset();
   });
 
   describe("rankMissionsByUserScoring", () => {
@@ -172,28 +159,24 @@ describe("matchingEngineService", () => {
       expect(result.tookMs).toBeGreaterThanOrEqual(0);
     });
 
-    it("injects the SQL filter from the publisher rules into the candidate jobs", async () => {
+    it("joint directement le snapshot complet pour le diffuseur", async () => {
       prismaMock.$queryRaw
-        .mockResolvedValueOnce([
-          {
-            id: "user-scoring-publisher-filter",
-          },
-        ])
+        .mockResolvedValueOnce([{ id: "user-scoring-table-filter" }])
         .mockResolvedValueOnce([]);
-      publisherDiffusionRuleServiceMock.buildMissionPublisherDiffusionRuleSql.mockResolvedValue(Prisma.sql`AND m."publisher_id" = ${"annonceur-1"}`);
       missionMatchingResultRepositoryMock.createForUserScoringVersion.mockResolvedValue({
-        id: "mission-matching-result-publisher-filter",
+        id: "mission-matching-result-table-filter",
       });
 
       await matchingEngineService.rankMissionsByUserScoring({
-        userScoringId: "user-scoring-publisher-filter",
+        userScoringId: "user-scoring-table-filter",
         publisherId: "publisher-diffuseur-1",
       });
 
-      expect(publisherDiffusionRuleServiceMock.buildMissionPublisherDiffusionRuleSql).toHaveBeenCalledWith("publisher-diffuseur-1", { missionAlias: "m" });
-
       const rankingSql = getSqlText(prismaMock.$queryRaw.mock.calls[1][0]);
-      expect(rankingSql).toContain('AND m."publisher_id" =');
+      expect(rankingSql).toContain('JOIN "mission_diffusion" md');
+      expect(rankingSql).toContain('md."mission_id" = m."id"');
+      expect(rankingSql).toContain('md."distribution_publisher_id" =');
+      expect(rankingSql).not.toContain('FROM "mission_diffusion" md\n      WHERE');
     });
 
     it("does not query taxonomy scores when no mission is ranked", async () => {

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -1,7 +1,6 @@
 import { Prisma } from "@/db/core";
 import { prisma } from "@/db/postgres";
 import { missionMatchingResultRepository } from "@/repositories/mission-matching-result";
-import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import { GATE_TAXONOMIES } from "@engagement/taxonomy";
 import { CURRENT_MATCHING_ENGINE_VERSION, MATCHING_ENGINE_TAXONOMIES, MATCHING_ENGINE_TOP_RESULTS_LIMIT, MATCHING_ENGINE_VERSIONS } from "./config";
 import type { MatchMissionItem, MatchingEngineTaxonomy, MissionMatchingResultItem, RankMissionsByUserScoringInput, RankMissionsByUserScoringResult } from "./types";
@@ -75,7 +74,7 @@ const assertUserScoringExists = async (userScoringId: string): Promise<void> => 
 
 const buildRanking = (params: {
   userScoringId: string;
-  publisherRuleSql?: Prisma.Sql;
+  publisherDiffusionJoinSql?: Prisma.Sql;
   taxonomyWeights: Record<MatchingEngineTaxonomy, number>;
   taxonomyWeight: number;
   geoWeight: number;
@@ -202,9 +201,9 @@ const buildRanking = (params: {
      AND me."status" = 'completed'
     JOIN "mission" m
       ON m."id" = ms."mission_id"
+    ${params.publisherDiffusionJoinSql ?? Prisma.empty}
     WHERE m."deleted_at" IS NULL
       AND m."status_code" = 'ACCEPTED'
-      ${params.publisherRuleSql ?? Prisma.empty}
     ORDER BY
       ms."mission_id" ASC,
       me."completed_at" DESC NULLS LAST,
@@ -529,12 +528,14 @@ const buildRanking = (params: {
 `;
 };
 
-const buildPublisherRuleSql = async (publisherId?: string): Promise<Prisma.Sql> => {
+const buildPublisherDiffusionJoinSql = (publisherId?: string): Prisma.Sql => {
   if (!publisherId) {
     return Prisma.empty;
   }
 
-  return publisherDiffusionRuleService.buildMissionPublisherDiffusionRuleSql(publisherId, { missionAlias: "m" });
+  return Prisma.sql`JOIN "mission_diffusion" md
+    ON md."mission_id" = m."id"
+   AND md."distribution_publisher_id" = ${publisherId}`;
 };
 
 const buildTaxonomyScoresSql = (params: { userScoringId: string; missionScoringIds: string[] }) => Prisma.sql`
@@ -642,11 +643,10 @@ const resolveRankingParams = (input: RankMissionsByUserScoringInput) => {
 
 const buildRankingSqlForInput = async (input: RankMissionsByUserScoringInput): Promise<Prisma.Sql> => {
   const params = resolveRankingParams(input);
-  const publisherRuleSql = await buildPublisherRuleSql(input.publisherId);
 
   return buildRanking({
     userScoringId: input.userScoringId,
-    publisherRuleSql,
+    publisherDiffusionJoinSql: buildPublisherDiffusionJoinSql(input.publisherId),
     taxonomyWeights: params.taxonomyWeights,
     taxonomyWeight: params.taxonomyWeight,
     geoWeight: params.geoWeight,

--- a/api/src/services/mission-browse/__tests__/index.test.ts
+++ b/api/src/services/mission-browse/__tests__/index.test.ts
@@ -154,42 +154,15 @@ describe("missionBrowseService.browse", () => {
     expect(facets.domaine).toEqual([]);
   });
 
-  it("restreint le détail aux publishers whitelistés", async () => {
+  it("restreint le détail au snapshot matérialisé du diffuseur", async () => {
     await missionBrowseService.findById("mission-1", "diffuseur-1");
 
     expect(findOneMissionByMock).toHaveBeenCalledWith({
       id: "mission-1",
-      publisherId: { in: ["annonceur-1", "annonceur-2"] },
+      missionDiffusions: { some: { distributionPublisherId: "diffuseur-1" } },
       deletedAt: null,
       statusCode: "ACCEPTED",
     });
-  });
-
-  it("restreint le détail avec les enfants organisation supportés", async () => {
-    findRulesMock.mockResolvedValue([
-      buildRule("annonceur-1", { id: "root-1" }),
-      buildRule("po-1", { id: "child-1", combinedWithId: "root-1", field: "publisherOrganization.clientId" }),
-    ]);
-
-    await missionBrowseService.findById("mission-1", "diffuseur-1");
-
-    expect(findOneMissionByMock).toHaveBeenCalledWith({
-      id: "mission-1",
-      AND: [{ publisherId: "annonceur-1" }, { publisherOrganization: { clientId: "po-1" } }],
-      deletedAt: null,
-      statusCode: "ACCEPTED",
-    });
-  });
-
-  it("ne restreint pas le détail quand aucune règle n'existe", async () => {
-    findRulesMock.mockResolvedValue([]);
-
-    await missionBrowseService.findById("mission-1", "diffuseur-1");
-
-    expect(findOneMissionByMock).toHaveBeenCalledWith({
-      id: "mission-1",
-      deletedAt: null,
-      statusCode: "ACCEPTED",
-    });
+    expect(findRulesMock).not.toHaveBeenCalled();
   });
 });

--- a/api/src/services/mission-browse/index.ts
+++ b/api/src/services/mission-browse/index.ts
@@ -139,15 +139,9 @@ export const missionBrowseService = {
   },
 
   async findById(id: string, diffuseurPublisherId: string, addressId?: string): Promise<MissionDetailResponse | null> {
-    const rules = await publisherDiffusionRuleService.findRules({ publisherId: diffuseurPublisherId });
-    const diffusionFilter = publisherDiffusionRulesToMissionFilter(rules);
-    if (diffusionFilter.kind === "none") {
-      return null;
-    }
-
     const mission = await missionService.findOneMissionBy({
       id,
-      ...(diffusionFilter.kind === "filter" ? diffusionFilter.missionWhere : {}),
+      missionDiffusions: { some: { distributionPublisherId: diffuseurPublisherId } },
       deletedAt: null,
       statusCode: "ACCEPTED",
     });

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -213,7 +213,12 @@ export const buildWhere = async (filters: MissionSearchFilters): Promise<Prisma.
   // Le snapshot contient l'allowlist explicite et le scope propre du diffuseur.
   if (filters.diffuseurPublisherId) {
     const diffusionWhere: Prisma.MissionWhereInput = { missionDiffusions: { some: { distributionPublisherId: filters.diffuseurPublisherId } } };
-    const restrictedDiffusionWhere = filters.publisherIds?.length ? { AND: [diffusionWhere, { publisherId: { in: filters.publisherIds } }] } : diffusionWhere;
+    const restrictedDiffusionWhere: Prisma.MissionWhereInput =
+      filters.publisherIds === undefined
+        ? diffusionWhere
+        : filters.publisherIds.length === 0
+          ? { id: { in: [] } }
+          : { AND: [diffusionWhere, { publisherId: { in: filters.publisherIds } }] };
     const existingAnd = Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : [];
     where.AND = [...existingAnd, restrictedDiffusionWhere];
   } else if (filters.publisherIds?.length) {

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -8,7 +8,6 @@ import { activityService } from "@/services/activity";
 import { buildMissionEnrichmentScoringWhere, missionEnrichmentService } from "@/services/mission-enrichment";
 import { changesRequireEnrichment } from "@/services/mission-enrichment/triggers";
 import { missionEventService } from "@/services/mission-event";
-import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import type {
   MissionCreateInput,
   MissionFacets,
@@ -23,7 +22,6 @@ import { PublisherOrganizationWithRelations } from "@/types/publisher-organizati
 import { calculateBoundingBox } from "@/utils";
 import { buildJobBoardMap, computeAddressHash, deriveMissionLocation, EVENT_TYPES, getMissionChanges, normalizeMissionAddresses } from "@/utils/mission";
 import { normalizeOptionalString, normalizeStringList } from "@/utils/normalize";
-import { optimizeMissionDiffusionRuleWhere } from "@/utils/publisher-diffusion-rule-query";
 import { publisherService } from "./publisher";
 import publisherOrganizationService from "./publisher-organization";
 
@@ -212,19 +210,13 @@ export const buildWhere = async (filters: MissionSearchFilters): Promise<Prisma.
   const orConditions: Prisma.MissionWhereInput[] = [];
   const andConditions: Prisma.MissionWhereInput[] = [];
 
-  // Restriction par publisher : les diffusion rules du diffuseur (allowlist `OR` de scopes
-  // `publisherId === annonceur AND <critères>`) font autorité. À défaut de rules, on retombe
-  // sur la simple liste d'annonceurs.
-  let publisherRestrictionApplied = false;
+  // Le snapshot contient l'allowlist explicite et le scope propre du diffuseur.
   if (filters.diffuseurPublisherId) {
-    const diffusionWhere = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere(filters.diffuseurPublisherId, filters.publisherIds);
-    if (Object.keys(diffusionWhere).length > 0) {
-      const existingAnd = Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : [];
-      where.AND = [...existingAnd, diffusionWhere];
-      publisherRestrictionApplied = true;
-    }
-  }
-  if (!publisherRestrictionApplied && filters.publisherIds?.length) {
+    const diffusionWhere: Prisma.MissionWhereInput = { missionDiffusions: { some: { distributionPublisherId: filters.diffuseurPublisherId } } };
+    const restrictedDiffusionWhere = filters.publisherIds?.length ? { AND: [diffusionWhere, { publisherId: { in: filters.publisherIds } }] } : diffusionWhere;
+    const existingAnd = Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : [];
+    where.AND = [...existingAnd, restrictedDiffusionWhere];
+  } else if (filters.publisherIds?.length) {
     where.publisherId = { in: filters.publisherIds };
   }
 
@@ -583,185 +575,6 @@ const baseInclude: MissionInclude = {
   jobBoards: true,
 };
 
-const MAX_SPLIT_DIFFUSION_SCOPES = 8;
-// Une page peut être très loin dans le feed historique d'un partenaire. On lit les
-// scopes par lots pour ne pas reconstruire en mémoire `skip + limit` résultats à
-// chaque appel, tout en évitant le tri disque de la requête monolithique.
-const SPLIT_DIFFUSION_PAGE_BATCH_SIZE = 5_000;
-
-type MissionPageIndexRow = {
-  id: string;
-  startAt: Date | null;
-  scopeIndex: number;
-};
-
-const compareMissionPageIndexRows = (a: MissionPageIndexRow, b: MissionPageIndexRow) => {
-  if (a.startAt === null && b.startAt !== null) {
-    return -1;
-  }
-  if (a.startAt !== null && b.startAt === null) {
-    return 1;
-  }
-  if (a.startAt !== null && b.startAt !== null) {
-    const dateDiff = b.startAt.getTime() - a.startAt.getTime();
-    if (dateDiff !== 0) {
-      return dateDiff;
-    }
-  }
-  return a.scopeIndex - b.scopeIndex;
-};
-
-type MissionPageCursor = Pick<MissionPageIndexRow, "id" | "startAt">;
-
-type MissionPageScopeStream = {
-  where: Prisma.MissionWhereInput;
-  scopeIndex: number;
-  rows: MissionPageIndexRow[];
-  rowIndex: number;
-  cursor: MissionPageCursor | null;
-  exhausted: boolean;
-};
-
-const buildMissionPageCursorWhere = (cursor: MissionPageCursor): Prisma.MissionWhereInput => {
-  // PostgreSQL trie les NULL avant les dates avec `DESC`. Une fois les NULL
-  // parcourus, il faut donc reprendre sur toutes les dates renseignées.
-  if (cursor.startAt === null) {
-    return {
-      OR: [{ startAt: null, id: { lt: cursor.id } }, { startAt: { not: null } }],
-    };
-  }
-
-  return {
-    AND: [
-      { startAt: { not: null } },
-      {
-        OR: [{ startAt: { lt: cursor.startAt } }, { startAt: cursor.startAt, id: { lt: cursor.id } }],
-      },
-    ],
-  };
-};
-
-const fetchMissionPageScopeBatch = async (stream: MissionPageScopeStream): Promise<void> => {
-  if (stream.exhausted) {
-    return;
-  }
-
-  const where = stream.cursor ? ({ AND: [stream.where, buildMissionPageCursorWhere(stream.cursor)] } satisfies Prisma.MissionWhereInput) : stream.where;
-  const rows = await prisma.mission.findMany({
-    where,
-    select: { id: true, startAt: true },
-    orderBy: [{ startAt: Prisma.SortOrder.desc }, { id: Prisma.SortOrder.desc }],
-    take: SPLIT_DIFFUSION_PAGE_BATCH_SIZE,
-  });
-
-  stream.rows = rows.map((row) => ({ ...row, scopeIndex: stream.scopeIndex }));
-  stream.rowIndex = 0;
-  stream.cursor = rows.length ? rows[rows.length - 1] : stream.cursor;
-  stream.exhausted = rows.length < SPLIT_DIFFUSION_PAGE_BATCH_SIZE;
-};
-
-const findMissionPageIdsByScopeStreams = async (scopeWheres: Prisma.MissionWhereInput[], skip: number, limit: number): Promise<string[]> => {
-  if (limit === 0) {
-    return [];
-  }
-
-  const streams: MissionPageScopeStream[] = scopeWheres.map((where, scopeIndex) => ({
-    where,
-    scopeIndex,
-    rows: [],
-    rowIndex: 0,
-    cursor: null,
-    exhausted: false,
-  }));
-
-  await Promise.all(streams.map(fetchMissionPageScopeBatch));
-
-  const pageIds: string[] = [];
-  let remainingToSkip = skip;
-
-  while (pageIds.length < limit) {
-    const stream = streams.reduce<MissionPageScopeStream | null>((best, candidate) => {
-      if (candidate.rowIndex === candidate.rows.length) {
-        return best;
-      }
-      if (!best || compareMissionPageIndexRows(candidate.rows[candidate.rowIndex], best.rows[best.rowIndex]) < 0) {
-        return candidate;
-      }
-      return best;
-    }, null);
-
-    if (!stream) {
-      break;
-    }
-
-    const row = stream.rows[stream.rowIndex];
-    stream.rowIndex += 1;
-    if (remainingToSkip > 0) {
-      remainingToSkip -= 1;
-    } else {
-      pageIds.push(row.id);
-    }
-
-    if (stream.rowIndex === stream.rows.length) {
-      await fetchMissionPageScopeBatch(stream);
-    }
-  }
-
-  return pageIds;
-};
-
-const hydrateMissionPage = async (ids: string[], select: MissionSelect | null, moderatedBy: string | null = null): Promise<MissionRecord[]> => {
-  if (!ids.length) {
-    return [];
-  }
-
-  const missions = await missionRepository.findMany({
-    where: { id: { in: ids } },
-    include: select ? undefined : baseInclude,
-    select: select ?? undefined,
-  });
-  const missionById = new Map(missions.map((mission) => [mission.id, mission]));
-
-  return ids
-    .map((id) => missionById.get(id))
-    .filter((mission): mission is Mission => Boolean(mission))
-    .map((mission) => toMissionRecord(mission as MissionWithRelations, moderatedBy));
-};
-
-const tryFindMissionsBySplitDiffusionScopes = async (
-  filters: MissionSearchFilters,
-  select: MissionSelect | null = null
-): Promise<{ data: MissionRecord[]; total: number } | null> => {
-  if (!filters.diffuseurPublisherId || filters.includeDeleted || filters.deletedAt || (filters.statusCode ?? "ACCEPTED") !== "ACCEPTED") {
-    return null;
-  }
-
-  const diffusionFilter = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateFilter(filters.diffuseurPublisherId, filters.publisherIds);
-  const hasDistinctScopes = diffusionFilter.scopes.length > 1 && new Set(diffusionFilter.scopePublisherIds).size === diffusionFilter.scopePublisherIds.length;
-  if (!hasDistinctScopes || diffusionFilter.scopes.length > MAX_SPLIT_DIFFUSION_SCOPES) {
-    return null;
-  }
-
-  const baseWhere = await buildWhere({ ...filters, diffuseurPublisherId: undefined, publisherIds: [] });
-  // `scopes` est conservé non optimisé pour la construction de l'allowlist. Il
-  // faut fusionner ici les exclusions d'organisation soeurs : sans cela Prisma
-  // génère une jointure `publisher_organization` par règle `is_not`.
-  const scopeWheres = diffusionFilter.scopes.map(
-    (scope) =>
-      ({ AND: [baseWhere, optimizeMissionDiffusionRuleWhere(scope)] }) satisfies Prisma.MissionWhereInput
-  );
-
-  const [pageIds, scopeCounts] = await Promise.all([
-    findMissionPageIdsByScopeStreams(scopeWheres, filters.skip, filters.limit),
-    Promise.all(scopeWheres.map((where) => missionRepository.count(where))),
-  ]);
-
-  return {
-    data: await hydrateMissionPage(pageIds, select, filters.moderationAcceptedFor ?? null),
-    total: scopeCounts.reduce((sum, count) => sum + count, 0),
-  };
-};
-
 export const missionService = {
   async enqueueMissionProcessing(missionId: string): Promise<void> {
     try {
@@ -845,11 +658,6 @@ export const missionService = {
   },
 
   async findMissions(filters: MissionSearchFilters, select: MissionSelect | null = null): Promise<{ data: MissionRecord[]; total: number }> {
-    const splitDiffusionResult = await tryFindMissionsBySplitDiffusionScopes(filters, select);
-    if (splitDiffusionResult) {
-      return splitDiffusionResult;
-    }
-
     const where = await buildWhere(filters);
 
     const [missions, total] = await Promise.all([

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -10,9 +10,6 @@ const prismaMock = prisma as unknown as {
   publisher: {
     findMany: ReturnType<typeof vi.fn>;
   };
-  mission: {
-    count: ReturnType<typeof vi.fn>;
-  };
 };
 
 const buildRule = (overrides: Record<string, unknown> = {}) => ({
@@ -286,44 +283,5 @@ describe("publisherDiffusionRuleService.findDistributionPublisherIdsForSnapshot"
       select: { id: true },
     });
     expect(publisherIds).toEqual(["api-only", "rule-only", "both"]);
-  });
-});
-
-describe("publisherDiffusionRuleService.canPublisherAccessMission", () => {
-  beforeEach(() => {
-    prismaMock.publisherDiffusionRule.findMany.mockReset();
-    prismaMock.mission.count.mockReset();
-  });
-
-  it("allows access when the publisher has no diffusion rules", async () => {
-    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([]);
-
-    const canAccess = await publisherDiffusionRuleService.canPublisherAccessMission({ publisherId: "publisher-1", missionId: "mission-1" });
-
-    expect(canAccess).toBe(true);
-    expect(prismaMock.mission.count).not.toHaveBeenCalled();
-  });
-
-  it("checks the mission against applicable diffusion rules", async () => {
-    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ value: "annonceur-1" })]);
-    prismaMock.mission.count.mockResolvedValue(1);
-
-    const canAccess = await publisherDiffusionRuleService.canPublisherAccessMission({ publisherId: "publisher-1", missionId: "mission-1" });
-
-    expect(canAccess).toBe(true);
-    expect(prismaMock.mission.count).toHaveBeenCalledWith({
-      where: {
-        AND: [{ id: "mission-1" }, { OR: [{ publisherId: "annonceur-1" }, { publisherId: "publisher-1" }] }],
-      },
-    });
-  });
-
-  it("rejects access when the mission does not match applicable diffusion rules", async () => {
-    prismaMock.publisherDiffusionRule.findMany.mockResolvedValue([buildRule({ value: "annonceur-1" })]);
-    prismaMock.mission.count.mockResolvedValue(0);
-
-    const canAccess = await publisherDiffusionRuleService.canPublisherAccessMission({ publisherId: "publisher-1", missionId: "mission-1" });
-
-    expect(canAccess).toBe(false);
   });
 });

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -8,12 +8,7 @@ import type {
   PublisherDiffusionRuleFindParams,
   PublisherDiffusionRuleRecord,
 } from "@/types/publisher-diffusion-rule";
-import {
-  buildMissionPublisherDiffusionRuleConditionFromRule,
-  buildMissionPublisherDiffusionRuleSqlFromRules,
-  isPublisherDiffusionRuleArrayField,
-  optimizeMissionDiffusionRuleWhere,
-} from "@/utils/publisher-diffusion-rule-query";
+import { buildMissionPublisherDiffusionRuleConditionFromRule, isPublisherDiffusionRuleArrayField, optimizeMissionDiffusionRuleWhere } from "@/utils/publisher-diffusion-rule-query";
 
 type PublisherDiffusionRuleWithChildren = PublisherDiffusionRule & {
   combinedRules?: PublisherDiffusionRule[];
@@ -87,11 +82,7 @@ const buildScopeCondition = (rule: PublisherDiffusionRule, childrenByParentId: M
  * s'il ne figure pas dans sa propre allowlist. `publisherIds` restreint
  * optionnellement aux annonceurs demandés (param `publisher` de la route).
  */
-const buildAllowlistFilter = (
-  rules: PublisherDiffusionRule[],
-  diffuseurPublisherId: string,
-  publisherIds?: string[]
-): MissionDiffuseurCandidateFilter => {
+const buildAllowlistFilter = (rules: PublisherDiffusionRule[], diffuseurPublisherId: string, publisherIds?: string[]): MissionDiffuseurCandidateFilter => {
   const { roots, childrenByParentId } = groupRulesByParent(rules);
   const allowlistRoots = roots.filter((root) => root.field === "publisherId" && root.operator === "is");
   const diffuseurIsRequested = !publisherIds || publisherIds.includes(diffuseurPublisherId);
@@ -216,15 +207,6 @@ export const publisherDiffusionRuleService = {
   async buildMissionDiffuseurSnapshotWhere(publisherId: string): Promise<Prisma.MissionWhereInput> {
     const candidateWhere = await this.buildMissionDiffuseurCandidateWhere(publisherId);
     return Object.keys(candidateWhere).length === 0 ? { publisherId } : candidateWhere;
-  },
-
-  async buildMissionPublisherDiffusionRuleSql(publisherId: string, options: { missionAlias?: string } = {}): Promise<Prisma.Sql> {
-    const rules = await publisherDiffusionRuleRepository.findMany({
-      where: { publisherId },
-      orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
-    });
-
-    return buildMissionPublisherDiffusionRuleSqlFromRules(rules, options);
   },
 
   isValueDiffused({ rules, field, value }: { rules: PublisherDiffusionRuleRecord[]; field: string; value: string }): boolean {

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -1,6 +1,5 @@
 import { Prisma, PublisherDiffusionRule } from "@/db/core";
 import { RESSOURCE_ALREADY_EXIST } from "@/error";
-import { missionRepository } from "@/repositories/mission";
 import { publisherRepository } from "@/repositories/publisher";
 import { publisherDiffusionRuleRepository } from "@/repositories/publisher-diffusion-rule";
 import type {
@@ -217,22 +216,6 @@ export const publisherDiffusionRuleService = {
   async buildMissionDiffuseurSnapshotWhere(publisherId: string): Promise<Prisma.MissionWhereInput> {
     const candidateWhere = await this.buildMissionDiffuseurCandidateWhere(publisherId);
     return Object.keys(candidateWhere).length === 0 ? { publisherId } : candidateWhere;
-  },
-
-  async canPublisherAccessMission({ publisherId, missionId }: { publisherId: string; missionId: string }): Promise<boolean> {
-    const rules = await findOrderedRules(publisherId);
-    if (rules.length === 0) {
-      return true;
-    }
-
-    const { where: diffusionRuleWhere } = buildAllowlistFilter(rules, publisherId);
-    if (Object.keys(diffusionRuleWhere).length === 0) {
-      return false;
-    }
-
-    const count = await missionRepository.count({ AND: [{ id: missionId }, diffusionRuleWhere] });
-
-    return count > 0;
   },
 
   async buildMissionPublisherDiffusionRuleSql(publisherId: string, options: { missionAlias?: string } = {}): Promise<Prisma.Sql> {

--- a/api/src/services/widget-mission.ts
+++ b/api/src/services/widget-mission.ts
@@ -13,10 +13,13 @@ const buildWidgetWhere = async (widget: WidgetRecord, filters: MissionSearchFilt
   if (!widget.jvaModeration) {
     return buildWhere(filters);
   }
+  if (filters.publisherIds?.length === 0) {
+    return buildWhere(filters);
+  }
 
   const jvaPublishers = widget.publishers.filter((publisherId) => publisherId === PUBLISHER_IDS.JEVEUXAIDER);
   const otherPublishers = widget.publishers.filter((publisherId) => publisherId !== PUBLISHER_IDS.JEVEUXAIDER);
-  const baseWhere = await buildWhere({ ...filters, publisherIds: [], moderationAcceptedFor: undefined });
+  const baseWhere = await buildWhere({ ...filters, publisherIds: undefined, moderationAcceptedFor: undefined });
   const orConditions: Prisma.MissionWhereInput[] = [];
 
   if (jvaPublishers.length) {

--- a/api/src/types/mission.ts
+++ b/api/src/types/mission.ts
@@ -189,7 +189,7 @@ export type MissionRecord = {
   Partial<Record<MissionModerationDateKey, Date | null>>;
 
 export type MissionSearchFilters = {
-  publisherIds: string[];
+  publisherIds?: string[];
   statusCode?: MissionStatusCode;
   statusComment?: string;
   diffuseurPublisherId?: string;

--- a/api/src/v0/mission/constants.ts
+++ b/api/src/v0/mission/constants.ts
@@ -1,5 +1,3 @@
-export const NO_PARTNER = "NO_PARTNER";
-export const NO_PARTNER_MESSAGE = "Vous n'avez pas encore accès à des missions. Contactez quentin.dallery@beta.gouv.fr pour vous donner accès aux missions";
 export const MISSION_FIELDS = [
   "_id",
   "clientId",

--- a/api/src/v0/mission/controller.ts
+++ b/api/src/v0/mission/controller.ts
@@ -6,7 +6,6 @@ import { MissionType, Prisma } from "@/db/core";
 import { INVALID_PARAMS, INVALID_QUERY, NOT_FOUND } from "@/error";
 import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { missionService } from "@/services/mission";
-import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import type { MissionRecord, MissionRemote, MissionSearchFilters } from "@/types/mission";
 import { PublisherRequest } from "@/types/passport";
 import type { PublisherRecordWithRelations } from "@/types/publisher";
@@ -278,16 +277,12 @@ router.get("/:id", async (req: PublisherRequest, res: Response, next: NextFuncti
       id: params.data.id,
       statusCode: "ACCEPTED",
       deletedAt: null,
+      missionDiffusions: { some: { distributionPublisherId: user.id } },
       ...(user.moderator ? { moderationStatuses: { some: { publisherId: user.id, status: "ACCEPTED" } } } : {}),
     };
 
     const mission = await missionService.findOneMissionBy(missionWhere, user.moderator ? user.id : null);
     if (!mission) {
-      return res.status(404).send({ ok: false, code: NOT_FOUND });
-    }
-
-    const canAccessMission = await publisherDiffusionRuleService.canPublisherAccessMission({ publisherId: user.id, missionId: mission.id });
-    if (!canAccessMission) {
       return res.status(404).send({ ok: false, code: NOT_FOUND });
     }
 

--- a/api/src/v0/mission/controller.ts
+++ b/api/src/v0/mission/controller.ts
@@ -10,7 +10,6 @@ import type { MissionRecord, MissionRemote, MissionSearchFilters } from "@/types
 import { PublisherRequest } from "@/types/passport";
 import type { PublisherRecordWithRelations } from "@/types/publisher";
 import { getDistanceFromLatLonInKm, getDistanceKm } from "@/utils";
-import { NO_PARTNER, NO_PARTNER_MESSAGE } from "@/v0/mission/constants";
 import { buildData } from "@/v0/mission/transformer";
 import { normalizeQueryArray, parseDateFilter } from "@/v0/mission/utils";
 
@@ -81,11 +80,6 @@ router.get("/", async (req: PublisherRequest, res: Response, next: NextFunction)
       return res.status(400).send({ ok: false, code: INVALID_QUERY, message: query.error });
     }
 
-    if (!user.publishers || !user.publishers.length) {
-      res.locals = { code: NO_PARTNER, message: NO_PARTNER_MESSAGE };
-      return res.status(400).send({ ok: false, code: NO_PARTNER, message: NO_PARTNER_MESSAGE });
-    }
-
     if (req.query.size && query.data.limit === 10000) {
       query.data.limit = parseInt(req.query.size as string, 10);
     }
@@ -93,16 +87,9 @@ router.get("/", async (req: PublisherRequest, res: Response, next: NextFunction)
       query.data.skip = parseInt(req.query.from as string, 10);
     }
 
-    const allowedPublisherIds = user.publishers.map((p) => p.publisherId);
-    if (!allowedPublisherIds.length) {
-      res.locals = { code: NO_PARTNER, message: NO_PARTNER_MESSAGE };
-      return res.status(400).send({ ok: false, code: NO_PARTNER, message: NO_PARTNER_MESSAGE });
-    }
-
-    // Les ids hors scope ne sont pas filtrés ici : on les passe au service, qui applique le
-    // gating de diffusion (via diffuseurPublisherId) et renvoie 0 résultat pour le hors-scope.
-    const requestedPublisherIds = normalizeQueryArray(query.data.publisher);
-    const publisherIds = requestedPublisherIds?.length ? requestedPublisherIds : allowedPublisherIds;
+    // Sans filtre explicite, le snapshot est l'unique source du périmètre de diffusion.
+    // Un publisher demandé hors snapshot renvoie simplement 0 résultat.
+    const publisherIds = normalizeQueryArray(query.data.publisher);
 
     const filters: MissionSearchFilters = {
       publisherIds,
@@ -165,11 +152,6 @@ router.get("/search", async (req: PublisherRequest, res: Response, next: NextFun
       return res.status(400).send({ ok: false, code: INVALID_QUERY, message: query.error });
     }
 
-    if (!user.publishers || !user.publishers.length) {
-      res.locals = { code: NO_PARTNER, message: NO_PARTNER_MESSAGE };
-      return res.status(400).send({ ok: false, code: NO_PARTNER, message: NO_PARTNER_MESSAGE });
-    }
-
     if (req.query.size && query.data.limit === 10000) {
       query.data.limit = parseInt(req.query.size as string, 10);
     }
@@ -177,16 +159,9 @@ router.get("/search", async (req: PublisherRequest, res: Response, next: NextFun
       query.data.skip = parseInt(req.query.from as string, 10);
     }
 
-    const allowedPublisherIds = user.publishers.map((p) => p.publisherId);
-    if (!allowedPublisherIds.length) {
-      res.locals = { code: NO_PARTNER, message: NO_PARTNER_MESSAGE };
-      return res.status(400).send({ ok: false, code: NO_PARTNER, message: NO_PARTNER_MESSAGE });
-    }
-
-    // Les ids hors scope ne sont pas filtrés ici : on les passe au service, qui applique le
-    // gating de diffusion (via diffuseurPublisherId) et renvoie 0 résultat pour le hors-scope.
-    const requestedPublisherIds = normalizeQueryArray(query.data.publisher);
-    const publisherIds = requestedPublisherIds?.length ? requestedPublisherIds : allowedPublisherIds;
+    // Sans filtre explicite, le snapshot est l'unique source du périmètre de diffusion.
+    // Un publisher demandé hors snapshot renvoie simplement 0 résultat.
+    const publisherIds = normalizeQueryArray(query.data.publisher);
 
     const filters: MissionSearchFilters = {
       publisherIds,
@@ -267,10 +242,6 @@ router.get("/:id", async (req: PublisherRequest, res: Response, next: NextFuncti
     if (!params.success) {
       res.locals = { code: INVALID_PARAMS, message: JSON.stringify(params.error) };
       return res.status(400).send({ ok: false, code: INVALID_PARAMS, message: params.error });
-    }
-
-    if (!user.publishers?.length) {
-      return res.status(404).send({ ok: false, code: NOT_FOUND });
     }
 
     const missionWhere: Prisma.MissionWhereInput = {

--- a/api/src/v2/activity.ts
+++ b/api/src/v2/activity.ts
@@ -5,7 +5,6 @@ import zod from "zod";
 import { FORBIDDEN, INVALID_BODY, INVALID_PARAMS, NOT_FOUND } from "@/error";
 import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import missionService from "@/services/mission";
-import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import { statEventService } from "@/services/stat-event";
 import { StatEventRecord } from "@/types";
 import { PublisherRequest } from "@/types/passport";
@@ -140,7 +139,11 @@ router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction
         return res.status(404).send({ ok: false, code: NOT_FOUND, message: "Mission not found" });
       }
 
-      const canAccessMission = await publisherDiffusionRuleService.canPublisherAccessMission({ publisherId: user.id, missionId: mission.id });
+      const canAccessMission =
+        (await missionService.countBy({
+          id: mission.id,
+          missionDiffusions: { some: { distributionPublisherId: user.id } },
+        })) > 0;
       if (!canAccessMission) {
         return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Mission not accessible" });
       }

--- a/api/tests/integration/api/checks/metrics.test.ts
+++ b/api/tests/integration/api/checks/metrics.test.ts
@@ -32,7 +32,7 @@ describe("HTTP metrics integration", () => {
 
     const response = await request(app).get("/v0/mission").set("x-api-key", publisher.apikey!);
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(200);
     expect(recorder.records).toHaveLength(1);
     expect(recorder.records[0]).toMatchObject({
       environment: "test",

--- a/api/tests/integration/api/endpoints/iframe/aggs.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/aggs.test.ts
@@ -127,6 +127,29 @@ describe("GET /iframe/:id/aggs", () => {
   });
 
   describe("Default aggregations", () => {
+    it("should keep widget publishers as fallback for a widget-only publisher without diffusion root", async () => {
+      const widgetOwner = await createTestPublisher({
+        hasApiRights: false,
+        hasCampaignRights: false,
+        hasWidgetRights: true,
+      });
+      const selectedPublisher = await createTestPublisher();
+      await createTestMission({
+        publisherId: selectedPublisher.id,
+        title: "Mission Solidarité",
+        domain: "Solidarité",
+      });
+      const widgetOnly = await createTestWidget({
+        fromPublisher: widgetOwner,
+        publishers: [selectedPublisher.id],
+        type: "benevolat",
+      });
+
+      const response = await request(app).get(`/iframe/${widgetOnly.id}/aggs`).expect(200);
+
+      expect(response.body.data.domain).toEqual(expect.arrayContaining([{ key: "Solidarité", doc_count: 1 }]));
+    });
+
     it("should aggregate by domain with correct counts", async () => {
       const response = await request(app).get(`/iframe/${widget.id}/aggs`).expect(200);
 

--- a/api/tests/integration/api/endpoints/iframe/aggs.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/aggs.test.ts
@@ -6,7 +6,7 @@ import { createTestMission, createTestPublisher, createTestWidget } from "../../
 import { createTestApp } from "../../../../testApp";
 
 describe("GET /iframe/:id/aggs", () => {
-  const app = createTestApp();
+  const app = createTestApp({ syncMissionDiffusion: true });
   let widget: WidgetRecord;
   let publisher: PublisherRecord;
 

--- a/api/tests/integration/api/endpoints/iframe/aggs.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/aggs.test.ts
@@ -150,6 +150,38 @@ describe("GET /iframe/:id/aggs", () => {
       expect(response.body.data.domain).toEqual(expect.arrayContaining([{ key: "Solidarité", doc_count: 1 }]));
     });
 
+    it("should combine snapshot and widget-only publishers in aggregations", async () => {
+      const rootedPublisher = await createTestPublisher();
+      const widgetOnlyPublisher = await createTestPublisher();
+      const widgetOwner = await createTestPublisher({
+        publishers: [{ publisherId: rootedPublisher.id }],
+      });
+      await createTestMission({
+        publisherId: rootedPublisher.id,
+        title: "Mission matérialisée",
+        domain: "Environnement",
+      });
+      await createTestMission({
+        publisherId: widgetOnlyPublisher.id,
+        title: "Mission widget-only",
+        domain: "Solidarité",
+      });
+      const hybridWidget = await createTestWidget({
+        fromPublisher: widgetOwner,
+        publishers: [rootedPublisher.id, widgetOnlyPublisher.id],
+        type: "benevolat",
+      });
+
+      const response = await request(app).get(`/iframe/${hybridWidget.id}/aggs`).expect(200);
+
+      expect(response.body.data.domain).toEqual(
+        expect.arrayContaining([
+          { key: "Environnement", doc_count: 1 },
+          { key: "Solidarité", doc_count: 1 },
+        ])
+      );
+    });
+
     it("should aggregate by domain with correct counts", async () => {
       const response = await request(app).get(`/iframe/${widget.id}/aggs`).expect(200);
 

--- a/api/tests/integration/api/endpoints/iframe/search.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/search.test.ts
@@ -519,6 +519,28 @@ describe("GET /iframe/:id/search", () => {
       expect(response.body.total).toBe(2);
     });
 
+    it("should return no mission when publisher selection is explicitly empty", async () => {
+      const rootedPublisher = await createTestPublisher();
+      const widgetOwner = await createTestPublisher({
+        publishers: [{ publisherId: rootedPublisher.id }],
+      });
+      await createTestMission({
+        publisherId: rootedPublisher.id,
+        title: "Mission présente dans le snapshot",
+      });
+      const emptyWidget = await createTestWidget({
+        fromPublisher: widgetOwner,
+        publishers: [],
+        jvaModeration: true,
+        type: "benevolat",
+      });
+
+      const response = await request(app).get(`/iframe/${emptyWidget.id}/search`).expect(200);
+
+      expect(response.body.total).toBe(0);
+      expect(response.body.data).toEqual([]);
+    });
+
     it("should apply multiple organization rules with OR combinator", async () => {
       const widgetWithOrganizationRules = await createTestWidget({
         fromPublisher: publisher,

--- a/api/tests/integration/api/endpoints/iframe/search.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/search.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import type { MissionRecord } from "@/types/mission";
 import type { PublisherRecord } from "@/types/publisher";
@@ -474,6 +475,48 @@ describe("GET /iframe/:id/search", () => {
 
       expect(response.body.total).toBe(1);
       expect(response.body.data[0]._id).toBe(selectedMission.id);
+    });
+
+    it("should combine the diffusion snapshot with widget-only publishers", async () => {
+      const rootedPublisher = await createTestPublisher();
+      const widgetOnlyPublisher = await createTestPublisher();
+      const widgetOwner = await createTestPublisher({
+        publishers: [{ publisherId: rootedPublisher.id }],
+      });
+      const includedRootedMission = await createTestMission({
+        organizationClientId: `included-rooted-${randomUUID()}`,
+        publisherId: rootedPublisher.id,
+        title: "Mission du publisher matérialisé",
+      });
+      const excludedRootedMission = await createTestMission({
+        organizationClientId: `excluded-rooted-${randomUUID()}`,
+        publisherId: rootedPublisher.id,
+        title: "Mission exclue du snapshot",
+      });
+      const widgetOnlyMission = await createTestMission({
+        publisherId: widgetOnlyPublisher.id,
+        title: "Mission du publisher widget-only",
+      });
+      await publisherDiffusionRuleService.createScopedRule({
+        diffuseurPublisherId: widgetOwner.id,
+        annonceurPublisherId: rootedPublisher.id,
+        field: "publisherOrganization.clientId",
+        fieldType: "string",
+        operator: "is_not",
+        value: excludedRootedMission.organizationClientId!,
+      });
+      const hybridWidget = await createTestWidget({
+        fromPublisher: widgetOwner,
+        publishers: [rootedPublisher.id, widgetOnlyPublisher.id],
+        type: "benevolat",
+      });
+
+      const response = await request(app).get(`/iframe/${hybridWidget.id}/search`).expect(200);
+
+      const missionIds = response.body.data.map((mission: MissionRecord) => mission._id);
+      expect(missionIds).toEqual(expect.arrayContaining([includedRootedMission.id, widgetOnlyMission.id]));
+      expect(missionIds).not.toContain(excludedRootedMission.id);
+      expect(response.body.total).toBe(2);
     });
 
     it("should apply multiple organization rules with OR combinator", async () => {

--- a/api/tests/integration/api/endpoints/iframe/search.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/search.test.ts
@@ -1,7 +1,7 @@
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import type { MissionRecord } from "@/types/mission";
 import type { PublisherRecord } from "@/types/publisher";
 import type { WidgetRecord } from "@/types/widget";
-import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import request from "supertest";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createTestMission, createTestPublisher, createTestWidget, createTestWidgetRule } from "../../../../fixtures";
@@ -451,6 +451,29 @@ describe("GET /iframe/:id/search", () => {
       const titles = response.body.data.map((mission: MissionRecord) => mission.title);
       expect(titles).toEqual(expect.arrayContaining(["Mission Environnement Paris", "Mission Santé Marseille"]));
       expect(titles).not.toContain("Mission Éducation Lyon");
+    });
+
+    it("should keep widget publishers as fallback for a widget-only publisher without diffusion root", async () => {
+      const widgetOwner = await createTestPublisher({
+        hasApiRights: false,
+        hasCampaignRights: false,
+        hasWidgetRights: true,
+      });
+      const selectedPublisher = await createTestPublisher();
+      const selectedMission = await createTestMission({
+        publisherId: selectedPublisher.id,
+        title: "Mission du publisher sélectionné",
+      });
+      const widgetOnly = await createTestWidget({
+        fromPublisher: widgetOwner,
+        publishers: [selectedPublisher.id],
+        type: "benevolat",
+      });
+
+      const response = await request(app).get(`/iframe/${widgetOnly.id}/search`).expect(200);
+
+      expect(response.body.total).toBe(1);
+      expect(response.body.data[0]._id).toBe(selectedMission.id);
     });
 
     it("should apply multiple organization rules with OR combinator", async () => {

--- a/api/tests/integration/api/endpoints/iframe/search.test.ts
+++ b/api/tests/integration/api/endpoints/iframe/search.test.ts
@@ -8,7 +8,7 @@ import { createTestMission, createTestPublisher, createTestWidget, createTestWid
 import { createTestApp } from "../../../../testApp";
 
 describe("GET /iframe/:id/search", () => {
-  const app = createTestApp();
+  const app = createTestApp({ syncMissionDiffusion: true });
   let widget: WidgetRecord;
   let publisher: PublisherRecord;
   let mission1: MissionRecord;

--- a/api/tests/integration/api/endpoints/v0/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v0/mission.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import request from "supertest";
 
+import { MissionDiffusionRebuildHandler } from "@/jobs/mission-diffusion-rebuild/handler";
 import { missionModerationStatusService } from "@/services/mission-moderation-status";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import type { MissionRecord, PublisherRecord } from "@/types";
@@ -611,6 +612,66 @@ describe("Mission API Integration Tests", () => {
       expect(response.status).toBe(200);
       expect(response.body.ok).toBe(true);
       expect(response.body.data._id).toBe(mission.id);
+    });
+
+    it("should use the materialized diffusion snapshot while live rules are stale", async () => {
+      const owner = await createTestPublisher({ name: "Stale Detail Owner" });
+      const diffuseur = await createTestPublisher({
+        name: "Stale Detail Diffuseur",
+        publishers: [{ publisherId: owner.id }],
+      });
+      const mission = await createTestMission({
+        publisherId: owner.id,
+        title: "Mission kept in stale snapshot",
+        statusCode: "ACCEPTED",
+      });
+
+      await new MissionDiffusionRebuildHandler().handle({});
+      const roots = await publisherDiffusionRuleService.findRules({
+        publisherId: diffuseur.id,
+        combinedWithId: null,
+        field: "publisherId",
+      });
+      await Promise.all(roots.map((root) => publisherDiffusionRuleService.deleteRule(root.id)));
+
+      const staleSnapshotApp = createTestApp();
+      const listResponse = await request(staleSnapshotApp).get("/v0/mission").set("x-api-key", diffuseur.apikey!).expect(200);
+      const detailResponse = await request(staleSnapshotApp).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!).expect(200);
+
+      expect(listResponse.body.data.map((item: MissionRecord) => item._id)).toContain(mission.id);
+      expect(detailResponse.body.data._id).toBe(mission.id);
+    });
+
+    it("should keep a materialized exclusion until the next snapshot rebuild", async () => {
+      const owner = await createTestPublisher({ name: "Stale Exclusion Owner" });
+      const diffuseur = await createTestPublisher({
+        name: "Stale Exclusion Diffuseur",
+        publishers: [{ publisherId: owner.id }],
+      });
+      const mission = await createTestMission({
+        organizationClientId: `stale-exclusion-${randomUUID()}`,
+        publisherId: owner.id,
+        title: "Mission excluded from stale snapshot",
+        statusCode: "ACCEPTED",
+      });
+      const exclusion = await publisherDiffusionRuleService.createScopedRule({
+        diffuseurPublisherId: diffuseur.id,
+        annonceurPublisherId: owner.id,
+        field: "publisherOrganization.clientId",
+        fieldType: "string",
+        operator: "is_not",
+        value: mission.organizationClientId!,
+      });
+
+      await new MissionDiffusionRebuildHandler().handle({});
+      await publisherDiffusionRuleService.deleteRule(exclusion.id);
+
+      const staleSnapshotApp = createTestApp();
+      const listResponse = await request(staleSnapshotApp).get("/v0/mission").set("x-api-key", diffuseur.apikey!).expect(200);
+      const detailResponse = await request(staleSnapshotApp).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!).expect(404);
+
+      expect(listResponse.body.data.map((item: MissionRecord) => item._id)).not.toContain(mission.id);
+      expect(detailResponse.body.code).toBe("NOT_FOUND");
     });
 
     it("should return 404 for a mission outside publisher diffusion scope", async () => {

--- a/api/tests/integration/api/endpoints/v0/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v0/mission.test.ts
@@ -614,25 +614,28 @@ describe("Mission API Integration Tests", () => {
       expect(response.body.data._id).toBe(mission.id);
     });
 
-    it("should use the materialized diffusion snapshot while live rules are stale", async () => {
+    it("should keep materialized access until the next snapshot rebuild", async () => {
       const owner = await createTestPublisher({ name: "Stale Detail Owner" });
       const diffuseur = await createTestPublisher({
         name: "Stale Detail Diffuseur",
         publishers: [{ publisherId: owner.id }],
       });
       const mission = await createTestMission({
+        organizationClientId: `stale-access-${randomUUID()}`,
         publisherId: owner.id,
         title: "Mission kept in stale snapshot",
         statusCode: "ACCEPTED",
       });
 
       await new MissionDiffusionRebuildHandler().handle({});
-      const roots = await publisherDiffusionRuleService.findRules({
-        publisherId: diffuseur.id,
-        combinedWithId: null,
-        field: "publisherId",
+      await publisherDiffusionRuleService.createScopedRule({
+        diffuseurPublisherId: diffuseur.id,
+        annonceurPublisherId: owner.id,
+        field: "publisherOrganization.clientId",
+        fieldType: "string",
+        operator: "is_not",
+        value: mission.organizationClientId!,
       });
-      await Promise.all(roots.map((root) => publisherDiffusionRuleService.deleteRule(root.id)));
 
       const staleSnapshotApp = createTestApp();
       const listResponse = await request(staleSnapshotApp).get("/v0/mission").set("x-api-key", diffuseur.apikey!).expect(200);

--- a/api/tests/integration/api/endpoints/v0/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v0/mission.test.ts
@@ -641,10 +641,12 @@ describe("Mission API Integration Tests", () => {
       const listResponse = await request(staleSnapshotApp).get("/v0/mission").set("x-api-key", diffuseur.apikey!).expect(200);
       const searchResponse = await request(staleSnapshotApp).get("/v0/mission/search").set("x-api-key", diffuseur.apikey!).expect(200);
       const detailResponse = await request(staleSnapshotApp).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!).expect(200);
+      const browseDetailResponse = await request(staleSnapshotApp).get(`/missions/browse/${mission.id}`).set("x-api-key", diffuseur.apikey!).expect(200);
 
       expect(listResponse.body.data.map((item: MissionRecord) => item._id)).toContain(mission.id);
       expect(searchResponse.body.hits.map((item: MissionRecord) => item._id)).toContain(mission.id);
       expect(detailResponse.body.data._id).toBe(mission.id);
+      expect(browseDetailResponse.body.data.id).toBe(mission.id);
     });
 
     it("should keep a materialized exclusion until the next snapshot rebuild", async () => {

--- a/api/tests/integration/api/endpoints/v0/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v0/mission.test.ts
@@ -246,12 +246,13 @@ describe("Mission API Integration Tests", () => {
       expect(response.body.code).toBe("INVALID_QUERY");
     });
 
-    it("should return 400 if publisher has no access", async () => {
+    it("should use the materialized own scope when publisher has no live partner", async () => {
       const noAccessPublisher = await createTestPublisher({ publishers: [] });
+      const ownMission = await createTestMission({ publisherId: noAccessPublisher.id, title: "Own snapshot mission" });
       const response = await authenticatedGet("/v0/mission", noAccessPublisher.apikey!);
-      expect(response.status).toBe(400);
-      expect(response.body.ok).toBe(false);
-      expect(response.body.code).toBe("NO_PARTNER");
+      expect(response.status).toBe(200);
+      expect(response.body.total).toBe(1);
+      expect(response.body.data[0]._id).toBe(ownMission.id);
     });
 
     it("should filter by domain", async () => {
@@ -614,34 +615,35 @@ describe("Mission API Integration Tests", () => {
       expect(response.body.data._id).toBe(mission.id);
     });
 
-    it("should keep materialized access until the next snapshot rebuild", async () => {
+    it("should keep list and detail aligned after a root removal until the next snapshot rebuild", async () => {
       const owner = await createTestPublisher({ name: "Stale Detail Owner" });
+      const remainingOwner = await createTestPublisher({ name: "Remaining Detail Owner" });
       const diffuseur = await createTestPublisher({
         name: "Stale Detail Diffuseur",
-        publishers: [{ publisherId: owner.id }],
+        publishers: [{ publisherId: owner.id }, { publisherId: remainingOwner.id }],
       });
       const mission = await createTestMission({
-        organizationClientId: `stale-access-${randomUUID()}`,
         publisherId: owner.id,
         title: "Mission kept in stale snapshot",
         statusCode: "ACCEPTED",
       });
 
       await new MissionDiffusionRebuildHandler().handle({});
-      await publisherDiffusionRuleService.createScopedRule({
-        diffuseurPublisherId: diffuseur.id,
-        annonceurPublisherId: owner.id,
-        field: "publisherOrganization.clientId",
-        fieldType: "string",
-        operator: "is_not",
-        value: mission.organizationClientId!,
+      const [removedRoot] = await publisherDiffusionRuleService.findRules({
+        publisherId: diffuseur.id,
+        combinedWithId: null,
+        field: "publisherId",
+        value: owner.id,
       });
+      await publisherDiffusionRuleService.deleteRule(removedRoot.id);
 
       const staleSnapshotApp = createTestApp();
       const listResponse = await request(staleSnapshotApp).get("/v0/mission").set("x-api-key", diffuseur.apikey!).expect(200);
+      const searchResponse = await request(staleSnapshotApp).get("/v0/mission/search").set("x-api-key", diffuseur.apikey!).expect(200);
       const detailResponse = await request(staleSnapshotApp).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!).expect(200);
 
       expect(listResponse.body.data.map((item: MissionRecord) => item._id)).toContain(mission.id);
+      expect(searchResponse.body.data.map((item: MissionRecord) => item._id)).toContain(mission.id);
       expect(detailResponse.body.data._id).toBe(mission.id);
     });
 
@@ -762,14 +764,15 @@ describe("Mission API Integration Tests", () => {
       expect(response.body.code).toBe("NOT_FOUND");
     });
 
-    it("should return 404 when publisher has no diffusion partner", async () => {
+    it("should return an own mission from the snapshot when publisher has no live partner", async () => {
       const noAccessPublisher = await createTestPublisher({ publishers: [] });
+      const ownMission = await createTestMission({ publisherId: noAccessPublisher.id, title: "Own detail snapshot mission" });
 
-      const response = await authenticatedGet(`/v0/mission/${mission1.id}`, noAccessPublisher.apikey!);
+      const response = await authenticatedGet(`/v0/mission/${ownMission.id}`, noAccessPublisher.apikey!);
 
-      expect(response.status).toBe(404);
-      expect(response.body.ok).toBe(false);
-      expect(response.body.code).toBe("NOT_FOUND");
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data._id).toBe(ownMission.id);
     });
 
     it("should return 404 for a mission outside publisher diffusion scope through v2 mount", async () => {

--- a/api/tests/integration/api/endpoints/v0/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v0/mission.test.ts
@@ -9,7 +9,8 @@ import { createTestMission, createTestPublisher } from "../../../../fixtures";
 import { createTestApp } from "../../../../testApp";
 
 describe("Mission API Integration Tests", () => {
-  const app = createTestApp();
+  const app = createTestApp({ syncMissionDiffusion: true });
+  const authenticatedGet = (path: string, apiKey: string) => request(app).get(path).set("x-api-key", apiKey);
   let publisher: PublisherRecord;
   let apiKey: string;
   let mission1: MissionRecord;
@@ -119,7 +120,7 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("should return a list of missions with correct format", async () => {
-      const response = await request(app).get("/v0/mission").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission", apiKey);
 
       expect(response.status).toBe(200);
       expect(response.body.ok).toBe(true);
@@ -155,7 +156,7 @@ describe("Mission API Integration Tests", () => {
       const roots = await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, combinedWithId: null, field: "publisherId" });
       expect(roots.map((rule) => rule.value).sort()).toEqual([annonceurA.id, annonceurB.id].sort());
 
-      const response = await request(app).get("/v0/mission").set("x-api-key", diffuseur.apikey!);
+      const response = await authenticatedGet("/v0/mission", diffuseur.apikey!);
 
       expect(response.status).toBe(200);
       expect(response.body.ok).toBe(true);
@@ -202,7 +203,7 @@ describe("Mission API Integration Tests", () => {
         value: excludedMissionB.organizationClientId!,
       });
 
-      const response = await request(app).get("/v0/mission").set("x-api-key", diffuseur.apikey!);
+      const response = await authenticatedGet("/v0/mission", diffuseur.apikey!);
 
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(2);
@@ -212,7 +213,7 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("should expose compensation fields on missions", async () => {
-      const response = await request(app).get("/v0/mission").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission", apiKey);
       expect(response.status).toBe(200);
       const target = response.body.data.find((mission: any) => mission._id === mission1.id);
       expect(target).toBeDefined();
@@ -222,12 +223,12 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("should respect limit and skip parameters", async () => {
-      const response1 = await request(app).get("/v0/mission?limit=1").set("x-api-key", apiKey);
+      const response1 = await authenticatedGet("/v0/mission?limit=1", apiKey);
       expect(response1.status).toBe(200);
       expect(response1.body.data.length).toBe(1);
       expect(response1.body.limit).toBe(1);
 
-      const response2 = await request(app).get("/v0/mission?skip=1").set("x-api-key", apiKey);
+      const response2 = await authenticatedGet("/v0/mission?skip=1", apiKey);
       expect(response2.status).toBe(200);
       expect(response2.body.skip).toBe(1);
       expect(response2.body.data.length).toBe(2);
@@ -238,7 +239,7 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("should return 400 for invalid query parameters", async () => {
-      const response = await request(app).get("/v0/mission?limit=invalid").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission?limit=invalid", apiKey);
       expect(response.status).toBe(400);
       expect(response.body.ok).toBe(false);
       expect(response.body.code).toBe("INVALID_QUERY");
@@ -246,21 +247,21 @@ describe("Mission API Integration Tests", () => {
 
     it("should return 400 if publisher has no access", async () => {
       const noAccessPublisher = await createTestPublisher({ publishers: [] });
-      const response = await request(app).get("/v0/mission").set("x-api-key", noAccessPublisher.apikey!);
+      const response = await authenticatedGet("/v0/mission", noAccessPublisher.apikey!);
       expect(response.status).toBe(400);
       expect(response.body.ok).toBe(false);
       expect(response.body.code).toBe("NO_PARTNER");
     });
 
     it("should filter by domain", async () => {
-      const response = await request(app).get("/v0/mission?domain=culture").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission?domain=culture", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.data[0]._id).toBe(mission1.id);
     });
 
     it("should filter by city", async () => {
-      const response = await request(app).get("/v0/mission?city=Paris").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission?city=Paris", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(2);
       const ids = response.body.data.map((m: any) => m._id!);
@@ -270,7 +271,7 @@ describe("Mission API Integration Tests", () => {
 
     it("should filter by publisherId", async () => {
       const publisherIdToFilter = publisher.publishers[1].publisherId;
-      const response = await request(app).get(`/v0/mission?publisher=${publisherIdToFilter}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission?publisher=${publisherIdToFilter}`, apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.data[0]._id).toBe(mission2.id);
@@ -280,7 +281,7 @@ describe("Mission API Integration Tests", () => {
       const outsidePublisher = await createTestPublisher({ name: "Outside Publisher" });
       await createTestMission({ publisherId: outsidePublisher.id, title: "Outside mission", clientId: `outside-${randomUUID()}` });
 
-      const response = await request(app).get(`/v0/mission?publisher=${outsidePublisher.id}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission?publisher=${outsidePublisher.id}`, apiKey);
 
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(0);
@@ -288,7 +289,7 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("should filter by keywords", async () => {
-      const response = await request(app).get("/v0/mission?keywords=Lyon").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission?keywords=Lyon", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.data[0]._id).toBe(mission2.id);
@@ -296,7 +297,7 @@ describe("Mission API Integration Tests", () => {
 
     it("should filter by location", async () => {
       // Near Lyon
-      const response = await request(app).get("/v0/mission?lat=45.767&lon=4.836&distance=10km").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission?lat=45.767&lon=4.836&distance=10km", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.data[0]._id).toBe(mission2.id);
@@ -304,7 +305,7 @@ describe("Mission API Integration Tests", () => {
 
     it("should filter by activity", async () => {
       await createTestMission({ organizationClientId: "org-4", publisherId: publisher.publishers[0].publisherId, activities: ["education"] });
-      const response = await request(app).get("/v0/mission?activity=education").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission?activity=education", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.data[0].activity).toBe("education");
@@ -313,20 +314,20 @@ describe("Mission API Integration Tests", () => {
     it("should filter by clientId", async () => {
       const specificClientId = "client-abc-123";
       await createTestMission({ organizationClientId: "org-5", publisherId: publisher.publishers[0].publisherId, clientId: specificClientId });
-      const response = await request(app).get(`/v0/mission?clientId=${specificClientId}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission?clientId=${specificClientId}`, apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.data[0].clientId).toBe(specificClientId);
     });
 
     it("should filter by country", async () => {
-      const response = await request(app).get("/v0/mission?country=France").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission?country=France", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(3);
     });
 
     it("should filter by departmentName", async () => {
-      const response = await request(app).get("/v0/mission?departmentName=Rhône").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission?departmentName=Rhône", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.data[0]._id).toBe(mission2.id);
@@ -335,7 +336,7 @@ describe("Mission API Integration Tests", () => {
     it("should filter by organizationRNA", async () => {
       const specificRNA = "W987654321";
       await createTestMission({ organizationClientId: "org-6", publisherId: publisher.publishers[0].publisherId, organizationRNA: specificRNA });
-      const response = await request(app).get(`/v0/mission?organizationRNA=${specificRNA}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission?organizationRNA=${specificRNA}`, apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.data[0].organizationRNA).toBe(specificRNA);
@@ -343,7 +344,7 @@ describe("Mission API Integration Tests", () => {
 
     it("should filter by organizationStatusJuridique", async () => {
       await createTestMission({ organizationClientId: "org-7", publisherId: publisher.publishers[0].publisherId, organizationStatusJuridique: "Fondation" });
-      const response = await request(app).get("/v0/mission?organizationStatusJuridique=Fondation").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission?organizationStatusJuridique=Fondation", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.data[0].organizationStatusJuridique).toBe("Fondation");
@@ -351,7 +352,7 @@ describe("Mission API Integration Tests", () => {
 
     it("should filter by openToMinors", async () => {
       await createTestMission({ publisherId: publisher.publishers[0].publisherId, openToMinors: true });
-      const response = await request(app).get("/v0/mission?openToMinors=yes").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission?openToMinors=yes", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.data[0].openToMinors).toBe("yes");
@@ -359,7 +360,7 @@ describe("Mission API Integration Tests", () => {
 
     it("should filter by remote", async () => {
       await createTestMission({ publisherId: publisher.publishers[0].publisherId, remote: "full" });
-      const response = await request(app).get("/v0/mission?remote=full").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission?remote=full", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.data[0].remote).toBe("full");
@@ -367,7 +368,7 @@ describe("Mission API Integration Tests", () => {
 
     it("should filter by reducedMobilityAccessible", async () => {
       await createTestMission({ publisherId: publisher.publishers[0].publisherId, reducedMobilityAccessible: false });
-      const response = await request(app).get("/v0/mission?reducedMobilityAccessible=no").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission?reducedMobilityAccessible=no", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.data[0].reducedMobilityAccessible).toBe("no");
@@ -375,28 +376,28 @@ describe("Mission API Integration Tests", () => {
 
     it("should filter by snu", async () => {
       await createTestMission({ publisherId: publisher.publishers[0].publisherId, snu: true });
-      const response = await request(app).get("/v0/mission/?snu=true").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/?snu=true", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
     });
 
     it("should filter by type", async () => {
       await createTestMission({ publisherId: publisher.publishers[0].publisherId, type: "volontariat_service_civique" });
-      const response = await request(app).get(`/v0/mission?type=${"volontariat_service_civique"}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission?type=${"volontariat_service_civique"}`, apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.data[0].type).toBe("volontariat_service_civique");
     });
 
     it("should return 400 for an invalid type value", async () => {
-      const response = await request(app).get("/v0/mission?type=volontariat").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission?type=volontariat", apiKey);
       expect(response.status).toBe(400);
     });
 
     it("should filter by createdAt (gt)", async () => {
       const date = new Date();
       date.setSeconds(date.getSeconds() - 1);
-      const response = await request(app).get(`/v0/mission?createdAt=gt:${date.toISOString()}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission?createdAt=gt:${date.toISOString()}`, apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(3);
     });
@@ -404,7 +405,7 @@ describe("Mission API Integration Tests", () => {
     it("should filter by startAt (lt)", async () => {
       const futureDate = new Date();
       futureDate.setDate(futureDate.getDate() + 1);
-      const response = await request(app).get(`/v0/mission?startAt=lt:${futureDate.toISOString()}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission?startAt=lt:${futureDate.toISOString()}`, apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(3);
     });
@@ -417,7 +418,7 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("should return a list of missions with correct format and facets", async () => {
-      const response = await request(app).get("/v0/mission/search").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search", apiKey);
 
       expect(response.status).toBe(200);
       expect(response.body.ok).toBe(true);
@@ -438,7 +439,7 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("should expose compensation fields within search results", async () => {
-      const response = await request(app).get("/v0/mission/search").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search", apiKey);
       expect(response.status).toBe(200);
       const target = response.body.hits.find((mission: any) => mission._id === mission1.id);
       expect(target).toBeDefined();
@@ -448,7 +449,7 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("should filter by keywords", async () => {
-      const response = await request(app).get("/v0/mission/search?keywords=Lyon").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?keywords=Lyon", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.hits[0]._id).toBe(mission2.id);
@@ -456,7 +457,7 @@ describe("Mission API Integration Tests", () => {
 
     it("should filter by geo-location", async () => {
       // Near Lyon
-      const response = await request(app).get("/v0/mission/search?lat=45.76&lon=4.83&distance=10km").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?lat=45.76&lon=4.83&distance=10km", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.hits[0]._id).toBe(mission2.id);
@@ -464,34 +465,34 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("should respect limit and skip parameters", async () => {
-      const response = await request(app).get("/v0/mission/search?limit=1&skip=1").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?limit=1&skip=1", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.hits.length).toBe(1);
       expect(response.body.total).toBe(3);
     });
 
     it("should filter by activity", async () => {
-      const response = await request(app).get("/v0/mission/search?activity=arts").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?activity=arts", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.hits[0]._id).toBe(mission1.id);
     });
 
     it("should filter by city", async () => {
-      const response = await request(app).get("/v0/mission/search?city=Paris").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?city=Paris", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(2);
     });
 
     it("should filter by clientId", async () => {
-      const response = await request(app).get(`/v0/mission/search?clientId=${mission1.clientId}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission/search?clientId=${mission1.clientId}`, apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.hits[0]._id).toBe(mission1.id);
     });
 
     it("should filter by multiple clientIds", async () => {
-      const response = await request(app).get(`/v0/mission/search?clientId=${mission1.clientId},${mission3.clientId}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission/search?clientId=${mission1.clientId},${mission3.clientId}`, apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(2);
       const clientIds = response.body.hits.map((h: any) => h.clientId);
@@ -500,27 +501,27 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("should filter by country", async () => {
-      const response = await request(app).get("/v0/mission/search?country=France").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?country=France", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(3);
     });
 
     it("should filter by departmentName", async () => {
-      const response = await request(app).get("/v0/mission/search?departmentName=Rhône").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?departmentName=Rhône", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
     });
 
     it("should filter by domain", async () => {
       await createTestMission({ publisherId: publisher.publishers[0].publisherId, domain: "arts" });
-      const response = await request(app).get("/v0/mission/search?domain=arts").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?domain=arts", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
     });
 
     it("should filter by openToMinors", async () => {
       await createTestMission({ publisherId: publisher.publishers[0].publisherId, openToMinors: true });
-      const response = await request(app).get("/v0/mission/search?openToMinors=yes").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?openToMinors=yes", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.hits[0].openToMinors).toBe("yes");
@@ -528,20 +529,20 @@ describe("Mission API Integration Tests", () => {
 
     it("should filter by organizationRNA", async () => {
       await createTestMission({ publisherId: publisher.publishers[0].publisherId, organizationRNA: "XXX" });
-      const response = await request(app).get("/v0/mission/search?organizationRNA=XXX").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?organizationRNA=XXX", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
     });
 
     it("should filter by organizationStatusJuridique", async () => {
       await createTestMission({ organizationClientId: "org-7", publisherId: publisher.publishers[0].publisherId, organizationStatusJuridique: "Fondation" });
-      const response = await request(app).get("/v0/mission/search?organizationStatusJuridique=Fondation").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?organizationStatusJuridique=Fondation", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
     });
 
     it("should filter by publisher", async () => {
-      const response = await request(app).get(`/v0/mission/search?publisher=${mission2.publisherId}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission/search?publisher=${mission2.publisherId}`, apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
       expect(response.body.hits[0]._id).toBe(mission2.id);
@@ -549,28 +550,28 @@ describe("Mission API Integration Tests", () => {
 
     it("should filter by remote", async () => {
       await createTestMission({ publisherId: publisher.publishers[0].publisherId, remote: "full" });
-      const response = await request(app).get("/v0/mission/search?remote=full").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?remote=full", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
     });
 
     it("should filter by reducedMobilityAccessible", async () => {
       await createTestMission({ publisherId: publisher.publishers[0].publisherId, reducedMobilityAccessible: false });
-      const response = await request(app).get("/v0/mission/search?reducedMobilityAccessible=no").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?reducedMobilityAccessible=no", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
     });
 
     it("should filter by startAt (gt)", async () => {
       await createTestMission({ publisherId: publisher.publishers[0].publisherId, startAt: new Date("2028-01-01") });
-      const response = await request(app).get("/v0/mission/search?startAt=gt:2027-12-31").set("x-api-key", apiKey);
+      const response = await authenticatedGet("/v0/mission/search?startAt=gt:2027-12-31", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
     });
 
     it("should filter by type", async () => {
       await createTestMission({ publisherId: publisher.publishers[0].publisherId, type: "volontariat_service_civique" });
-      const response = await request(app).get(`/v0/mission/search?type=${"volontariat_service_civique"}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission/search?type=${"volontariat_service_civique"}`, apiKey);
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
     });
@@ -583,7 +584,7 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("should return an existing mission with correct format", async () => {
-      const response = await request(app).get(`/v0/mission/${mission1._id}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission/${mission1._id}`, apiKey);
 
       expect(response.status).toBe(200);
       expect(response.body.ok).toBe(true);
@@ -605,7 +606,7 @@ describe("Mission API Integration Tests", () => {
         statusCode: "ACCEPTED",
       });
 
-      const response = await request(app).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!);
+      const response = await authenticatedGet(`/v0/mission/${mission.id}`, diffuseur.apikey!);
 
       expect(response.status).toBe(200);
       expect(response.body.ok).toBe(true);
@@ -625,7 +626,7 @@ describe("Mission API Integration Tests", () => {
         statusCode: "ACCEPTED",
       });
 
-      const response = await request(app).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!);
+      const response = await authenticatedGet(`/v0/mission/${mission.id}`, diffuseur.apikey!);
 
       expect(response.status).toBe(404);
       expect(response.body.ok).toBe(false);
@@ -653,7 +654,7 @@ describe("Mission API Integration Tests", () => {
         value: mission.organizationClientId!,
       });
 
-      const response = await request(app).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!);
+      const response = await authenticatedGet(`/v0/mission/${mission.id}`, diffuseur.apikey!);
 
       expect(response.status).toBe(404);
       expect(response.body.ok).toBe(false);
@@ -671,7 +672,7 @@ describe("Mission API Integration Tests", () => {
         title: "Refused detail mission",
         statusCode: "REFUSED",
       });
-      const refusedResponse = await request(app).get(`/v0/mission/${refusedMission.id}`).set("x-api-key", diffuseur.apikey!);
+      const refusedResponse = await authenticatedGet(`/v0/mission/${refusedMission.id}`, diffuseur.apikey!);
 
       expect(refusedResponse.status).toBe(404);
       expect(refusedResponse.body.code).toBe("NOT_FOUND");
@@ -690,7 +691,7 @@ describe("Mission API Integration Tests", () => {
         deleted: true,
       });
 
-      const response = await request(app).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!);
+      const response = await authenticatedGet(`/v0/mission/${mission.id}`, diffuseur.apikey!);
 
       expect(response.status).toBe(404);
       expect(response.body.ok).toBe(false);
@@ -700,7 +701,7 @@ describe("Mission API Integration Tests", () => {
     it("should return 404 when publisher has no diffusion partner", async () => {
       const noAccessPublisher = await createTestPublisher({ publishers: [] });
 
-      const response = await request(app).get(`/v0/mission/${mission1.id}`).set("x-api-key", noAccessPublisher.apikey!);
+      const response = await authenticatedGet(`/v0/mission/${mission1.id}`, noAccessPublisher.apikey!);
 
       expect(response.status).toBe(404);
       expect(response.body.ok).toBe(false);
@@ -720,7 +721,7 @@ describe("Mission API Integration Tests", () => {
         statusCode: "ACCEPTED",
       });
 
-      const response = await request(app).get(`/v2/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!);
+      const response = await authenticatedGet(`/v2/mission/${mission.id}`, diffuseur.apikey!);
 
       expect(response.status).toBe(404);
       expect(response.body.ok).toBe(false);
@@ -729,7 +730,7 @@ describe("Mission API Integration Tests", () => {
 
     it("should return 404 for unknown id parameter", async () => {
       const id = randomUUID();
-      const response = await request(app).get(`/v0/mission/${id}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission/${id}`, apiKey);
       expect(response.status).toBe(404);
       expect(response.body.ok).toBe(false);
       expect(response.body.code).toBe("NOT_FOUND");
@@ -790,7 +791,7 @@ describe("Mission API Integration Tests", () => {
         title: "No moderation for this publisher",
       });
 
-      const response = await request(app).get("/v0/mission").set("x-api-key", moderatorPublisher.apikey!);
+      const response = await authenticatedGet("/v0/mission", moderatorPublisher.apikey!);
 
       expect(response.status).toBe(200);
       const ids = response.body.data.map((m: any) => m._id);
@@ -835,7 +836,7 @@ describe("Mission API Integration Tests", () => {
         title: null,
       });
 
-      const response = await request(app).get("/v0/mission/search").set("x-api-key", moderatorPublisher.apikey!);
+      const response = await authenticatedGet("/v0/mission/search", moderatorPublisher.apikey!);
 
       expect(response.status).toBe(200);
       const ids = response.body.hits.map((m: any) => m._id);
@@ -896,10 +897,10 @@ describe("Mission API Integration Tests", () => {
         title: "Detail no moderation mission",
       });
 
-      const acceptedResponse = await request(app).get(`/v0/mission/${acceptedMission.id}`).set("x-api-key", moderatorPublisher.apikey!);
-      const pendingResponse = await request(app).get(`/v0/mission/${pendingMission.id}`).set("x-api-key", moderatorPublisher.apikey!);
-      const refusedResponse = await request(app).get(`/v0/mission/${refusedMission.id}`).set("x-api-key", moderatorPublisher.apikey!);
-      const noModerationResponse = await request(app).get(`/v0/mission/${noModerationMission.id}`).set("x-api-key", moderatorPublisher.apikey!);
+      const acceptedResponse = await authenticatedGet(`/v0/mission/${acceptedMission.id}`, moderatorPublisher.apikey!);
+      const pendingResponse = await authenticatedGet(`/v0/mission/${pendingMission.id}`, moderatorPublisher.apikey!);
+      const refusedResponse = await authenticatedGet(`/v0/mission/${refusedMission.id}`, moderatorPublisher.apikey!);
+      const noModerationResponse = await authenticatedGet(`/v0/mission/${noModerationMission.id}`, moderatorPublisher.apikey!);
 
       expect(acceptedResponse.status).toBe(200);
       expect(acceptedResponse.body.data._id).toBe(acceptedMission.id);
@@ -922,7 +923,7 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("GET /v0/mission — joins multiple activities sorted alphabetically", async () => {
-      const response = await request(app).get(`/v0/mission?clientId=${multiActivityMission.clientId}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission?clientId=${multiActivityMission.clientId}`, apiKey);
 
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
@@ -930,7 +931,7 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("GET /v0/mission/search — joins multiple activities sorted alphabetically", async () => {
-      const response = await request(app).get(`/v0/mission/search?clientId=${multiActivityMission.clientId}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission/search?clientId=${multiActivityMission.clientId}`, apiKey);
 
       expect(response.status).toBe(200);
       expect(response.body.total).toBe(1);
@@ -938,7 +939,7 @@ describe("Mission API Integration Tests", () => {
     });
 
     it("GET /v0/mission/:id — joins multiple activities sorted alphabetically", async () => {
-      const response = await request(app).get(`/v0/mission/${multiActivityMission.id}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission/${multiActivityMission.id}`, apiKey);
 
       expect(response.status).toBe(200);
       expect(response.body.data.activity).toBe("arts, education, sport");
@@ -952,14 +953,14 @@ describe("Mission API Integration Tests", () => {
         activities: [],
       });
 
-      const response = await request(app).get(`/v0/mission/${noActivityMission.id}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission/${noActivityMission.id}`, apiKey);
 
       expect(response.status).toBe(200);
       expect(response.body.data.activity).toBeNull();
     });
 
     it("search facets list each activity individually from a multi-activity mission", async () => {
-      const response = await request(app).get(`/v0/mission/search?clientId=${multiActivityMission.clientId}`).set("x-api-key", apiKey);
+      const response = await authenticatedGet(`/v0/mission/search?clientId=${multiActivityMission.clientId}`, apiKey);
 
       expect(response.status).toBe(200);
       const activityKeys = response.body.facets.activities.map((f: any) => f.key);

--- a/api/tests/integration/api/endpoints/v0/mission.test.ts
+++ b/api/tests/integration/api/endpoints/v0/mission.test.ts
@@ -643,7 +643,7 @@ describe("Mission API Integration Tests", () => {
       const detailResponse = await request(staleSnapshotApp).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseur.apikey!).expect(200);
 
       expect(listResponse.body.data.map((item: MissionRecord) => item._id)).toContain(mission.id);
-      expect(searchResponse.body.data.map((item: MissionRecord) => item._id)).toContain(mission.id);
+      expect(searchResponse.body.hits.map((item: MissionRecord) => item._id)).toContain(mission.id);
       expect(detailResponse.body.data._id).toBe(mission.id);
     });
 

--- a/api/tests/integration/api/endpoints/v2/activity.test.ts
+++ b/api/tests/integration/api/endpoints/v2/activity.test.ts
@@ -214,7 +214,7 @@ describe("Activity V2 controller", () => {
       expect(createdApply?.clickId).toBeNull();
     });
 
-    it("records apply events without clickId using missionId when diffusion rules allow the mission", async () => {
+    it("records apply events without clickId using missionId when the diffusion snapshot allows the mission", async () => {
       const owner = await publisherService.createPublisher({ name: "Mission Owner Publisher", apikey: "mission-owner-key" });
       const diffuser = await publisherService.createPublisher({ name: "Allowed Diffuser Publisher", apikey: "allowed-diffuser-key" });
       const mission = await createTestMission({
@@ -224,14 +224,10 @@ describe("Activity V2 controller", () => {
         statusCode: "ACCEPTED",
       });
 
-      await prisma.publisherDiffusionRule.create({
+      await prisma.missionDiffusion.create({
         data: {
-          publisherId: diffuser.id,
-          field: "publisherId",
-          fieldType: "string",
-          operator: "is",
-          value: owner.id,
-          combinator: "or",
+          distributionPublisherId: diffuser.id,
+          missionId: mission.id,
         },
       });
 
@@ -254,7 +250,7 @@ describe("Activity V2 controller", () => {
       expect(createdApply?.clickId).toBeNull();
     });
 
-    it("records apply events without clickId using missionId when the diffuser has no rules", async () => {
+    it("returns 403 when the diffusion snapshot has no entry and the diffuser has no rules", async () => {
       const owner = await publisherService.createPublisher({ name: "No Rules Mission Owner", apikey: "no-rules-owner-key" });
       const diffuser = await publisherService.createPublisher({ name: "No Rules Diffuser", apikey: "no-rules-diffuser-key" });
       const mission = await createTestMission({
@@ -269,20 +265,11 @@ describe("Activity V2 controller", () => {
         .set("apikey", diffuser.apikey || "")
         .send({ missionId: mission.id, tag: "MIG" });
 
-      expect(response.status).toBe(200);
-      expect(response.body.ok).toBe(true);
-
-      const createdApply = await statEventService.findOneStatEventById(response.body.data._id);
-      expect(createdApply).toMatchObject({
-        type: "apply",
-        fromPublisherId: diffuser.id,
-        toPublisherId: owner.id,
-        missionId: mission.id,
-      });
+      expect(response.status).toBe(403);
+      expect(response.body).toEqual({ ok: false, code: "FORBIDDEN", message: "Mission not accessible" });
     });
 
-    it("returns 403 when missionId is outside the publisher diffusion rules", async () => {
-      const allowedOwner = await publisherService.createPublisher({ name: "Allowed Owner", apikey: "allowed-owner-key" });
+    it("returns 403 when live rules allow the mission but the diffusion snapshot has no entry", async () => {
       const otherOwner = await publisherService.createPublisher({ name: "Other Owner", apikey: "other-owner-key" });
       const diffuser = await publisherService.createPublisher({ name: "Restricted Diffuser", apikey: "restricted-diffuser-key" });
       const mission = await createTestMission({
@@ -298,7 +285,7 @@ describe("Activity V2 controller", () => {
           field: "publisherId",
           fieldType: "string",
           operator: "is",
-          value: allowedOwner.id,
+          value: otherOwner.id,
           combinator: "or",
         },
       });

--- a/api/tests/integration/api/mission-match.test.ts
+++ b/api/tests/integration/api/mission-match.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { createTestMission, createTestMissionEnrichment, createTestMissionScoring, createTestPublisher } from "../../fixtures";
 import { createTestApp } from "../../testApp";
 
-const app = createTestApp();
+const app = createTestApp({ syncMissionDiffusion: true });
 
 let apiKey: string;
 let publisherId: string;

--- a/api/tests/integration/docs/spec.test.ts
+++ b/api/tests/integration/docs/spec.test.ts
@@ -12,6 +12,7 @@
 import request from "supertest";
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { missionDiffusionRepository } from "@/repositories/mission-diffusion";
 import { createTestMission, createTestPublisher } from "../../fixtures";
 import { createStatEventFixture } from "../../fixtures/stat-event";
 import { app } from "./testOpenApiApp";
@@ -22,6 +23,7 @@ describe("OpenAPI spec compliance", () => {
   let annonceurApiKey: string;
   let annonceurId: string;
   let diffuseurApiKey: string;
+  let diffuseurId: string;
 
   beforeEach(async () => {
     const annonceur = await createTestPublisher({ name: "Annonceur" });
@@ -33,6 +35,7 @@ describe("OpenAPI spec compliance", () => {
       publishers: [{ publisherId: annonceur.id }],
     });
     diffuseurApiKey = diffuseur.apikey!;
+    diffuseurId = diffuseur.id;
   });
 
   // ── Missions (v0 — lecture diffuseur) ───────────────────────────────────
@@ -55,6 +58,7 @@ describe("OpenAPI spec compliance", () => {
   describe("GET /v0/mission/:id", () => {
     it("returns 200 when mission exists", async () => {
       const mission = await createTestMission({ publisherId: annonceurId });
+      await missionDiffusionRepository.createManyForDistributionPublisher(diffuseurId, [mission.id]);
       const res = await request(app).get(`/v0/mission/${mission.id}`).set("x-api-key", diffuseurApiKey);
       expect(res.status).toBe(200);
     });

--- a/api/tests/testApp.ts
+++ b/api/tests/testApp.ts
@@ -20,6 +20,7 @@ import UserController from "@/controllers/user";
 import UserScoringController from "@/controllers/user-scoring";
 import WarningController from "@/controllers/warning";
 import WidgetController from "@/controllers/widget";
+import { MissionDiffusionRebuildHandler } from "@/jobs/mission-diffusion-rebuild/handler";
 import bodyParserErrorHandler from "@/middlewares/body-parser-error-handler";
 import { auditLogger } from "@/middlewares/logger";
 import passport from "@/middlewares/passport";
@@ -34,8 +35,16 @@ import ViewV0Controller from "@/v0/view";
 import ActivityV2Controller from "@/v2/activity";
 import MissionV2WriteController from "@/v2/mission/controller";
 
+type TestAppOptions = {
+  auditLogs?: boolean;
+  metricsRecorder?: HttpMetricsRecorder;
+  syncMissionDiffusion?: boolean;
+};
+
+const missionDiffusionRebuildHandler = new MissionDiffusionRebuildHandler();
+
 // Create a test Express app with minimal configuration
-export const createTestApp = ({ auditLogs = false, metricsRecorder }: { auditLogs?: boolean; metricsRecorder?: HttpMetricsRecorder } = {}) => {
+export const createTestApp = ({ auditLogs = false, metricsRecorder, syncMissionDiffusion = false }: TestAppOptions = {}) => {
   const app = express();
 
   app.set("trust proxy", true);
@@ -48,6 +57,16 @@ export const createTestApp = ({ auditLogs = false, metricsRecorder }: { auditLog
   app.use(cookieParser());
   app.use(requestId);
   app.use(createHttpMetricsMiddleware(metricsRecorder));
+  if (syncMissionDiffusion) {
+    app.use(async (_req, _res, next) => {
+      try {
+        await missionDiffusionRebuildHandler.handle({});
+        next();
+      } catch (error) {
+        next(error);
+      }
+    });
+  }
   if (auditLogs) {
     app.use(auditLogger);
   }

--- a/terraform/jobs.tf
+++ b/terraform/jobs.tf
@@ -309,6 +309,29 @@ resource "scaleway_job_definition" "import-missions" {
   env = local.all_env_vars
 }
 
+# Job Definition for the 'mission-diffusion-rebuild' task (after import-missions)
+resource "scaleway_job_definition" "mission-diffusion-rebuild" {
+  count                  = var.enable_mission_jobs ? 1 : 0
+  name                   = "${terraform.workspace}-mission-diffusion-rebuild"
+  project_id             = var.project_id
+  cpu_limit              = 1000
+  memory_limit           = 2048
+  local_storage_capacity = 1024
+  image_uri              = local.image_uri
+  startup_command        = ["node"]
+  args                   = ["dist/jobs/run-job.js", "mission-diffusion-rebuild"]
+  timeout                = "60m"
+
+  cron {
+    # import-missions démarre à HH:15 avec un timeout de 60 min ; ce décalage
+    # laisse 15 min de marge avant le rebuild suivant.
+    schedule = "30 1,7,13,19 * * *"
+    timezone = "Europe/Paris"
+  }
+
+  env = local.all_env_vars
+}
+
 # Job Definition for the 'update-mission-enrichment' task (on-demand only, no cron)
 resource "scaleway_job_definition" "update-mission-enrichment" {
   name                   = "${terraform.workspace}-update-mission-enrichment"


### PR DESCRIPTION
## Description

Cette PR effectue le cutover des lectures de diffusion vers le snapshot `mission_diffusion`.

Les `PublisherDiffusionRule` restent la source déclarative : elles sont évaluées par le job de rebuild. La table `mission_diffusion` contient le résultat matérialisé de cette évaluation et devient la source des contrôles d'accès applicatifs.

## Changements

- le matching filtre les missions avec un `JOIN` direct sur `mission_diffusion` ;
- les listes, recherches et détails `v0/mission` utilisent `missionDiffusions.some` ;
- le détail `v2/mission`, qui partage le contrôleur de lecture v0, utilise le même snapshot ;
- la création d'une activité `v2/activity` à partir d'un `missionId` vérifie également `mission_diffusion` ;
- les lectures restent cohérentes entre liste et détail pendant la fenêtre de staleness entre deux rebuilds ;
- le split historique des scopes de `v0/mission` est supprimé ;
- la sémantique des root allowlists propres est conservée.

### Compatibilité temporaire des iframes

Les routes `iframe/*` sont vouées à être remplacées par Typesense.

Pour ne pas casser les publishers disposant uniquement de droits widget :

- le snapshot est appliqué lorsqu'une root de diffusion existe ;
- sinon, les routes conservent temporairement leur fallback historique sur `widget.publishers`.

Ce contournement est commenté dans le code et devra être supprimé avec les routes `iframe/*`.

### Rebuild périodique

Le job Scaleway `mission-diffusion-rebuild` est planifié toutes les 6 heures, après `import-missions` :

- imports à `00:15`, `06:15`, `12:15` et `18:15` ;
- rebuilds à `01:30`, `07:30`, `13:30` et `19:30` ;
- le décalage couvre le timeout de 60 minutes de l'import et conserve 15 minutes de marge.

La fraîcheur du snapshot suit donc cette cadence. Les règles live ne sont plus relues pour autoriser ponctuellement une mission entre deux rebuilds.

## Choix de périmètre

Le cutover reste volontairement simple :

- aucun feature flag ;
- aucun cache applicatif ;
- aucun script de benchmark ou de comparaison versionné ;
- aucun mécanisme de double lecture entre règles live et snapshot.

## Benchmarks

Mesures locales sur un jeu de données représentatif, après rebuild du snapshot :

| Parcours | P50 | P95 | Conclusion |
| --- | ---: | ---: | --- |
| `/missions/match` (`m3`, `limit=13`) | ~3,1 s | ~3,3 s | seuil de 5 s respecté |
| `v0/mission` — première page | ~185 ms | ~235 ms | latence stable |
| `v0/mission` — parcours complet | ~366 ms | ~516 ms | pagination profonde fonctionnelle sans cache |

Le filtre `mission_diffusion` est lu par index et ne constitue pas le point chaud du matching.

## Dépendances

- #1297 : création et rebuild de `mission_diffusion` ;
- #1322 : optimisation de la requête de matching.

Ces deux PR sont fusionnées dans `staging` et intégrées à cette branche.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [x] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Validation

- [x] compilation TypeScript ;
- [x] ESLint ciblé ;
- [x] couverture des lectures matching, v0/v2, iframe et activité v2 ;
- [x] scénarios de staleness entre règles live et snapshot ;
- [x] vérification de l'équivalence du snapshot ;
- [x] benchmarks des chemins de lecture après rebuild ;
- [x] formatage Terraform.

## Déploiement

Avant le cutover applicatif, vérifier qu'un rebuild récent de `mission_diffusion` a réussi dans l'environnement cible. Le job planifié maintient ensuite le snapshot toutes les 6 heures.

Le rollback applicatif consiste à redéployer la version précédente. La table peut rester en place et continuer à être reconstruite.
