### PR TITLE
fix(plateform): fix rgaa content on hover non-conformities (10.13)

### DIFF
--- a/plateform/app/components/layout/internal-user-flag-indicator.tsx
+++ b/plateform/app/components/layout/internal-user-flag-indicator.tsx
@@ -4,6 +4,7 @@ import { isInternalUserFlagEnabled } from "~/utils/internal-user-flag";
 
 export default function InternalUserFlagIndicator() {
   const [visible, setVisible] = useState(false);
+  const [helpHidden, setHelpHidden] = useState(false);
 
   useEffect(() => {
     try {
@@ -12,6 +13,16 @@ export default function InternalUserFlagIndicator() {
       setVisible(isInternalUserFlagEnabled(window.location.search, { getItem: () => null }));
     }
   }, []);
+
+  // RGAA 10.13 : le panneau d'aide affiché au survol/focus doit pouvoir être masqué à la touche Échap.
+  useEffect(() => {
+    if (!visible) return;
+    const hideHelpOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setHelpHidden(true);
+    };
+    document.addEventListener("keydown", hideHelpOnEscape);
+    return () => document.removeEventListener("keydown", hideHelpOnEscape);
+  }, [visible]);
 
   function handleReactivateTracking() {
     disableInternalUserFlag();
@@ -24,7 +35,7 @@ export default function InternalUserFlagIndicator() {
   if (!visible) return null;
 
   return (
-    <div className="group fixed bottom-3 left-3 z-[2000] flex items-end gap-2">
+    <div className="group fixed bottom-3 left-3 z-[2000] flex items-end gap-2" onMouseLeave={() => setHelpHidden(false)} onBlur={() => setHelpHidden(false)}>
       <button
         type="button"
         className="flex size-11 items-center justify-center rounded-full bg-title-grey text-background shadow-card"
@@ -35,7 +46,7 @@ export default function InternalUserFlagIndicator() {
       </button>
       <div
         id="internal-user-flag-help"
-        className="pointer-events-none mb-0 hidden w-72 rounded-md border border-border-default-grey bg-background p-3 text-title-grey shadow-card group-hover:block group-focus-within:block"
+        className={`pointer-events-none mb-0 hidden w-72 rounded-md border border-border-default-grey bg-background p-3 text-title-grey shadow-card ${helpHidden ? "" : "group-hover:block group-focus-within:block"}`}
       >
         <p className="fr-text--sm mb-2!">
           Mode interne actif : les prochains événements de ce navigateur sont marqués <strong>internal_user</strong> et peuvent être exclus des statistiques.

--- a/plateform/app/components/results/mission-map.tsx
+++ b/plateform/app/components/results/mission-map.tsx
@@ -68,33 +68,42 @@ interface Props {
 export default function MissionMap({ items, center, onMarkerClick, selectionPadding, activeMissionId, onMissionHover }: Props) {
   const mapRef = useRef<L.Map | null>(null);
 
+  // RGAA 10.13 : le contenu additionnel affiché au survol/focus doit pouvoir être masqué à la touche Échap.
+  useEffect(() => {
+    const closeTooltipsOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      mapRef.current?.eachLayer((layer) => {
+        if (layer instanceof L.Marker) layer.closeTooltip();
+      });
+    };
+    document.addEventListener("keydown", closeTooltipsOnEscape);
+    return () => document.removeEventListener("keydown", closeTooltipsOnEscape);
+  }, []);
+
   const handleMarkerSelect = (item: MissionMatchItem, position: GeoPosition) => {
     if (selectionPadding && mapRef.current) mapRef.current.panInside(position, { paddingBottomRight: selectionPadding });
     onMarkerClick?.(item);
   };
 
-  const missions = useMemo<MapMission[]>(
-    () => {
-      const positionedMissions = items.map((item, index) => {
-        const addressNeutralized = hasNeutralizedAddress(item);
-        const hasPreciseCoordinates = !addressNeutralized && typeof item.mission.location.closestLat === "number" && typeof item.mission.location.closestLon === "number";
-        const addressLabel = !addressNeutralized ? getAddressLabel(item) : null;
-        const position: GeoPosition = hasPreciseCoordinates
-          ? [item.mission.location.closestLat!, item.mission.location.closestLon!]
-          : getNearbyPosition(center, item.mission.id, index);
+  const missions = useMemo<MapMission[]>(() => {
+    const positionedMissions = items.map((item, index) => {
+      const addressNeutralized = hasNeutralizedAddress(item);
+      const hasPreciseCoordinates = !addressNeutralized && typeof item.mission.location.closestLat === "number" && typeof item.mission.location.closestLon === "number";
+      const addressLabel = !addressNeutralized ? getAddressLabel(item) : null;
+      const position: GeoPosition = hasPreciseCoordinates
+        ? [item.mission.location.closestLat!, item.mission.location.closestLon!]
+        : getNearbyPosition(center, item.mission.id, index);
 
-        return {
-          item,
-          addressLabel,
-          position,
-          usesRemoteIcon: item.mission.remote === "full" || (!hasPreciseCoordinates && !addressLabel && item.mission.remote !== "local"),
-        };
-      });
+      return {
+        item,
+        addressLabel,
+        position,
+        usesRemoteIcon: item.mission.remote === "full" || (!hasPreciseCoordinates && !addressLabel && item.mission.remote !== "local"),
+      };
+    });
 
-      return spreadOverlappingPositions(positionedMissions);
-    },
-    [center, items],
-  );
+    return spreadOverlappingPositions(positionedMissions);
+  }, [center, items]);
 
   const boundsPositions = useMemo<[number, number][]>(() => (missions.length > 0 ? missions.map((mission) => mission.position) : [center]), [missions, center]);
 
@@ -123,7 +132,7 @@ export default function MissionMap({ items, center, onMarkerClick, selectionPadd
               }}
             >
               {onMissionHover && (
-                <Tooltip direction="top" offset={[0, -8]} opacity={1} className="mission-map__tooltip">
+                <Tooltip interactive direction="top" offset={[0, -8]} opacity={1} className="mission-map__tooltip">
                   <strong className="mission-map__tooltip-title">{item.mission.title}</strong>
                   <span className="mission-map__tooltip-address">{addressLabel ?? getFallbackAddressLabel(item)}</span>
                 </Tooltip>


### PR DESCRIPTION
## Description

Corrige les deux non-conformités RGAA **10.13** (contenus additionnels affichés au survol ou au focus contrôlables) relevées lors de l'audit d'accessibilité de `plateform` :

- **Carte des missions** (`app/components/results/mission-map.tsx`, 🟠 majeur) : l'infobulle Leaflet affichée au survol d'un pin est désormais `interactive` — elle reste ouverte quand on la survole (Leaflet lui applique `pointer-events: auto` et propage ses événements au marqueur) — et peut être masquée à la touche Échap (fermeture de toutes les infobulles ouvertes).
- **Indicateur « mode interne »** (`app/components/layout/internal-user-flag-indicator.tsx`, 🟡 mineur) : le panneau d'aide affiché au survol/focus peut être masqué à la touche Échap ; il réapparaît normalement au prochain survol ou focus (réinitialisation au `mouseleave`/`blur`).

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/10-13-Contenus-additionnels-au-survol-focus-contr-lables-3a372a322d508043afd9dceeac6e928d?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Points techniques** :

- Les écouteurs Échap sont posés au niveau du document (et non en `onKeyDown` sur le composant) car le contenu peut être affiché au survol souris sans qu'aucun élément n'ait le focus.
- Effet secondaire bénin sur la carte : un clic sur l'infobulle interactive est propagé au marqueur et sélectionne donc la mission (cohérent avec le comportement attendu).

**Vérification manuelle suggérée** :

- Sur `/results/:id` : survoler un pin, déplacer la souris sur l'infobulle (elle doit rester ouverte), appuyer sur Échap (elle doit se fermer).
- Avec `?internal=true` : même vérification sur l'indicateur « mode interne » en bas à gauche (souris et clavier via Tab).

**Validation** : `npm --workspace=plateform run typecheck` et `npm --workspace=plateform run lint` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)