### PR TITLE
fix(plateform): fix rgaa 9.2 landmark structure on mission detail

### DIFF
--- a/plateform/app/routes/mission-detail.tsx
+++ b/plateform/app/routes/mission-detail.tsx
@@ -105,42 +105,40 @@ export default function MissionDetailPage() {
   }
 
   return (
-    <>
-      <GradientBg>
-        <main id="contenu" tabIndex={-1} className="min-h-screen">
-          {mission.photo && (
-            <div className="h-[216px] w-full overflow-hidden md:hidden">
-              <img src={mission.photo} alt="" className="h-full w-full object-cover" />
-            </div>
-          )}
-
-          <div className={`mx-auto max-w-[1200px] ${userScoringId ? "pb-6" : "pb-28"} md:pt-6 md:px-6 md:py-10 bg-beige-gris-galet-975 md:bg-transparent`}>
-            <Link to={backPath} className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-line fr-btn--icon-left mb-6 hidden! md:inline-flex!">
-              {backLabel}
-            </Link>
-            <div className="flex flex-col md:flex-row md:items-start gap-6">
-              <div className="flex min-w-0 flex-1 flex-col gap-0! md:gap-6!">
-                <MissionHeroCard mission={mission} />
-                {mission.location && <MissionLocationCard location={mission.location} />}
-                <div className="md:hidden">
-                  <MissionCtaPanel mission={mission} userScoringId={userScoringId} />
-                </div>
-                <MissionDescriptionCard mission={mission} />
-              </div>
-
-              <aside className="hidden w-[384px] flex-none md:block">
-                <div className="sticky top-4 flex flex-col">
-                  {mission.photo && (
-                    <div className="h-[216px] w-full overflow-hidden">
-                      <img src={mission.photo} alt="" className="h-full w-full object-cover" />
-                    </div>
-                  )}
-                  <MissionCtaPanel mission={mission} userScoringId={userScoringId} />
-                </div>
-              </aside>
-            </div>
+    <main id="contenu" tabIndex={-1}>
+      <GradientBg className="bg-size-[100%_680px] min-h-screen">
+        {mission.photo && (
+          <div className="h-[216px] w-full overflow-hidden md:hidden">
+            <img src={mission.photo} alt="" className="h-full w-full object-cover" />
           </div>
-        </main>
+        )}
+
+        <div className={`mx-auto max-w-[1200px] ${userScoringId ? "pb-6" : "pb-28"} md:pt-6 md:px-6 md:py-10 bg-beige-gris-galet-975 md:bg-transparent`}>
+          <Link to={backPath} className="fr-btn fr-btn--tertiary-no-outline fr-icon-arrow-left-line fr-btn--icon-left mb-6 hidden! md:inline-flex!">
+            {backLabel}
+          </Link>
+          <div className="flex flex-col md:flex-row md:items-start gap-6">
+            <div className="flex min-w-0 flex-1 flex-col gap-0! md:gap-6!">
+              <MissionHeroCard mission={mission} />
+              {mission.location && <MissionLocationCard location={mission.location} />}
+              <div className="md:hidden">
+                <MissionCtaPanel mission={mission} userScoringId={userScoringId} />
+              </div>
+              <MissionDescriptionCard mission={mission} />
+            </div>
+
+            <aside className="hidden w-[384px] flex-none md:block">
+              <div className="sticky top-4 flex flex-col">
+                {mission.photo && (
+                  <div className="h-[216px] w-full overflow-hidden">
+                    <img src={mission.photo} alt="" className="h-full w-full object-cover" />
+                  </div>
+                )}
+                <MissionCtaPanel mission={mission} userScoringId={userScoringId} />
+              </div>
+            </aside>
+          </div>
+        </div>
       </GradientBg>
 
       {userScoringId && <SimilarMissions userScoringId={userScoringId} currentMissionId={mission.id} />}
@@ -151,6 +149,6 @@ export default function MissionDetailPage() {
         </a>
         {deadlineLabel && <p className="text-mention-grey text-sm! md:hidden text-center! mt-4! mb-0!">{deadlineLabel}</p>}
       </div>
-    </>
+    </main>
   );
 }

--- a/plateform/app/routes/missions.tsx
+++ b/plateform/app/routes/missions.tsx
@@ -245,7 +245,7 @@ export default function MissionsPage() {
             <>
               {/* RGAA 9.1 : titre de section masqué — les cartes mission sont des <h3>, sans autre titre visible entre le h1 et la grille. */}
               <h2 className="fr-sr-only">Liste des missions</h2>
-              <ul role="list" className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 mx-auto gap-6 w-fit list-none! p-0! m-0!">
+              <ul role="list" className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 mx-auto! gap-6 w-fit list-none! p-0! m-0!">
                 {items.map((mission) => (
                   <li key={mission.id}>
                     <MissionCard


### PR DESCRIPTION
## Description

Corrige la non-conformité **RGAA 9.2 (majeur)** relevée par l'audit sur la page de détail mission : la section « Découvre ta sélection de missions » (`SimilarMissions`) et la barre fixe « Postuler » (mobile) étaient rendues après `</main>`, donc hors de tout landmark — inaccessibles en navigation par régions au lecteur d'écran.

**Changements** :

- `mission-detail.tsx` : `<main id="contenu">` devient l'élément racine de la page et englobe désormais `GradientBg`, `SimilarMissions` et la barre « Postuler », sur le même pattern que `/` et `/missions`. Le `min-h-screen` est déplacé sur `GradientBg` et la hauteur du dégradé est ajustée (`bg-size` 680px).
- `missions.tsx` : centrage forcé de la grille de missions (`mx-auto!`).

## Liens utiles

- 📝 Audit RGAA : `plateform/audits/`

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- La barre « Postuler » reste en `position: fixed` : son déplacement dans `<main>` ne change pas son positionnement (aucun ancêtre avec `transform`).
- Les états `loading` et `error` ne sont pas touchés : tout leur contenu est déjà dans `<main>`.
- Vérifié en desktop et mobile, `npm run typecheck` et `npm run lint` passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)