### PR TITLE
fix(api): optimize mission matching ranking query

### DIFF
--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -133,6 +133,9 @@ describe("matchingEngineService", () => {
       const rankingSql = getSqlText(prismaMock.$queryRaw.mock.calls[1][0]);
       expect(rankingSql).toContain('ma."id" AS "closest_address_id"');
       expect(rankingSql).toContain('ORDER BY "distance_km" ASC, ma."created_at" ASC, ma."id" ASC');
+      expect(rankingSql).toContain('ems."mission_id",\n      msv."mission_scoring_id"');
+      expect(rankingSql).toContain('MAX(cmr."weighted_sum") AS "weighted_sum"');
+      expect(rankingSql).not.toContain('LEFT JOIN taxonomy_scores ts\n      ON ts."mission_scoring_id" = cm."mission_scoring_id"');
       expect(result.items).toEqual([
         {
           missionId: "mission-1",
@@ -494,6 +497,8 @@ describe("matchingEngineService", () => {
       expect(rankingSql).toContain("WHEN m.\"remote\"::text = 'local' THEN CAST(");
       expect(rankingSql).toContain('JOIN "mission" m');
       expect(rankingSql).toContain("forced_remote_candidates AS (");
+      expect(rankingSql).toContain("unscored_remote_missions AS (");
+      expect(rankingSql).toContain("EXCEPT");
       expect(rankingSql).toContain("m.\"remote\"::text IN ('full', 'local')");
       expect(rankingSql).toContain("FROM forced_remote_candidates rfc");
       expect(rankingSql).toContain('WHEN m."remote"::text IN (\'full\', \'local\') THEN NULL ELSE gs."distance_km" END');

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -431,7 +431,7 @@ const buildRanking = (params: {
           CAST(${TAXONOMY_OR_BASE_SCORE} AS double precision) +
           ((1.0 - CAST(${TAXONOMY_OR_BASE_SCORE} AS double precision)) * LEAST(gmv."taxonomy_sum" / NULLIF(udt."taxonomy_total", 0), 1.0))
         ) * COALESCE(dw."taxonomy_weight", 1.0)
-      ), 0) AS "weighted_sum"
+      ) FILTER (WHERE gmv."taxonomy_key" IS NOT NULL), 0) AS "weighted_sum"
     FROM geographic_candidates gc
     LEFT JOIN LATERAL (
       SELECT

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -100,40 +100,48 @@ const buildRanking = (params: {
   const forcedRemoteCandidatesCteSql = !forcedRemoteActive
     ? Prisma.empty
     : Prisma.sql`
+  remote_missions AS (
+    SELECT
+      ems."mission_id",
+      ems."mission_scoring_id"
+    FROM eligible_mission_scorings ems
+    JOIN "mission" m
+      ON m."id" = ems."mission_id"
+     AND m."remote"::text IN ('full', 'local')
+    WHERE EXISTS (SELECT 1 FROM user_geo)
+  ),
+  unscored_remote_missions AS (
+    SELECT
+      rm."mission_id",
+      rm."mission_scoring_id"
+    FROM remote_missions rm
+    EXCEPT
+    SELECT
+      ts."mission_id",
+      ts."mission_scoring_id"
+    FROM taxonomy_scores ts
+  ),
   forced_remote_candidates AS (
-    -- On priorise les missions remote par score taxonomie (comme l'ordre d'origine) mais sans le
-    -- nested loop O(remote × taxonomy) : le join est piloté DEPUIS taxonomy_scores (→ hash join,
-    -- comme taxonomy_candidates) au lieu d'un LEFT JOIN depuis le côté remote.
     SELECT
       rc."mission_id",
-      rc."mission_scoring_id"
+      rc."mission_scoring_id",
+      rc."weighted_sum"
     FROM (
-      -- (1) missions remote AVEC score taxonomie, triées par pertinence
       SELECT
-        ems."mission_id",
-        ems."mission_scoring_id",
+        ts."mission_id",
+        ts."mission_scoring_id",
         ts."weighted_sum" AS "weighted_sum"
       FROM taxonomy_scores ts
-      JOIN eligible_mission_scorings ems
-        ON ems."mission_scoring_id" = ts."mission_scoring_id"
       JOIN "mission" m
-        ON m."id" = ems."mission_id"
+        ON m."id" = ts."mission_id"
        AND m."remote"::text IN ('full', 'local')
       WHERE EXISTS (SELECT 1 FROM user_geo)
       UNION ALL
-      -- (2) missions remote SANS score taxonomie (score 0), en complément du pool
       SELECT
-        ems."mission_id",
-        ems."mission_scoring_id",
+        urm."mission_id",
+        urm."mission_scoring_id",
         CAST(0 AS double precision) AS "weighted_sum"
-      FROM eligible_mission_scorings ems
-      JOIN "mission" m
-        ON m."id" = ems."mission_id"
-       AND m."remote"::text IN ('full', 'local')
-      WHERE EXISTS (SELECT 1 FROM user_geo)
-        AND NOT EXISTS (
-          SELECT 1 FROM taxonomy_scores ts WHERE ts."mission_scoring_id" = ems."mission_scoring_id"
-        )
+      FROM unscored_remote_missions urm
     ) rc
     ORDER BY rc."weighted_sum" DESC, rc."mission_id" ASC
     LIMIT ${params.geoCandidateLimit}
@@ -145,7 +153,8 @@ const buildRanking = (params: {
     SELECT
       rfc."mission_id",
       rfc."mission_scoring_id",
-      CAST(NULL AS double precision) AS "distance_km"
+      CAST(NULL AS double precision) AS "distance_km",
+      rfc."weighted_sum"
     FROM forced_remote_candidates rfc`;
 
   // Une mission remote=full/local ignore toute adresse : on nullifie distance/closest_* pour ne pas polluer
@@ -264,6 +273,7 @@ const buildRanking = (params: {
   ),
   matched_values AS (
     SELECT
+      ems."mission_id",
       msv."mission_scoring_id",
       uv."taxonomy_key",
       SUM(uv."user_score" * msv."score") AS "taxonomy_sum"
@@ -273,10 +283,11 @@ const buildRanking = (params: {
      AND msv."value_key" = uv."value_key"
     JOIN eligible_mission_scorings ems
       ON ems."mission_scoring_id" = msv."mission_scoring_id"
-    GROUP BY msv."mission_scoring_id", uv."taxonomy_key"
+    GROUP BY ems."mission_id", msv."mission_scoring_id", uv."taxonomy_key"
   ),
   taxonomy_scores AS (
     SELECT
+      mv."mission_id",
       mv."mission_scoring_id",
       SUM(
         (
@@ -289,18 +300,17 @@ const buildRanking = (params: {
       ON udt."taxonomy_key" = mv."taxonomy_key"
     LEFT JOIN taxonomy_weights dw
       ON dw."taxonomy_key" = mv."taxonomy_key"
-    GROUP BY mv."mission_scoring_id"
+    GROUP BY mv."mission_id", mv."mission_scoring_id"
   ),
   taxonomy_candidates AS (
     SELECT
-      ems."mission_id",
-      ems."mission_scoring_id"
+      ts."mission_id",
+      ts."mission_scoring_id",
+      ts."weighted_sum"
     FROM taxonomy_scores ts
-    JOIN eligible_mission_scorings ems
-      ON ems."mission_scoring_id" = ts."mission_scoring_id"
     CROSS JOIN weighted_user_totals ut
     WHERE ut."taxonomy_total" > 0
-    ORDER BY ts."weighted_sum" / ut."taxonomy_total" DESC, ems."mission_id" ASC
+    ORDER BY ts."weighted_sum" / ut."taxonomy_total" DESC, ts."mission_id" ASC
     LIMIT ${params.taxonomyCandidateLimit}
   ),
   user_geo AS (
@@ -398,13 +408,7 @@ const buildRanking = (params: {
     ORDER BY ems."mission_id" ASC
     LIMIT ${params.offset + params.limit}
   ),${forcedRemoteCandidatesCteSql}
-  candidate_mission_rows AS (
-    SELECT
-      tc."mission_id",
-      tc."mission_scoring_id",
-      CAST(NULL AS double precision) AS "distance_km"
-    FROM taxonomy_candidates tc
-    UNION ALL
+  geographic_candidates AS (
     SELECT
       gc."mission_id",
       gc."mission_scoring_id",
@@ -416,18 +420,64 @@ const buildRanking = (params: {
       fgc."mission_scoring_id",
       fgc."distance_km"
     FROM fallback_geo_candidates fgc
+  ),
+  geographic_candidate_scores AS (
+    SELECT
+      gc."mission_id",
+      gc."mission_scoring_id",
+      gc."distance_km",
+      COALESCE(SUM(
+        (
+          CAST(${TAXONOMY_OR_BASE_SCORE} AS double precision) +
+          ((1.0 - CAST(${TAXONOMY_OR_BASE_SCORE} AS double precision)) * LEAST(gmv."taxonomy_sum" / NULLIF(udt."taxonomy_total", 0), 1.0))
+        ) * COALESCE(dw."taxonomy_weight", 1.0)
+      ), 0) AS "weighted_sum"
+    FROM geographic_candidates gc
+    LEFT JOIN LATERAL (
+      SELECT
+        uv."taxonomy_key",
+        SUM(uv."user_score" * msv."score") AS "taxonomy_sum"
+      FROM user_values uv
+      JOIN "mission_scoring_value" msv
+        ON msv."taxonomy_key" = uv."taxonomy_key"
+       AND msv."value_key" = uv."value_key"
+       AND msv."mission_scoring_id" = gc."mission_scoring_id"
+      GROUP BY uv."taxonomy_key"
+    ) gmv ON TRUE
+    LEFT JOIN user_taxonomy_totals udt
+      ON udt."taxonomy_key" = gmv."taxonomy_key"
+    LEFT JOIN taxonomy_weights dw
+      ON dw."taxonomy_key" = gmv."taxonomy_key"
+    GROUP BY gc."mission_id", gc."mission_scoring_id", gc."distance_km"
+  ),
+  candidate_mission_rows AS (
+    SELECT
+      tc."mission_id",
+      tc."mission_scoring_id",
+      CAST(NULL AS double precision) AS "distance_km",
+      tc."weighted_sum"
+    FROM taxonomy_candidates tc
+    UNION ALL
+    SELECT
+      gcs."mission_id",
+      gcs."mission_scoring_id",
+      gcs."distance_km",
+      gcs."weighted_sum"
+    FROM geographic_candidate_scores gcs
     UNION ALL
     SELECT
       fc."mission_id",
       fc."mission_scoring_id",
-      CAST(NULL AS double precision) AS "distance_km"
+      CAST(NULL AS double precision) AS "distance_km",
+      CAST(0 AS double precision) AS "weighted_sum"
     FROM fallback_candidates fc${forcedRemoteCandidatesUnionSql}
   ),
   candidate_missions AS (
     SELECT
       cmr."mission_id",
       cmr."mission_scoring_id",
-      MIN(cmr."distance_km") AS "distance_km"
+      MIN(cmr."distance_km") AS "distance_km",
+      MAX(cmr."weighted_sum") AS "weighted_sum"
     FROM candidate_mission_rows cmr
     GROUP BY cmr."mission_id", cmr."mission_scoring_id"
   ),
@@ -477,7 +527,7 @@ const buildRanking = (params: {
       cm."mission_id",
       cm."mission_scoring_id",
       CASE
-        WHEN ut."taxonomy_total" > 0 THEN COALESCE(ts."weighted_sum", 0) / ut."taxonomy_total"
+        WHEN ut."taxonomy_total" > 0 THEN cm."weighted_sum" / ut."taxonomy_total"
         ELSE 0
       END AS "taxonomy_score",
       CASE
@@ -494,8 +544,6 @@ const buildRanking = (params: {
     CROSS JOIN weighted_user_totals ut
     JOIN "mission" m
       ON m."id" = cm."mission_id"
-    LEFT JOIN taxonomy_scores ts
-      ON ts."mission_scoring_id" = cm."mission_scoring_id"
     LEFT JOIN geo_scores gs
       ON gs."mission_scoring_id" = cm."mission_scoring_id"
   )

--- a/api/tests/integration/api/mission-match.test.ts
+++ b/api/tests/integration/api/mission-match.test.ts
@@ -71,6 +71,34 @@ const createRemoteLocalMissionWithoutMatch = async () => {
   return mission;
 };
 
+const createOnsiteMissionWithoutMatch = async () => {
+  const mission = await createTestMission({
+    publisherId,
+    title: "Mission sur site sans match taxonomie",
+    domain: "solidarite",
+    addresses: [
+      {
+        street: "1 rue de Test",
+        postalCode: "75001",
+        departmentCode: "75",
+        departmentName: "Paris",
+        city: "Paris",
+        region: "Ile-de-France",
+        country: "France",
+        location: { lat: 48.8566, lon: 2.3522 },
+        geolocStatus: "FOUND",
+      },
+    ],
+  });
+  const enrichment = await createTestMissionEnrichment({ missionId: mission.id });
+  await createTestMissionScoring({
+    missionId: mission.id,
+    missionEnrichmentId: enrichment.id,
+    values: [{ taxonomyKey: "domaine", valueKey: "sport", score: 1 }],
+  });
+  return mission;
+};
+
 // Mission remote=full AVEC une adresse géocodée proche : sous m3, la distance doit tout de même être
 // ignorée (nullifiée) pour ne pas fausser l'affichage ni avgDistanceKmTop5.
 const createRemoteFullMissionWithAddress = async () => {
@@ -208,6 +236,22 @@ describe("GET /missions/match", () => {
     expect(item.mission.remote).toBe("local");
     expect(item.mission.location.distanceKm).toBeNull();
     expect(item.mission.location.city).toBeNull();
+  });
+
+  it("keeps the taxonomy score at zero for a nearby onsite mission without taxonomy match", async () => {
+    const mission = await createOnsiteMissionWithoutMatch();
+    const userScoringId = await createGeoUserScoring();
+
+    const response = await withApiKey(request(app).get("/missions/match")).query({
+      userScoringId,
+      engineVersion: "m3",
+    });
+
+    expect(response.status).toBe(200);
+    const item = response.body.data.items.find((entry: { mission: { id: string } }) => entry.mission.id === mission.id);
+    expect(item).toBeDefined();
+    expect(item.match.taxonomyScore).toBe(0);
+    expect(item.match.geoScore).toBe(1);
   });
 
   it("does not surface the same full-remote mission under m2 (candidate pool gap it fixes)", async () => {


### PR DESCRIPTION
## Description

Cette PR optimise la requête SQL du moteur `/missions/match` sans dépendre de `mission_diffusion`.

Elle :

- propage `mission_id` dans `matched_values` et `taxonomy_scores` afin de construire directement les candidats taxonomiques ;
- fait porter `weighted_sum` par les différents flux de candidats jusqu'au classement final ;
- recalcule le score taxonomique complémentaire uniquement pour le sous-ensemble borné de candidats géographiques ;
- remplace l'anti-jointure remote répétitive par une différence d'ensembles avec `EXCEPT` ;
- supprime la jointure finale non bornée entre tous les candidats et `taxonomy_scores`.

La cause racine était une forte sous-estimation des CTE par PostgreSQL. Elle conduisait à des boucles imbriquées rejetant jusqu'à 226 millions de combinaisons dans le flux taxonomique, puis 54,6 millions lors du classement final.

## Impact

Le contrat HTTP, les versions m1/m2/m3, les pondérations, les gates, le traitement remote, la pagination et la persistance du top 20 restent inchangés.

Comparaison avant/après sur le profil de production de référence, avec `offset=1` : mêmes 13 missions, même ordre, mêmes scores, distances et adresses.

### Performances en production

Profil : `bf8b45eb-6db7-4385-b735-ada113bee8b5`  
Publisher : `6c6a6ed4cf9795a1d770c1e2`  
Version : `m3`, limite : `13`

| Mesure | Avant | Après |
| --- | ---: | ---: |
| Médiane `tookMs`, offset 0 | 31 030 ms | 2 346 ms |
| `EXPLAIN ANALYZE` à chaud | 51 075 ms | 2 256 ms |
| Plus grande jointure rejetée | 226 454 168 lignes | 117 180 lignes |

Mesures finales offset 0 : 2 215 ms, 3 057 ms et 2 346 ms. Le premier plan après refroidissement des caches a pris 12 237 ms, contre 51 075 ms auparavant.

## Liens utiles

- Ticket Notion : non applicable

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [x] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés
- [x] Respect des standards de code (ESLint)
- [x] Aucune migration de données nécessaire
