### PR TITLE
refactor(api): xml import ssrf

### DIFF
--- a/api/src/jobs/import-missions/utils/xml.ts
+++ b/api/src/jobs/import-missions/utils/xml.ts
@@ -3,6 +3,7 @@ import { XMLParser } from "fast-xml-parser";
 import { captureException } from "@/error";
 import type { PublisherRecord } from "@/types/publisher";
 import { MissionXML } from "@/jobs/import-missions/types";
+import { safeFetch, UnsafeFetchUrlError } from "@/utils/safe-fetch";
 
 export const fetchXML = async (publisher: PublisherRecord): Promise<{ ok: boolean; data: string; error?: string; status?: number }> => {
   try {
@@ -15,17 +16,20 @@ export const fetchXML = async (publisher: PublisherRecord): Promise<{ ok: boolea
       headers.set("Authorization", `Basic ${btoa(`${publisher.feedUsername}:${publisher.feedPassword}`)}`);
     }
     console.log(`[${publisher.name}] Fetching xml from ${publisher.feed}`);
-    const response = await fetch(publisher.feed.trim(), { headers });
+    const response = await safeFetch(publisher.feed.trim(), { headers });
 
     if (!response.ok) {
       return { ok: false, data: "", error: response.statusText, status: response.status };
     }
     return { ok: true, data: await response.text() };
   } catch (error: any) {
+    if (error instanceof UnsafeFetchUrlError) {
+      return { ok: false, data: "", error: "Unsafe feed URL", status: 400 };
+    }
     if (error.message?.includes("Failed to fetch") || error.message?.includes("fetch failed")) {
       return { ok: false, data: "", error: "Failed to fetch XML", status: 500 };
     }
-    captureException(error, { extra: { publisher } });
+    captureException(error, { extra: { publisherId: publisher.id, publisherName: publisher.name, feed: publisher.feed } });
     return { ok: false, data: "", error: error.message, status: 500 };
   }
 };

--- a/api/src/jobs/import-organizations/handler.ts
+++ b/api/src/jobs/import-organizations/handler.ts
@@ -11,6 +11,7 @@ import { importRnaService } from "@/services/import-rna";
 import { BaseHandler } from "@/jobs/base/handler";
 import { JobResult } from "@/jobs/types";
 import { readZip } from "@/jobs/import-organizations/zip";
+import { safeFetch } from "@/utils/safe-fetch";
 
 const RNA_DATASETS_ID = "58e53811c751df03df38f42d";
 
@@ -71,7 +72,7 @@ export class ImportOrganizationsHandler implements BaseHandler<ImportOrganizatio
 
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
-      const response = await fetch(resource.url, { signal: controller.signal as any });
+      const response = await safeFetch(resource.url, { signal: controller.signal as any });
       clearTimeout(timeout);
 
       if (!response.ok || !response.body) {

--- a/api/src/utils/__tests__/safe-fetch.test.ts
+++ b/api/src/utils/__tests__/safe-fetch.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { lookupMock } = vi.hoisted(() => ({ lookupMock: vi.fn() }));
+
+vi.mock("node:dns/promises", () => ({ lookup: lookupMock }));
+
+import { safeFetch, UnsafeFetchUrlError, validateExternalUrl } from "@/utils/safe-fetch";
+
+const publicAddress = [{ address: "93.184.216.34", family: 4 }];
+
+describe("safeFetch", () => {
+  beforeEach(() => {
+    lookupMock.mockResolvedValue(publicAddress);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each(["file:///etc/passwd", "ftp://example.org/feed.xml", "http://169.254.169.254/latest/meta-data", "http://127.0.0.1/feed.xml", "http://[::1]/feed.xml", "http://[::ffff:127.0.0.1]/feed.xml"]) (
+    "rejects unsafe URL %s",
+    async (url) => {
+      await expect(validateExternalUrl(url)).rejects.toBeInstanceOf(UnsafeFetchUrlError);
+    },
+  );
+
+  it("rejects a hostname resolving to an internal IP address", async () => {
+    lookupMock.mockResolvedValue([{ address: "10.0.0.42", family: 4 }]);
+
+    await expect(validateExternalUrl("https://partner.example/feed.xml")).rejects.toThrow("blocked IP");
+  });
+
+  it("rejects a hostname when one of its addresses is internal", async () => {
+    lookupMock.mockResolvedValue([...publicAddress, { address: "192.168.1.10", family: 4 }]);
+
+    await expect(validateExternalUrl("https://partner.example/feed.xml")).rejects.toThrow("blocked IP");
+  });
+
+  it("allows the globally reachable NAT64 prefix", async () => {
+    await expect(validateExternalUrl("https://[64:ff9b::808:808]/feed.xml")).resolves.toBeInstanceOf(URL);
+  });
+
+  it("validates every redirect and omits authorization from redirected requests", async () => {
+    lookupMock.mockImplementation(async (hostname: string) => (hostname === "feed.example" ? publicAddress : [{ address: "1.1.1.1", family: 4 }]));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 302, headers: { location: "https://cdn.example/feed.xml" } }))
+      .mockResolvedValueOnce(new Response("<xml />", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await safeFetch("https://feed.example/feed.xml", { headers: { Authorization: "Basic secret" } });
+
+    expect(await response.text()).toBe("<xml />");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(new Headers(fetchMock.mock.calls[0][1].headers).get("authorization")).toBe("Basic secret");
+    expect(new Headers(fetchMock.mock.calls[1][1].headers).has("authorization")).toBe(false);
+  });
+
+  it("does not request a redirect target that resolves to an internal IP address", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 302, headers: { location: "http://169.254.169.254/latest/meta-data" } }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(safeFetch("https://feed.example/feed.xml")).rejects.toThrow("blocked IP");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/api/src/utils/safe-fetch.ts
+++ b/api/src/utils/safe-fetch.ts
@@ -65,10 +65,11 @@ const withoutSensitiveHeaders = (headersInit: HeadersInit | undefined): Headers 
 
 export const safeFetch = async (input: string | URL, init: RequestInit = {}): Promise<Response> => {
   let url = await validateExternalUrl(input);
+  let requestUrl = typeof input === "string" ? input : input.toString();
   let headers = init.headers;
 
   for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
-    const response = await fetch(url, { ...init, headers, redirect: "manual" });
+    const response = await fetch(requestUrl, { ...init, headers, redirect: "manual" });
     if (!REDIRECT_STATUS_CODES.has(response.status)) {
       return response;
     }
@@ -80,6 +81,7 @@ export const safeFetch = async (input: string | URL, init: RequestInit = {}): Pr
     }
 
     url = await validateExternalUrl(new URL(location, url));
+    requestUrl = url.toString();
     headers = withoutSensitiveHeaders(init.headers);
   }
 

--- a/api/src/utils/safe-fetch.ts
+++ b/api/src/utils/safe-fetch.ts
@@ -1,0 +1,87 @@
+import { lookup } from "node:dns/promises";
+import { BlockList, isIP } from "node:net";
+
+const MAX_REDIRECTS = 3;
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
+const BLOCKED_CIDRS = [
+  "0.0.0.0/8",
+  "10.0.0.0/8",
+  "100.64.0.0/10",
+  "127.0.0.0/8",
+  "169.254.0.0/16",
+  "172.16.0.0/12",
+  "192.168.0.0/16",
+  "::/128",
+  "::1/128",
+  "100::/64",
+  "fc00::/7",
+  "fe80::/10",
+] as const;
+
+const blockedIps = new BlockList();
+for (const cidr of BLOCKED_CIDRS) {
+  const [network, prefix] = cidr.split("/") as [string, string];
+  blockedIps.addSubnet(network, Number(prefix), isIP(network) === 4 ? "ipv4" : "ipv6");
+}
+
+export class UnsafeFetchUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsafeFetchUrlError";
+  }
+}
+
+const isBlockedIp = (address: string): boolean => {
+  const family = isIP(address);
+  return family !== 0 && blockedIps.check(address, family === 4 ? "ipv4" : "ipv6");
+};
+
+export const validateExternalUrl = async (input: string | URL): Promise<URL> => {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    throw new UnsafeFetchUrlError("Invalid URL");
+  }
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, "");
+  if (!hostname || url.username || url.password || !["http:", "https:"].includes(url.protocol)) {
+    throw new UnsafeFetchUrlError("Invalid URL");
+  }
+
+  const addresses = isIP(hostname) ? [hostname] : (await lookup(hostname, { all: true, verbatim: true })).map(({ address }) => address);
+  if (!addresses.length || addresses.some(isBlockedIp)) {
+    throw new UnsafeFetchUrlError("URL resolves to a blocked IP address");
+  }
+
+  return url;
+};
+
+const withoutSensitiveHeaders = (headersInit: HeadersInit | undefined): Headers => {
+  const headers = new Headers(headersInit);
+  ["authorization", "cookie", "proxy-authorization"].forEach((header) => headers.delete(header));
+  return headers;
+};
+
+export const safeFetch = async (input: string | URL, init: RequestInit = {}): Promise<Response> => {
+  let url = await validateExternalUrl(input);
+  let headers = init.headers;
+
+  for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
+    const response = await fetch(url, { ...init, headers, redirect: "manual" });
+    if (!REDIRECT_STATUS_CODES.has(response.status)) {
+      return response;
+    }
+
+    const location = response.headers.get("location");
+    await response.body?.cancel();
+    if (!location || redirectCount === MAX_REDIRECTS) {
+      throw new UnsafeFetchUrlError("Invalid redirect response");
+    }
+
+    url = await validateExternalUrl(new URL(location, url));
+    headers = withoutSensitiveHeaders(init.headers);
+  }
+
+  throw new UnsafeFetchUrlError("Too many redirects");
+};

--- a/api/tests/integration/jobs/import-missions/import-missions.handler.test.ts
+++ b/api/tests/integration/jobs/import-missions/import-missions.handler.test.ts
@@ -9,6 +9,10 @@ import { importService } from "@/services/import";
 import { missionService } from "@/services/mission";
 import { createTestImport, createTestMission, createTestPublisher } from "../../../fixtures";
 
+const { lookupMock } = vi.hoisted(() => ({ lookupMock: vi.fn() }));
+
+vi.mock("node:dns/promises", () => ({ lookup: lookupMock }));
+
 const originalFetch = global.fetch;
 global.fetch = vi.fn();
 
@@ -25,6 +29,7 @@ describe("Import missions job (integration test)", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    lookupMock.mockResolvedValue([{ address: "1.1.1.1", family: 4 }]);
     (global.fetch as any).mockReset();
   });
 


### PR DESCRIPTION
## Description

Corrige la vulnérabilité SSRF identifiée sur les imports de flux partenaires et de ressources RNA.

- Ajoute un `safeFetch` commun aux deux imports.
- Accepte uniquement les URL `http` et `https`.
- Résout le nom de domaine et bloque les adresses privées, locales ou non routables.
- Désactive le suivi automatique des redirections ; chaque cible est validée manuellement, avec une limite de 3 redirections.
- Retire les en-têtes sensibles (`Authorization`, cookies) après la requête initiale.
- Évite d’envoyer les identifiants de flux à Sentry en cas d’erreur.

## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/SSRF-sur-l-import-XML-39972a322d5080f28159f0226d498dd0?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Les redirections vers des CDN partenaires restent compatibles, mais leur URL est validée avant chaque requête. Les tests couvrent notamment les IP internes, les redirections vers le metadata service et l’absence de transmission du Basic-auth après redirection.