### PR TITLE
fix(plateform): fix rgaa fieldset non-conformity (11.5)

### DIFF
--- a/plateform/app/components/missions/filters.tsx
+++ b/plateform/app/components/missions/filters.tsx
@@ -191,7 +191,8 @@ function FilterAccordion({ filter, open, onToggleOpen, onChange }: FilterAccordi
       </button>
 
       {open && (
-        <div className="mt-3 flex flex-col gap-2">
+        <fieldset className="mt-3 flex w-full min-w-0 flex-col gap-2">
+          <legend className="sr-only">{filter.label}</legend>
           {isSingle && (
             <div className="fr-radio-group">
               <input type="radio" id={`${reactId}-all`} name={`${reactId}-group`} checked={filter.selected.length === 0} onChange={() => onChange([])} />
@@ -224,7 +225,7 @@ function FilterAccordion({ filter, open, onToggleOpen, onChange }: FilterAccordi
               </div>
             );
           })}
-        </div>
+        </fieldset>
       )}
     </div>
   );


### PR DESCRIPTION
## Description

Corrige la non-conformité RGAA **11.5** (champs de même nature regroupés) relevée lors de l'audit sur la feuille de filtres mobile des missions.

**Changements** :

- `plateform/app/components/missions/filters.tsx` : dans `FilterAccordion`, le conteneur des radios/checkboxes devient un `<fieldset>` avec une `<legend className="sr-only">{filter.label}</legend>`, afin que chaque option soit rattachée programmatiquement au nom de son filtre pour les lecteurs d'écran.

Aucun changement visuel : la légende est masquée (même pattern que le `Combobox` desktop).

## Liens utiles

- 📝 Ticket Notion : N/A (audit RGAA interne)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Vérifié avec `npm --workspace=plateform run typecheck` et `npm --workspace=plateform run lint` (OK).
- Le `FilterSelect` (le `<select>` natif) n'est pas concerné : son `<label>` assure déjà le rattachement.
- Complète les corrections RGAA précédentes sur `plateform` (#1310).

🤖 Generated with [Claude Code](https://claude.com/claude-code)