### PR TITLE
fix(plateform): add required field mention to quiz steps

### DIFF
--- a/plateform/app/components/quiz/checkbox-group-rich.tsx
+++ b/plateform/app/components/quiz/checkbox-group-rich.tsx
@@ -9,9 +9,10 @@ type Props = {
   options: StepOption[];
   selected: string[];
   error?: string;
+  required?: boolean;
 };
 
-export default function CheckboxGroupRich({ title, subtitle, onChange, options, selected, error }: Props) {
+export default function CheckboxGroupRich({ title, subtitle, onChange, options, selected, error, required }: Props) {
   const toggle = (taxonomyKey: string) => {
     const next = selected.includes(taxonomyKey) ? selected.filter((v) => v !== taxonomyKey) : [...selected, taxonomyKey];
     onChange(next);
@@ -28,7 +29,13 @@ export default function CheckboxGroupRich({ title, subtitle, onChange, options, 
     >
       <legend className="mb-10! ml-2!" id="checkbox-group-rich-legend">
         <h1 className="fr-h1 mb-0!">{title}</h1>
-        {subtitle && <span className="fr-text--lead font-normal block mt-4! mb-0!">{subtitle}</span>}
+        {subtitle && (
+          <span className="fr-text--lead font-normal block mt-4! mb-0!">
+            {subtitle}
+            {required && <span className="fr-hint-text inline! font-normal mb-0!"> (Réponse obligatoire)</span>}
+          </span>
+        )}
+        {!subtitle && required && <span className="fr-hint-text font-normal block mt-2! mb-0!">Réponse obligatoire</span>}
       </legend>
       <div className="fr-fieldset__content grid grid-cols-1 md:grid-cols-2 max-w-4xl! mx-0! gap-x-6 gap-y-4!">
         {options.map((o) => (

--- a/plateform/app/routes/quiz/duree.tsx
+++ b/plateform/app/routes/quiz/duree.tsx
@@ -48,7 +48,7 @@ export default function DureeStep() {
 
   return (
     <>
-      <CheckboxGroupRich title={DEFAULT_TITLE} subtitle={DEFAULT_SUBTITLE} onChange={handleSelect} options={options} selected={selected} error={error} />
+      <CheckboxGroupRich title={DEFAULT_TITLE} subtitle={DEFAULT_SUBTITLE} onChange={handleSelect} options={options} selected={selected} error={error} required />
       <NextButton onClick={handleNext} skip />
     </>
   );

--- a/plateform/app/routes/quiz/motivation.tsx
+++ b/plateform/app/routes/quiz/motivation.tsx
@@ -93,7 +93,7 @@ export default function MotivationStep() {
 
   return (
     <>
-      <RadioGroupRich title={DEFAULT_TITLE} subtitle={DEFAULT_SUBTITLE} onChange={handleChange} options={options} error={error} selected={selected} />
+      <RadioGroupRich title={DEFAULT_TITLE} subtitle={DEFAULT_SUBTITLE} onChange={handleChange} options={options} error={error} selected={selected} required />
       <NextButton onClick={handleNext} skip />
     </>
   );

--- a/plateform/app/routes/quiz/precision-competences.tsx
+++ b/plateform/app/routes/quiz/precision-competences.tsx
@@ -54,7 +54,7 @@ export default function PrecisionCompetencesStep() {
 
   return (
     <>
-      <CheckboxGroupRich title={title} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} />
+      <CheckboxGroupRich title={title} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} required />
       <NextButton onClick={handleNext} skip />
     </>
   );

--- a/plateform/app/routes/quiz/precision-domaine.tsx
+++ b/plateform/app/routes/quiz/precision-domaine.tsx
@@ -55,7 +55,7 @@ export default function PrecisionDomaineStep() {
 
   return (
     <>
-      <CheckboxGroupRich title={title} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} />
+      <CheckboxGroupRich title={title} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} required />
       <NextButton onClick={handleNext} skip />
     </>
   );

--- a/plateform/app/routes/quiz/precision-formation-onisep.tsx
+++ b/plateform/app/routes/quiz/precision-formation-onisep.tsx
@@ -55,7 +55,7 @@ export default function PrecisionFormationOnisepStep() {
 
   return (
     <>
-      <CheckboxGroupRich title={title} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} />
+      <CheckboxGroupRich title={title} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} required />
       <NextButton onClick={handleNext} skip />
     </>
   );

--- a/plateform/app/routes/quiz/precision-international.tsx
+++ b/plateform/app/routes/quiz/precision-international.tsx
@@ -41,7 +41,7 @@ export default function PrecisionInternationalStep() {
 
   return (
     <>
-      <CheckboxGroupRich title={DEFAULT_TITLE} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} />
+      <CheckboxGroupRich title={DEFAULT_TITLE} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} required />
       <NextButton onClick={handleNext} skip />
     </>
   );

--- a/plateform/app/routes/quiz/precision-parcoursup-formation.tsx
+++ b/plateform/app/routes/quiz/precision-parcoursup-formation.tsx
@@ -35,7 +35,7 @@ export default function PrecisionParcoursupFormationStep() {
 
   return (
     <>
-      <RadioGroup title={DEFAULT_TITLE} onChange={handleSelect} options={STEP_OPTIONS} error={error} selected={selected} />
+      <RadioGroup title={DEFAULT_TITLE} onChange={handleSelect} options={STEP_OPTIONS} error={error} selected={selected} required />
       <NextButton onClick={handleNext} skip />
     </>
   );

--- a/plateform/app/routes/quiz/precision-reprendre-activite.tsx
+++ b/plateform/app/routes/quiz/precision-reprendre-activite.tsx
@@ -45,7 +45,7 @@ export default function PrecisionReprendreActiviteStep() {
 
   return (
     <>
-      <CheckboxGroupRich title={DEFAULT_TITLE} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} />
+      <CheckboxGroupRich title={DEFAULT_TITLE} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} required />
       <NextButton onClick={handleNext} skip />
     </>
   );

--- a/plateform/app/routes/quiz/precision-servir-pays.tsx
+++ b/plateform/app/routes/quiz/precision-servir-pays.tsx
@@ -43,7 +43,7 @@ export default function PrecisionServirPaysStep() {
 
   return (
     <>
-      <CheckboxGroupRich title={DEFAULT_TITLE} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} />
+      <CheckboxGroupRich title={DEFAULT_TITLE} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} required />
       <NextButton onClick={handleNext} skip />
     </>
   );

--- a/plateform/app/routes/quiz/precision-thematique.tsx
+++ b/plateform/app/routes/quiz/precision-thematique.tsx
@@ -44,7 +44,7 @@ export default function PrecisionThematiqueStep() {
 
   return (
     <>
-      <CheckboxGroupRich title={DEFAULT_TITLE} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} />
+      <CheckboxGroupRich title={DEFAULT_TITLE} onChange={handleSelect} options={STEP_OPTIONS} selected={selected} error={error} required />
       <NextButton onClick={handleNext} skip />
     </>
   );


### PR DESCRIPTION
## Description

Corrige la non-conformité RGAA **11.10 (contrôle de saisie des formulaires)** relevée lors de l'audit : dix steps du quiz refusaient de continuer sans réponse mais n'indiquaient l'obligation ni visuellement ni via les attributs d'accessibilité — l'utilisateur ne la découvrait qu'après l'erreur.

**Changements** :
- Ajout d'une prop `required` à `CheckboxGroupRich`, avec la même mécanique de légende que `RadioGroup`/`RadioGroupRich` : mention « (Réponse obligatoire) » accolée au sous-titre, ou en ligne dédiée sous le titre s'il n'y a pas de sous-titre.
- Passage de `required` sur les 10 steps concernés : `duree`, `precision-domaine`, `precision-competences`, `precision-formation-onisep`, `precision-international`, `precision-reprendre-activite`, `precision-servir-pays`, `precision-thematique` (CheckboxGroupRich), `motivation` (RadioGroupRich) et `precision-parcoursup-formation` (RadioGroup).

L'ensemble du parcours quiz est désormais cohérent avec les steps `handicap`, `statut`, `age` et `localisation` qui affichaient déjà la mention.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Point d'attention accessibilité** : contrairement aux radios, `aria-required` n'a volontairement **pas** été ajouté sur les cases à cocher individuelles de `CheckboxGroupRich` — sur une checkbox, cet attribut signifie « cette case précise doit être cochée », ce qui serait faux (une seule réponse suffit) et créerait une restitution trompeuse au lecteur d'écran. La mention visible dans la légende du `fieldset`, restituée avec le groupe, couvre le critère 11.10.

Validation effectuée : `typecheck` et `lint` OK. Changement purement visuel/a11y, sans logique nouvelle — pas de test unitaire ajouté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)