### PR TITLE
fix(plateform): RGAA 3.2 (dark theme text contrast)

### DIFF
--- a/plateform/app/components/quiz/mission-card.tsx
+++ b/plateform/app/components/quiz/mission-card.tsx
@@ -11,7 +11,7 @@ type MissionCardProps = {
 export default function MissionCard({ imageSrc, category = "Solidarité", title, size = "md", className = "" }: MissionCardProps) {
   return (
     <div
-      className={`bg-white rounded-xl shadow-md overflow-hidden p-2 gap-2 flex flex-col ${size === "sm" ? "w-60 h-72 md:w-60 md:h-72" : "w-56 h-72 md:w-72 md:h-80"} ${className}`}
+      className={`bg-background rounded-xl shadow-md overflow-hidden p-2 gap-2 flex flex-col ${size === "sm" ? "w-60 h-72 md:w-60 md:h-72" : "w-56 h-72 md:w-72 md:h-80"} ${className}`}
     >
       <div className="relative h-[80%]">
         <img src={imageSrc} alt="" className="block w-full object-cover rounded h-full" />

--- a/plateform/app/main.css
+++ b/plateform/app/main.css
@@ -254,6 +254,7 @@
 }
 
 .mission-map__tooltip.leaflet-tooltip {
+  background-color: var(--background-default-grey);
   border: none;
   border-radius: 12px;
   box-shadow: 0 4px 16px rgb(0 0 0 / 16%);
@@ -261,6 +262,10 @@
   min-width: 220px;
   padding: 10px 14px;
   white-space: normal;
+}
+
+.mission-map__tooltip.leaflet-tooltip-top::before {
+  border-top-color: var(--background-default-grey);
 }
 
 .mission-map__tooltip-title {

--- a/plateform/app/routes/mission-detail.tsx
+++ b/plateform/app/routes/mission-detail.tsx
@@ -145,7 +145,7 @@ export default function MissionDetailPage() {
 
       {userScoringId && <SimilarMissions userScoringId={userScoringId} currentMissionId={mission.id} />}
 
-      <div className="fixed right-0 bottom-0 left-0 z-10 border-t border-[#DDD] bg-white px-5 py-4 md:hidden">
+      <div className="fixed right-0 bottom-0 left-0 z-10 border-t border-border-default-grey bg-background px-5 py-4 md:hidden">
         <a href={mission.applicationUrl} target="_blank" rel="noopener noreferrer" className="fr-btn w-full! justify-center!">
           Postuler
         </a>


### PR DESCRIPTION
## Description

Corrige les 3 non-conformités au critère RGAA 3.2 (contraste texte/arrière-plan) relevées par l'audit du 20/07/2026 (`audits/rgaa-2026-07-20.md`) : des zones combinaient un fond blanc codé en dur avec des couleurs de texte thémables, rendant le texte illisible en thème sombre (le site active `data-fr-scheme="system"`).

**Changements** (dans les 3 cas, le fond devient thémable plutôt que de figer le texte) :

- `routes/mission-detail.tsx` : la barre fixe mobile « Postuler » passe de `bg-white` / `border-[#DDD]` à `bg-background` / `border-border-default-grey` — la date limite en `text-mention-grey` retrouve un contraste ≥ 4,5:1 en sombre.
- `main.css` : les infobulles Leaflet de la carte des résultats reçoivent `background-color: var(--background-default-grey)` ; la flèche de l'infobulle (`.leaflet-tooltip-top::before`, blanche dans leaflet.css) est surchargée avec la même variable.
- `components/quiz/mission-card.tsx` : la carte d'illustration du quiz passe de `bg-white` à `bg-background` — le titre `fr-text` et la mention « Service Civique » (couleurs DSFR par défaut) redeviennent lisibles.

## Liens utiles

- 📝 Audit RGAA : `audits/rgaa-2026-07-20.md` (constat [NC] 3.2)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Changement purement visuel : `typecheck` et `lint` passent, pas de logique modifiée.
- À vérifier visuellement en thème sombre : fiche mission en mobile (barre « Postuler »), survol d'un marqueur sur la carte des résultats, écrans de transition du quiz (steps motivation et localisation).
- La surcharge de la flèche de l'infobulle Leaflet va au-delà du constat de l'audit : sans elle, la flèche restait blanche sous l'infobulle sombre (le composant utilise `direction="top"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)