### PR TITLE
fix(plateform): fix combobox focus loss and keyboard navigation

### DIFF
--- a/plateform/app/components/ui/combobox.tsx
+++ b/plateform/app/components/ui/combobox.tsx
@@ -15,10 +15,16 @@ interface ComboboxProps {
 export default function Combobox({ label, placeholder, options, selected, onChange, className, single }: ComboboxProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  // Vrai pendant une interaction au pointeur (souris/tactile) : en sélection unique, seule une
+  // sélection au pointeur ferme le panneau ; aux flèches clavier il reste ouvert pour parcourir.
+  const pointerRef = useRef(false);
   const reactId = useId();
   const panelId = `${reactId}-panel`;
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
+  // Sélection figée à l'ouverture pour le tri : sinon chaque sélection aux flèches réordonnerait
+  // la liste sous le focus pendant la navigation clavier.
+  const [sortedSelection, setSortedSelection] = useState<string[]>([]);
 
   useEffect(() => {
     if (!open) {
@@ -42,15 +48,21 @@ export default function Combobox({ label, placeholder, options, selected, onChan
     };
   }, [open]);
 
-  // En sélection unique, la valeur sélectionnée est remontée en première position (tri stable).
-  const orderedOptions = single ? [...options].sort((a, b) => (selected.includes(b.value) ? 1 : 0) - (selected.includes(a.value) ? 1 : 0)) : options;
+  // En sélection unique, la valeur sélectionnée à l'ouverture est remontée en première position (tri stable).
+  const orderedOptions = single ? [...options].sort((a, b) => (sortedSelection.includes(b.value) ? 1 : 0) - (sortedSelection.includes(a.value) ? 1 : 0)) : options;
   const visibleOptions = search ? orderedOptions.filter((option) => option.label.toLowerCase().includes(search.toLowerCase())) : orderedOptions;
 
   const toggleOption = (option: ComboboxOption) => {
     const isSelected = selected.includes(option.value);
     if (single) {
       onChange(isSelected ? [] : [option.value]);
-      setOpen(false);
+      // Au pointeur, la sélection ferme le panneau et restitue le focus au déclencheur (RGAA 7.3).
+      // Aux flèches clavier (change natif des radios), le panneau reste ouvert pour parcourir.
+      if (pointerRef.current) {
+        pointerRef.current = false;
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
       return;
     }
     onChange(isSelected ? selected.filter((value) => value !== option.value) : [...selected, option.value]);
@@ -61,14 +73,24 @@ export default function Combobox({ label, placeholder, options, selected, onChan
   const summaryLabel = hasSelection ? `${selectedOptions[0].label}${selectedOptions.length > 1 ? ` +${selectedOptions.length - 1}` : ""}` : placeholder;
 
   return (
-    <div className="relative" ref={wrapperRef}>
+    <div
+      className="relative"
+      ref={wrapperRef}
+      onBlur={(event) => {
+        // Ferme le panneau quand le focus sort du composant (Tab), comme un select natif.
+        if (open && event.relatedTarget instanceof Node && !wrapperRef.current?.contains(event.relatedTarget)) setOpen(false);
+      }}
+    >
       <button
         ref={triggerRef}
         type="button"
         className={`w-full px-4 text-left transition-colors hover:bg-background-default-grey-hover ${className}`}
         aria-expanded={open}
         aria-controls={panelId}
-        onClick={() => setOpen((value) => !value)}
+        onClick={() => {
+          setSortedSelection(selected);
+          setOpen((value) => !value);
+        }}
       >
         <span className="fr-text text-title-grey">{label}</span>
 
@@ -98,7 +120,22 @@ export default function Combobox({ label, placeholder, options, selected, onChan
             {search ? `${visibleOptions.length} option${visibleOptions.length > 1 ? "s" : ""} disponible${visibleOptions.length > 1 ? "s" : ""}` : ""}
           </p>
 
-          <fieldset className="max-h-60 w-full min-w-0 overflow-y-auto" tabIndex={-1}>
+          <fieldset
+            className="max-h-60 w-full min-w-0 overflow-y-auto"
+            tabIndex={-1}
+            onPointerDown={() => {
+              pointerRef.current = true;
+            }}
+            onKeyDown={(event) => {
+              pointerRef.current = false;
+              // Entrée valide la sélection en cours et ferme le panneau.
+              if (event.key === "Enter") {
+                event.preventDefault();
+                setOpen(false);
+                triggerRef.current?.focus();
+              }
+            }}
+          >
             <legend className="sr-only">Sélectionner {label.toLowerCase()}</legend>
 
             <div className="px-4">


### PR DESCRIPTION
## Description

Corrige la non-conformité **RGAA 7.3 (mineur)** relevée par l'audit sur le combobox des filtres missions en sélection unique : la sélection d'une option fermait le panneau en démontant l'élément focusé, le focus clavier retombait sur `<body>`. En corrigeant, un second problème a été constaté : les flèches clavier sélectionnaient et fermaient immédiatement le panneau (comportement natif des radios), rendant impossible le parcours des options au clavier.

**Changements** (`plateform/app/components/ui/combobox.tsx`, mode sélection unique) :

- **Flèches clavier** : la sélection s'applique mais le panneau reste ouvert pour parcourir les options. La distinction souris/clavier se fait via un drapeau posé sur `pointerdown` (jamais émis au clavier).
- **Entrée** : valide la sélection et ferme le panneau, focus restitué au bouton déclencheur (aligné sur Échap, déjà en place).
- **Souris/tactile** : comportement inchangé — clic = sélection + fermeture, avec focus restitué au déclencheur (RGAA 7.3).
- **Tab sortant** : ferme le panneau comme un select natif (`onBlur` sur le wrapper).
- **Tri figé à l'ouverture** : le tri « sélection en premier » était recalculé à chaque render et aurait réordonné la liste sous le focus à chaque flèche ; il est maintenant capturé à l'ouverture du panneau.

## Liens utiles

- 📝 Audit RGAA : `plateform/audits/`

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Le mode multi-sélection (checkboxes) est inchangé, hormis Entrée qui ferme désormais aussi le panneau.
- Test manuel : sur `/missions` (desktop), ouvrir un filtre à sélection unique au clavier → les flèches parcourent sans fermer ni réordonner, Entrée/Échap ferment avec focus sur le bouton ; à la souris, un clic sur une option ferme directement.
- `npm run typecheck` et `npm run lint` passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)