### PR TITLE
fix(plateform): fix rgaa 3.3 contrast on quiz address listbox

### DIFF
--- a/plateform/app/main.css
+++ b/plateform/app/main.css
@@ -18,6 +18,7 @@
   --color-beige-gris-galet: var(--beige-gris-galet-925-125);
   --color-title-grey: var(--text-title-grey);
   --color-mention-grey: var(--text-mention-grey);
+  --color-inverted-blue-france: var(--text-inverted-blue-france);
   /* Borders */
   --color-border-default-grey: var(--border-default-grey);
   --color-border-plain-error: var(--border-plain-error);
@@ -26,6 +27,7 @@
   --color-blue-france-950: var(--blue-france-950-100); /* #ECECFE00 */
   --color-blue-france-975: var(--blue-france-975-75);
   --color-beige-gris-galet-975: var(--beige-gris-galet-975-75); /* #F9F6F2 */
+  --color-action-high-blue-france: var(--background-action-high-blue-france);
   --color-background-default-grey-hover: var(--background-default-grey-hover);
   --color-background-default-grey-active: var(--background-default-grey-active);
   --color-background: var(--background-default-grey);

--- a/plateform/app/routes/quiz/localisation.tsx
+++ b/plateform/app/routes/quiz/localisation.tsx
@@ -242,7 +242,7 @@ export default function LocalisationStep() {
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => handleSelect(option)}
                   onMouseEnter={() => setActiveIndex(index)}
-                  className={`py-2 px-3 cursor-pointer text-sm ${index === activeIndex ? "bg-background-default-grey-hover" : "hover:bg-background-default-grey-hover"}`}
+                  className={`py-2 px-3 cursor-pointer text-sm ${index === activeIndex ? "bg-action-high-blue-france text-inverted-blue-france" : "hover:bg-background-default-grey-hover"}`}
                 >
                   {option.label}
                 </li>


### PR DESCRIPTION
## Description

Correction d'accessibilité suite à l'audit RGAA 4.1.2 (critère 3.3) sur le step localisation du quiz.

**Changements** :
- **RGAA 3.3** — l'option active du listbox d'autocomplétion d'adresse (navigation clavier via `aria-activedescendant`) était signalée par `background-default-grey-hover` (`#F6F6F6` sur blanc, ratio ≈ 1,1:1), donc visuellement indiscernable. Elle passe au style inversé DSFR : fond `--background-action-high-blue-france` + texte `--text-inverted-blue-france` (ratio largement supérieur aux 3:1 requis, garanti aussi en thème sombre grâce aux tokens appairés).
- Ajout des deux tokens correspondants dans le bloc `@theme` de `main.css`, selon la convention existante du projet.

## Liens utiles

- 📝 Ticket Notion : —

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Changement purement visuel, aucune logique modifiée : validation par `typecheck` + `lint` + vérification manuelle du step localisation (taper une adresse puis naviguer aux flèches : l'option ciblée apparaît en bleu inversé).
- Le hover souris des autres options garde le gris léger existant (ce n'est pas un indicateur d'état, donc hors périmètre du critère 3.3).
- Piste écartée : le pattern `fr-ds-combobox` vu sur d'autres sites de l'État vient de Démarches Simplifiées (composant maison, absent du DSFR core, y compris en 1.15.1) ; son style d'option active repose sur un écart de fonds lui-même < 3:1, le style inversé retenu est plus robuste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)