### PR TITLE
fix(analytics): fix public stats overcount from department fan-out

### DIFF
--- a/analytics/dbt/analytics/models/marts/stats/__models.yml
+++ b/analytics/dbt/analytics/models/marts/stats/__models.yml
@@ -85,6 +85,10 @@ models:
       Agrégats mensuels des événements `global_events`, ventilés par type d’événement,
       domaine de mission, type de mission (catégorie publisher) et département (ou national).
       Utilisé pour les KPI publics mensuels (redirections, candidatures).
+      `event_count` compte les événements **distincts** (`stat_event_id`) : une mission
+      multi-départements ne gonfle donc pas l’agrégat national. Par conception, le total
+      national (`is_all_department = true`) n’est PAS la somme des départements (un même
+      événement compte dans chaque département de la mission, mais une seule fois au national).
     columns:
       - name: year
         description: Année d’agrégation.
@@ -107,13 +111,16 @@ models:
       - name: mission_domain
         description: Domaine de mission associé (`unknown` si non rattaché).
       - name: mission_type
-        description: Catégorie de mission (`benevolat`, `volontariat`, `all`).
+        description: >
+          Catégorie de mission (`benevolat`, `volontariat`, `all`, `unknown` si non rattaché).
       - name: type
         description: Type d'événement (`click`, `apply`, `print`, `account`).
         tests:
           - not_null
       - name: event_count
-        description: Nombre d’événements agrégés.
+        description: >
+          Nombre d’événements distincts (`count(distinct stat_event_id)`) : dédoublonne le
+          fan-out de la jointure département pour ne compter chaque événement qu’une fois.
         tests:
           - not_null
       - name: max_updated_at

--- a/analytics/dbt/analytics/models/marts/stats/global_events_monthly.sql
+++ b/analytics/dbt/analytics/models/marts/stats/global_events_monthly.sql
@@ -54,12 +54,13 @@ affected_months as (
 
 base as (
   select
+    ge.stat_event_id,
     extract(year from ge.created_at)::int as year,
     extract(month from ge.created_at)::int as month,
     date_trunc('month', ge.created_at)::date as month_start,
     mad.department,
     ge.type,
-    mad.publisher_category as mission_type,
+    coalesce(mad.publisher_category, 'unknown') as mission_type,
     coalesce(mad.mission_domain, 'unknown') as mission_domain,
     greatest(
       coalesce(ge.updated_at, ge.created_at),
@@ -91,7 +92,7 @@ dept as (
     mission_domain,
     mission_type,
     type,
-    count(*) as event_count,
+    count(distinct stat_event_id) as event_count,
     max(updated_at) as max_updated_at
   from base
   where department is not null
@@ -109,7 +110,7 @@ dept_all_mission as (
     mission_domain,
     'all' as mission_type,
     type,
-    count(*) as event_count,
+    count(distinct stat_event_id) as event_count,
     max(updated_at) as max_updated_at
   from base
   where department is not null
@@ -126,7 +127,7 @@ all_dept as (
     mission_domain,
     mission_type,
     type,
-    count(*) as event_count,
+    count(distinct stat_event_id) as event_count,
     max(updated_at) as max_updated_at
   from base
   group by year, month, month_start, mission_domain, mission_type, type
@@ -142,7 +143,7 @@ all_dept_all_mission as (
     mission_domain,
     'all' as mission_type,
     type,
-    count(*) as event_count,
+    count(distinct stat_event_id) as event_count,
     max(updated_at) as max_updated_at
   from base
   group by year, month, month_start, mission_domain, type


### PR DESCRIPTION
## Description

Corrige le sur-comptage des KPI publics mensuels dans `global_events_monthly`.
La jointure sur `int_mission_active_department_range` (grain 1 ligne par
mission/département) dupliquait chaque événement par le nombre de départements
de la mission : 4,5x en prod (ex. 382 737 clics affichés en juin pour 85 858
réels). Les rollups « tous départements » sont désormais calculés en
`count(distinct stat_event_id)`, donc chaque événement compté une seule fois.

Deuxième correctif : `publisher_category` NULL tombait dans la `unique_key` du
modèle incrémental, ce qui empêchait le `delete+insert` de dédoublonner
(`NULL != NULL`) et faisait grossir la table à chaque run. Ajout d'un
`coalesce(publisher_category, 'unknown')`, aligné sur le traitement de
`mission_domain`.

Les vues départementales (`is_all_department = false`) sont inchangées : à
grain 1 ligne/mission/département, `count(distinct)` = `count(*)` (vérifié sur
le département 75). Par conception, le total national n'est pas la somme des
départements (un événement compte dans chaque département de la mission, mais
une seule fois au national).

## Liens utiles

- 📝 Ticket Notion : [https://app.notion.com/p/jeveuxaider/Probl-mes-avec-la-page-stats-de-l-API-3a472a322d50800dbd7ce6e2c8afd375?d=e4272a322d50822198d7034ebce59cec]

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

⚠️ **Action requise au déploiement prod** : le pipeline incrémental ne suffit
pas. Il faut lancer une fois, après merge, un
`dbt run --select global_events_monthly --full-refresh` sur la **prod** pour :
1. purger les lignes `mission_type = NULL` déjà accumulées (le `delete+insert`
   ne peut pas les matcher après le passage à `'unknown'`) ;
2. recalculer tout l'historique avec le `count(distinct)` (l'incrémental ne
   recompute que les mois récents).
