### PR TITLE
fix(plateform): add aria-controls to mobile filters accordion

### DIFF
--- a/plateform/app/components/missions/filters.tsx
+++ b/plateform/app/components/missions/filters.tsx
@@ -45,7 +45,7 @@ export function MissionFiltersTrigger({ filters, onChange }: MissionFiltersProps
 
   return (
     <>
-      <button type="button" className="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-filter-line bg-background! md:hidden!" onClick={() => setOpen(true)}>
+      <button type="button" className="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-filter-line bg-background! md:hidden! shrink-0!" onClick={() => setOpen(true)}>
         Filtres{totalSelected > 0 ? ` (${totalSelected})` : ""}
       </button>
       {open && <MobileFiltersSheet filters={filters} onChange={onChange} onClose={() => setOpen(false)} />}
@@ -179,6 +179,7 @@ interface FilterAccordionProps {
 
 function FilterAccordion({ filter, open, onToggleOpen, onChange }: FilterAccordionProps) {
   const reactId = useId();
+  const panelId = `${reactId}-panel`;
   const isSingle = filter.single === true;
 
   const toggleOption = (value: string) => {
@@ -188,13 +189,13 @@ function FilterAccordion({ filter, open, onToggleOpen, onChange }: FilterAccordi
 
   return (
     <div>
-      <button type="button" className="flex w-full items-center justify-between" aria-expanded={open} onClick={onToggleOpen}>
+      <button type="button" className="flex w-full items-center justify-between" aria-expanded={open} aria-controls={panelId} onClick={onToggleOpen}>
         <span className="fr-text--lead font-bold text-title-grey leading-none! mb-0!">{filter.label}</span>
         <i className={`fr-icon-arrow-down-s-line text-blue-france-sun transition-transform ${open ? "rotate-180" : ""}`} aria-hidden="true" />
       </button>
 
       {open && (
-        <fieldset className="mt-3 flex w-full min-w-0 flex-col gap-2">
+        <fieldset id={panelId} className="mt-3 flex w-full min-w-0 flex-col gap-2">
           <legend className="sr-only">{filter.label}</legend>
           {isSingle && (
             <div className="fr-radio-group">


### PR DESCRIPTION
## Description

Corrige la non-conformité RGAA 7.1 relevée lors de l'audit : le bouton d'accordéon des filtres mobiles (`plateform/app/components/missions/filters.tsx`) portait `aria-expanded` mais pas d'`aria-controls`, et le `<fieldset>` du panneau n'avait pas d'`id`.

**Changements** :
- Ajout d'un `panelId` dérivé du `useId()` existant dans `FilterAccordion`
- `aria-controls={panelId}` sur le bouton d'en-tête de l'accordéon
- `id={panelId}` sur le `<fieldset>` du panneau (même pattern que le Combobox desktop)
- Ajout de `shrink-0!` sur le bouton « Filtres » mobile pour éviter qu'il ne se compresse

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Le panneau reste rendu conditionnellement (comme celui du Combobox desktop) : quand l'accordéon est fermé, `aria-expanded="false"` indique l'état, et `aria-controls` référence le panneau dès qu'il est présent dans le DOM. `typecheck` et `lint` passent sans erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)