### PR TITLE
fix(plateform): fix rgaa title non-conformities (8.6, 9.1)

### DIFF
--- a/plateform/app/components/results/pinned-missions.tsx
+++ b/plateform/app/components/results/pinned-missions.tsx
@@ -18,7 +18,8 @@ export default function PinnedMissions({ items, loading, error, userScoringId, s
     <div className="relative w-full px-6">
       {!loading && error && (
         <div className="fr-alert fr-alert--error my-6" role="alert">
-          <h3 className="fr-alert__title">Une erreur est survenue</h3>
+          {/* RGAA 9.1 : en état d'erreur le h1 « X missions pour toi » n'est pas rendu — ce titre devient le titre principal de la page. */}
+          <h1 className="fr-alert__title">Une erreur est survenue</h1>
           <p>{error}</p>
         </div>
       )}

--- a/plateform/app/config/quiz-flow.ts
+++ b/plateform/app/config/quiz-flow.ts
@@ -23,6 +23,8 @@ export type StepId =
 export interface StepDef {
   id: StepId;
   route: string;
+  // Titre de la question, utilisé pour le <title> de la page (RGAA 8.6). À garder synchronisé avec le wording affiché dans le step component.
+  title: string;
   condition?: Condition;
 }
 
@@ -31,70 +33,79 @@ export interface StepDef {
 // L'ordre ici dicte l'ordre de navigation (goNext/goBack).
 export const QUIZ_FLOW: StepDef[] = [
   // Étape 1 — age.
-  { id: "age", route: "/quiz/age" },
+  { id: "age", route: "/quiz/age", title: "Quel âge as-tu ?" },
   // Étape 2 — handicap.
-  { id: "handicap", route: "/quiz/handicap", condition: numericRange("age", 26, 30) },
+  { id: "handicap", route: "/quiz/handicap", title: "Es-tu en situation de handicap reconnue ?", condition: numericRange("age", 26, 30) },
   // Étape 3 — statut.
-  { id: "statut", route: "/quiz/statut" },
+  { id: "statut", route: "/quiz/statut", title: "Que fais-tu en ce moment ?" },
   // Étape 4 — localisation.
-  { id: "localisation", route: "/quiz/localisation" },
+  { id: "localisation", route: "/quiz/localisation", title: "Où veux-tu chercher des missions ?" },
   // Étape 5 — duree.
-  { id: "duree", route: "/quiz/duree" },
+  { id: "duree", route: "/quiz/duree", title: "Combien de temps aimerais-tu consacrer à ta mission ?" },
   // Étape 6 — motivation. Les options sont filtrées dans le step via `hiddenIf` selon la réponse à `statut`.
-  { id: "motivation", route: "/quiz/motivation" },
+  { id: "motivation", route: "/quiz/motivation", title: "Qu’est-ce qui te motive le plus ?" },
 
   // Étape 7 — précisions sur la motivation (embranchement).
   // → me_sentir_utile (toutes branches) : mapping référentiel `engagement_intent`.
   {
     id: "precision_thematique",
     route: "/quiz/precision-thematique",
+    title: "Parmi ces choix, quelle thématique te parle le plus ?",
     condition: or(screenAnswer("motivation", "me_sentir_utile"), screenAnswer("motivation", "reprendre_confiance")),
   },
   // → booster_parcoursup (lyceen) : 2 sous-steps avant le step domaine commun.
   {
     id: "precision_parcoursup_formation",
     route: "/quiz/precision-parcoursup-formation",
+    title: "As-tu déjà une formation précise en tête ?",
     condition: screenAnswer("motivation", "booster_parcoursup"),
   },
   {
     id: "precision_parcoursup_formation_nom",
     route: "/quiz/precision-parcoursup-formation-nom",
+    title: "Indique le nom de la formation",
     condition: and(screenAnswer("motivation", "booster_parcoursup"), screenAnswer("precision_parcoursup_formation", "oui")),
   },
   // → step `domaine` partagé : decouvrir_domaine, booster_parcoursup, ne_sais_pas. Titre adapté au contexte dans le step.
   {
     id: "precision_domaine",
     route: "/quiz/precision-domaine",
+    title: "Dans quel domaine aimerais-tu avoir une expérience ?",
     condition: or(screenAnswer("motivation", "decouvrir_domaine"), screenAnswer("motivation", "booster_parcoursup"), screenAnswer("motivation", "ne_sais_pas")),
   },
   // → step `formation_onisep` partagé : tester_orientation, experience_terrain, preparer_reconversion.
   {
     id: "precision_formation_onisep",
     route: "/quiz/precision-formation-onisep",
+    title: "Vers quoi veux-tu t'orienter ?",
     condition: or(screenAnswer("motivation", "tester_orientation"), screenAnswer("motivation", "experience_terrain"), screenAnswer("motivation", "preparer_reconversion")),
   },
   // → step `competence_rome` partagé : booster_cv, enrichir_cv, competences_interet_general.
   {
     id: "precision_competences",
     route: "/quiz/precision-competences",
+    title: "Quel domaine de compétences t'attire le plus ?",
     condition: or(screenAnswer("motivation", "booster_cv"), screenAnswer("motivation", "enrichir_cv"), screenAnswer("motivation", "competences_interet_general")),
   },
   // → reprendre_activite (demandeur d'emploi) : mapping référentiel ROME (secteurs d'activité).
   {
     id: "precision_reprendre_activite",
     route: "/quiz/precision-reprendre-activite",
+    title: "Quel secteur d'activité t'attirerait le plus ?",
     condition: screenAnswer("motivation", "reprendre_activite"),
   },
   // → servir_le_pays (toutes branches applicables).
   {
     id: "precision_servir_pays",
     route: "/quiz/precision-servir-pays",
+    title: "Quel type d'engagement pourrait t'intéresser le plus ?",
     condition: screenAnswer("motivation", "servir_le_pays"),
   },
   // → partir_etranger (étudiant + actif), masqué si `type_mission = ponctuelle` (règle produit).
   {
     id: "precision_international",
     route: "/quiz/precision-international",
+    title: "Dans quelle région du monde souhaiterais-tu partir ?",
     condition: and(screenAnswer("motivation", "partir_etranger"), not(screenAnswer("duree", "ponctuelle"))),
   },
 ];

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -243,16 +243,20 @@ export default function MissionsPage() {
             )}
 
             {items.length > 0 && (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 mx-auto gap-6 w-fit">
-                {items.map((mission) => (
-                  <MissionCard
-                    key={mission.id}
-                    mission={mission}
-                    link={{ type: "internal", to: `/missions/${mission.id}`, state: { entrySource: "missions_list" } satisfies MissionDetailNavState }}
-                    onClick={() => trackMissionClickedFromBrowse(mission, { section: "missions_list", entryPage: "missions_list", opensExternal: false })}
-                  />
-                ))}
-              </div>
+              <>
+                {/* RGAA 9.1 : titre de section masqué — les cartes mission sont des <h3>, sans autre titre visible entre le h1 et la grille. */}
+                <h2 className="fr-sr-only">Liste des missions</h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 mx-auto gap-6 w-fit">
+                  {items.map((mission) => (
+                    <MissionCard
+                      key={mission.id}
+                      mission={mission}
+                      link={{ type: "internal", to: `/missions/${mission.id}`, state: { entrySource: "missions_list" } satisfies MissionDetailNavState }}
+                      onClick={() => trackMissionClickedFromBrowse(mission, { section: "missions_list", entryPage: "missions_list", opensExternal: false })}
+                    />
+                  ))}
+                </div>
+              </>
             )}
 
             <div className="fr-mt-6w">

--- a/plateform/app/routes/quiz/_layout.tsx
+++ b/plateform/app/routes/quiz/_layout.tsx
@@ -5,8 +5,8 @@ import QuizHeader from "~/components/quiz/header";
 import LoadingRecap from "~/components/quiz/loading-recap";
 import { QUIZ_FLOW, type StepDef, type StepId } from "~/config/quiz-flow";
 import { invalidateInitialMatches } from "~/services/matching";
-import { createUserScoring, updateUserScoring } from "~/services/user-scoring";
 import { trackQuizBackNavigated, trackQuizCompleted, trackQuizStepCompleted } from "~/services/tracking/events";
+import { createUserScoring, updateUserScoring } from "~/services/user-scoring";
 import { useQuizStore } from "~/stores/quiz";
 import { evalCondition } from "~/utils/conditions";
 import { buildPayload, refreshSteps } from "~/utils/quiz";
@@ -24,8 +24,11 @@ export type QuizOutletContext = {
   currentStepIndex: number;
 };
 
-export function meta(): Route.MetaDescriptors {
-  return [{ title: "Quiz Engagement" }, { name: "robots", content: "noindex, nofollow" }];
+// Titre par step (RGAA 8.6) : les routes enfants n'exportent pas de meta(), celui-ci s'applique à toutes.
+export function meta({ location }: Route.MetaArgs): Route.MetaDescriptors {
+  const step = QUIZ_FLOW.find((s) => s.route === location.pathname);
+  const title = step ? `${step.title} — Quiz Engagement — Trouve ta mission` : "Quiz Engagement — Trouve ta mission";
+  return [{ title }, { name: "robots", content: "noindex, nofollow" }];
 }
 
 // Client-only : évite les mismatchs d'hydratation liés au store persisté en localStorage.

--- a/plateform/app/utils/__tests__/quiz.test.ts
+++ b/plateform/app/utils/__tests__/quiz.test.ts
@@ -4,7 +4,7 @@ import type { QuizAnswers } from "~/types/quiz";
 import { screenAnswer } from "~/utils/conditions";
 import { buildPayload, refreshSteps } from "../quiz";
 
-const step = (id: StepId, condition?: StepDef["condition"]): StepDef => ({ id, route: `/quiz/${id}`, condition });
+const step = (id: StepId, condition?: StepDef["condition"]): StepDef => ({ id, route: `/quiz/${id}`, title: id, condition });
 
 describe("refreshSteps", () => {
   const flow: StepDef[] = [step("age"), step("handicap", screenAnswer("age", "26_30")), step("statut"), step("localisation")];


### PR DESCRIPTION
## Description

Corrige deux non-conformités RGAA relevées lors de l'audit de `plateform/` :

**8.6 — Titre de page pertinent (Majeur)** : les 15 étapes du quiz partageaient le titre « Quiz Engagement ».

- Ajout d'un champ `title` par step dans `QUIZ_FLOW` (wording repris des questions affichées).
- Le `meta()` de `quiz/_layout.tsx` génère désormais le titre par étape depuis `location.pathname` : « Quel âge as-tu ? — Quiz Engagement — Trouve ta mission ». Les routes enfants n'exportant pas de `meta()`, celui du layout s'applique partout — pas de duplication du `robots: noindex` dans 16 fichiers.

**9.1 — Hiérarchie des titres** :

- `/missions` (Majeur) : saut h1 → h3 vers les cartes mission. Ajout d'un `<h2 class="fr-sr-only">Liste des missions</h2>` avant la grille (patron de `pinned-missions.tsx`).
- `/results` en état d'erreur (Mineur) : le seul titre de page était le `<h3>` de l'alerte (le h1 « X missions pour toi » est conditionné à `!error`). Le titre d'alerte devient un `<h1>` — l'abaisser en `<p>` aurait laissé la page sans aucun h1 (NC 9.1.1).

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket 1](https://app.notion.com/p/jeveuxaider/8-6-Titre-de-page-pertinent-3a372a322d5080c8af1ef1517b8290fb?source=copy_link)
- 📝 Ticket Notion : [Lien vers le ticket 2](https://app.notion.com/p/jeveuxaider/9-1-Hi-rarchie-des-titres-3a372a322d50809e9310d42171792e0b?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Les steps à titre dynamique (`precision-domaine`, `precision-formation-onisep`, `precision-competences`) adaptent leur h1 selon la réponse à `motivation` (stockée en `localStorage`, inaccessible depuis `meta()`) : leur `<title>` utilise le wording par défaut du step — pertinent au sens RGAA, mais pas toujours identique au h1 affiché.
- Anomalie de wording repérée (hors périmètre) : le h1 de `precision-parcoursup-formation-nom` est « Dans quel domaine aimerais-tu avoir une expérience ? », identique à `precision-domaine`, alors que la page demande le nom de la formation. Le `<title>` utilise « Indique le nom de la formation » ; le h1 mériterait un correctif séparé.
- Point résiduel connu : sur le layout mobile de `/results` en erreur, l'alerte (et donc le h1) vit dans le panneau dépliable masqué tant qu'il n'est pas ouvert — comportement inchangé par rapport à l'existant.
- Validation : `typecheck`, `lint` et `test` (111 tests) passent sur `plateform`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)