### PR TITLE
refactor(api): add mission diffusion in typesense schema

### DIFF
--- a/api/src/jobs/setup-search-collections/handler.ts
+++ b/api/src/jobs/setup-search-collections/handler.ts
@@ -1,13 +1,13 @@
 import { BaseHandler } from "@/jobs/base/handler";
 import { JobResult } from "@/jobs/types";
 import { ensureSearchCollection } from "@/services/search/collections";
-import missionSchemaV3 from "@/services/search/collections/missions/schemas/v3";
+import missionSchemaV4 from "@/services/search/collections/missions/schemas/v4";
 
 const LOG_PREFIX = "[setup-search-collections-job]";
 
 // Manifest des collections à initialiser.
 // Pour ajouter une collection : importer son dernier schéma et l'ajouter ici.
-const SCHEMAS = [missionSchemaV3];
+const SCHEMAS = [missionSchemaV4];
 
 export interface SetupSearchCollectionsJobResult extends JobResult {
   collections: string[];

--- a/api/src/services/mission-index/__tests__/index.test.ts
+++ b/api/src/services/mission-index/__tests__/index.test.ts
@@ -27,6 +27,7 @@ const buildMission = (overrides: Record<string, unknown> = {}) => ({
   deletedAt: null,
   statusCode: "ACCEPTED",
   addresses: [{ departmentCode: "75" }],
+  missionDiffusions: [{ distributionPublisherId: "diffuser-1" }, { distributionPublisherId: "diffuser-2" }],
   missionScorings: [
     {
       missionScoringValues: [{ taxonomyKey: "domaine", valueKey: "social_solidarite" }],
@@ -66,9 +67,32 @@ describe("missionIndexService.upsert", () => {
         publisherOrganizationClientId: "client-org-1",
         publisherOrganizationParentOrganizations: ["Réseau 1", "Réseau 2"],
         departmentCodes: ["75"],
+        distributionPublisherIds: ["diffuser-1", "diffuser-2"],
         domaine: ["social_solidarite"],
       })
     );
     expect(deleteDocumentMock).not.toHaveBeenCalled();
+  });
+
+  it("indexe les diffuseurs du snapshot en dédupliquant", async () => {
+    prismaMock.mission.findUnique.mockResolvedValue(
+      buildMission({
+        missionDiffusions: [{ distributionPublisherId: "diffuser-1" }, { distributionPublisherId: "diffuser-1" }, { distributionPublisherId: "diffuser-2" }],
+      })
+    );
+    upsertDocumentMock.mockResolvedValue(undefined);
+
+    await missionIndexService.upsert("mission-1");
+
+    expect(upsertDocumentMock).toHaveBeenCalledWith(expect.objectContaining({ distributionPublisherIds: ["diffuser-1", "diffuser-2"] }));
+  });
+
+  it("indexe un tableau vide de diffuseurs quand la mission n'est dans aucun snapshot", async () => {
+    prismaMock.mission.findUnique.mockResolvedValue(buildMission({ missionDiffusions: [] }));
+    upsertDocumentMock.mockResolvedValue(undefined);
+
+    await missionIndexService.upsert("mission-1");
+
+    expect(upsertDocumentMock).toHaveBeenCalledWith(expect.objectContaining({ distributionPublisherIds: [] }));
   });
 });

--- a/api/src/services/mission-index/index.ts
+++ b/api/src/services/mission-index/index.ts
@@ -54,6 +54,9 @@ export const missionIndexService = {
         addresses: {
           select: { departmentCode: true },
         },
+        missionDiffusions: {
+          select: { distributionPublisherId: true },
+        },
         missionScorings: {
           orderBy: { createdAt: "desc" },
           take: 1,
@@ -73,6 +76,8 @@ export const missionIndexService = {
     }
 
     const departmentCodes = [...new Set(mission.addresses.map((a) => a.departmentCode).filter((c): c is string => c !== null && c !== undefined))];
+    // Diffuseurs autorisés issus du snapshot mission_diffusion. Toujours renseigné, y compris `[]`.
+    const distributionPublisherIds = [...new Set(mission.missionDiffusions.map((d) => d.distributionPublisherId))];
     const taxonomyIndex = buildTaxonomyIndex(mission.missionScorings[0]?.missionScoringValues ?? []);
 
     const document: MissionIndexDocument = {
@@ -82,6 +87,7 @@ export const missionIndexService = {
       ...(mission.publisherOrganization?.clientId ? { publisherOrganizationClientId: mission.publisherOrganization.clientId } : {}),
       publisherOrganizationParentOrganizations: mission.publisherOrganization?.parentOrganizations ?? [],
       departmentCodes,
+      distributionPublisherIds,
       ...taxonomyIndex,
     };
 

--- a/api/src/services/search/collections/missions/schemas/v4.ts
+++ b/api/src/services/search/collections/missions/schemas/v4.ts
@@ -1,0 +1,27 @@
+import type { TaxonomyKey } from "@engagement/taxonomy";
+
+import { TYPESENSE_MISSION_COLLECTION } from "@/config";
+import type { SearchCollectionSchema } from "@/services/search/types";
+
+import { MISSION_TAXONOMY_FIELDS_V3 } from "./v3";
+
+// Snapshot statique des champs indexés à l'instant de la v4.
+// Ajout par rapport à la v3 : `distributionPublisherIds` (diffuseurs autorisés par le snapshot mission_diffusion).
+// Pour ajouter/retirer des champs, créer un v5.ts — ne pas modifier ce fichier.
+export const MISSION_TAXONOMY_FIELDS_V4: TaxonomyKey[] = MISSION_TAXONOMY_FIELDS_V3;
+const taxonomyFields = MISSION_TAXONOMY_FIELDS_V4;
+
+const schema: SearchCollectionSchema = {
+  name: TYPESENSE_MISSION_COLLECTION,
+  fields: [
+    { name: "publisherId", type: "string", facet: true },
+    { name: "publisherOrganizationId", type: "string", facet: true, optional: true },
+    { name: "publisherOrganizationClientId", type: "string", facet: true, optional: true },
+    { name: "publisherOrganizationParentOrganizations", type: "string[]", facet: true, optional: true },
+    { name: "departmentCodes", type: "string[]", facet: true },
+    { name: "distributionPublisherIds", type: "string[]", facet: true, optional: true },
+    ...taxonomyFields.map((name) => ({ name, type: "string[]" as const, facet: true, optional: true })),
+  ],
+};
+
+export default schema;

--- a/api/src/services/search/collections/missions/types.ts
+++ b/api/src/services/search/collections/missions/types.ts
@@ -7,4 +7,5 @@ export type MissionIndexDocument = Partial<Record<IndexedTaxonomyKey, string[]>>
   publisherOrganizationClientId?: string;
   publisherOrganizationParentOrganizations?: string[];
   departmentCodes: string[];
+  distributionPublisherIds?: string[];
 };


### PR DESCRIPTION
## Description

Première phase (préparation) du cutover de `/missions/browse` vers le snapshot `mission_diffusion`.

Aujourd'hui, `mission-browse` autorise la liste et le détail par deux sources différentes : `browse()` reconstruit les droits depuis les règles live (`PublisherDiffusionRule` → `filter_by` Typesense), tandis que `findById()` lit déjà le snapshot `mission_diffusion` (depuis #1302). Une mission peut donc apparaître en liste puis renvoyer 404 en détail. La cible est de faire de `mission_diffusion` l'unique source d'autorisation. Comme Typesense assure la pagination et les facettes, l'autorisation doit être portée **dans le document**.

Cette PR installe le champ et son alimentation, **sans modifier `browse()`** (le cutover est fait en phase 2, dans une PR dédiée) :

- **Schéma Typesense v4** (`schemas/v4.ts`, repart de v3 immuable) : ajout de `distributionPublisherIds: string[]` (`optional`, `facet`). Champ ajouté par `ALTER` additif via `setup-search-collections` — pas de nouvelle collection.
- **Type** `MissionIndexDocument` : ajout de `distributionPublisherIds?: string[]`.
- **Indexation** (`missionIndexService.upsert`) : chargement de `missionDiffusions` et alimentation du champ (dédupliqué, **toujours renseigné, y compris `[]`**).

## Liens utiles

- [Ticket Notion](https://app.notion.com/p/jeveuxaider/Cutover-de-missions-browse-vers-la-table-mission_diffusion-3a572a322d508044a929ecf3de16576b?source=copy_link)
- 🔗 Contexte : #1302 (materialized mission diffusion)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

**`browse()` est inchangé** dans cette PR : elle est sans effet fonctionnel côté API tant que le champ n'est pas consommé (phase 2).

**Ordre de déploiement (impératif)** — le champ doit être présent partout avant tout cutover :

1. Déployer cette PR (code d'`upsert` qui alimente le champ).
2. `npm run job -- setup-search-collections {} --env <env>` (ajoute le champ v4 à la collection).
3. Réindexation complète : `npm run job -- update-mission-index '{}' --env <env>`.
4. Gate de couverture : nb missions actives indexées == nb documents avec `distributionPublisherIds` renseigné ; pour plusieurs diffuseurs, comparer les ids PostgreSQL (`missionDiffusionRepository`) vs Typesense.

Déployer le code d'`upsert` **avant** la réindexation garantit que toute mission ré-indexée par le chemin normal (`mission.index`) pendant la fenêtre porte déjà le champ.

**Points d'attention reviewer** :
- Volumétrie : ~178 diffuseurs par mission active en moyenne (jusqu'à ~377) → le champ `string[]` peut être volumineux, mais reste indexé sans coût de `filter_by`.
- La réindexation complète est requise pour la couverture (case « Migration de données » cochée à ce titre — aucune migration Prisma).

**Suite (phase 2, PR dédiée)** : bascule de `browse()` sur `distributionPublisherIds`, synchronisation Typesense après rebuild via le bus async + contrôle de dérive.
