### PR TITLE
fix(api): ensure secret only for the API

### DIFF
--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -5,9 +5,11 @@ export const PORT_WORKER = process.env.PORT_WORKER || 4001;
 export const ENV = process.env.ENV || "development";
 const DEFAULT_SECRET = "not-so-secret";
 
-if (ENV !== "development" && (!process.env.SECRET || process.env.SECRET === DEFAULT_SECRET)) {
-  throw new Error("SECRET must be configured with a non-default value when ENV is not development");
-}
+export const ensureJwtSecretIsConfigured = () => {
+  if (ENV !== "development" && (!process.env.SECRET || process.env.SECRET === DEFAULT_SECRET)) {
+    throw new Error("SECRET must be configured with a non-default value when ENV is not development");
+  }
+};
 
 export const SECRET = process.env.SECRET || DEFAULT_SECRET;
 export const IMAGE_VERSION = process.env.IMAGE_VERSION || "unknown";

--- a/api/src/middlewares/passport.ts
+++ b/api/src/middlewares/passport.ts
@@ -5,10 +5,12 @@ import passport from "passport";
 import { HeaderAPIKeyStrategy } from "passport-headerapikey";
 import { ExtractJwt, Strategy as JwtStrategy } from "passport-jwt";
 
-import { PUBLISHER_IDS, SECRET } from "@/config";
+import { ensureJwtSecretIsConfigured, PUBLISHER_IDS, SECRET } from "@/config";
 import { captureException } from "@/error";
 import { publisherService } from "@/services/publisher";
 import { userService } from "@/services/user";
+
+ensureJwtSecretIsConfigured();
 
 const userOptions = {
   jwtFromRequest: (req: Request) => ExtractJwt.fromAuthHeaderWithScheme("jwt")(req),


### PR DESCRIPTION
## Description

Corrige le durcissement de la configuration JWT afin de ne pas bloquer `api-worker`.

- La vérification de `SECRET` est exécutée lors de l’initialisation des stratégies Passport JWT, et non plus à l’import de la configuration partagée.
- L’API refuse toujours de démarrer hors développement si `SECRET` est absent ou vaut `not-so-secret`.
- `api-worker` peut démarrer sans `SECRET`, car il n’expose pas les stratégies JWT.
- Les stratégies JWT restent limitées à l’algorithme `HS256`.


## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
