### PR TITLE
fix(plateform): fix rgaa 11.13 autocomplete on quiz localisation input

### DIFF
--- a/plateform/app/routes/quiz/localisation.tsx
+++ b/plateform/app/routes/quiz/localisation.tsx
@@ -223,7 +223,7 @@ export default function LocalisationStep() {
             value={value}
             onChange={(e) => handleChange(e.target.value)}
             onKeyDown={handleKeyDown}
-            autoComplete="off"
+            autoComplete="street-address"
           />
           <span className="fr-icon-map-pin-2-line absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none" aria-hidden="true" />
           {showOptions && options.length > 0 && (


### PR DESCRIPTION
## Description

Corrige la non-conformité RGAA 11.13 (WCAG 1.3.5) sur le champ d'adresse du step localisation du quiz : le champ demande « ton adresse » (donnée personnelle) mais avait `autoComplete="off"`, ce qui masquait sa finalité aux navigateurs et technologies d'assistance.

**Changements** :
- `autoComplete="off"` → `autoComplete="street-address"` sur `#localisation-input` (`app/routes/quiz/localisation.tsx`)

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Cohabitation autofill navigateur / liste de suggestions custom** :
- L'autofill natif du navigateur peut désormais s'afficher au-dessus de la listbox custom, mais le conflit reste limité : la listbox n'apparaît qu'à partir de 3 caractères saisis, et Chrome ignorait déjà `autocomplete="off"` sur les champs détectés comme adresse.
- Le submit exige toujours une sélection dans la liste custom (lat/lon requis) ; si l'utilisateur remplit le champ via l'autofill navigateur, le message d'erreur existant « Sélectionne une adresse dans la liste de suggestions » le guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)