### PR TITLE
fix(plateform): fix rgaa link non-conformities (6.1, 13.2)

### DIFF
--- a/plateform/app/components/landing/mission-examples.tsx
+++ b/plateform/app/components/landing/mission-examples.tsx
@@ -46,38 +46,29 @@ export default function MissionExamples({ missions, className }: Props) {
           aria-atomic="false"
         >
           <div className="flex w-max gap-4 px-[10vw] pb-4 md:pl-0 md:pr-8">
-            {missions.map((mission, i) => {
-              const href = mission.applicationUrl ?? "#";
-              return (
-                <Link
-                  key={mission.id}
-                  to={href}
-                  onClick={() => trackMissionClickedFromBrowse(mission, { section: "homepage_examples", entryPage: "homepage", opensExternal: Boolean(mission.applicationUrl) })}
-                  role="group"
-                  aria-roledescription="slide"
-                  aria-label={`Mission ${i + 1} sur ${missions.length}`}
-                  className="bg-background flex w-[80vw] max-w-[360px] shrink-0 snap-center overflow-hidden shadow-lg border border-border-default-grey underline-none! bg-none! hover:bg-background! md:w-[360px]"
-                >
-                  {mission.domainLogo ? (
-                    <img src={mission.domainLogo} alt="" className="w-28 shrink-0 object-cover" loading="lazy" />
-                  ) : (
-                    <div className="bg-beige-gris-galet w-28 shrink-0" />
-                  )}
-                  <div className="flex flex-1 flex-col gap-4 p-6">
-                    <p className="fr-h6 line-clamp-2 mb-0!">{mission.title}</p>
-                    <div className="fr-mt-auto flex items-center gap-2">
-                      {mission.publisherLogo && (
-                        <div className="size-10 rounded object-contain bg-white">
-                          <img src={mission.publisherLogo} alt="" className="size-full object-contain" />
-                        </div>
-                      )}
-
-                      {mission.publisherName && <span className="fr-text--xs text-mention-grey line-clamp-1 mb-0!">{mission.publisherName}</span>}
-                    </div>
+            {missions.map((mission, i) => (
+              <div
+                key={mission.id}
+                role="group"
+                aria-roledescription="slide"
+                aria-label={`Mission ${i + 1} sur ${missions.length}`}
+                className="w-[80vw] max-w-[360px] shrink-0 snap-center md:w-[360px]"
+              >
+                {mission.applicationUrl ? (
+                  <Link
+                    to={mission.applicationUrl}
+                    onClick={() => trackMissionClickedFromBrowse(mission, { section: "homepage_examples", entryPage: "homepage", opensExternal: true })}
+                    className="bg-background flex h-full w-full overflow-hidden shadow-lg border border-border-default-grey underline-none! bg-none! hover:bg-background!"
+                  >
+                    <MissionSlideContent mission={mission} />
+                  </Link>
+                ) : (
+                  <div className="bg-background flex h-full w-full overflow-hidden shadow-lg border border-border-default-grey">
+                    <MissionSlideContent mission={mission} />
                   </div>
-                </Link>
-              );
-            })}
+                )}
+              </div>
+            ))}
           </div>
         </div>
 
@@ -123,5 +114,25 @@ export default function MissionExamples({ missions, className }: Props) {
         </button>
       </div>
     </section>
+  );
+}
+
+function MissionSlideContent({ mission }: { mission: MissionBrowse }) {
+  return (
+    <>
+      {mission.domainLogo ? <img src={mission.domainLogo} alt="" className="w-28 shrink-0 object-cover" loading="lazy" /> : <div className="bg-beige-gris-galet w-28 shrink-0" />}
+      <div className="flex flex-1 flex-col gap-4 p-6">
+        <p className="fr-h6 line-clamp-2 mb-0!">{mission.title}</p>
+        <div className="fr-mt-auto flex items-center gap-2">
+          {mission.publisherLogo && (
+            <div className="size-10 rounded object-contain bg-white">
+              <img src={mission.publisherLogo} alt="" className="size-full object-contain" />
+            </div>
+          )}
+
+          {mission.publisherName && <span className="fr-text--xs text-mention-grey line-clamp-1 mb-0!">{mission.publisherName}</span>}
+        </div>
+      </div>
+    </>
   );
 }

--- a/plateform/app/components/landing/pro-space.tsx
+++ b/plateform/app/components/landing/pro-space.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router";
 import Highlight from "../ui/highlight";
 
 type Benefit = {
@@ -37,9 +36,6 @@ export default function ProSpace() {
           <p className="fr-text--lead text-default-grey fr-mb-4w hidden! md:block!">
             Professionnels de l'éducation, conseillers, parents. Orientez facilement les jeunes vers des missions adaptées à leurs envies et leur rythme.
           </p>
-          <Link to="#" className="fr-btn fr-btn--secondary hidden! md:block!">
-            Accéder aux ressources
-          </Link>
         </div>
 
         <div className="flex-1 grid grid-cols-1 gap-12 md:gap-8 sm:grid-cols-2 px-4! md:px-0!">
@@ -51,9 +47,6 @@ export default function ProSpace() {
             </div>
           ))}
         </div>
-        <Link to="#" className="fr-btn fr-btn--secondary block! md:hidden! w-full! text-center!">
-          Accéder aux ressources
-        </Link>
       </div>
     </section>
   );

--- a/plateform/app/components/layout/partners.tsx
+++ b/plateform/app/components/layout/partners.tsx
@@ -52,7 +52,7 @@ export default function Partners({ style = "default" }: { style?: "default" | "c
               </div>
               <div className="flex-1">
                 <p className="fr-mb-0 font-bold">
-                  <a href={partner.url} target="_blank" rel="noopener noreferrer" className="text-title-grey bg-none!">
+                  <a href={partner.url} target="_blank" rel="noopener noreferrer" title={`${partner.name} - nouvelle fenêtre`} className="text-title-grey bg-none!">
                     {partner.name}
                   </a>
                 </p>

--- a/plateform/app/components/mission-detail/cta-panel.tsx
+++ b/plateform/app/components/mission-detail/cta-panel.tsx
@@ -56,7 +56,7 @@ export default function MissionCtaPanel({ mission, userScoringId, deadlineLabel 
       <hr className="h-px! pb-0! bg-border-default-grey -mx-5! md:mx-0!" />
 
       <div className="flex flex-col gap-3">
-        <a href={mission.applicationUrl} target="_blank" rel="noopener noreferrer" className="fr-btn w-full! justify-center!">
+        <a href={mission.applicationUrl} target="_blank" rel="noopener noreferrer" title="Découvrir la mission - nouvelle fenêtre" className="fr-btn w-full! justify-center!">
           Découvrir la mission
         </a>
 

--- a/plateform/app/components/mission-detail/location-card.tsx
+++ b/plateform/app/components/mission-detail/location-card.tsx
@@ -42,6 +42,7 @@ export default function MissionLocationCard({ location }: MissionLocationCardPro
           href={mapsHref}
           target="_blank"
           rel="noopener noreferrer"
+          title="Ouvrir sur Google Maps - nouvelle fenêtre"
           className="fr-btn fr-btn--secondary fr-icon-map-pin-2-line fr-btn--icon-left w-full! justify-center! md:hidden!"
         >
           Ouvrir sur Google Maps

--- a/plateform/app/components/missions/mission-card.tsx
+++ b/plateform/app/components/missions/mission-card.tsx
@@ -30,7 +30,15 @@ export default function MissionCard({ mission, link, onClick }: MissionCardProps
         {mission.title}
       </Link>
     ) : link?.type === "external" ? (
-      <a href={link.href} onClick={onClick} target="_blank" rel="noopener noreferrer" className="text-title-grey! fr-h6! bg-none! mb-0!" style={clampStyle}>
+      <a
+        href={link.href}
+        onClick={onClick}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={`${mission.title} - nouvelle fenêtre`}
+        className="text-title-grey! fr-h6! bg-none! mb-0!"
+        style={clampStyle}
+      >
         {mission.title}
       </a>
     ) : (

--- a/plateform/app/components/quiz/exit-modal.tsx
+++ b/plateform/app/components/quiz/exit-modal.tsx
@@ -32,7 +32,7 @@ export default function ExitModal({ className }: ExitModalProps) {
           <Link to="/" className="fr-btn fr-btn--secondary">
             Retourner à l'accueil
           </Link>
-          <Link to="/quiz/results" className="fr-btn">
+          <Link to="/missions" className="fr-btn">
             Voir toutes les missions
           </Link>
         </div>

--- a/plateform/app/components/ui/location-map.tsx
+++ b/plateform/app/components/ui/location-map.tsx
@@ -5,7 +5,7 @@ import { MAPTILER_API_KEY } from "~/services/config";
 
 export const MAPTILER_BASIC_URL = MAPTILER_API_KEY ? `https://api.maptiler.com/maps/basic-v2/256/{z}/{x}/{y}.png?key=${MAPTILER_API_KEY}` : null;
 export const MAPTILER_ATTRIBUTION =
-  '<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>';
+  '<a href="https://www.maptiler.com/copyright/" target="_blank" title="&copy; MapTiler - nouvelle fenêtre">&copy; MapTiler</a> <a href="https://www.openstreetmap.org/copyright" target="_blank" title="&copy; OpenStreetMap contributors - nouvelle fenêtre">&copy; OpenStreetMap contributors</a>';
 
 export const TILE_LAYER_PROPS = {
   attribution: MAPTILER_API_KEY ? MAPTILER_ATTRIBUTION : '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',

--- a/plateform/app/routes/mentions-legales.tsx
+++ b/plateform/app/routes/mentions-legales.tsx
@@ -52,7 +52,7 @@ export default function MentionsLegales() {
         <h2>Réutilisation des contenus</h2>
         <p>
           Sauf mention contraire, les contenus de ce site sont publiés sous licence{" "}
-          <a href="https://www.etalab.gouv.fr/licence-ouverte-open-licence" target="_blank" rel="noopener">
+          <a href="https://www.etalab.gouv.fr/licence-ouverte-open-licence" target="_blank" rel="noopener" title="etalab-2.0 - nouvelle fenêtre">
             etalab-2.0
           </a>
           .

--- a/plateform/app/routes/mission-detail.tsx
+++ b/plateform/app/routes/mission-detail.tsx
@@ -146,7 +146,7 @@ export default function MissionDetailPage() {
       {userScoringId && <SimilarMissions userScoringId={userScoringId} currentMissionId={mission.id} />}
 
       <div className="fixed right-0 bottom-0 left-0 z-10 border-t border-[#DDD] bg-white px-5 py-4 md:hidden">
-        <a href={mission.applicationUrl} target="_blank" rel="noopener noreferrer" className="fr-btn w-full! justify-center!">
+        <a href={mission.applicationUrl} target="_blank" rel="noopener noreferrer" title="Postuler - nouvelle fenêtre" className="fr-btn w-full! justify-center!">
           Postuler
         </a>
         {deadlineLabel && <p className="text-mention-grey text-sm! md:hidden text-center! mt-4! mb-0!">{deadlineLabel}</p>}

--- a/plateform/app/routes/politique-de-confidentialite.tsx
+++ b/plateform/app/routes/politique-de-confidentialite.tsx
@@ -65,7 +65,12 @@ export default function PolitiqueDeConfidentialite() {
           </li>
           <li>
             Ou par le biais du formulaire de saisine en ligne :{" "}
-            <a href="https://www.education.gouv.fr/contacter-le-delegue-la-protection-des-donnees-dpd-469373" target="_blank" rel="noopener">
+            <a
+              href="https://www.education.gouv.fr/contacter-le-delegue-la-protection-des-donnees-dpd-469373"
+              target="_blank"
+              rel="noopener"
+              title="https://www.education.gouv.fr/contacter-le-delegue-la-protection-des-donnees-dpd-469373 - nouvelle fenêtre"
+            >
               https://www.education.gouv.fr/contacter-le-delegue-la-protection-des-donnees-dpd-469373
             </a>
             . Le responsable de traitement s'engage à vous répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à compter de la réception de votre demande.
@@ -96,7 +101,12 @@ export default function PolitiqueDeConfidentialite() {
                 <td>France</td>
                 <td>Hébergement des données</td>
                 <td>
-                  <a href="https://www-uploads.scaleway.com/Data_Processing_Agreement_03092021_6e2ca4da3c.pdf" target="_blank" rel="noopener">
+                  <a
+                    href="https://www-uploads.scaleway.com/Data_Processing_Agreement_03092021_6e2ca4da3c.pdf"
+                    target="_blank"
+                    rel="noopener"
+                    title="Data Processing Agreement - nouvelle fenêtre"
+                  >
                     Data Processing Agreement
                   </a>
                 </td>
@@ -106,7 +116,7 @@ export default function PolitiqueDeConfidentialite() {
                 <td>France</td>
                 <td>Solution d'e-mailing</td>
                 <td>
-                  <a href="https://www.brevo.com/legal/termsofuse/#annex" target="_blank" rel="noopener">
+                  <a href="https://www.brevo.com/legal/termsofuse/#annex" target="_blank" rel="noopener" title="Conditions d'utilisation - nouvelle fenêtre">
                     Conditions d'utilisation
                   </a>
                 </td>


### PR DESCRIPTION
## Description

Corrections des non-conformités liens relevées par l'audit RGAA sur `plateform/` (critères **6.1 — Liens explicites** et **13.2 — Nouvelle fenêtre**).

**Changements** :

- `exit-modal.tsx` : le bouton « Voir toutes les missions » pointe vers `/missions` au lieu de `/quiz/results` (route inexistante → 404)
- `pro-space.tsx` : retrait des deux CTA « Accéder aux ressources » qui pointaient vers `#` (aucune URL réelle disponible pour le moment)
- `mission-examples.tsx` : les attributs `role="group"` / `aria-roledescription="slide"` / `aria-label` du carrousel sont déplacés sur un conteneur par slide (le lien retrouve le titre de la mission comme nom accessible) ; plus de lien rendu quand `applicationUrl` est absente (contenu extrait dans un sous-composant `MissionSlideContent`)
- Ajout d'un `title="libellé - nouvelle fenêtre"` sur les 11 liens `target="_blank"` : carte mission externe, partenaires, « Découvrir la mission », « Postuler », « Ouvrir sur Google Maps », attribution MapTiler/OSM, pages légales

## Liens utiles

- 📝 Ticket Notion : —

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Validation effectuée : `typecheck` + `lint` OK (changements purement markup/visuels). Une vérification visuelle rapide de la landing (section pro + carrousel) est recommandée.
- **Reste hors périmètre de cette PR** (en attente des URLs) : le lien « Statistiques » du footer (toujours vers `#`) et le rétablissement des CTA « Accéder aux ressources ».
- Le constat 13.2 restant de l'audit est couvert ici via le pattern DSFR `title="… - nouvelle fenêtre"`, identique aux liens institutionnels du footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)