### PR TITLE
fix(api): allow publishers to access moderation of their own missions

### DIFF
--- a/api/src/controllers/moderation.ts
+++ b/api/src/controllers/moderation.ts
@@ -77,7 +77,10 @@ router.post("/search", passport.authenticate("user", { session: false }), async 
 
     const userPublisherIds = req.user.publishers.map((publisherId: string) => publisherId.toString());
     if (req.user.role !== "admin" && !userPublisherIds.includes(moderator.id)) {
-      return res.status(403).send({ ok: false, code: FORBIDDEN });
+      const requestedPublisherIds = body.data.publisherIds || [];
+      if (requestedPublisherIds.length === 0 || !requestedPublisherIds.every((publisherId) => userPublisherIds.includes(publisherId))) {
+        return res.status(403).send({ ok: false, code: FORBIDDEN });
+      }
     }
 
     const filters: ModerationFilters = {
@@ -125,7 +128,10 @@ router.post("/aggs", passport.authenticate("user", { session: false }), async (r
 
     const userPublisherIds = req.user.publishers.map((publisherId: string) => publisherId.toString());
     if (req.user.role !== "admin" && !userPublisherIds.includes(moderator.id)) {
-      return res.status(403).send({ ok: false, code: FORBIDDEN });
+      const requestedPublisherIds = body.data.publisherIds || [];
+      if (requestedPublisherIds.length === 0 || !requestedPublisherIds.every((publisherId) => userPublisherIds.includes(publisherId))) {
+        return res.status(403).send({ ok: false, code: FORBIDDEN });
+      }
     }
 
     const filters: ModerationFilters = {

--- a/api/tests/integration/api/endpoints/moderation.test.ts
+++ b/api/tests/integration/api/endpoints/moderation.test.ts
@@ -63,6 +63,32 @@ describe("Moderation API endpoints (integration test)", () => {
       expect(res.status).toBe(403);
     });
 
+    it("allows a partner user requesting only their own publisherIds", async () => {
+      const { token } = await createTestUser({ role: "user", publishers: [partner.id] });
+      await createMissionWithModeration({ publisherId: partner.id });
+
+      const res = await request(app)
+        .post("/moderation/search")
+        .set("Authorization", `jwt ${token}`)
+        .send({ publisherIds: [partner.id] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+    });
+
+    it("should return 403 when a partner user requests publisherIds outside their own publishers", async () => {
+      const { token } = await createTestUser({ role: "user", publishers: [partner.id] });
+      const otherPublisher = await createTestPublisher();
+
+      const res = await request(app)
+        .post("/moderation/search")
+        .set("Authorization", `jwt ${token}`)
+        .send({ publisherIds: [partner.id, otherPublisher.id] });
+
+      expect(res.status).toBe(403);
+    });
+
     it("should return empty results when there are no moderation records for this moderator", async () => {
       const otherPublisher = await createTestPublisher({ moderator: true });
 
@@ -183,6 +209,31 @@ describe("Moderation API endpoints (integration test)", () => {
       const { token } = await createTestUser({ role: "user", publishers: [partner.id] });
 
       const res = await request(app).post("/moderation/aggs").set("Authorization", `jwt ${token}`).send({ moderatorId: jva.id });
+
+      expect(res.status).toBe(403);
+    });
+
+    it("allows a partner user requesting only their own publisherIds", async () => {
+      const { token } = await createTestUser({ role: "user", publishers: [partner.id] });
+      await createMissionWithModeration({ publisherId: partner.id, moderationStatus: "PENDING" });
+
+      const res = await request(app)
+        .post("/moderation/aggs")
+        .set("Authorization", `jwt ${token}`)
+        .send({ publisherIds: [partner.id] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.status.find((s: any) => s.key === "PENDING")?.doc_count).toBe(1);
+    });
+
+    it("should return 403 when a partner user requests publisherIds outside their own publishers", async () => {
+      const { token } = await createTestUser({ role: "user", publishers: [partner.id] });
+      const otherPublisher = await createTestPublisher();
+
+      const res = await request(app)
+        .post("/moderation/aggs")
+        .set("Authorization", `jwt ${token}`)
+        .send({ publisherIds: [partner.id, otherPublisher.id] });
 
       expect(res.status).toBe(403);
     });


### PR DESCRIPTION
## Description

Depuis la #1261, `/moderation/search` et `/moderation/aggs` exigent que l'utilisateur soit membre du publisher **modérateur** (JeVeuxAider, valeur par défaut de `moderatorId`). Or la page « Vos missions → Modération » est utilisée par des annonceurs qui interrogent leurs propres missions via `publisherIds` : n'étant pas membres de JVA, ils recevaient un 403 et la page restait bloquée sur le loader.

**Changements** :
- Un utilisateur non-admin, non membre du modérateur, est désormais autorisé si **tous** les `publisherIds` demandés appartiennent à ses propres publishers (sinon 403).
- La protection de la #1261 reste intacte : impossible de lire les statuts de modération d'un publisher auquel on n'est pas rattaché, et le back-office modérateur exige toujours d'être membre du modérateur.

## Liens utiles

- 📝 Ticket Notion : [Lien](https://app.notion.com/p/jeveuxaider/Erreur-d-acces-la-mod-ration-partenaire-cae72a322d50837296c80178fdcc9293?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)
- PR à l'origine de la régression : #1261

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- 4 nouveaux tests d'intégration (`moderation.test.ts`) : annonceur → 200 sur ses propres `publisherIds`, 403 s'il demande un publisher tiers, pour `/search` et `/aggs` (50/50 verts en local).
- Cas réel reproduit : user Benevolt (`5f592d415655a711feb4460e`) sur la page « Vos missions → Modération ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)