### PR TITLE
fix(plateform): fix rgaa structure non-conformities (9.2)

### DIFF
--- a/plateform/app/components/layout/footer.tsx
+++ b/plateform/app/components/layout/footer.tsx
@@ -2,9 +2,12 @@ import { useLocation } from "react-router";
 import { useIsMobile } from "~/hooks/useIsMobile";
 import { isGlobalFooterVisible } from "~/utils/layout";
 
-export function FooterContent() {
+// RGAA 9.2 : sur les résultats mobile, le footer est rendu dans le panneau dépliable, à
+// l'intérieur du <main>. `landmark={false}` retire le role="contentinfo" explicite pour ne pas
+// créer un landmark imbriqué (un <footer> descendant de <main> n'est pas un landmark en HTML).
+export function FooterContent({ landmark = true }: { landmark?: boolean }) {
   return (
-    <footer className="fr-footer" role="contentinfo" id="footer" tabIndex={-1}>
+    <footer className="fr-footer" role={landmark ? "contentinfo" : undefined} id="footer" tabIndex={-1}>
       <div className="fr-container">
         <div className="fr-footer__body">
           <div className="fr-footer__brand fr-enlarge-link">

--- a/plateform/app/components/mission-detail/cta-panel.tsx
+++ b/plateform/app/components/mission-detail/cta-panel.tsx
@@ -24,7 +24,7 @@ export default function MissionCtaPanel({ mission, userScoringId, deadlineLabel 
   const compensationLabel = mission.compensation ? formatCompensation(mission.compensation, { withType: true }) : null;
 
   return (
-    <aside className={`md:shadow-card flex flex-col gap-6 bg-background px-5! py-5! md:p-6! ${className}`}>
+    <div className={`md:shadow-card flex flex-col gap-6 bg-background px-5! py-5! md:p-6! ${className}`}>
       <hr className="h-px! pb-0! bg-border-default-grey -mx-5! md:hidden!" />
 
       {(durationLabel || mission.schedule) && (
@@ -64,6 +64,6 @@ export default function MissionCtaPanel({ mission, userScoringId, deadlineLabel 
 
         {deadlineLabel && <p className="text-mention-grey text-sm! md:hidden text-center!">{deadlineLabel}</p>}
       </div>
-    </aside>
+    </div>
   );
 }

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -209,61 +209,58 @@ export default function MissionsPage() {
   };
 
   return (
-    <>
-      <main id="contenu" tabIndex={-1}>
-        <GradientBg>
-          <div className="fr-container pt-4 md:pt-16">
-            <div className="flex items-center justify-between gap-4">
-              <h1 className="fr-h1 m-0!">Trouve ta mission</h1>
-              <MissionFiltersTrigger filters={filterDefs} onChange={handleFilterChange} />
+    <main id="contenu" tabIndex={-1}>
+      <GradientBg>
+        <div className="fr-container pt-4 md:pt-16">
+          <div className="flex items-center justify-between gap-4">
+            <h1 className="fr-h1 m-0!">Trouve ta mission</h1>
+            <MissionFiltersTrigger filters={filterDefs} onChange={handleFilterChange} />
+          </div>
+          <p role="status" className="fr-text--lead hidden md:block">
+            {loading && total === 0 ? "Chargement…" : `${total.toLocaleString("fr-FR")} mission${total > 1 ? "s" : ""} disponible${total > 1 ? "s" : ""}`}
+          </p>
+          <MissionFiltersBar filters={filterDefs} onChange={handleFilterChange} />
+        </div>
+
+        <div className="fr-container my-4 md:my-8">
+          {error && (
+            <div role="alert" className="fr-alert fr-alert--error fr-mb-4w">
+              <p>Erreur lors du chargement des missions : {error}</p>
             </div>
-            <p role="status" className="fr-text--lead hidden md:block">
-              {loading && total === 0 ? "Chargement…" : `${total.toLocaleString("fr-FR")} mission${total > 1 ? "s" : ""} disponible${total > 1 ? "s" : ""}`}
+          )}
+
+          {loading && items.length === 0 && (
+            <p role="status" className="fr-text--sm">
+              Chargement des missions…
             </p>
-            <MissionFiltersBar filters={filterDefs} onChange={handleFilterChange} />
-          </div>
+          )}
 
-          <div className="fr-container my-4 md:my-8">
-            {error && (
-              <div role="alert" className="fr-alert fr-alert--error fr-mb-4w">
-                <p>Erreur lors du chargement des missions : {error}</p>
-              </div>
-            )}
-
-            {loading && items.length === 0 && (
-              <p role="status" className="fr-text--sm">
-                Chargement des missions…
-              </p>
-            )}
-
-            {!loading && !error && items.length === 0 && (
-              <div role="status" className="fr-alert fr-alert--info">
-                <p>Aucune mission ne correspond à ces filtres.</p>
-              </div>
-            )}
-
-            {items.length > 0 && (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 mx-auto gap-6 w-fit">
-                {items.map((mission) => (
-                  <MissionCard
-                    key={mission.id}
-                    mission={mission}
-                    link={{ type: "internal", to: `/missions/${mission.id}`, state: { entrySource: "missions_list" } satisfies MissionDetailNavState }}
-                    onClick={() => trackMissionClickedFromBrowse(mission, { section: "missions_list", entryPage: "missions_list", opensExternal: false })}
-                  />
-                ))}
-              </div>
-            )}
-
-            <div className="fr-mt-6w">
-              <Pagination page={page} totalPages={totalPages} onPageChange={handlePageChange} />
+          {!loading && !error && items.length === 0 && (
+            <div role="status" className="fr-alert fr-alert--info">
+              <p>Aucune mission ne correspond à ces filtres.</p>
             </div>
-          </div>
-        </GradientBg>
-      </main>
-      <Newsletter title="Inscris-toi à la newsletter" subtitle="1 email. Pas de spam." ctaText="Je m'inscris" hintText="Tu te désinscris quand tu veux." />
+          )}
 
+          {items.length > 0 && (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 mx-auto gap-6 w-fit">
+              {items.map((mission) => (
+                <MissionCard
+                  key={mission.id}
+                  mission={mission}
+                  link={{ type: "internal", to: `/missions/${mission.id}`, state: { entrySource: "missions_list" } satisfies MissionDetailNavState }}
+                  onClick={() => trackMissionClickedFromBrowse(mission, { section: "missions_list", entryPage: "missions_list", opensExternal: false })}
+                />
+              ))}
+            </div>
+          )}
+
+          <div className="fr-mt-6w">
+            <Pagination page={page} totalPages={totalPages} onPageChange={handlePageChange} />
+          </div>
+        </div>
+      </GradientBg>
+      <Newsletter title="Inscris-toi à la newsletter" subtitle="1 email. Pas de spam." ctaText="Je m'inscris" hintText="Tu te désinscris quand tu veux." />
       <Partners />
-    </>
+    </main>
   );
 }

--- a/plateform/app/routes/results.tsx
+++ b/plateform/app/routes/results.tsx
@@ -261,7 +261,7 @@ export default function ResultsPage() {
               hintText="En renseignant ton adresse électronique, tu acceptes de recevoir de nouvelles offres de missions. Tu pourras te désinscrire à tout moment."
             />
             <Partners style="compact" />
-            <FooterContent />
+            <FooterContent landmark={false} />
           </div>
         </div>
 
@@ -383,14 +383,15 @@ export default function ResultsPage() {
             />
           </section>
         )}
+
+        <Newsletter
+          title="Reçois tes missions par email"
+          subtitle="1 email par mois avec les missions qui pourraient t'intéresser."
+          ctaText="Recevoir mes missions"
+          hintText="En renseignant ton adresse électronique, tu acceptes de recevoir de nouvelles offres de missions. Tu pourras te désinscrire à tout moment."
+        />
+        <Partners style="compact" />
       </main>
-      <Newsletter
-        title="Reçois tes missions par email"
-        subtitle="1 email par mois avec les missions qui pourraient t'intéresser."
-        ctaText="Recevoir mes missions"
-        hintText="En renseignant ton adresse électronique, tu acceptes de recevoir de nouvelles offres de missions. Tu pourras te désinscrire à tout moment."
-      />
-      <Partners style="compact" />
       <EmailMissionsModal userScoringId={userScoringId} open={emailModalOpen} onOpenChange={setEmailModalOpen} hideTrigger />
     </>
   );


### PR DESCRIPTION
## Description

Corrige les 3 constats du critère RGAA 9.2 (structure du document — landmarks) relevés lors de l'audit de la plateforme :

- **Footer imbriqué dans `<main>` (results mobile, 🟠 majeur)** : `FooterContent` accepte une prop `landmark` (défaut `true`). Le panneau mobile des résultats passe `landmark={false}` : le `role="contentinfo"` explicite est retiré dans ce contexte (un `<footer>` descendant de `<main>` n'est pas un landmark en HTML), le footer global de `root.tsx` est inchangé. La cible `#footer` du lien d'évitement et la gestion du focus sont conservées.
- **Newsletter/Partners hors landmark (missions + results desktop, 🟡 mineur)** : déplacés à l'intérieur du `<main>`, alignés sur la structure de la page d'accueil. Aucun changement visuel.
- **`<aside>` imbriqué dans un `<aside>` (mission-detail, 🟡 mineur)** : le panneau CTA (`cta-panel.tsx`) devient un `<div>` ; l'`<aside>` de la sidebar desktop reste le landmark `complementary`.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/9-2-Structure-du-document-coh-rente-3a372a322d50809bb123cbbe0aff2036?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement (`typecheck` + `lint` OK)
- [ ] Tests unitaires ajoutés/modifiés si nécessaire (changement purement structurel JSX)
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Le gros du diff de `missions.tsx` est une réindentation (suppression du fragment devenu inutile) : lire le diff en masquant les espaces (`?w=1`), le changement réel fait ~6 lignes.
- À vérifier visuellement : pages missions et résultats desktop (Newsletter/Partners déplacés dans le DOM mais rendu identique) et panneau mobile des résultats (lien d'évitement « Pied de page » toujours fonctionnel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)