### PR TITLE
fix(plateform): fix rgaa minor non-conformities from audit

### DIFF
--- a/plateform/app/components/landing/how-it-works.tsx
+++ b/plateform/app/components/landing/how-it-works.tsx
@@ -95,17 +95,17 @@ export default function HowItWorks({ onStartQuiz }: { onStartQuiz: () => void })
           aria-live="polite"
           aria-atomic="false"
         >
-          <div className="flex w-max gap-6 px-[10vw] pb-4 md:grid md:w-auto md:grid-cols-2 md:gap-6 md:px-0 md:pb-0 lg:grid-cols-4">
+          <ul role="list" className="flex w-max gap-6 px-[10vw] pb-4 md:grid md:w-auto md:grid-cols-2 md:gap-6 md:px-0 md:pb-0 lg:grid-cols-4 list-none! p-0! m-0!">
             {FEATURES.map((feature) => (
-              <div
+              <li
                 key={feature.icon}
                 className="bg-background flex w-[80vw] shrink-0 snap-center flex-col items-center gap-4 p-8 text-center shadow-lg md:w-auto md:p-10 lg:mx-auto lg:max-w-60 lg:p-6"
               >
                 <img src={feature.icon} alt="" className="size-16 dark:box-content dark:rounded-full dark:bg-white dark:p-3" aria-hidden="true" />
                 <p className="fr-text--lead text-title-grey font-bold mb-0!">{feature.title}</p>
-              </div>
+              </li>
             ))}
-          </div>
+          </ul>
         </div>
 
         <div className="fr-mb-3w flex justify-center gap-3 md:hidden">

--- a/plateform/app/components/landing/mission-examples.tsx
+++ b/plateform/app/components/landing/mission-examples.tsx
@@ -67,7 +67,7 @@ export default function MissionExamples({ missions, className }: Props) {
                         <div className="fr-mt-auto flex items-center gap-2">
                           {mission.publisherLogo && (
                             <div className="size-10 rounded object-contain bg-white">
-                              <img src={mission.publisherLogo} alt={mission.publisherName ? "" : "Logo du diffuseur de la mission"} className="size-full object-contain" />
+                              <img src={mission.publisherLogo} aria-hidden="true" className="size-full object-contain" />
                             </div>
                           )}
 
@@ -140,7 +140,7 @@ function MissionSlideContent({ mission }: { mission: MissionBrowse }) {
         <div className="fr-mt-auto flex items-center gap-2">
           {mission.publisherLogo && (
             <div className="size-10 rounded object-contain bg-white">
-              <img src={mission.publisherLogo} alt={mission.publisherName ? "" : "Logo du diffuseur de la mission"} className="size-full object-contain" />
+              <img src={mission.publisherLogo} aria-hidden="true" className="size-full object-contain" />
             </div>
           )}
 

--- a/plateform/app/components/landing/mission-examples.tsx
+++ b/plateform/app/components/landing/mission-examples.tsx
@@ -67,7 +67,7 @@ export default function MissionExamples({ missions, className }: Props) {
                         <div className="fr-mt-auto flex items-center gap-2">
                           {mission.publisherLogo && (
                             <div className="size-10 rounded object-contain bg-white">
-                              <img src={mission.publisherLogo} alt="" className="size-full object-contain" />
+                              <img src={mission.publisherLogo} alt={mission.publisherName ? "" : "Logo du diffuseur de la mission"} className="size-full object-contain" />
                             </div>
                           )}
 
@@ -140,7 +140,7 @@ function MissionSlideContent({ mission }: { mission: MissionBrowse }) {
         <div className="fr-mt-auto flex items-center gap-2">
           {mission.publisherLogo && (
             <div className="size-10 rounded object-contain bg-white">
-              <img src={mission.publisherLogo} alt="" className="size-full object-contain" />
+              <img src={mission.publisherLogo} alt={mission.publisherName ? "" : "Logo du diffuseur de la mission"} className="size-full object-contain" />
             </div>
           )}
 

--- a/plateform/app/components/landing/pro-space.tsx
+++ b/plateform/app/components/landing/pro-space.tsx
@@ -41,7 +41,9 @@ export default function ProSpace() {
         <div className="flex-1 grid grid-cols-1 gap-12 md:gap-8 sm:grid-cols-2 px-4! md:px-0!">
           {BENEFITS.map((benefit) => (
             <div key={benefit.title} className="flex flex-col items-center md:items-start gap-2">
-              <div className="bg-yellow-tournesol-925 flex size-12 items-center justify-center rounded-full text-2xl">{benefit.icon}</div>
+              <div className="bg-yellow-tournesol-925 flex size-12 items-center justify-center rounded-full text-2xl" aria-hidden="true">
+                {benefit.icon}
+              </div>
               <h3 className="fr-h5 fr-mb-0 text-default-grey text-center md:text-left">{benefit.title}</h3>
               <p className="fr-text--lead text-default-grey fr-mb-0 text-center md:text-left">{benefit.body}</p>
             </div>

--- a/plateform/app/components/landing/testimonials.tsx
+++ b/plateform/app/components/landing/testimonials.tsx
@@ -12,6 +12,7 @@ type Testimonial = {
   id: string;
   image: string;
   domain: string;
+  skillIcon: string;
   skill: string;
   title: string;
   publisherName: string;
@@ -28,7 +29,8 @@ const TESTIMONIALS: Testimonial[] = [
     id: "1",
     image: TestimonialSophie,
     domain: "Sécurité",
-    skill: "❤️ Aider les autres",
+    skillIcon: "❤️",
+    skill: "Aider les autres",
     title: "Sophie, infirmière 2 fois par semaine depuis 3 mois",
     publisherName: "La réserve des armées",
     publisherLogo: RocLogo,
@@ -37,7 +39,8 @@ const TESTIMONIALS: Testimonial[] = [
     id: "2",
     image: TestimonialSeb,
     domain: "Solidarité",
-    skill: "💡 Développe tes...",
+    skillIcon: "💡",
+    skill: "Développe tes...",
     title: "Séb, améliore la qualité de vie des personnes en situation de handicap depuis 6 mois",
     publisherName: "Service Civique",
     publisherLogo: AscLogo,
@@ -46,7 +49,8 @@ const TESTIMONIALS: Testimonial[] = [
     id: "3",
     image: TestimonialAdrien,
     domain: "Solidarité",
-    skill: "💡 Développe tes...",
+    skillIcon: "💡",
+    skill: "Développe tes...",
     title: "Adrien, accompagne des mineurs étrangers vers la réussite de leur apprentissage depuis 9 mois",
     publisherName: "Service Civique",
     publisherLogo: AscLogo,
@@ -55,7 +59,8 @@ const TESTIMONIALS: Testimonial[] = [
     id: "4",
     image: TestimonialMarie,
     domain: "Sécurité",
-    skill: "❤️ Aider les autres",
+    skillIcon: "❤️",
+    skill: "Aider les autres",
     title: "Marie, pompier 2 fois par semaine depuis 7 mois",
     publisherName: "Sapeurs-pompiers volontaires",
     publisherLogo: SpvLogo,
@@ -118,7 +123,10 @@ export default function Testimonials({ onStartQuiz }: { onStartQuiz: () => void 
                 <div className="flex flex-1 flex-col gap-4 p-6">
                   <div className="flex flex-wrap gap-2">
                     <span className="bg-blue-france-950 text-blue-france-sun inline-flex items-center rounded-full px-2 text-sm font-bold">{testimonial.domain}</span>
-                    <span className="bg-blue-france-950 text-blue-france-sun inline-flex items-center rounded-full px-2 text-sm font-bold">{testimonial.skill}</span>
+                    <span className="bg-blue-france-950 text-blue-france-sun inline-flex items-center gap-1 rounded-full px-2 text-sm font-bold">
+                      <span aria-hidden="true">{testimonial.skillIcon}</span>
+                      {testimonial.skill}
+                    </span>
                   </div>
                   <h3 className="fr-h6 text-title-grey mb-0!">{testimonial.title}</h3>
                   <div className="flex items-center gap-3 fr-mt-auto pt-2">

--- a/plateform/app/components/layout/newsletter.tsx
+++ b/plateform/app/components/layout/newsletter.tsx
@@ -76,6 +76,7 @@ export default function Newsletter({
                   id="newsletter-email"
                   name="email"
                   type="email"
+                  autoComplete="email"
                   required
                   aria-required="true"
                   aria-invalid={error ? true : undefined}

--- a/plateform/app/components/layout/partners.tsx
+++ b/plateform/app/components/layout/partners.tsx
@@ -44,9 +44,12 @@ export default function Partners({ style = "default" }: { style?: "default" | "c
         <h2 className="fr-h2 mb-2!">Il y a plein d'autres missions…</h2>
         <p className="mb-6! text-title-grey fr-text--lead">…directement sur les sites qui les proposent, jettes-y un coup d'oeil !</p>
 
-        <div className={`${style === "compact" ? "flex flex-col md:flex-row items-start justify-between gap-8 md:gap-0" : "grid grid-cols-1 gap-4 md:grid-cols-2"}`}>
+        <ul
+          role="list"
+          className={`list-none! p-0! m-0! ${style === "compact" ? "flex flex-col md:flex-row items-start justify-between gap-8 md:gap-0" : "grid grid-cols-1 gap-4 md:grid-cols-2"}`}
+        >
           {PARTNERS.map((partner) => (
-            <div key={partner.name} className={`flex items-start gap-2 ${style === "compact" ? "flex-1" : "gap-4"}`}>
+            <li key={partner.name} className={`flex items-start gap-2 ${style === "compact" ? "flex-1" : "gap-4"}`}>
               <div className="flex items-center justify-center bg-white rounded-sm p-1">
                 <img src={partner.logo} alt="" className="size-10 shrink-0 rounded object-contain" aria-hidden="true" />
               </div>
@@ -58,9 +61,9 @@ export default function Partners({ style = "default" }: { style?: "default" | "c
                 </p>
                 <p className="fr-mb-0 fr-text--sm fr-text--mention-grey">{partner.description}</p>
               </div>
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
       </div>
     </section>
   );

--- a/plateform/app/components/mission-detail/email-mission-details-modal.tsx
+++ b/plateform/app/components/mission-detail/email-mission-details-modal.tsx
@@ -105,6 +105,7 @@ export default function EmailMissionModal({ missionId, publisherId, userScoringI
                 id={emailId}
                 name="email"
                 type="email"
+                autoComplete="email"
                 required
                 aria-required="true"
                 aria-invalid={error ? true : undefined}

--- a/plateform/app/components/mission-detail/similar-missions.tsx
+++ b/plateform/app/components/mission-detail/similar-missions.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export default function SimilarMissions({ userScoringId, currentMissionId }: Props) {
   const [items, setItems] = useState<MissionMatchItem[]>([]);
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLUListElement>(null);
 
   useEffect(() => {
     fetchMatches(userScoringId, 11, 0)
@@ -39,13 +39,13 @@ export default function SimilarMissions({ userScoringId, currentMissionId }: Pro
           </div>
         </div>
 
-        <div ref={scrollRef} className="flex snap-x snap-mandatory gap-5 overflow-x-auto pb-2 scrollbar-none">
+        <ul ref={scrollRef} role="list" className="flex snap-x snap-mandatory gap-5 overflow-x-auto pb-2 scrollbar-none list-none! p-0! m-0!">
           {items.map((item, index) => (
-            <div key={item.mission.id} className="w-[310px] flex-none snap-start md:w-[283px]">
+            <li key={item.mission.id} className="w-[310px] flex-none snap-start md:w-[283px]">
               <MatchMissionCard item={item} section="similar" rank={index + 1} userScoringId={userScoringId} />
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
 
         <div className="mt-6 flex justify-center gap-3 md:hidden">
           <NavButtons onScroll={scrollBy} />

--- a/plateform/app/components/missions/mission-card.tsx
+++ b/plateform/app/components/missions/mission-card.tsx
@@ -71,7 +71,9 @@ export default function MissionCard({ mission, link, onClick }: MissionCardProps
             {(mission.publisherName ?? mission.publisherLogo) && (
               <div className="text-mention-grey fr-mt-2w flex items-center justify-end gap-2 text-xs">
                 {mission.publisherName && <span className="line-clamp-1">{mission.publisherName}</span>}
-                {mission.publisherLogo && <img src={mission.publisherLogo} alt="" className="max-w-20 object-contain" loading="lazy" />}
+                {mission.publisherLogo && (
+                  <img src={mission.publisherLogo} alt={mission.publisherName ? "" : "Logo du diffuseur de la mission"} className="max-w-20 object-contain" loading="lazy" />
+                )}
               </div>
             )}
           </div>

--- a/plateform/app/components/quiz/checkbox-group-rich.tsx
+++ b/plateform/app/components/quiz/checkbox-group-rich.tsx
@@ -51,7 +51,9 @@ export default function CheckboxGroupRich({ title, subtitle, onChange, options, 
                 {o.label}
                 {o.disabled ? <span className="fr-hint-text">{DISABLED_OPTION_HINT}</span> : o.sublabel && <span className="fr-hint-text">{o.sublabel}</span>}
               </label>
-              <div className="fr-checkbox-rich__pictogram">{o.icon && <div className="text-2xl">{o.icon}</div>}</div>
+              <div className="fr-checkbox-rich__pictogram" aria-hidden="true">
+                {o.icon && <div className="text-2xl">{o.icon}</div>}
+              </div>
             </div>
           </div>
         ))}

--- a/plateform/app/components/quiz/mission-card.tsx
+++ b/plateform/app/components/quiz/mission-card.tsx
@@ -11,11 +11,11 @@ type MissionCardProps = {
 export default function MissionCard({ imageSrc, category = "Solidarité", title, size = "md", className = "" }: MissionCardProps) {
   return (
     <div
-      className={`bg-background rounded-xl shadow-md overflow-hidden p-2 gap-2 flex flex-col ${size === "sm" ? "w-60 h-72 md:w-60 md:h-72" : "w-56 h-72 md:w-72 md:h-80"} ${className}`}
+      className={`bg-background rounded-xl shadow-md p-2 gap-2 flex flex-col ${size === "sm" ? "w-60 min-h-72 md:w-60 md:min-h-72" : "w-56 min-h-72 md:w-72 md:min-h-80"} ${className}`}
     >
-      <div className="relative h-[80%]">
-        <img src={imageSrc} alt="" className="block w-full object-cover rounded h-full" />
-        <span className="absolute top-2 left-2 px-1 py-0.5 rounded-full text-[10px] leading-none font-semibold bg-blue-france-950 text-blue-france-sun">{category}</span>
+      <div className="relative flex-1">
+        <img src={imageSrc} alt="" className="absolute inset-0 h-full w-full object-cover rounded" />
+        <span className="absolute top-2 left-2 px-1 py-0.5 rounded-full text-xs leading-none font-semibold bg-blue-france-950 text-blue-france-sun">{category}</span>
       </div>
       <div className="flex flex-col gap-2">
         <p className="fr-text font-bold mb-0!">{title}</p>

--- a/plateform/app/components/quiz/radio-group-rich.tsx
+++ b/plateform/app/components/quiz/radio-group-rich.tsx
@@ -42,7 +42,9 @@ export default function RadioGroupRich({ title, subtitle, onChange, options, sel
                 {o.label}
                 {o.disabled ? <span className="fr-hint-text">{DISABLED_OPTION_HINT}</span> : o.sublabel && <span className="fr-hint-text">{o.sublabel}</span>}
               </label>
-              <div className="fr-radio-rich__pictogram">{o.icon && <div className="text-2xl">{o.icon}</div>}</div>
+              <div className="fr-radio-rich__pictogram" aria-hidden="true">
+                {o.icon && <div className="text-2xl">{o.icon}</div>}
+              </div>
             </div>
           </div>
         ))}

--- a/plateform/app/components/results/email-missions-modal.tsx
+++ b/plateform/app/components/results/email-missions-modal.tsx
@@ -102,6 +102,7 @@ export default function EmailMissionsModal({ userScoringId, open: controlledOpen
                   id={emailId}
                   name="email"
                   type="email"
+                  autoComplete="email"
                   required
                   aria-required="true"
                   aria-invalid={error ? true : undefined}

--- a/plateform/app/components/results/matching-debug-modal.tsx
+++ b/plateform/app/components/results/matching-debug-modal.tsx
@@ -56,6 +56,7 @@ export default function MatchingDebugModal({ items, userValues }: Props) {
           <section>
             <h3 className="matching-debug__title">Score global</h3>
             <table className="matching-debug__table">
+              <caption className="sr-only">Score global</caption>
               <tbody>
                 <tr>
                   <th scope="row">Score total</th>
@@ -81,6 +82,7 @@ export default function MatchingDebugModal({ items, userValues }: Props) {
             <h3 className="matching-debug__title">Scores par taxonomie</h3>
             <div className="matching-debug__table-wrapper">
               <table className="matching-debug__table">
+                <caption className="sr-only">Scores par taxonomie</caption>
                 <thead>
                   <tr>
                     <th scope="col">Taxonomie</th>
@@ -109,6 +111,7 @@ export default function MatchingDebugModal({ items, userValues }: Props) {
             <h3 className="matching-debug__title">Score user</h3>
             <div className="matching-debug__table-wrapper">
               <table className="matching-debug__table">
+                <caption className="sr-only">Score user</caption>
                 <thead>
                   <tr>
                     <th scope="col">Taxonomie</th>
@@ -139,6 +142,7 @@ export default function MatchingDebugModal({ items, userValues }: Props) {
             <h3 className="matching-debug__title">Valeurs taxonomiques de la mission</h3>
             <div className="matching-debug__table-wrapper">
               <table className="matching-debug__table">
+                <caption className="sr-only">Valeurs taxonomiques de la mission</caption>
                 <thead>
                   <tr>
                     <th scope="col">Taxonomie</th>

--- a/plateform/app/components/results/mission-map.tsx
+++ b/plateform/app/components/results/mission-map.tsx
@@ -2,7 +2,7 @@ import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import type { MissionMatchItem } from "@engagement/dto";
 import { useEffect, useId, useMemo, useRef } from "react";
-import { MapContainer, Marker, Popup, TileLayer, Tooltip, useMap } from "react-leaflet";
+import { MapContainer, Marker, Popup, TileLayer, Tooltip, ZoomControl, useMap } from "react-leaflet";
 import { TILE_LAYER_PROPS, createEmojiIcon } from "~/components/ui/location-map";
 import { type GeoPosition, getNearbyPosition } from "~/utils/geo";
 
@@ -10,14 +10,12 @@ type MapMission = {
   item: MissionMatchItem;
   position: GeoPosition;
   addressLabel: string | null;
-  usesRemoteIcon: boolean;
+  icon: L.DivIcon;
 };
 
-const classicIcon = createEmojiIcon("📍");
-const remoteIcon = createEmojiIcon("👨‍💻");
 const activeIcon = L.divIcon({
   className: "",
-  html: `<div class="mission-map__emoji-marker mission-map__emoji-marker--active">📍</div>`,
+  html: `<div class="mission-map__emoji-marker mission-map__emoji-marker--active" role="img" aria-label="Mission sélectionnée">📍</div>`,
   iconSize: [22, 22],
   iconAnchor: [11, 11],
   popupAnchor: [0, -12],
@@ -94,11 +92,14 @@ export default function MissionMap({ items, center, onMarkerClick, selectionPadd
         ? [item.mission.location.closestLat!, item.mission.location.closestLon!]
         : getNearbyPosition(center, item.mission.id, index);
 
+      const usesRemoteIcon = item.mission.remote === "full" || (!hasPreciseCoordinates && !addressLabel && item.mission.remote !== "local");
+      const markerLabel = usesRemoteIcon ? "Mission à distance" : item.mission.location.city ? `Mission à ${item.mission.location.city}` : "Mission en présentiel";
+
       return {
         item,
         addressLabel,
         position,
-        usesRemoteIcon: item.mission.remote === "full" || (!hasPreciseCoordinates && !addressLabel && item.mission.remote !== "local"),
+        icon: createEmojiIcon(usesRemoteIcon ? "👨‍💻" : "📍", markerLabel),
       };
     });
 
@@ -116,15 +117,17 @@ export default function MissionMap({ items, center, onMarkerClick, selectionPadd
         Carte interactive localisant les missions proposées. La liste des missions présente les mêmes informations sous forme textuelle accessible.
       </p>
       <MapContainer ref={mapRef} center={center} zoom={12} className="mission-map" zoomControl={false}>
+        {/* RGAA 13.10 : alternative en pointage simple au zoom par pincement (geste multipoint). */}
+        <ZoomControl zoomInTitle="Zoomer" zoomOutTitle="Dézoomer" />
         <TileLayer {...TILE_LAYER_PROPS} />
         <BoundsFitter positions={boundsPositions} />
-        {missions.map(({ item, position, addressLabel, usesRemoteIcon }) => {
+        {missions.map(({ item, position, addressLabel, icon }) => {
           const isActive = item.mission.id === activeMissionId;
           return (
             <Marker
               key={item.mission.id}
               position={position}
-              icon={isActive ? activeIcon : usesRemoteIcon ? remoteIcon : classicIcon}
+              icon={isActive ? activeIcon : icon}
               zIndexOffset={isActive ? 1000 : 0}
               keyboard={false}
               eventHandlers={{

--- a/plateform/app/components/results/other-missions.tsx
+++ b/plateform/app/components/results/other-missions.tsx
@@ -36,19 +36,19 @@ export default function OtherMissions({
           Chargement…
         </p>
       ) : (
-        <div className={gridClassName}>
+        <ul role="list" className={`${gridClassName} list-none! p-0! m-0!`}>
           {items.map((item, index) => {
             // Rang dans la section "other", 1-based et tenant compte de la pagination
             // (page 1 → 1..pageSize, page 2 → pageSize+1.., etc.). Indépendant des missions pinned.
             const rank = (page - 1) * OTHER_RESULTS_PAGE_SIZE + index + 1;
             return (
-              <div key={item.mission.id} className="relative">
+              <li key={item.mission.id} className="relative">
                 <MatchMissionCard item={item} section="other" rank={rank} userScoringId={userScoringId} />
                 {showDebug && <DebugButton missionId={item.mission.id} />}
-              </div>
+              </li>
             );
           })}
-        </div>
+        </ul>
       )}
 
       <div className="fr-mt-3w">

--- a/plateform/app/components/results/pinned-missions.tsx
+++ b/plateform/app/components/results/pinned-missions.tsx
@@ -27,9 +27,9 @@ export default function PinnedMissions({ items, loading, error, userScoringId, s
         <>
           {/* RGAA 9.1 : titre de section masqué — les cartes mission sont des <h3>, le h1 « X missions pour toi » est le seul titre visible au-dessus. */}
           <h2 className="fr-sr-only">Les missions sélectionnées pour toi</h2>
-          <div className="grid grid-cols-1 gap-6 pb-6 md:grid-cols-2 md:px-4">
+          <ul role="list" className="grid grid-cols-1 gap-6 pb-6 md:grid-cols-2 md:px-4 list-none! p-0! m-0!">
             {items.map((item, index) => (
-              <div
+              <li
                 key={item.mission.id}
                 className={`relative w-full transition-shadow md:max-w-[330px] ${item.mission.id === highlightedMissionId ? "shadow-card ring-2 ring-blue-france-sun" : ""}`}
                 onMouseEnter={() => onMissionHover?.(item.mission.id)}
@@ -37,9 +37,9 @@ export default function PinnedMissions({ items, loading, error, userScoringId, s
               >
                 <MatchMissionCard item={item} section="pinned" rank={index + 1} userScoringId={userScoringId} />
                 {showDebug && <DebugButton missionId={item.mission.id} />}
-              </div>
+              </li>
             ))}
-          </div>
+          </ul>
 
           <div className="pb-8 md:px-6">
             <EmailMissionsModal userScoringId={userScoringId} />

--- a/plateform/app/components/ui/combobox.tsx
+++ b/plateform/app/components/ui/combobox.tsx
@@ -93,6 +93,11 @@ export default function Combobox({ label, placeholder, options, selected, onChan
             <i className="fr-icon-search-line fr-icon--sm pointer-events-none absolute top-1/2 right-3 -translate-y-1/2" aria-hidden="true" />
           </div>
 
+          {/* RGAA 7.5 : annonce le résultat du filtrage aux technologies d'assistance. */}
+          <p className="sr-only" aria-live="polite">
+            {search ? `${visibleOptions.length} option${visibleOptions.length > 1 ? "s" : ""} disponible${visibleOptions.length > 1 ? "s" : ""}` : ""}
+          </p>
+
           <fieldset className="max-h-60 w-full min-w-0 overflow-y-auto" tabIndex={-1}>
             <legend className="sr-only">Sélectionner {label.toLowerCase()}</legend>
 
@@ -135,7 +140,7 @@ export default function Combobox({ label, placeholder, options, selected, onChan
 
           {hasSelection && (
             <div className="flex justify-end border-t border-border-default-grey p-4">
-              <button type="button" className="fr-btn fr-btn--sm fr-btn--tertiary" onClick={() => onChange([])}>
+              <button type="button" className="fr-btn fr-btn--sm fr-btn--tertiary" aria-label={`Effacer le filtre ${label}`} onClick={() => onChange([])}>
                 Effacer
               </button>
             </div>

--- a/plateform/app/components/ui/location-map.tsx
+++ b/plateform/app/components/ui/location-map.tsx
@@ -5,7 +5,7 @@ import { MAPTILER_API_KEY } from "~/services/config";
 
 export const MAPTILER_BASIC_URL = MAPTILER_API_KEY ? `https://api.maptiler.com/maps/basic-v2/256/{z}/{x}/{y}.png?key=${MAPTILER_API_KEY}` : null;
 export const MAPTILER_ATTRIBUTION =
-  '<a href="https://www.maptiler.com/copyright/" target="_blank" title="&copy; MapTiler - nouvelle fenêtre">&copy; MapTiler</a> <a href="https://www.openstreetmap.org/copyright" target="_blank" title="&copy; OpenStreetMap contributors - nouvelle fenêtre">&copy; OpenStreetMap contributors</a>';
+  '<a href="https://www.maptiler.com/copyright/" target="_blank" title="&copy; MapTiler - nouvelle fenêtre">&copy; MapTiler</a> <a href="https://www.openstreetmap.org/copyright" target="_blank" title="&copy; contributeurs OpenStreetMap - nouvelle fenêtre">&copy; contributeurs OpenStreetMap</a>';
 
 export const TILE_LAYER_PROPS = {
   attribution: MAPTILER_API_KEY ? MAPTILER_ATTRIBUTION : '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
@@ -15,16 +15,16 @@ export const TILE_LAYER_PROPS = {
   url: MAPTILER_BASIC_URL ?? "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
 };
 
-export const createEmojiIcon = (emoji: string) =>
+export const createEmojiIcon = (emoji: string, ariaLabel: string) =>
   L.divIcon({
     className: "",
-    html: `<div class="mission-map__emoji-marker">${emoji}</div>`,
+    html: `<div class="mission-map__emoji-marker" role="img" aria-label="${ariaLabel}">${emoji}</div>`,
     iconSize: [22, 22],
     iconAnchor: [11, 11],
     popupAnchor: [0, -12],
   });
 
-const pinIcon = createEmojiIcon("📍");
+const pinIcon = createEmojiIcon("📍", "Localisation de la mission");
 
 interface LocationMapProps {
   lat: number;

--- a/plateform/app/main.css
+++ b/plateform/app/main.css
@@ -241,7 +241,7 @@
   border-radius: 9999px;
   box-shadow: 0 3px 10px rgb(0 0 0 / 16%);
   display: grid;
-  font-size: 12px;
+  font-size: 0.75rem;
   height: 22px;
   justify-items: center;
   line-height: 1;
@@ -271,14 +271,14 @@
 .mission-map__tooltip-title {
   color: var(--text-title-grey);
   display: block;
-  font-size: 13px;
+  font-size: 0.8125rem;
   line-height: 1.3;
 }
 
 .mission-map__tooltip-address {
   color: var(--text-mention-grey);
   display: block;
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 1.3;
   margin-top: 2px;
 }

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -216,7 +216,8 @@ export default function MissionsPage() {
             <h1 className="fr-h1 m-0!">Trouve ta mission</h1>
             <MissionFiltersTrigger filters={filterDefs} onChange={handleFilterChange} />
           </div>
-          <p role="status" className="fr-text--lead hidden md:block">
+          {/* RGAA 7.5 : masqué visuellement (pas retiré du DOM) sur mobile pour que le résultat du filtrage reste annoncé. */}
+          <p role="status" className="fr-text--lead sr-only md:not-sr-only">
             {loading && total === 0 ? "Chargement…" : `${total.toLocaleString("fr-FR")} mission${total > 1 ? "s" : ""} disponible${total > 1 ? "s" : ""}`}
           </p>
           <MissionFiltersBar filters={filterDefs} onChange={handleFilterChange} />
@@ -244,16 +245,17 @@ export default function MissionsPage() {
             <>
               {/* RGAA 9.1 : titre de section masqué — les cartes mission sont des <h3>, sans autre titre visible entre le h1 et la grille. */}
               <h2 className="fr-sr-only">Liste des missions</h2>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 mx-auto gap-6 w-fit">
+              <ul role="list" className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 mx-auto gap-6 w-fit list-none! p-0! m-0!">
                 {items.map((mission) => (
-                  <MissionCard
-                    key={mission.id}
-                    mission={mission}
-                    link={{ type: "internal", to: `/missions/${mission.id}`, state: { entrySource: "missions_list" } satisfies MissionDetailNavState }}
-                    onClick={() => trackMissionClickedFromBrowse(mission, { section: "missions_list", entryPage: "missions_list", opensExternal: false })}
-                  />
+                  <li key={mission.id}>
+                    <MissionCard
+                      mission={mission}
+                      link={{ type: "internal", to: `/missions/${mission.id}`, state: { entrySource: "missions_list" } satisfies MissionDetailNavState }}
+                      onClick={() => trackMissionClickedFromBrowse(mission, { section: "missions_list", entryPage: "missions_list", opensExternal: false })}
+                    />
+                  </li>
                 ))}
-              </div>
+              </ul>
             </>
           )}
 

--- a/plateform/app/routes/politique-de-confidentialite.tsx
+++ b/plateform/app/routes/politique-de-confidentialite.tsx
@@ -87,6 +87,7 @@ export default function PolitiqueDeConfidentialite() {
         </p>
         <div className="fr-table">
           <table>
+            <caption className="fr-sr-only">Sous-traitants et garanties associées</caption>
             <thead>
               <tr>
                 <th scope="col">Partenaire</th>
@@ -107,7 +108,7 @@ export default function PolitiqueDeConfidentialite() {
                     rel="noopener"
                     title="Data Processing Agreement - nouvelle fenêtre"
                   >
-                    Data Processing Agreement
+                    <span lang="en">Data Processing Agreement</span>
                   </a>
                 </td>
               </tr>
@@ -136,6 +137,7 @@ export default function PolitiqueDeConfidentialite() {
         <h3>Traceurs soumis à consentement</h3>
         <div className="fr-table">
           <table>
+            <caption className="fr-sr-only">Traceurs soumis à consentement</caption>
             <thead>
               <tr>
                 <th scope="col">Outil</th>

--- a/plateform/app/routes/quiz/localisation.tsx
+++ b/plateform/app/routes/quiz/localisation.tsx
@@ -231,10 +231,9 @@ export default function LocalisationStep() {
                   id={`${LISTBOX_ID}-option-${index}`}
                   role="option"
                   aria-selected={index === activeIndex}
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    handleSelect(option);
-                  }}
+                  // RGAA 13.11 : preventDefault au mousedown pour garder le focus sur l'input, sélection au click (annulable en éloignant le pointeur).
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => handleSelect(option)}
                   onMouseEnter={() => setActiveIndex(index)}
                   className={`py-2 px-3 cursor-pointer text-sm ${index === activeIndex ? "bg-background-default-grey-hover" : "hover:bg-background-default-grey-hover"}`}
                 >
@@ -244,6 +243,11 @@ export default function LocalisationStep() {
             </ul>
           )}
         </div>
+
+        {/* RGAA 7.5 : annonce l'apparition et la mise à jour des suggestions d'adresse. */}
+        <p className="sr-only" aria-live="polite">
+          {showOptions && options.length > 0 ? `${options.length} suggestion${options.length > 1 ? "s" : ""} d'adresse disponible${options.length > 1 ? "s" : ""}` : ""}
+        </p>
 
         <button type="button" className="fr-btn fr-btn--secondary justify-center! w-full!" onClick={handleUseMyLocation} disabled={locating}>
           📍 Utiliser ma position


### PR DESCRIPTION
## Description

Corrige un lot de non-conformités RGAA mineures relevées lors de l'audit d'accessibilité de `plateform` :

- **Listes (9.3)** : les grilles et carrousels de cartes deviennent de vraies listes `ul`/`li` avec `role="list"` — étapes « comment ça marche », partenaires, missions similaires, missions épinglées, autres missions et liste `/missions`.
- **Images et pictogrammes (1.2)** : pictogrammes emoji décoratifs passés en `aria-hidden` (bénéfices espace pro, tags des témoignages, pictogrammes des options riches du quiz) ; `alt` de repli « Logo du diffuseur de la mission » quand le nom du diffuseur n'est pas affiché à côté du logo.
- **Tableaux (5.4)** : ajout de `caption` masquées sur les tableaux de la modale de debug matching et de la politique de confidentialité.
- **Statuts (7.5)** : annonces `aria-live` du résultat du filtrage (combobox de filtres, suggestions d'adresse de l'étape localisation) ; le compteur de missions de `/missions` reste annoncé sur mobile (`sr-only` au lieu de `hidden`).
- **Langue (8.7)** : `lang="en"` sur « Data Processing Agreement » ; attribution de la carte « contributeurs OpenStreetMap » traduite.
- **Cartes Leaflet (1.2 / 13.10)** : marqueurs emoji avec `role="img"` et `aria-label` explicite (« Mission à distance », « Mission à {ville} », « Mission sélectionnée ») ; boutons « Zoomer / Dézoomer » sur la carte des résultats en alternative au zoom par pincement.
- **Gestes pointeur (13.11)** : sélection des suggestions d'adresse déclenchée au `click` (annulable en éloignant le pointeur) et non plus au `mousedown`.
- **Formulaires (11.13)** : `autocomplete="email"` sur les champs email (newsletter, modales d'envoi de missions par email).
- **Agrandissement du texte (10.4)** : tailles de police de la carte converties en `rem` ; carte mission du quiz en hauteur minimale pour absorber l'agrandissement du texte.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Vérification manuelle suggérée** :

- Landing : cartes « comment ça marche », témoignages et partenaires annoncés comme listes par un lecteur d'écran.
- `/missions` : filtrer et vérifier l'annonce du nombre de missions (y compris sur mobile).
- `/results/:id` : boutons de zoom de la carte au clavier, labels des marqueurs.
- Quiz, étape localisation : suggestions d'adresse annoncées, sélection à la souris toujours fonctionnelle.

**Validation** : `npm --workspace=plateform run typecheck` et `npm --workspace=plateform run lint` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)