### PR TITLE
fix(plateform): relevel partner headings in mission description

### DIFF
--- a/plateform/app/services/api/__tests__/sanitize.test.ts
+++ b/plateform/app/services/api/__tests__/sanitize.test.ts
@@ -8,8 +8,15 @@ describe("sanitizeDescriptionHtml", () => {
     expect(sanitizeDescriptionHtml(html)).toBe(html);
   });
 
-  it("conserve les balises de titre", () => {
-    expect(sanitizeDescriptionHtml("<h1>Titre</h1><h3>Sous-titre</h3><p>Texte</p>")).toBe("<h1>Titre</h1><h3>Sous-titre</h3><p>Texte</p>");
+  it("re-nivelle les titres sous le h2 de la section en conservant la hiérarchie relative", () => {
+    expect(sanitizeDescriptionHtml("<h1>Titre</h1><h2>Titre</h2><h3>Titre</h3><h4>Titre</h4><h5>Titre</h5><h6>Titre</h6>")).toBe(
+      "<h3>Titre</h3><h4>Titre</h4><h5>Titre</h5><h6>Titre</h6><p>Titre</p><p>Titre</p>",
+    );
+  });
+
+  it("évite les sauts de titre : les niveaux utilisés sont ramenés à h3, h4, … sans trou", () => {
+    expect(sanitizeDescriptionHtml("<h2>Titre</h2><h4>Sous-titre</h4><h2>Titre</h2>")).toBe("<h3>Titre</h3><h4>Sous-titre</h4><h3>Titre</h3>");
+    expect(sanitizeDescriptionHtml("<h5>Titre</h5><p>Texte</p>")).toBe("<h3>Titre</h3><p>Texte</p>");
   });
 
   it("conserve blockquote, s et sup", () => {

--- a/plateform/app/services/api/sanitize.ts
+++ b/plateform/app/services/api/sanitize.ts
@@ -11,4 +11,18 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   allowedSchemes: ["http", "https", "mailto"],
 };
 
-export const sanitizeDescriptionHtml = (html: string): string => sanitizeHtml(html, SANITIZE_OPTIONS);
+// RGAA 9.1 : la description est restituée sous le h2 « Présentation de la mission ». Les niveaux
+// de titre réellement utilisés par le partenaire sont re-nivelés dans l'ordre vers h3 → h6, ce qui
+// conserve leur hiérarchie relative sans introduire de saut de niveau ; au-delà de 4 niveaux
+// distincts, les titres les plus profonds deviennent des paragraphes.
+export const sanitizeDescriptionHtml = (html: string): string => {
+  const clean = sanitizeHtml(html, SANITIZE_OPTIONS);
+  const headingLevels = [...new Set([...clean.matchAll(/<h([1-6])/g)].map((match) => Number(match[1])))].sort((a, b) => a - b);
+  if (headingLevels.length === 0) return clean;
+
+  const transformTags: Record<string, string> = {};
+  headingLevels.forEach((level, index) => {
+    transformTags[`h${level}`] = index < 4 ? `h${index + 3}` : "p";
+  });
+  return sanitizeHtml(clean, { ...SANITIZE_OPTIONS, transformTags });
+};


### PR DESCRIPTION
## Description

Corrige le constat RGAA 9.1 (hiérarchie des titres) sur la fiche mission : le HTML des descriptions issues des flux partenaires (JVA, Service Civique, SPV) conservait les balises `h1`–`h6` telles quelles, ce qui pouvait produire un second `h1` sur la page ou des titres au même niveau que le `h2` « Présentation de la mission » qui les englobe.

**Changements** :

- `sanitizeDescriptionHtml` re-nivelle désormais les titres à la sanitisation : les niveaux réellement utilisés par le partenaire sont remappés dans l'ordre vers `h3` → `h6`, ce qui conserve leur hiérarchie relative **sans introduire de saut de niveau** (ex. un flux qui n'utilise que des `h2` donne des `h3`, pas des `h4` orphelins).
- Au-delà de 4 niveaux de titre distincts, les titres les plus profonds deviennent des paragraphes.
- Tests unitaires ajoutés : conservation de la hiérarchie relative sur l'échelle complète `h1`–`h6`, absence de saut quand le flux démarre à `h2` ou n'utilise qu'un seul niveau profond.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://www.notion.so/...)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Le contenu des titres transformés est conservé, seule la balise change (`transformTags` de `sanitize-html`) ; les attributs restent filtrés comme avant.
- Limite connue (contenu pathologique) : si un partenaire inverse sa propre hiérarchie (un `h3` avant son premier `h2`), l'ordre relatif est conservé tel quel — on ne répare pas une structure incohérente à la source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JvdjGgA7HRJmTA7YWjbkU