### PR TITLE
refactor(api): serve mission-browse diffusion from mission_diffusion snapshot

### DIFF
--- a/api/src/jobs/mission-diffusion-rebuild/__tests__/handler.test.ts
+++ b/api/src/jobs/mission-diffusion-rebuild/__tests__/handler.test.ts
@@ -19,8 +19,17 @@ vi.mock("@/services/publisher-diffusion-rule", () => ({
   },
 }));
 
+vi.mock("@/services/async-task", () => ({
+  asyncTaskBus: { publish: vi.fn() },
+}));
+
+vi.mock("@/error", () => ({
+  captureException: vi.fn(),
+}));
+
 import { MissionDiffusionRebuildHandler } from "@/jobs/mission-diffusion-rebuild/handler";
 import { missionDiffusionRepository } from "@/repositories/mission-diffusion";
+import { asyncTaskBus } from "@/services/async-task";
 import { missionDiffusionService } from "@/services/mission-diffusion";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 
@@ -34,10 +43,15 @@ const serviceMock = missionDiffusionService as unknown as {
 const ruleServiceMock = publisherDiffusionRuleService as unknown as {
   findDistributionPublisherIdsForSnapshot: ReturnType<typeof vi.fn>;
 };
+const asyncTaskBusMock = asyncTaskBus as unknown as {
+  publish: ReturnType<typeof vi.fn>;
+};
 
 describe("MissionDiffusionRebuildHandler", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.spyOn(console, "log").mockImplementation(() => undefined);
+    asyncTaskBusMock.publish.mockResolvedValue(undefined);
   });
 
   it("rebuild chaque diffuseur actif puis purge et agrège les compteurs", async () => {
@@ -49,10 +63,10 @@ describe("MissionDiffusionRebuildHandler", () => {
 
     const result = await new MissionDiffusionRebuildHandler().handle({});
 
-    expect(serviceMock.rebuildForDistributionPublisher).toHaveBeenNthCalledWith(1, "d1", { dryRun: false });
-    expect(serviceMock.rebuildForDistributionPublisher).toHaveBeenNthCalledWith(2, "d2", { dryRun: false });
+    expect(serviceMock.rebuildForDistributionPublisher).toHaveBeenNthCalledWith(1, "d1", { dryRun: false, onMissionsTouched: expect.any(Function) });
+    expect(serviceMock.rebuildForDistributionPublisher).toHaveBeenNthCalledWith(2, "d2", { dryRun: false, onMissionsTouched: expect.any(Function) });
     expect(repositoryMock.deleteRowsForDistributionPublishersNotIn).toHaveBeenCalledWith(["d1", "d2"]);
-    expect(result).toMatchObject({ distributionPublishers: 2, added: 3, removed: 12, prunedDistributionPublishers: 5 });
+    expect(result).toMatchObject({ distributionPublishers: 2, added: 3, removed: 12, prunedDistributionPublishers: 5, reindexRequested: 0, reindexFailed: 0 });
   });
 
   it("compte la purge sans supprimer en dry-run", async () => {
@@ -62,9 +76,38 @@ describe("MissionDiffusionRebuildHandler", () => {
 
     const result = await new MissionDiffusionRebuildHandler().handle({ dryRun: true });
 
-    expect(serviceMock.rebuildForDistributionPublisher).toHaveBeenCalledWith("d1", { dryRun: true });
+    expect(serviceMock.rebuildForDistributionPublisher).toHaveBeenCalledWith("d1", { dryRun: true, onMissionsTouched: expect.any(Function) });
     expect(repositoryMock.countRowsForDistributionPublishersNotIn).toHaveBeenCalledWith(["d1"]);
     expect(repositoryMock.deleteRowsForDistributionPublishersNotIn).not.toHaveBeenCalled();
     expect(result).toMatchObject({ distributionPublishers: 1, added: 2, removed: 5, prunedDistributionPublishers: 4, dryRun: true });
+  });
+
+  it("republie sur le bus les missions touchées et compte les réindexations", async () => {
+    ruleServiceMock.findDistributionPublisherIdsForSnapshot.mockResolvedValue(["d1"]);
+    serviceMock.rebuildForDistributionPublisher.mockImplementation(async (_id: string, options: { onMissionsTouched?: (ids: string[]) => Promise<void> }) => {
+      await options.onMissionsTouched?.(["m1", "m2"]);
+      return { distributionPublisherId: "d1", desired: 2, added: 1, removed: 1, durationMs: 1 };
+    });
+    repositoryMock.deleteRowsForDistributionPublishersNotIn.mockResolvedValue(0);
+
+    const result = await new MissionDiffusionRebuildHandler().handle({});
+
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.index", payload: { missionId: "m1", action: "upsert" } });
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.index", payload: { missionId: "m2", action: "upsert" } });
+    expect(result).toMatchObject({ reindexRequested: 2, reindexFailed: 0 });
+  });
+
+  it("compte les échecs de republication sans faire échouer le rebuild global", async () => {
+    ruleServiceMock.findDistributionPublisherIdsForSnapshot.mockResolvedValue(["d1"]);
+    asyncTaskBusMock.publish.mockRejectedValue(new Error("SQS down"));
+    serviceMock.rebuildForDistributionPublisher.mockImplementation(async (_id: string, options: { onMissionsTouched?: (ids: string[]) => Promise<void> }) => {
+      await options.onMissionsTouched?.(["m1"]);
+      return { distributionPublisherId: "d1", desired: 1, added: 1, removed: 0, durationMs: 1 };
+    });
+    repositoryMock.deleteRowsForDistributionPublishersNotIn.mockResolvedValue(0);
+
+    const result = await new MissionDiffusionRebuildHandler().handle({});
+
+    expect(result).toMatchObject({ reindexRequested: 0, reindexFailed: 1, success: false });
   });
 });

--- a/api/src/jobs/mission-diffusion-rebuild/__tests__/handler.test.ts
+++ b/api/src/jobs/mission-diffusion-rebuild/__tests__/handler.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/repositories/mission-diffusion", () => ({
   missionDiffusionRepository: {
+    findMissionIdsForDistributionPublishersNotIn: vi.fn(),
     deleteRowsForDistributionPublishersNotIn: vi.fn(),
     countRowsForDistributionPublishersNotIn: vi.fn(),
   },
@@ -34,6 +35,7 @@ import { missionDiffusionService } from "@/services/mission-diffusion";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 
 const repositoryMock = missionDiffusionRepository as unknown as {
+  findMissionIdsForDistributionPublishersNotIn: ReturnType<typeof vi.fn>;
   deleteRowsForDistributionPublishersNotIn: ReturnType<typeof vi.fn>;
   countRowsForDistributionPublishersNotIn: ReturnType<typeof vi.fn>;
 };
@@ -52,6 +54,7 @@ describe("MissionDiffusionRebuildHandler", () => {
     vi.clearAllMocks();
     vi.spyOn(console, "log").mockImplementation(() => undefined);
     asyncTaskBusMock.publish.mockResolvedValue(undefined);
+    repositoryMock.findMissionIdsForDistributionPublishersNotIn.mockResolvedValue([]);
   });
 
   it("rebuild chaque diffuseur actif puis purge et agrège les compteurs", async () => {
@@ -79,6 +82,8 @@ describe("MissionDiffusionRebuildHandler", () => {
     expect(serviceMock.rebuildForDistributionPublisher).toHaveBeenCalledWith("d1", { dryRun: true, onMissionsTouched: expect.any(Function) });
     expect(repositoryMock.countRowsForDistributionPublishersNotIn).toHaveBeenCalledWith(["d1"]);
     expect(repositoryMock.deleteRowsForDistributionPublishersNotIn).not.toHaveBeenCalled();
+    expect(repositoryMock.findMissionIdsForDistributionPublishersNotIn).not.toHaveBeenCalled();
+    expect(asyncTaskBusMock.publish).not.toHaveBeenCalled();
     expect(result).toMatchObject({ distributionPublishers: 1, added: 2, removed: 5, prunedDistributionPublishers: 4, dryRun: true });
   });
 
@@ -109,5 +114,20 @@ describe("MissionDiffusionRebuildHandler", () => {
     const result = await new MissionDiffusionRebuildHandler().handle({});
 
     expect(result).toMatchObject({ reindexRequested: 0, reindexFailed: 1, success: false });
+  });
+
+  it("republie les missions des diffuseurs purgés pour qu'elles perdent le diffuseur dans Typesense", async () => {
+    ruleServiceMock.findDistributionPublisherIdsForSnapshot.mockResolvedValue(["d1"]);
+    serviceMock.rebuildForDistributionPublisher.mockResolvedValue({ distributionPublisherId: "d1", desired: 1, added: 0, removed: 0, durationMs: 1 });
+    repositoryMock.findMissionIdsForDistributionPublishersNotIn.mockResolvedValue(["m-purged-1", "m-purged-2"]);
+    repositoryMock.deleteRowsForDistributionPublishersNotIn.mockResolvedValue(3);
+
+    const result = await new MissionDiffusionRebuildHandler().handle({});
+
+    // Collecte avant purge, sur les diffuseurs hors population.
+    expect(repositoryMock.findMissionIdsForDistributionPublishersNotIn).toHaveBeenCalledWith(["d1"]);
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.index", payload: { missionId: "m-purged-1", action: "upsert" } });
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.index", payload: { missionId: "m-purged-2", action: "upsert" } });
+    expect(result).toMatchObject({ reindexRequested: 2 });
   });
 });

--- a/api/src/jobs/mission-diffusion-rebuild/handler.ts
+++ b/api/src/jobs/mission-diffusion-rebuild/handler.ts
@@ -1,8 +1,13 @@
+import { captureException } from "@/error";
 import { BaseHandler } from "@/jobs/base/handler";
 import { JobResult } from "@/jobs/types";
 import { missionDiffusionRepository } from "@/repositories/mission-diffusion";
+import { asyncTaskBus } from "@/services/async-task";
 import { missionDiffusionService } from "@/services/mission-diffusion";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
+
+// Concurrence de publication des tâches de réindexation Typesense (une par mission touchée).
+const REINDEX_PUBLISH_CONCURRENCY = 50;
 
 export interface MissionDiffusionRebuildJobPayload {
   dryRun?: boolean;
@@ -13,6 +18,8 @@ export interface MissionDiffusionRebuildJobResult extends JobResult {
   added?: number;
   removed?: number;
   prunedDistributionPublishers?: number;
+  reindexRequested?: number;
+  reindexFailed?: number;
   durationMs?: number;
   dryRun?: boolean;
 }
@@ -33,9 +40,34 @@ export class MissionDiffusionRebuildHandler implements BaseHandler<MissionDiffus
     const distributionPublisherIds = await publisherDiffusionRuleService.findDistributionPublisherIdsForSnapshot();
     let added = 0;
     let removed = 0;
+    let reindexRequested = 0;
+    let reindexFailed = 0;
+
+    // Resynchronise Typesense au fil du rebuild : chaque mission dont l'appartenance au snapshot a
+    // changé est republiée sur le bus (at-least-once, récupérable via SQS). Les doublons entre
+    // diffuseurs sont sans effet (upsert idempotent côté worker).
+    const republishTouchedMissions = async (missionIds: string[]): Promise<void> => {
+      for (let i = 0; i < missionIds.length; i += REINDEX_PUBLISH_CONCURRENCY) {
+        const batch = missionIds.slice(i, i + REINDEX_PUBLISH_CONCURRENCY);
+        await Promise.all(
+          batch.map(async (missionId) => {
+            try {
+              await asyncTaskBus.publish({ type: "mission.index", payload: { missionId, action: "upsert" } });
+              reindexRequested++;
+            } catch (error) {
+              reindexFailed++;
+              captureException(error, { extra: { missionId } });
+            }
+          })
+        );
+      }
+    };
 
     for (const distributionPublisherId of distributionPublisherIds) {
-      const distributionPublisher = await missionDiffusionService.rebuildForDistributionPublisher(distributionPublisherId, { dryRun });
+      const distributionPublisher = await missionDiffusionService.rebuildForDistributionPublisher(distributionPublisherId, {
+        dryRun,
+        onMissionsTouched: republishTouchedMissions,
+      });
       added += distributionPublisher.added;
       removed += distributionPublisher.removed;
       console.log(
@@ -51,19 +83,21 @@ export class MissionDiffusionRebuildHandler implements BaseHandler<MissionDiffus
 
     const mode = dryRun ? "Dry-run done" : "Done";
     console.log(
-      `[MissionDiffusionRebuild] ${mode}: ${distributionPublisherIds.length} distribution publishers, +${added} / -${removed} lignes (dont ${prunedDistributionPublishers} purgées), en ${durationMs}ms`
+      `[MissionDiffusionRebuild] ${mode}: ${distributionPublisherIds.length} distribution publishers, +${added} / -${removed} lignes (dont ${prunedDistributionPublishers} purgées), ${reindexRequested} réindexations demandées (${reindexFailed} échecs), en ${durationMs}ms`
     );
 
     return {
-      success: true,
+      success: reindexFailed === 0,
       timestamp: new Date(),
       distributionPublishers: distributionPublisherIds.length,
       added,
       removed,
       prunedDistributionPublishers,
+      reindexRequested,
+      reindexFailed,
       durationMs,
       dryRun,
-      message: `${dryRun ? "Dry-run : " : ""}${distributionPublisherIds.length} publishers de diffusion rebuild : +${added} / -${removed} lignes en ${durationMs}ms`,
+      message: `${dryRun ? "Dry-run : " : ""}${distributionPublisherIds.length} publishers de diffusion rebuild : +${added} / -${removed} lignes, ${reindexRequested} réindexations en ${durationMs}ms`,
     };
   }
 }

--- a/api/src/jobs/mission-diffusion-rebuild/handler.ts
+++ b/api/src/jobs/mission-diffusion-rebuild/handler.ts
@@ -6,9 +6,6 @@ import { asyncTaskBus } from "@/services/async-task";
 import { missionDiffusionService } from "@/services/mission-diffusion";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 
-// Concurrence de publication des tâches de réindexation Typesense (une par mission touchée).
-const REINDEX_PUBLISH_CONCURRENCY = 50;
-
 export interface MissionDiffusionRebuildJobPayload {
   dryRun?: boolean;
 }
@@ -44,23 +41,21 @@ export class MissionDiffusionRebuildHandler implements BaseHandler<MissionDiffus
     let reindexFailed = 0;
 
     // Resynchronise Typesense au fil du rebuild : chaque mission dont l'appartenance au snapshot a
-    // changé est republiée sur le bus (at-least-once, récupérable via SQS). Les doublons entre
+    // changé est republiée sur le bus (at-least-once, récupérable via SQS). On empile tout dans la
+    // file d'un coup ; c'est au worker de réguler son débit de traitement. Les doublons entre
     // diffuseurs sont sans effet (upsert idempotent côté worker).
     const republishTouchedMissions = async (missionIds: string[]): Promise<void> => {
-      for (let i = 0; i < missionIds.length; i += REINDEX_PUBLISH_CONCURRENCY) {
-        const batch = missionIds.slice(i, i + REINDEX_PUBLISH_CONCURRENCY);
-        await Promise.all(
-          batch.map(async (missionId) => {
-            try {
-              await asyncTaskBus.publish({ type: "mission.index", payload: { missionId, action: "upsert" } });
-              reindexRequested++;
-            } catch (error) {
-              reindexFailed++;
-              captureException(error, { extra: { missionId } });
-            }
-          })
-        );
-      }
+      await Promise.all(
+        missionIds.map(async (missionId) => {
+          try {
+            await asyncTaskBus.publish({ type: "mission.index", payload: { missionId, action: "upsert" } });
+            reindexRequested++;
+          } catch (error) {
+            reindexFailed++;
+            captureException(error, { extra: { missionId } });
+          }
+        })
+      );
     };
 
     for (const distributionPublisherId of distributionPublisherIds) {

--- a/api/src/jobs/mission-diffusion-rebuild/handler.ts
+++ b/api/src/jobs/mission-diffusion-rebuild/handler.ts
@@ -44,6 +44,9 @@ export class MissionDiffusionRebuildHandler implements BaseHandler<MissionDiffus
     // changé est republiée sur le bus (at-least-once, récupérable via SQS). On empile tout dans la
     // file d'un coup ; c'est au worker de réguler son débit de traitement. Les doublons entre
     // diffuseurs sont sans effet (upsert idempotent côté worker).
+    // Récupération : un échec de publish laisse `reindexFailed>0` (success=false) sans que la ligne SQL
+    // déjà écrite soit rejouée ⇒ relancer alors `update-mission-index` (réindexation complète) pour
+    // reconverger Typesense sur PostgreSQL.
     const republishTouchedMissions = async (missionIds: string[]): Promise<void> => {
       await Promise.all(
         missionIds.map(async (missionId) => {

--- a/api/src/jobs/mission-diffusion-rebuild/handler.ts
+++ b/api/src/jobs/mission-diffusion-rebuild/handler.ts
@@ -70,10 +70,17 @@ export class MissionDiffusionRebuildHandler implements BaseHandler<MissionDiffus
       );
     }
 
+    // Missions des diffuseurs sortis de la population : collectées AVANT la purge, puis republiées pour
+    // qu'elles perdent le diffuseur dans `distributionPublisherIds` côté Typesense (sinon elles
+    // continueraient d'apparaître dans /browse pour ce diffuseur jusqu'à une réindexation externe).
+    const prunedMissionIds = dryRun ? [] : await missionDiffusionRepository.findMissionIdsForDistributionPublishersNotIn(distributionPublisherIds);
+
     const prunedDistributionPublishers = dryRun
       ? await missionDiffusionRepository.countRowsForDistributionPublishersNotIn(distributionPublisherIds)
       : await missionDiffusionRepository.deleteRowsForDistributionPublishersNotIn(distributionPublisherIds);
     removed += prunedDistributionPublishers;
+
+    await republishTouchedMissions(prunedMissionIds);
     const durationMs = Date.now() - start.getTime();
 
     const mode = dryRun ? "Dry-run done" : "Done";

--- a/api/src/repositories/mission-diffusion.ts
+++ b/api/src/repositories/mission-diffusion.ts
@@ -63,6 +63,19 @@ export const missionDiffusionRepository = {
     return result.count;
   },
 
+  // Missions ayant au moins une ligne pour un publisher de diffusion sorti de la population du snapshot.
+  // À collecter AVANT la purge pour pouvoir les réindexer (elles doivent perdre ce diffuseur dans
+  // Typesense). Liste vide ⇒ toutes les missions matérialisées (mêmes bornes que la purge).
+  // `groupBy` = DISTINCT côté Postgres : borné au nombre de missions distinctes (≤ stock des missions),
+  // et non au nombre de lignes lues (contrairement au `distinct` Prisma, post-traité côté client).
+  async findMissionIdsForDistributionPublishersNotIn(distributionPublisherIds: string[], tx?: Prisma.TransactionClient): Promise<string[]> {
+    const rows = await client(tx).missionDiffusion.groupBy({
+      by: ["missionId"],
+      where: distributionPublisherIds.length ? { distributionPublisherId: { notIn: distributionPublisherIds } } : {},
+    });
+    return rows.map((row) => row.missionId);
+  },
+
   // Purge les lignes des publishers de diffusion sortis de la population du snapshot.
   // Liste vide ⇒ table vidée.
   async deleteRowsForDistributionPublishersNotIn(distributionPublisherIds: string[], tx?: Prisma.TransactionClient): Promise<number> {

--- a/api/src/services/mission-browse/__tests__/index.test.ts
+++ b/api/src/services/mission-browse/__tests__/index.test.ts
@@ -32,6 +32,8 @@ vi.mock("@/services/mission", () => ({
   missionService: { findMissionsByIds: findMissionsByIdsMock, findOneMissionBy: findOneMissionByMock },
 }));
 
+// Le service ne doit plus consulter les règles de diffusion live : ce mock est conservé pour garantir
+// (via not.toHaveBeenCalled) qu'aucun chemin ne les réintroduit.
 vi.mock("@/services/publisher-diffusion-rule", () => ({
   publisherDiffusionRuleService: { findRules: findRulesMock },
 }));
@@ -39,20 +41,8 @@ vi.mock("@/services/publisher-diffusion-rule", () => ({
 import { missionBrowseService } from "@/services/mission-browse";
 
 const baseParams = { page: 1, pageSize: 20, diffuseurPublisherId: "diffuseur-1" };
-const buildRule = (value: string, overrides: Record<string, unknown> = {}) => ({
-  id: `rule-${value}`,
-  publisherId: "diffuseur-1",
-  combinedWithId: null,
-  field: "publisherId",
-  fieldType: "string",
-  operator: "is",
-  value,
-  combinator: "or",
-  position: 0,
-  createdAt: new Date("2026-01-01T00:00:00.000Z"),
-  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
-  ...overrides,
-});
+// Filtre de diffusion attendu : le snapshot `mission_diffusion` dénormalisé dans le document Typesense.
+const DIFFUSION = "distributionPublisherIds:=`diffuseur-1`";
 
 describe("missionBrowseService.browse", () => {
   beforeEach(() => {
@@ -63,25 +53,18 @@ describe("missionBrowseService.browse", () => {
     multiSearchMock.mockResolvedValue(emptyMultiSearchResult());
     findMissionsByIdsMock.mockResolvedValue([]);
     findOneMissionByMock.mockResolvedValue(null);
-    findRulesMock.mockResolvedValue([buildRule("annonceur-1"), buildRule("annonceur-2")]);
   });
 
-  it("ne restreint pas la recherche quand aucune règle n'existe", async () => {
-    findRulesMock.mockResolvedValue([]);
-
+  it("applique systématiquement le filtre de diffusion issu du snapshot", async () => {
     await missionBrowseService.browse(baseParams);
 
-    expect(findRulesMock).toHaveBeenCalledWith({ publisherId: "diffuseur-1" });
-    expect(resultsSearch().filter_by).toBeUndefined();
+    expect(resultsSearch().filter_by).toBe(DIFFUSION);
   });
 
-  it("court-circuite quand des règles existent mais qu'aucune n'est supportée", async () => {
-    findRulesMock.mockResolvedValue([buildRule("annonceur-1", { field: "publisherOrganization.clientId" })]);
+  it("n'interroge plus les règles de diffusion live", async () => {
+    await missionBrowseService.browse(baseParams);
 
-    const result = await missionBrowseService.browse(baseParams);
-
-    expect(result).toEqual({ data: [], total: 0, page: 1, pageSize: 20, facets: {} });
-    expect(multiSearchMock).not.toHaveBeenCalled();
+    expect(findRulesMock).not.toHaveBeenCalled();
   });
 
   it("envoie une requête résultats + une requête par facette en un seul multi_search", async () => {
@@ -95,6 +78,14 @@ describe("missionBrowseService.browse", () => {
     expect(searches.slice(1).map((s) => s.facet_by)).toEqual(FACET_FIELDS);
   });
 
+  it("applique le filtre de diffusion à toutes les facettes", async () => {
+    await missionBrowseService.browse(baseParams);
+
+    for (const field of FACET_FIELDS) {
+      expect(facetSearch(field).filter_by).toBe(DIFFUSION);
+    }
+  });
+
   it("demande assez de valeurs pour la facette des départements", async () => {
     await missionBrowseService.browse(baseParams);
 
@@ -102,23 +93,10 @@ describe("missionBrowseService.browse", () => {
     expect(facetSearch("domaine").max_facet_values).toBe(100);
   });
 
-  it("applique la whitelist des annonceurs autorisés", async () => {
-    await missionBrowseService.browse(baseParams);
-
-    expect(findRulesMock).toHaveBeenCalledWith({ publisherId: "diffuseur-1" });
-    expect(resultsSearch().filter_by).toBe("publisherId:=[`annonceur-1`,`annonceur-2`]");
-  });
-
-  it("combine le publisher demandé avec la whitelist sans faire confiance au paramètre", async () => {
+  it("combine le publisher demandé avec le filtre de diffusion sans faire confiance au paramètre", async () => {
     await missionBrowseService.browse({ ...baseParams, publisherId: "annonceur-3" });
 
-    expect(resultsSearch().filter_by).toBe("publisherId:=[`annonceur-1`,`annonceur-2`] && publisherId:=`annonceur-3`");
-  });
-
-  it("combine le publisher demandé quand il est dans la whitelist", async () => {
-    await missionBrowseService.browse({ ...baseParams, publisherId: "annonceur-2" });
-
-    expect(resultsSearch().filter_by).toBe("publisherId:=[`annonceur-1`,`annonceur-2`] && publisherId:=`annonceur-2`");
+    expect(resultsSearch().filter_by).toBe(`${DIFFUSION} && publisherId:=\`annonceur-3\``);
   });
 
   it("calcule chaque facette en excluant son propre groupe (facettes disjonctives)", async () => {
@@ -128,13 +106,12 @@ describe("missionBrowseService.browse", () => {
       secteur_activite: ["sante"], // un autre groupe
     });
 
-    const diffusion = "publisherId:=[`annonceur-1`,`annonceur-2`]";
     // Les parts suivent l'ordre de INDEXED_TAXONOMY_KEYS : secteur_activite avant type_mission.
-    const allGroups = `${diffusion} && secteur_activite:=[\`sante\`] && type_mission:=[\`benevolat\`,\`volontariat\`]`;
+    const allGroups = `${DIFFUSION} && secteur_activite:=[\`sante\`] && type_mission:=[\`benevolat\`,\`volontariat\`]`;
     // La facette type_mission ignore SA sélection mais garde diffusion + l'autre groupe.
-    expect(facetSearch("type_mission").filter_by).toBe(`${diffusion} && secteur_activite:=[\`sante\`]`);
+    expect(facetSearch("type_mission").filter_by).toBe(`${DIFFUSION} && secteur_activite:=[\`sante\`]`);
     // La facette secteur_activite ignore SA sélection mais garde diffusion + type_mission.
-    expect(facetSearch("secteur_activite").filter_by).toBe(`${diffusion} && type_mission:=[\`benevolat\`,\`volontariat\`]`);
+    expect(facetSearch("secteur_activite").filter_by).toBe(`${DIFFUSION} && type_mission:=[\`benevolat\`,\`volontariat\`]`);
     // Une facette d'un groupe non sélectionné garde tous les filtres.
     expect(facetSearch("domaine").filter_by).toBe(allGroups);
     // La requête résultats applique tous les filtres.

--- a/api/src/services/mission-browse/__tests__/index.test.ts
+++ b/api/src/services/mission-browse/__tests__/index.test.ts
@@ -5,7 +5,6 @@ import { MISSION_BROWSE_FACET_FIELDS } from "@/services/search/collections/missi
 const multiSearchMock = vi.hoisted(() => vi.fn());
 const findMissionsByIdsMock = vi.hoisted(() => vi.fn());
 const findOneMissionByMock = vi.hoisted(() => vi.fn());
-const findRulesMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/services/search/collections/missions/client", () => ({
   missionSearchClient: { multiSearch: multiSearchMock },
@@ -32,12 +31,6 @@ vi.mock("@/services/mission", () => ({
   missionService: { findMissionsByIds: findMissionsByIdsMock, findOneMissionBy: findOneMissionByMock },
 }));
 
-// Le service ne doit plus consulter les règles de diffusion live : ce mock est conservé pour garantir
-// (via not.toHaveBeenCalled) qu'aucun chemin ne les réintroduit.
-vi.mock("@/services/publisher-diffusion-rule", () => ({
-  publisherDiffusionRuleService: { findRules: findRulesMock },
-}));
-
 import { missionBrowseService } from "@/services/mission-browse";
 
 const baseParams = { page: 1, pageSize: 20, diffuseurPublisherId: "diffuseur-1" };
@@ -49,7 +42,6 @@ describe("missionBrowseService.browse", () => {
     multiSearchMock.mockReset();
     findMissionsByIdsMock.mockReset();
     findOneMissionByMock.mockReset();
-    findRulesMock.mockReset();
     multiSearchMock.mockResolvedValue(emptyMultiSearchResult());
     findMissionsByIdsMock.mockResolvedValue([]);
     findOneMissionByMock.mockResolvedValue(null);
@@ -59,12 +51,6 @@ describe("missionBrowseService.browse", () => {
     await missionBrowseService.browse(baseParams);
 
     expect(resultsSearch().filter_by).toBe(DIFFUSION);
-  });
-
-  it("n'interroge plus les règles de diffusion live", async () => {
-    await missionBrowseService.browse(baseParams);
-
-    expect(findRulesMock).not.toHaveBeenCalled();
   });
 
   it("envoie une requête résultats + une requête par facette en un seul multi_search", async () => {
@@ -140,6 +126,5 @@ describe("missionBrowseService.browse", () => {
       deletedAt: null,
       statusCode: "ACCEPTED",
     });
-    expect(findRulesMock).not.toHaveBeenCalled();
   });
 });

--- a/api/src/services/mission-browse/index.ts
+++ b/api/src/services/mission-browse/index.ts
@@ -1,9 +1,7 @@
 import type { MissionBrowseFacetCount, MissionBrowseFilters, MissionBrowseResponse, MissionDetailResponse } from "@engagement/dto";
 
 import { missionService } from "@/services/mission";
-import { publisherDiffusionRuleService } from "@/services/publisher-diffusion-rule";
 import { missionSearchClient } from "@/services/search/collections/missions/client";
-import { publisherDiffusionRulesToMissionFilter } from "@/services/search/collections/missions/diffusion-rules-filter";
 import { INDEXED_TAXONOMY_KEYS, IndexedTaxonomyKey, MISSION_BROWSE_FACET_FIELDS } from "@/services/search/collections/missions/fields";
 import type { MissionIndexDocument } from "@/services/search/collections/missions/types";
 import { buildSearchEqualFilter, buildSearchListFilter } from "@/services/search/filter";
@@ -34,14 +32,6 @@ const toArray = (v: string | string[] | undefined): string[] | undefined => {
   }
   return Array.isArray(v) ? v : [v];
 };
-
-const emptyBrowseResponse = (params: Pick<BrowseParams, "page" | "pageSize">): MissionBrowseResponse => ({
-  data: [],
-  total: 0,
-  page: params.page,
-  pageSize: params.pageSize,
-  facets: {},
-});
 
 const DEFAULT_MAX_FACET_VALUES = 100;
 const MAX_FACET_VALUES_BY_FIELD: Partial<Record<(typeof MISSION_BROWSE_FACET_FIELDS)[number], number>> = {
@@ -81,8 +71,8 @@ const buildFacetFilterParts = (params: BrowseParams): Map<string, string> => {
   return parts;
 };
 
-const buildBrowseSearches = (params: BrowseParams, diffusionFilterBy?: string): SearchQueryParams<MissionIndexDocument>[] => {
-  const alwaysParts = [diffusionFilterBy ?? "", buildAlwaysFilterPart(params) ?? ""].filter(Boolean);
+const buildBrowseSearches = (params: BrowseParams, diffusionFilterBy: string): SearchQueryParams<MissionIndexDocument>[] => {
+  const alwaysParts = [diffusionFilterBy, buildAlwaysFilterPart(params) ?? ""].filter(Boolean);
   const facetParts = buildFacetFilterParts(params);
 
   const filterByExcluding = (excludedField?: string): string | undefined => {
@@ -105,13 +95,10 @@ const buildBrowseSearches = (params: BrowseParams, diffusionFilterBy?: string): 
 
 export const missionBrowseService = {
   async browse(params: BrowseParams): Promise<MissionBrowseResponse> {
-    const rules = await publisherDiffusionRuleService.findRules({ publisherId: params.diffuseurPublisherId });
-    const diffusionFilter = publisherDiffusionRulesToMissionFilter(rules);
-    if (diffusionFilter.kind === "none") {
-      return emptyBrowseResponse(params);
-    }
-
-    const searches = buildBrowseSearches(params, diffusionFilter.kind === "filter" ? diffusionFilter.filterBy : undefined);
+    // Autorisation de diffusion = snapshot `mission_diffusion` dénormalisé dans le document Typesense.
+    // Un diffuseur sans ligne de snapshot filtre naturellement à zéro (aucune lecture des rules live).
+    const diffusionFilterBy = buildSearchEqualFilter("distributionPublisherIds", params.diffuseurPublisherId);
+    const searches = buildBrowseSearches(params, diffusionFilterBy);
 
     const searchResults = await (async () => {
       try {

--- a/api/src/services/mission-diffusion/__tests__/index.test.ts
+++ b/api/src/services/mission-diffusion/__tests__/index.test.ts
@@ -172,4 +172,32 @@ describe("missionDiffusionService.rebuildForDistributionPublisher", () => {
     expect(missionDiffusionRepositoryMock.createManyForDistributionPublisher).not.toHaveBeenCalled();
     expect(missionDiffusionRepositoryMock.deleteManyForDistributionPublisher).not.toHaveBeenCalled();
   });
+
+  it("signale via onMissionsTouched les missions retirées puis ajoutées", async () => {
+    ruleServiceMock.buildMissionDiffuseurSnapshotWhere.mockResolvedValue({ publisherId: "annonceur-1" });
+    missionDiffusionRepositoryMock.findMissionIdsPageByDistributionPublisher.mockResolvedValue(["m2", "m4"]);
+    missionRepositoryMock.findIds.mockResolvedValue(["m2"]);
+    missionRepositoryMock.findIdsPage.mockResolvedValue(["m1", "m2", "m3"]);
+    missionDiffusionRepositoryMock.findExistingMissionIdsForDistributionPublisher.mockResolvedValue(["m2"]);
+    const onMissionsTouched = vi.fn().mockResolvedValue(undefined);
+
+    await missionDiffusionService.rebuildForDistributionPublisher("publisher-1", { onMissionsTouched });
+
+    // Suppressions avant insertions : m4 retirée, puis m1/m3 ajoutées.
+    expect(onMissionsTouched).toHaveBeenNthCalledWith(1, ["m4"]);
+    expect(onMissionsTouched).toHaveBeenNthCalledWith(2, ["m1", "m3"]);
+  });
+
+  it("n'appelle pas onMissionsTouched en dry-run", async () => {
+    ruleServiceMock.buildMissionDiffuseurSnapshotWhere.mockResolvedValue({ publisherId: "annonceur-1" });
+    missionDiffusionRepositoryMock.findMissionIdsPageByDistributionPublisher.mockResolvedValue(["m2", "m4"]);
+    missionRepositoryMock.findIds.mockResolvedValue(["m2"]);
+    missionRepositoryMock.findIdsPage.mockResolvedValue(["m1", "m2", "m3"]);
+    missionDiffusionRepositoryMock.findExistingMissionIdsForDistributionPublisher.mockResolvedValue(["m2"]);
+    const onMissionsTouched = vi.fn().mockResolvedValue(undefined);
+
+    await missionDiffusionService.rebuildForDistributionPublisher("publisher-1", { dryRun: true, onMissionsTouched });
+
+    expect(onMissionsTouched).not.toHaveBeenCalled();
+  });
 });

--- a/api/src/services/mission-diffusion/index.ts
+++ b/api/src/services/mission-diffusion/index.ts
@@ -16,6 +16,14 @@ export type MissionDiffusionRebuildDistributionPublisherResult = {
   dryRun?: boolean;
 };
 
+// Callback invoqué au fil des lots avec les missionId dont l'appartenance au snapshot a changé
+// (ajoutées ou retirées). Sert à resynchroniser Typesense après application des écritures. Jamais
+// appelé en dryRun.
+type RebuildOptions = {
+  dryRun?: boolean;
+  onMissionsTouched?: (missionIds: string[]) => Promise<void>;
+};
+
 const chunk = <T>(items: T[], size: number): T[][] => {
   const batches: T[][] = [];
   for (let index = 0; index < items.length; index += size) {
@@ -26,7 +34,7 @@ const chunk = <T>(items: T[], size: number): T[][] => {
 
 type SnapshotWhere = Awaited<ReturnType<typeof publisherDiffusionRuleService.buildMissionDiffuseurSnapshotWhere>>;
 
-const deleteStaleRowsByPages = async (distributionPublisherId: string, snapshotWhere: SnapshotWhere, options: { dryRun?: boolean }): Promise<number> => {
+const deleteStaleRowsByPages = async (distributionPublisherId: string, snapshotWhere: SnapshotWhere, options: RebuildOptions): Promise<number> => {
   let removed = 0;
   let afterMissionId: string | undefined;
 
@@ -45,6 +53,10 @@ const deleteStaleRowsByPages = async (distributionPublisherId: string, snapshotW
       removed += options.dryRun ? batch.length : await missionDiffusionRepository.deleteManyForDistributionPublisher(distributionPublisherId, batch);
     }
 
+    if (!options.dryRun && toRemove.length > 0 && options.onMissionsTouched) {
+      await options.onMissionsTouched(toRemove);
+    }
+
     if (existingIds.length < READ_PAGE_SIZE) {
       break;
     }
@@ -53,11 +65,7 @@ const deleteStaleRowsByPages = async (distributionPublisherId: string, snapshotW
   return removed;
 };
 
-const createMissingRowsByPages = async (
-  distributionPublisherId: string,
-  snapshotWhere: SnapshotWhere,
-  options: { dryRun?: boolean }
-): Promise<{ desired: number; added: number }> => {
+const createMissingRowsByPages = async (distributionPublisherId: string, snapshotWhere: SnapshotWhere, options: RebuildOptions): Promise<{ desired: number; added: number }> => {
   let desired = 0;
   let added = 0;
   let afterId: string | undefined;
@@ -78,6 +86,10 @@ const createMissingRowsByPages = async (
       added += options.dryRun ? batch.length : await missionDiffusionRepository.createManyForDistributionPublisher(distributionPublisherId, batch);
     }
 
+    if (!options.dryRun && toAdd.length > 0 && options.onMissionsTouched) {
+      await options.onMissionsTouched(toAdd);
+    }
+
     if (desiredIds.length < READ_PAGE_SIZE) {
       break;
     }
@@ -91,7 +103,7 @@ export const missionDiffusionService = {
    * Reconstruit le snapshot d'un publisher de diffusion par diff paginé. Les suppressions sont
    * appliquées avant les insertions pour éviter un snapshot transitoirement plus permissif.
    */
-  async rebuildForDistributionPublisher(distributionPublisherId: string, options: { dryRun?: boolean } = {}): Promise<MissionDiffusionRebuildDistributionPublisherResult> {
+  async rebuildForDistributionPublisher(distributionPublisherId: string, options: RebuildOptions = {}): Promise<MissionDiffusionRebuildDistributionPublisherResult> {
     const start = Date.now();
     const snapshotWhere = await publisherDiffusionRuleService.buildMissionDiffuseurSnapshotWhere(distributionPublisherId);
 

--- a/api/src/services/search/collections/missions/schemas/v4.ts
+++ b/api/src/services/search/collections/missions/schemas/v4.ts
@@ -3,12 +3,11 @@ import type { TaxonomyKey } from "@engagement/taxonomy";
 import { TYPESENSE_MISSION_COLLECTION } from "@/config";
 import type { SearchCollectionSchema } from "@/services/search/types";
 
-import { MISSION_TAXONOMY_FIELDS_V3 } from "./v3";
-
-// Snapshot statique des champs indexés à l'instant de la v4.
-// Ajout par rapport à la v3 : `distributionPublisherIds` (diffuseurs autorisés par le snapshot mission_diffusion).
-// Pour ajouter/retirer des champs, créer un v5.ts — ne pas modifier ce fichier.
-export const MISSION_TAXONOMY_FIELDS_V4: TaxonomyKey[] = MISSION_TAXONOMY_FIELDS_V3;
+// Snapshot statique et autonome des champs indexés à l'instant de la v4 (aucune dépendance aux
+// versions précédentes). Ajout par rapport à la v3 : `distributionPublisherIds` (diffuseurs autorisés
+// par le snapshot mission_diffusion). Pour ajouter/retirer des champs, créer un v5.ts — ne pas modifier
+// ce fichier.
+export const MISSION_TAXONOMY_FIELDS_V4: TaxonomyKey[] = ["domaine", "secteur_activite", "type_mission", "tranche_age", "dispositif"];
 const taxonomyFields = MISSION_TAXONOMY_FIELDS_V4;
 
 const schema: SearchCollectionSchema = {

--- a/api/src/services/search/collections/missions/schemas/v4.ts
+++ b/api/src/services/search/collections/missions/schemas/v4.ts
@@ -3,11 +3,12 @@ import type { TaxonomyKey } from "@engagement/taxonomy";
 import { TYPESENSE_MISSION_COLLECTION } from "@/config";
 import type { SearchCollectionSchema } from "@/services/search/types";
 
-// Snapshot statique et autonome des champs indexés à l'instant de la v4 (aucune dépendance aux
-// versions précédentes). Ajout par rapport à la v3 : `distributionPublisherIds` (diffuseurs autorisés
-// par le snapshot mission_diffusion). Pour ajouter/retirer des champs, créer un v5.ts — ne pas modifier
-// ce fichier.
-export const MISSION_TAXONOMY_FIELDS_V4: TaxonomyKey[] = ["domaine", "secteur_activite", "type_mission", "tranche_age", "dispositif"];
+import { MISSION_TAXONOMY_FIELDS_V3 } from "./v3";
+
+// Snapshot statique des champs indexés à l'instant de la v4.
+// Ajout par rapport à la v3 : `distributionPublisherIds` (diffuseurs autorisés par le snapshot mission_diffusion).
+// Pour ajouter/retirer des champs, créer un v5.ts — ne pas modifier ce fichier.
+export const MISSION_TAXONOMY_FIELDS_V4: TaxonomyKey[] = MISSION_TAXONOMY_FIELDS_V3;
 const taxonomyFields = MISSION_TAXONOMY_FIELDS_V4;
 
 const schema: SearchCollectionSchema = {

--- a/api/tests/integration/jobs/mission-diffusion/rebuild.handler.test.ts
+++ b/api/tests/integration/jobs/mission-diffusion/rebuild.handler.test.ts
@@ -1,10 +1,16 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// La resynchronisation Typesense (publication sur le bus des missions touchées) est couverte en tests
+// unitaires ; ici on la neutralise pour cibler la correction du snapshot Postgres, tout en gardant un
+// spy pour vérifier le câblage.
+const publishMock = vi.hoisted(() => vi.fn());
+vi.mock("@/services/async-task", () => ({ asyncTaskBus: { publish: publishMock } }));
 
 import { prisma } from "@/db/postgres";
 import { MissionDiffusionRebuildHandler } from "@/jobs/mission-diffusion-rebuild/handler";
 import { missionDiffusionRepository } from "@/repositories/mission-diffusion";
-import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import { publisherService } from "@/services/publisher";
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 
 import { createTestMission, createTestPublisher } from "../../../fixtures";
 
@@ -27,6 +33,8 @@ describe("MissionDiffusionRebuildHandler", () => {
   let annonceur: Awaited<ReturnType<typeof createTestPublisher>>;
 
   beforeEach(async () => {
+    publishMock.mockReset();
+    publishMock.mockResolvedValue(undefined);
     diffuser = await createTestPublisher({ name: "Diffuseur" });
     annonceur = await createTestPublisher({ name: "Annonceur", hasApiRights: false });
   });
@@ -48,6 +56,11 @@ describe("MissionDiffusionRebuildHandler", () => {
     // Ni les missions supprimées, ni les missions des publishers hors périmètre.
     expect((await tableMissionIds(diffuser.id)).has(deleted.id)).toBe(false);
     expect((await tableMissionIds(diffuser.id)).has(other.id)).toBe(false);
+
+    // Chaque mission ajoutée au snapshot est republiée sur le bus pour resynchroniser Typesense.
+    expect(result.reindexRequested).toBe(2);
+    expect(publishMock).toHaveBeenCalledWith({ type: "mission.index", payload: { missionId: fromAnnonceur.id, action: "upsert" } });
+    expect(publishMock).toHaveBeenCalledWith({ type: "mission.index", payload: { missionId: own.id, action: "upsert" } });
   });
 
   it("respecte une exclusion d'organisation (jointure publisher_organization réelle)", async () => {

--- a/api/tests/integration/jobs/mission-diffusion/rebuild.handler.test.ts
+++ b/api/tests/integration/jobs/mission-diffusion/rebuild.handler.test.ts
@@ -142,9 +142,13 @@ describe("MissionDiffusionRebuildHandler", () => {
     await publisherService.softDeletePublisher(diffuser.id);
     expect(await publisherDiffusionRuleService.findRules({ publisherId: diffuser.id })).not.toHaveLength(0);
 
+    // On isole la republication du run de purge (le premier run a déjà publié la mission à l'ajout).
+    publishMock.mockClear();
     const result = await handler.handle({});
 
     expect(await tableMissionIds(diffuser.id)).toEqual(new Set());
     expect(result.prunedDistributionPublishers).toBeGreaterThan(0);
+    // La mission purgée est republiée pour perdre le diffuseur côté Typesense.
+    expect(publishMock).toHaveBeenCalledWith({ type: "mission.index", payload: { missionId: mission.id, action: "upsert" } });
   });
 });


### PR DESCRIPTION
## Description

Seconde phase (cutover) du passage de `/missions/browse` sur le snapshot `mission_diffusion`.

La PR précédente (#1334, mergée) a installé et alimenté le champ Typesense `distributionPublisherIds`. Cette PR bascule l'autorisation de la liste dessus et supprime la dernière lecture des règles live dans `mission-browse`, ce qui aligne enfin la **liste** et le **détail** sur la même source (le détail lisait déjà `mission_diffusion` depuis #1302 — d'où l'incohérence liste/détail que ce chantier corrige).

**Cutover de `browse()`** — `services/mission-browse/index.ts`
- Suppression de `publisherDiffusionRuleService.findRules` + `publisherDiffusionRulesToMissionFilter` (plus aucune lecture de règle live dans ce service).
- Filtre de diffusion = `distributionPublisherIds:=<diffuseur>`, injecté dans `alwaysParts` → appliqué à la recherche principale **et** à toutes les sous-requêtes de facettes (facettes disjonctives préservées). Intersection avec le filtre `publisherId` explicite conservée.
- `findById()` inchangé (déjà sur `missionDiffusions.some`).

**Synchronisation Typesense après rebuild** — `services/mission-diffusion` + `jobs/mission-diffusion-rebuild`
- Le rebuild republie sur le bus async (`mission.index` / SQS) chaque mission dont l'appartenance au snapshot a changé (ajout/retrait), au fil des pages (at-least-once, récupérable ; jamais en `dryRun`).
- Compteurs `reindexRequested` / `reindexFailed` ajoutés au résultat ; `success=false` en cas d'échec de publication. Doublons entre diffuseurs sans effet (upsert idempotent côté worker).

## Liens utiles

- 🔗 PR précédente : #1334 (schéma v4 + alimentation `distributionPublisherIds`)
- [Ticket](https://app.notion.com/p/jeveuxaider/Cutover-de-missions-browse-vers-la-table-mission_diffusion-3a572a322d508044a929ecf3de16576b?source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Prérequis de déploiement** : cette PR ne doit être activée qu'une fois le champ `distributionPublisherIds` présent et peuplé sur tous les documents actifs (setup v4 + réindexation complète livrés en #1334), gate de couverture PostgreSQL ↔ Typesense vérifiée. Sinon `browse()` filtrerait sur un champ vide → résultats vides.

**Changements fonctionnels à valider produit** :
- **Diffuseur sans règle** : passait par « aucune restriction = toutes les missions indexées », devient « missions propres uniquement » (comportement du snapshot). Correction attendue, mais changement de visibilité en production.
- **Missions fraîches** : une mission créée n'entre dans le snapshot qu'au prochain rebuild (fenêtre 6 h+) → invisible en liste jusque-là. Liste et détail restent cohérents (le détail lit le même snapshot).

**Hors périmètre — PR dédiée à suivre** :
- **Drift-check** PostgreSQL ↔ Typesense (avec alignement de population : `mission_diffusion` contient plus large que l'index — non supprimées tous statuts — vs Typesense ACCEPTED + scorées). Rattrape un crash entre commit SQL et republication.
- **Diffuseurs purgés** de la population : leurs missions gardent le diffuseur dans Typesense tant que le drift-check ne les republie pas (le chemin incrémental ne couvre que les deltas par diffuseur en scope).