### PR TITLE
fix(plateform): RGAA 7.1 (assistive technology compatibility)

### DIFF
--- a/plateform/app/components/landing/mission-examples.tsx
+++ b/plateform/app/components/landing/mission-examples.tsx
@@ -32,7 +32,6 @@ export default function MissionExamples({ missions, className }: Props) {
     scrollRef.current.scrollBy({ left: offset, behavior: getScrollBehavior() });
   };
 
-  console.log(missions);
   if (!missions?.length) return null;
 
   return (
@@ -86,48 +85,48 @@ export default function MissionExamples({ missions, className }: Props) {
             })}
           </div>
         </div>
-      </div>
 
-      <div className="mt-6 flex justify-center gap-3 md:hidden">
-        <button
-          type="button"
-          onClick={() => handleScroll("left")}
-          disabled={!canScrollLeft}
-          aria-label="Voir les missions précédentes"
-          aria-controls="missions-carousel"
-          className="fr-btn fr-btn--secondary fr-icon-arrow-left-line fr-icon--md rounded-full"
-        ></button>
+        <div className="mt-6 flex justify-center gap-3 md:hidden">
+          <button
+            type="button"
+            onClick={() => handleScroll("left")}
+            disabled={!canScrollLeft}
+            aria-label="Voir les missions précédentes"
+            aria-controls="missions-carousel"
+            className="fr-btn fr-btn--secondary fr-icon-arrow-left-line fr-icon--md rounded-full"
+          ></button>
+          <button
+            type="button"
+            onClick={() => handleScroll("right")}
+            disabled={!canScrollRight}
+            aria-label="Voir les missions suivantes"
+            aria-controls="missions-carousel"
+            className="fr-btn fr-btn--secondary fr-icon-arrow-right-line fr-icon--md rounded-full"
+          ></button>
+        </div>
+
+        {canScrollLeft && (
+          <button
+            type="button"
+            onClick={() => handleScroll("left")}
+            aria-label="Voir les missions précédentes"
+            aria-controls="missions-carousel"
+            className="bg-background! text-title-grey absolute left-0 top-1/2 hidden size-12 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full shadow-md md:flex"
+          >
+            <span aria-hidden className="fr-icon-arrow-left-s-line" />
+          </button>
+        )}
         <button
           type="button"
           onClick={() => handleScroll("right")}
           disabled={!canScrollRight}
           aria-label="Voir les missions suivantes"
           aria-controls="missions-carousel"
-          className="fr-btn fr-btn--secondary fr-icon-arrow-right-line fr-icon--md rounded-full"
-        ></button>
-      </div>
-
-      {canScrollLeft && (
-        <button
-          type="button"
-          onClick={() => handleScroll("left")}
-          aria-label="Voir les missions précédentes"
-          aria-controls="missions-carousel"
-          className="bg-background! text-title-grey absolute left-0 top-1/2 hidden size-12 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full shadow-md md:flex"
+          className="bg-background! text-title-grey absolute right-0 top-1/2 hidden size-12 -translate-y-1/2 translate-x-1/2 items-center justify-center rounded-full shadow-md md:flex disabled:cursor-not-allowed disabled:opacity-40"
         >
-          <span aria-hidden className="fr-icon-arrow-left-s-line" />
+          <span aria-hidden className="fr-icon-arrow-right-s-line" />
         </button>
-      )}
-      <button
-        type="button"
-        onClick={() => handleScroll("right")}
-        disabled={!canScrollRight}
-        aria-label="Voir les missions suivantes"
-        aria-controls="missions-carousel"
-        className="bg-background! text-title-grey absolute right-0 top-1/2 hidden size-12 -translate-y-1/2 translate-x-1/2 items-center justify-center rounded-full shadow-md md:flex disabled:cursor-not-allowed disabled:opacity-40"
-      >
-        <span aria-hidden className="fr-icon-arrow-right-s-line" />
-      </button>
+      </div>
     </section>
   );
 }

--- a/plateform/app/components/landing/mission-examples.tsx
+++ b/plateform/app/components/landing/mission-examples.tsx
@@ -49,33 +49,31 @@ export default function MissionExamples({ missions, className }: Props) {
             {missions.map((mission, i) => {
               const href = mission.applicationUrl ?? "#";
               return (
-                <Link
-                  key={mission.id}
-                  to={href}
-                  onClick={() => trackMissionClickedFromBrowse(mission, { section: "homepage_examples", entryPage: "homepage", opensExternal: Boolean(mission.applicationUrl) })}
-                  role="group"
-                  aria-roledescription="slide"
-                  aria-label={`Mission ${i + 1} sur ${missions.length}`}
-                  className="bg-background flex w-[80vw] max-w-[360px] shrink-0 snap-center overflow-hidden shadow-lg border border-border-default-grey underline-none! bg-none! hover:bg-background! md:w-[360px]"
-                >
-                  {mission.domainLogo ? (
-                    <img src={mission.domainLogo} alt="" className="w-28 shrink-0 object-cover" loading="lazy" />
-                  ) : (
-                    <div className="bg-beige-gris-galet w-28 shrink-0" />
-                  )}
-                  <div className="flex flex-1 flex-col gap-4 p-6">
-                    <p className="fr-h6 line-clamp-2 mb-0!">{mission.title}</p>
-                    <div className="fr-mt-auto flex items-center gap-2">
-                      {mission.publisherLogo && (
-                        <div className="size-10 rounded object-contain bg-white">
-                          <img src={mission.publisherLogo} alt="" className="size-full object-contain" />
-                        </div>
-                      )}
+                <div key={mission.id} role="group" aria-roledescription="slide" aria-label={`Mission ${i + 1} sur ${missions.length}`} className="flex shrink-0 snap-center">
+                  <Link
+                    to={href}
+                    onClick={() => trackMissionClickedFromBrowse(mission, { section: "homepage_examples", entryPage: "homepage", opensExternal: Boolean(mission.applicationUrl) })}
+                    className="bg-background flex w-[80vw] max-w-[360px] shrink-0 overflow-hidden shadow-lg border border-border-default-grey underline-none! bg-none! hover:bg-background! md:w-[360px]"
+                  >
+                    {mission.domainLogo ? (
+                      <img src={mission.domainLogo} alt="" className="w-28 shrink-0 object-cover" loading="lazy" />
+                    ) : (
+                      <div className="bg-beige-gris-galet w-28 shrink-0" />
+                    )}
+                    <div className="flex flex-1 flex-col gap-4 p-6">
+                      <p className="fr-h6 line-clamp-2 mb-0!">{mission.title}</p>
+                      <div className="fr-mt-auto flex items-center gap-2">
+                        {mission.publisherLogo && (
+                          <div className="size-10 rounded object-contain bg-white">
+                            <img src={mission.publisherLogo} alt="" className="size-full object-contain" />
+                          </div>
+                        )}
 
-                      {mission.publisherName && <span className="fr-text--xs text-mention-grey line-clamp-1 mb-0!">{mission.publisherName}</span>}
+                        {mission.publisherName && <span className="fr-text--xs text-mention-grey line-clamp-1 mb-0!">{mission.publisherName}</span>}
+                      </div>
                     </div>
-                  </div>
-                </Link>
+                  </Link>
+                </div>
               );
             })}
           </div>

--- a/plateform/app/components/results/mission-map.tsx
+++ b/plateform/app/components/results/mission-map.tsx
@@ -73,28 +73,25 @@ export default function MissionMap({ items, center, onMarkerClick, selectionPadd
     onMarkerClick?.(item);
   };
 
-  const missions = useMemo<MapMission[]>(
-    () => {
-      const positionedMissions = items.map((item, index) => {
-        const addressNeutralized = hasNeutralizedAddress(item);
-        const hasPreciseCoordinates = !addressNeutralized && typeof item.mission.location.closestLat === "number" && typeof item.mission.location.closestLon === "number";
-        const addressLabel = !addressNeutralized ? getAddressLabel(item) : null;
-        const position: GeoPosition = hasPreciseCoordinates
-          ? [item.mission.location.closestLat!, item.mission.location.closestLon!]
-          : getNearbyPosition(center, item.mission.id, index);
+  const missions = useMemo<MapMission[]>(() => {
+    const positionedMissions = items.map((item, index) => {
+      const addressNeutralized = hasNeutralizedAddress(item);
+      const hasPreciseCoordinates = !addressNeutralized && typeof item.mission.location.closestLat === "number" && typeof item.mission.location.closestLon === "number";
+      const addressLabel = !addressNeutralized ? getAddressLabel(item) : null;
+      const position: GeoPosition = hasPreciseCoordinates
+        ? [item.mission.location.closestLat!, item.mission.location.closestLon!]
+        : getNearbyPosition(center, item.mission.id, index);
 
-        return {
-          item,
-          addressLabel,
-          position,
-          usesRemoteIcon: item.mission.remote === "full" || (!hasPreciseCoordinates && !addressLabel && item.mission.remote !== "local"),
-        };
-      });
+      return {
+        item,
+        addressLabel,
+        position,
+        usesRemoteIcon: item.mission.remote === "full" || (!hasPreciseCoordinates && !addressLabel && item.mission.remote !== "local"),
+      };
+    });
 
-      return spreadOverlappingPositions(positionedMissions);
-    },
-    [center, items],
-  );
+    return spreadOverlappingPositions(positionedMissions);
+  }, [center, items]);
 
   const boundsPositions = useMemo<[number, number][]>(() => (missions.length > 0 ? missions.map((mission) => mission.position) : [center]), [missions, center]);
 
@@ -117,6 +114,7 @@ export default function MissionMap({ items, center, onMarkerClick, selectionPadd
               position={position}
               icon={isActive ? activeIcon : usesRemoteIcon ? remoteIcon : classicIcon}
               zIndexOffset={isActive ? 1000 : 0}
+              keyboard={false}
               eventHandlers={{
                 ...(onMarkerClick ? { click: () => handleMarkerSelect(item, position) } : {}),
                 ...(onMissionHover ? { mouseover: () => onMissionHover(item.mission.id), mouseout: () => onMissionHover(null) } : {}),

--- a/plateform/app/components/ui/location-map.tsx
+++ b/plateform/app/components/ui/location-map.tsx
@@ -37,7 +37,7 @@ export default function LocationMap({ lat, lon, zoom = 15, className = "h-[180px
   return (
     <MapContainer center={[lat, lon]} zoom={zoom} className={className} zoomControl={false} scrollWheelZoom={false} dragging={false} doubleClickZoom={false}>
       <TileLayer {...TILE_LAYER_PROPS} />
-      <Marker position={[lat, lon]} icon={pinIcon} />
+      <Marker position={[lat, lon]} icon={pinIcon} interactive={false} keyboard={false} />
     </MapContainer>
   );
 }


### PR DESCRIPTION
## Description

Corrige trois non-conformités au critère RGAA 7.1 (compatibilité des scripts avec les technologies d'assistance) relevées lors de l'audit de la plateforme :

- **Carrousel de missions (landing)** : le `role="group"` / `aria-roledescription="slide"` était posé directement sur le `<Link>`, ce qui écrasait le rôle lien pour les technologies d'assistance. Les attributs de slide sont déplacés sur un `<div>` enveloppant ; le lien retrouve son rôle natif et son nom accessible (titre + organisme). **🟠 Majeur**
- **Carte des résultats (`mission-map`)** : les marqueurs Leaflet étaient focusables au clavier sans nom accessible (seul l'emoji était restitué). Ajout de `keyboard={false}` : la liste adjacente porte la même information, comme l'annonce déjà la description sr-only de la carte. **🟡 Mineur**
- **Mini-carte (`location-map`)** : le marqueur décoratif était focusable. Ajout de `interactive={false}` + `keyboard={false}`. **🟡 Mineur**

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- L'audit proposait aussi `alt={mission.title}` sur les marqueurs de `mission-map`, mais Leaflet n'applique l'option `alt` que sur les icônes `<img>` — ici ce sont des `divIcon`, l'option aurait été sans effet. D'où le choix de `keyboard={false}`.
- Conséquence à vérifier en review : sur la page résultats, la sélection d'une mission au clavier passe désormais uniquement par la liste (plus par les pins de la carte).
- `typecheck` et `lint` passent ; changement purement visuel/ARIA, pas de test unitaire ajouté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)