### PR TITLE
fix(api): revert jit disabling

### DIFF
--- a/api/scripts/benchmark-matching-engine.ts
+++ b/api/scripts/benchmark-matching-engine.ts
@@ -14,7 +14,6 @@
  *   --taxonomy-weight N        Poids taxonomie (defaut : moteur)
  *   --geo-weight N             Poids geo (defaut : moteur)
  *   --geo-half-decay-km N      Demi-vie geo en km (defaut : moteur)
- *   --publisher-id ID          Applique le filtre de diffusion du publisher (comme le vrai /match ; defaut : plateforme de l'engagement)
  *   --json                     Sortie JSON au lieu du tableau console
  *   --explain                  Affiche EXPLAIN (ANALYZE, BUFFERS) du SQL de ranking au lieu de mesurer
  */
@@ -22,7 +21,6 @@
 import dotenv from "dotenv";
 dotenv.config();
 
-import { PUBLISHER_IDS } from "@/config";
 import { Prisma } from "@/db/core";
 import { prisma } from "@/db/postgres";
 import { matchingEngineService } from "@/services/matching-engine";
@@ -47,7 +45,6 @@ type BenchmarkOptions = {
   taxonomyWeight?: number;
   geoWeight?: number;
   geoHalfDecayKm?: number;
-  publisherId?: string;
   json: boolean;
   explain: boolean;
 };
@@ -178,7 +175,6 @@ const parseOptions = (): BenchmarkOptions => ({
   taxonomyWeight: parseNumber("--taxonomy-weight"),
   geoWeight: parseNumber("--geo-weight"),
   geoHalfDecayKm: parseNumber("--geo-half-decay-km"),
-  publisherId: getFlagValue("--publisher-id") ?? PUBLISHER_IDS.PLATEFORME_ENGAGEMENT,
   json: args.includes("--json"),
   explain: args.includes("--explain"),
 });
@@ -321,7 +317,6 @@ const getSampledUserScorings = async (sampleSize: number): Promise<UserScoringCa
 
 const buildRankingInput = (options: BenchmarkOptions, userScoringId: string, limit: number, offset: number): RankMissionsByUserScoringInput => ({
   userScoringId,
-  publisherId: options.publisherId,
   version: options.version,
   limit,
   offset,

--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -21,7 +21,6 @@ import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 
 const prismaMock = prisma as unknown as {
   $queryRaw: ReturnType<typeof vi.fn>;
-  $transaction: ReturnType<typeof vi.fn>;
 };
 
 const missionMatchingResultRepositoryMock = missionMatchingResultRepository as unknown as {
@@ -59,10 +58,6 @@ const getSqlValues = (query: unknown): unknown[] => {
 describe("matchingEngineService", () => {
   beforeEach(() => {
     prismaMock.$queryRaw.mockReset();
-    // La requête de ranking passe par prisma.$transaction (SET LOCAL jit = off) : on exécute le
-    // callback avec le client mocké, de sorte que tx.$queryRaw reste le même mock (ordre préservé).
-    prismaMock.$transaction.mockReset();
-    prismaMock.$transaction.mockImplementation((callback: (tx: typeof prisma) => unknown) => callback(prisma));
     missionMatchingResultRepositoryMock.createForUserScoringVersion.mockReset();
     publisherDiffusionRuleServiceMock.buildMissionPublisherDiffusionRuleSql.mockReset();
   });

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -661,29 +661,6 @@ const buildRankingSqlForInput = async (input: RankMissionsByUserScoringInput): P
   });
 };
 
-/**
- * Exécute la requête de ranking avec le JIT PostgreSQL désactivé pour cette requête uniquement.
- *
- * Pourquoi : le filtre de diffusion d'un publisher (voir `buildPublisherRuleSql`) peut se déployer en
- * un très grand `OR` (allowlist de plusieurs centaines de publishers d'un réseau) ; combiné aux
- * grosses expressions `CASE` de scoring géo, le coût estimé du plan dépasse largement les seuils JIT
- * de Postgres (`jit_optimize_above_cost` / `jit_inline_above_cost`, défaut 500k). Postgres active
- * alors le JIT avec inlining + optimization et compile des centaines de fonctions : mesuré à ~4,4 s de
- * compilation pour une requête qui s'EXÉCUTE en ~0,9 s (staging, publisher à ~150 diffuseurs). Le JIT
- * est donc nettement perdant ici → on le coupe.
- *
- * `SET LOCAL` est borné à la transaction courante (d'où le `$transaction`) : aucun impact serveur,
- * aucune fuite via le pool de connexions, aucune autre requête/appli affectée, pas de config infra.
- * Compatible PG ≥ 11 (le paramètre `jit` existe même sans build LLVM, où il est un no-op inoffensif).
- * Ne touche que cette requête ; la 2e requête (détails taxonomie sur 20 ids) reste hors périmètre car
- * son coût est trop faible pour déclencher le JIT.
- */
-const runRankingQuery = async (sql: Prisma.Sql): Promise<DbRankRow[]> =>
-  prisma.$transaction(async (tx) => {
-    await tx.$executeRawUnsafe("SET LOCAL jit = off");
-    return tx.$queryRaw<DbRankRow[]>(sql);
-  });
-
 export const matchingEngineService = {
   async rankMissionsByUserScoring(input: RankMissionsByUserScoringInput): Promise<RankMissionsByUserScoringResult> {
     const startedAt = Date.now();
@@ -691,7 +668,7 @@ export const matchingEngineService = {
 
     await assertUserScoringExists(input.userScoringId);
 
-    const rows = await runRankingQuery(await buildRankingSqlForInput(input));
+    const rows = await prisma.$queryRaw<DbRankRow[]>(await buildRankingSqlForInput(input));
     const missionScoringIdsForDetails = rows.slice(0, MATCHING_ENGINE_TOP_RESULTS_LIMIT).map((row) => row.mission_scoring_id);
     const taxonomyScoresRows =
       missionScoringIdsForDetails.length > 0


### PR DESCRIPTION
Reverts betagouv/api-engagement#1275

Timeout sur la transaction : 
```
Transaction API error: A commit cannot be executed on an expired transaction. The timeout for this transaction was 5000 ms, however 18431 ms passed since the start of the transaction. Consider increasing the interactive transaction timeout or doing less...
```