### PR TITLE
fix(plateform): fix rgaa heading hierarchy and duplicate header links

### DIFF
--- a/plateform/app/components/landing/how-it-works.tsx
+++ b/plateform/app/components/landing/how-it-works.tsx
@@ -102,7 +102,7 @@ export default function HowItWorks({ onStartQuiz }: { onStartQuiz: () => void })
                 className="bg-background flex w-[80vw] shrink-0 snap-center flex-col items-center gap-4 p-8 text-center shadow-lg md:w-auto md:p-10 lg:mx-auto lg:max-w-60 lg:p-6"
               >
                 <img src={feature.icon} alt="" className="size-16 dark:box-content dark:rounded-full dark:bg-white dark:p-3" aria-hidden="true" />
-                <p className="fr-text--lead text-title-grey font-bold mb-0!">{feature.title}</p>
+                <h3 className="fr-text--lead text-title-grey font-bold">{feature.title}</h3>
               </li>
             ))}
           </ul>

--- a/plateform/app/components/landing/mission-examples.tsx
+++ b/plateform/app/components/landing/mission-examples.tsx
@@ -36,6 +36,8 @@ export default function MissionExamples({ missions, className }: Props) {
 
   return (
     <section className={`fr-pb-8w relative z-10 ${className}`} aria-roledescription="carousel" aria-label="Exemples de missions d'engagement">
+      {/* RGAA 9.1 : titre de section masqué — les titres de cartes sont des <h3>, sans saut depuis le h1 du hero. */}
+      <h2 className="fr-sr-only">Exemples de missions d'engagement</h2>
       <div className="fr-container max-w-7xl! relative">
         <div
           ref={scrollRef}
@@ -63,7 +65,7 @@ export default function MissionExamples({ missions, className }: Props) {
                         <div className="bg-beige-gris-galet w-28 shrink-0" />
                       )}
                       <div className="flex flex-1 flex-col gap-4 p-6">
-                        <p className="fr-h6 line-clamp-2 mb-0!">{mission.title}</p>
+                        <h3 className="fr-h6 line-clamp-2 mb-0!">{mission.title}</h3>
                         <div className="fr-mt-auto flex items-center gap-2">
                           {/* RGAA 1.1: if the publisher has no name, don't display the logo */}
                           {mission.publisherName && (
@@ -87,7 +89,7 @@ export default function MissionExamples({ missions, className }: Props) {
                         <div className="bg-beige-gris-galet w-28 shrink-0" />
                       )}
                       <div className="flex flex-1 flex-col gap-4 p-6">
-                        <p className="fr-h6 line-clamp-2 mb-0!">{mission.title}</p>
+                        <h3 className="fr-h6 line-clamp-2 mb-0!">{mission.title}</h3>
                         <div className="fr-mt-auto flex items-center gap-2">
                           {/* RGAA 1.1: if the publisher has no name, don't display the logo */}
                           {mission.publisherName && (

--- a/plateform/app/components/layout/footer.tsx
+++ b/plateform/app/components/layout/footer.tsx
@@ -43,7 +43,8 @@ export function FooterContent({ landmark = true }: { landmark?: boolean }) {
             <div className="fr-grid-row fr-grid-row--start fr-grid-row--gutters">
               {FOOTER_NAV_CATEGORIES.map((category) => (
                 <div key={category.title} className="fr-col-12 fr-col-sm-4 fr-col-md-3">
-                  <h3 className="fr-footer__top-cat">{category.title}</h3>
+                  {/* RGAA 9.1 : <h2> pour éviter un saut h1 → h3 sur les pages sans <h2> (plan du site, accessibilité). */}
+                  <h2 className="fr-footer__top-cat">{category.title}</h2>
                   <ul className="fr-footer__top-list">
                     {category.links.map((link) => (
                       <li key={link.to}>

--- a/plateform/app/components/layout/header.tsx
+++ b/plateform/app/components/layout/header.tsx
@@ -1,10 +1,12 @@
 import { Link, useLocation, useMatches } from "react-router";
+import { useIsMobile } from "~/hooks/useIsMobile";
 
 export default function Header() {
   const matches = useMatches();
   const location = useLocation();
-  const activeMatch = [...matches].reverse().find((m) => m.data != null);
-  const routeData = activeMatch?.data as { header?: string; backHref?: string | null } | undefined;
+  const isMobile = useIsMobile();
+  const activeMatch = [...matches].reverse().find((m) => m.loaderData != null);
+  const routeData = activeMatch?.loaderData as { header?: string; backHref?: string | null } | undefined;
 
   if (routeData?.header === "hidden") {
     return null;
@@ -13,9 +15,39 @@ export default function Header() {
   const isHome = location.pathname === "/";
   const backHref = routeData?.backHref;
 
+  // Rendu conditionnel plutôt que masquage CSS : une seule version du header dans le DOM,
+  // pour ne pas dupliquer les liens « Accueil — Trouve ta mission ».
+  if (isMobile) {
+    return (
+      <header role="banner" className="fr-header">
+        {isHome || backHref === null ? (
+          <div className="relative flex items-center px-4 py-2">
+            <p className="fr-logo fr-logo--sm mb-0">
+              République
+              <br />
+              Française
+            </p>
+            <Link to="/" title="Accueil — Trouve ta mission" className="fr-text--md fr-text--bold absolute left-1/2 -translate-x-1/2">
+              <p className="fr-header__service-title">Trouve ta mission</p>
+            </Link>
+          </div>
+        ) : (
+          <div className="relative flex h-14 items-center px-4">
+            <Link to={backHref ?? "/"} aria-label="Retour" className="fr-icon-arrow-left-line fr-btn--icon-left fr-btn--tertiary-no-outline font-semi-bold!">
+              Retour
+            </Link>
+            <Link to="/" title="Accueil — Trouve ta mission" className="fr-text--md fr-text--bold absolute left-1/2 -translate-x-1/2">
+              <p className="fr-header__service-title">Trouve ta mission</p>
+            </Link>
+          </div>
+        )}
+      </header>
+    );
+  }
+
   return (
     <header role="banner" className="fr-header">
-      <div className="fr-header__body hidden lg:block">
+      <div className="fr-header__body">
         <div className="fr-container">
           <div className="fr-header__body-row">
             <div className="fr-header__brand fr-enlarge-link">
@@ -29,7 +61,7 @@ export default function Header() {
                 </div>
               </div>
               <div className="fr-header__service">
-                <Link to="/" title="Trouve ta mission">
+                <Link to="/" title="Accueil — Trouve ta mission">
                   <p className="fr-header__service-title">Trouve ta mission</p>
                 </Link>
                 <p className="fr-header__service-tagline">Service public pour trouver une mission d'engagement</p>
@@ -38,28 +70,6 @@ export default function Header() {
           </div>
         </div>
       </div>
-
-      {isHome || backHref === null ? (
-        <div className="relative flex items-center px-4 py-2 lg:hidden">
-          <p className="fr-logo fr-logo--sm mb-0">
-            République
-            <br />
-            Française
-          </p>
-          <Link to="/" title="Trouve ta mission" className="fr-text--md fr-text--bold absolute left-1/2 -translate-x-1/2">
-            <p className="fr-header__service-title">Trouve ta mission</p>
-          </Link>
-        </div>
-      ) : (
-        <div className="relative flex h-14 items-center px-4 lg:hidden">
-          <Link to={backHref ?? "/"} aria-label="Retour" className="fr-icon-arrow-left-line fr-btn--icon-left fr-btn--tertiary-no-outline font-semi-bold!">
-            Retour
-          </Link>
-          <Link to="/" title="Trouve ta mission" className="fr-text--md fr-text--bold absolute left-1/2 -translate-x-1/2">
-            <p className="fr-header__service-title">Trouve ta mission</p>
-          </Link>
-        </div>
-      )}
     </header>
   );
 }


### PR DESCRIPTION
## Description

Corrige la non-conformité **RGAA 9.1 (mineur)** relevée par l'audit (hiérarchie de titres incohérente), et supprime les liens dupliqués du header en scindant les versions mobile/desktop.

**Changements** :

- `footer.tsx` : les catégories du footer passent de `<h3>` à `<h2 className="fr-footer__top-cat">` — plus de saut h1 → h3 sur les pages sans `<h2>` (plan du site, accessibilité). Aucun changement visuel, le style est porté par la classe DSFR.
- `mission-examples.tsx` : les titres de cartes du carrousel passent de `<p className="fr-h6">` à `<h3>`, avec un `<h2 className="fr-sr-only">` masqué en tête de section — sans lui, les `h3` auraient créé un saut h1 → h3 depuis le hero (même pattern que `pinned-missions.tsx`).
- `how-it-works.tsx` : les titres de cartes passent de `<p>` à `<h3>` sous le `<h2>` « Comment ça marche ».
- `header.tsx` : rendu conditionnel via `useIsMobile` au lieu du masquage CSS (`hidden lg:block` / `lg:hidden`) — une seule version du header dans le DOM, le lien « Trouve ta mission » n'apparaît plus qu'une fois.

## Liens utiles

- 📝 Audit RGAA : `plateform/audits/`

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- La transition `quiz/motivation.tsx` relevée par l'audit n'est volontairement pas traitée (écran probablement amené à disparaître).
- **Header — deux effets de bord à valider** : le point de bascule passe de `lg` (1024px, CSS) à 768px (breakpoint du hook, cohérent avec footer et résultats) — entre 768 et 1024px c'est désormais le header desktop qui s'affiche ; et `useIsMobile` démarrant à `false`, le HTML SSR contient brièvement le header desktop sur mobile avant hydratation (même compromis que le footer).
- `npm run typecheck` et `npm run lint` passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)