### PR TITLE
feat(api): add mission diffusion lifecycle worker

### DIFF
--- a/api/src/jobs/import-missions/handler.ts
+++ b/api/src/jobs/import-missions/handler.ts
@@ -248,6 +248,9 @@ async function importMissionssForPublisher(publisher: PublisherRecord, start: Da
       });
       const existingOrganizationsMap = new Map(existingOrganizations.map((o) => [o.clientId, o]));
       console.log(`[${publisher.name}] Found ${existingOrganizations.length} existing organizations`);
+      // Organisations dont le contenu a changé sur ce run : une mission par ailleurs inchangée
+      // mais rattachée à l'une d'elles doit tout de même être re-diffusée (réseaux/parentOrganizations).
+      const changedOrganizationClientIds = new Set<string>();
       let createdOrganizationsCount = 0;
       let updatedOrganizationsCount = 0;
       let unchangedOrganizationsCount = 0;
@@ -256,6 +259,8 @@ async function importMissionssForPublisher(publisher: PublisherRecord, start: Da
         const result = await upsertOrganization(organization, existing);
         if (result.action === "unchanged") {
           unchangedOrganizationsCount += 1;
+        } else {
+          changedOrganizationClientIds.add(organization.clientId);
         }
         existingOrganizationsMap.set(organization.clientId, result.organization);
         createdOrganizationsCount += result.action === "created" ? 1 : 0;
@@ -281,7 +286,8 @@ async function importMissionssForPublisher(publisher: PublisherRecord, start: Da
         }
 
         const existing = existingMap.get(mission.clientId) || null;
-        const result = await upsertMission(mission, existing);
+        const relatedDiffusionDataChanged = mission.organizationClientId ? changedOrganizationClientIds.has(mission.organizationClientId) : false;
+        const result = await upsertMission(mission, existing, { relatedDiffusionDataChanged });
         existingMap.set(mission.clientId, result.mission);
 
         if (result.action === "created") {

--- a/api/src/jobs/import-missions/utils/__tests__/db.test.ts
+++ b/api/src/jobs/import-missions/utils/__tests__/db.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createMock, updateMock, enqueueDiffusionMock, getMissionChangesMock } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  updateMock: vi.fn(),
+  enqueueDiffusionMock: vi.fn(),
+  getMissionChangesMock: vi.fn(),
+}));
+
+vi.mock("@/services/mission", () => ({
+  missionService: { create: createMock, update: updateMock, enqueueMissionDiffusion: enqueueDiffusionMock },
+}));
+vi.mock("@/services/publisher-organization", () => ({ default: {} }));
+vi.mock("@/utils/mission", () => ({ getMissionChanges: getMissionChangesMock }));
+vi.mock("@/utils/publisher-organization", () => ({ getPublisherOrganizationChanges: vi.fn() }));
+vi.mock("@/utils/job", () => ({ getJobTime: vi.fn() }));
+
+import { upsertMission } from "@/jobs/import-missions/utils/db";
+
+const existingMission = { id: "mission-1" } as never;
+const input = { clientId: "c-1" } as never;
+
+describe("upsertMission — re-diffusion sur changement de l'organisation liée", () => {
+  beforeEach(() => {
+    createMock.mockReset();
+    updateMock.mockReset().mockResolvedValue(existingMission);
+    enqueueDiffusionMock.mockReset().mockResolvedValue(undefined);
+    getMissionChangesMock.mockReset();
+  });
+
+  it("mission inchangée mais organisation liée modifiée → enqueue la diffusion sans réécrire la mission", async () => {
+    getMissionChangesMock.mockReturnValue(null);
+
+    const result = await upsertMission(input, existingMission, { relatedDiffusionDataChanged: true });
+
+    expect(result.action).toBe("unchanged");
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(enqueueDiffusionMock).toHaveBeenCalledWith("mission-1");
+  });
+
+  it("mission inchangée et organisation liée inchangée → aucun effet de bord", async () => {
+    getMissionChangesMock.mockReturnValue(null);
+
+    const result = await upsertMission(input, existingMission, { relatedDiffusionDataChanged: false });
+
+    expect(result.action).toBe("unchanged");
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(enqueueDiffusionMock).not.toHaveBeenCalled();
+  });
+
+  it("mission modifiée → propage relatedDiffusionDataChanged au service (pas d'enqueue direct)", async () => {
+    getMissionChangesMock.mockReturnValue({ places: { previous: 1, current: 2 } });
+
+    const result = await upsertMission(input, existingMission, { relatedDiffusionDataChanged: true });
+
+    expect(result.action).toBe("updated");
+    expect(updateMock).toHaveBeenCalledWith("mission-1", input, { relatedDiffusionDataChanged: true });
+    expect(enqueueDiffusionMock).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/jobs/import-missions/utils/db.ts
+++ b/api/src/jobs/import-missions/utils/db.ts
@@ -62,7 +62,11 @@ type UpsertMissionResult = {
  * @param existing - The existing mission from DB (or null if not found)
  * @returns The result of the upsert operation
  */
-export const upsertMission = async (input: ImportedMission, existing: MissionRecord | null): Promise<UpsertMissionResult> => {
+export const upsertMission = async (
+  input: ImportedMission,
+  existing: MissionRecord | null,
+  options: { relatedDiffusionDataChanged?: boolean } = {}
+): Promise<UpsertMissionResult> => {
   // Create new mission
   if (!existing) {
     const created = await missionService.create(input);
@@ -75,13 +79,21 @@ export const upsertMission = async (input: ImportedMission, existing: MissionRec
   // Check if update is needed
   const changes = getMissionChanges(existing, input);
   if (!changes) {
+    // La ligne mission est identique, mais une donnée de l'organisation liée (ex.
+    // réseaux/parentOrganizations) a pu changer : on redéclenche la diffusion sans réécrire
+    // la mission ni relancer l'enrichissement (cf. relatedDiffusionDataChanged côté API v2).
+    if (options.relatedDiffusionDataChanged) {
+      await missionService.enqueueMissionDiffusion(existing.id);
+    }
     return {
       action: "unchanged",
       mission: existing,
     };
   }
 
-  const updated = await missionService.update(existing.id, input as MissionUpdatePatch);
+  const updated = await missionService.update(existing.id, input as MissionUpdatePatch, {
+    relatedDiffusionDataChanged: options.relatedDiffusionDataChanged,
+  });
   return {
     action: "updated",
     mission: updated,

--- a/api/src/jobs/update-mission-scoring/handler.ts
+++ b/api/src/jobs/update-mission-scoring/handler.ts
@@ -83,7 +83,7 @@ export class UpdateMissionScoringHandler implements BaseHandler<UpdateMissionSco
       for (const enrichment of enrichments) {
         try {
           await missionScoringService.score({ missionId: enrichment.missionId, missionEnrichmentId: enrichment.id, force });
-          await asyncTaskBus.publish({ type: "mission.index", payload: { missionId: enrichment.missionId, action: "upsert" } });
+          await asyncTaskBus.publish({ type: "mission.diffusion", payload: { missionId: enrichment.missionId } });
           processed++;
           console.log(`${LOG_PREFIX} [${processed}/${enrichments.length}] scored mission=${enrichment.missionId}`);
         } catch (error) {

--- a/api/src/repositories/__tests__/mission-diffusion.test.ts
+++ b/api/src/repositories/__tests__/mission-diffusion.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { prisma } from "@/db/postgres";
+import { missionDiffusionRepository } from "@/repositories/mission-diffusion";
+
+const prismaMock = prisma as unknown as {
+  $queryRaw: ReturnType<typeof vi.fn>;
+};
+
+const getSqlText = (query: unknown): string => {
+  if (typeof query === "object" && query !== null && "strings" in query && Array.isArray(query.strings)) {
+    return query.strings.join("");
+  }
+  return "";
+};
+
+describe("missionDiffusionRepository.findDistributionPublisherIdsForMission", () => {
+  beforeEach(() => {
+    prismaMock.$queryRaw.mockReset();
+  });
+
+  it("ne requête pas PostgreSQL sans scope candidat", async () => {
+    await expect(missionDiffusionRepository.findDistributionPublisherIdsForMission("mission-1", [])).resolves.toEqual([]);
+    expect(prismaMock.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it("compile tous les scopes avec le compilateur SQL existant", async () => {
+    prismaMock.$queryRaw.mockResolvedValue([
+      { distributionPublisherId: "diffuseur-1" },
+      { distributionPublisherId: "diffuseur-1" },
+    ]);
+
+    const result = await missionDiffusionRepository.findDistributionPublisherIdsForMission("mission-1", [
+      {
+        distributionPublisherId: "diffuseur-1",
+        rules: [
+          { field: "publisherId", fieldType: "string", operator: "is", value: "annonceur-1", combinator: "or" },
+          {
+            field: "publisherOrganization.parentOrganizations",
+            fieldType: "string",
+            operator: "does_not_contain",
+            value: "network-1",
+            combinator: "or",
+          },
+        ],
+      },
+      {
+        distributionPublisherId: "diffuseur-2",
+        rules: [{ field: "publisherId", fieldType: "string", operator: "is", value: "annonceur-1", combinator: "or" }],
+      },
+    ]);
+
+    const sql = getSqlText(prismaMock.$queryRaw.mock.calls[0][0]);
+    expect(sql).toContain('FROM "mission" m');
+    expect(sql).toContain("UNION ALL");
+    expect(sql).toContain("unnest");
+    expect(result).toEqual(["diffuseur-1"]);
+  });
+});

--- a/api/src/repositories/mission-diffusion.ts
+++ b/api/src/repositories/mission-diffusion.ts
@@ -1,5 +1,11 @@
 import { Prisma } from "@/db/core";
 import { prisma } from "@/db/postgres";
+import { buildMissionPublisherDiffusionScopeSqlFromRules, type PublisherDiffusionRuleCondition } from "@/utils/publisher-diffusion-rule-query";
+
+export type MissionDiffusionPublisherScope = {
+  distributionPublisherId: string;
+  rules: PublisherDiffusionRuleCondition[];
+};
 
 // Permet d'exécuter les opérations dans une transaction Prisma existante (tx) ou hors transaction.
 const client = (tx?: Prisma.TransactionClient) => tx ?? prisma;
@@ -117,5 +123,24 @@ export const missionDiffusionRepository = {
 
       return { added: added.count, removed: removed.count };
     });
+  },
+
+  async findDistributionPublisherIdsForMission(missionId: string, scopes: MissionDiffusionPublisherScope[]): Promise<string[]> {
+    if (scopes.length === 0) {
+      return [];
+    }
+
+    const scopeQueries = scopes.map((scope) => {
+      return Prisma.sql`
+        SELECT ${scope.distributionPublisherId}::text AS "distributionPublisherId"
+        FROM "mission" m
+        WHERE m."id" = ${missionId}
+          AND m."deleted_at" IS NULL
+          ${buildMissionPublisherDiffusionScopeSqlFromRules(scope.rules)}
+      `;
+    });
+
+    const rows = await prisma.$queryRaw<Array<{ distributionPublisherId: string }>>(Prisma.sql`${Prisma.join(scopeQueries, " UNION ALL ")}`);
+    return Array.from(new Set(rows.map((row) => row.distributionPublisherId)));
   },
 };

--- a/api/src/repositories/mission-diffusion.ts
+++ b/api/src/repositories/mission-diffusion.ts
@@ -98,4 +98,24 @@ export const missionDiffusionRepository = {
   async count(tx?: Prisma.TransactionClient): Promise<number> {
     return client(tx).missionDiffusion.count();
   },
+
+  async replaceForMission(missionId: string, distributionPublisherIds: string[]): Promise<{ added: number; removed: number }> {
+    return prisma.$transaction(async (tx) => {
+      const removed = await tx.missionDiffusion.deleteMany({
+        where: {
+          missionId,
+          ...(distributionPublisherIds.length > 0 ? { distributionPublisherId: { notIn: distributionPublisherIds } } : {}),
+        },
+      });
+      const added =
+        distributionPublisherIds.length > 0
+          ? await tx.missionDiffusion.createMany({
+              data: distributionPublisherIds.map((distributionPublisherId) => ({ distributionPublisherId, missionId })),
+              skipDuplicates: true,
+            })
+          : { count: 0 };
+
+      return { added: added.count, removed: removed.count };
+    });
+  },
 };

--- a/api/src/services/__tests__/mission.test.ts
+++ b/api/src/services/__tests__/mission.test.ts
@@ -1,13 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { enqueueMock, captureExceptionMock } = vi.hoisted(() => ({
+const { enqueueMock, diffusionEnqueueMock, captureExceptionMock } = vi.hoisted(() => ({
   enqueueMock: vi.fn(),
+  diffusionEnqueueMock: vi.fn(),
   captureExceptionMock: vi.fn(),
 }));
 
 vi.mock("@/services/mission-enrichment", () => ({
   missionEnrichmentService: { enqueue: enqueueMock },
   buildMissionEnrichmentScoringWhere: vi.fn(),
+}));
+
+vi.mock("@/services/mission-diffusion", () => ({
+  missionDiffusionService: { enqueue: diffusionEnqueueMock },
 }));
 
 vi.mock("@/error", () => ({
@@ -63,6 +68,33 @@ describe("missionService.enqueueMissionProcessing", () => {
 
     expect(captureExceptionMock).toHaveBeenCalledWith(error, {
       extra: { context: "enqueueMissionProcessing", missionId: "mission-1" },
+    });
+  });
+});
+
+describe("missionService.enqueueMissionDiffusion", () => {
+  beforeEach(() => {
+    diffusionEnqueueMock.mockReset();
+    captureExceptionMock.mockReset();
+  });
+
+  it("délègue la publication au service de diffusion", async () => {
+    diffusionEnqueueMock.mockResolvedValue(undefined);
+
+    await missionService.enqueueMissionDiffusion("mission-1");
+
+    expect(diffusionEnqueueMock).toHaveBeenCalledWith("mission-1");
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("conserve le caractère best-effort de la publication", async () => {
+    const error = new Error("queue unavailable");
+    diffusionEnqueueMock.mockRejectedValue(error);
+
+    await expect(missionService.enqueueMissionDiffusion("mission-1")).resolves.toBeUndefined();
+
+    expect(captureExceptionMock).toHaveBeenCalledWith(error, {
+      extra: { context: "enqueueMissionDiffusion", missionId: "mission-1" },
     });
   });
 });

--- a/api/src/services/mission-diffusion/__tests__/index.test.ts
+++ b/api/src/services/mission-diffusion/__tests__/index.test.ts
@@ -15,6 +15,7 @@ vi.mock("@/repositories/mission-diffusion", () => ({
     findExistingMissionIdsForDistributionPublisher: vi.fn(),
     createManyForDistributionPublisher: vi.fn(),
     deleteManyForDistributionPublisher: vi.fn(),
+    findDistributionPublisherIdsForMission: vi.fn(),
     replaceForMission: vi.fn(),
   },
 }));
@@ -22,7 +23,7 @@ vi.mock("@/repositories/mission-diffusion", () => ({
 vi.mock("@/services/publisher-diffusion-rule", () => {
   const service = {
     buildMissionDiffuseurSnapshotWhere: vi.fn(),
-    findDistributionPublisherIdsForMission: vi.fn(),
+    findDistributionPublisherScopesForMission: vi.fn(),
   };
   return { default: service, publisherDiffusionRuleService: service };
 });
@@ -49,11 +50,12 @@ const missionDiffusionRepositoryMock = missionDiffusionRepository as unknown as 
   findExistingMissionIdsForDistributionPublisher: ReturnType<typeof vi.fn>;
   createManyForDistributionPublisher: ReturnType<typeof vi.fn>;
   deleteManyForDistributionPublisher: ReturnType<typeof vi.fn>;
+  findDistributionPublisherIdsForMission: ReturnType<typeof vi.fn>;
   replaceForMission: ReturnType<typeof vi.fn>;
 };
 const ruleServiceMock = publisherDiffusionRuleService as unknown as {
   buildMissionDiffuseurSnapshotWhere: ReturnType<typeof vi.fn>;
-  findDistributionPublisherIdsForMission: ReturnType<typeof vi.fn>;
+  findDistributionPublisherScopesForMission: ReturnType<typeof vi.fn>;
 };
 
 beforeEach(() => {
@@ -66,6 +68,7 @@ beforeEach(() => {
   missionDiffusionRepositoryMock.findExistingMissionIdsForDistributionPublisher.mockResolvedValue([]);
   missionDiffusionRepositoryMock.createManyForDistributionPublisher.mockImplementation(async (_distributionPublisherId: string, ids: string[]) => ids.length);
   missionDiffusionRepositoryMock.deleteManyForDistributionPublisher.mockImplementation(async (_distributionPublisherId: string, ids: string[]) => ids.length);
+  missionDiffusionRepositoryMock.findDistributionPublisherIdsForMission.mockResolvedValue([]);
   missionDiffusionRepositoryMock.replaceForMission.mockResolvedValue({ added: 0, removed: 0 });
 });
 
@@ -220,28 +223,22 @@ describe("missionDiffusionService.rebuildForMission", () => {
   it("remplace le snapshot de la mission par les diffuseurs calculés", async () => {
     missionRepositoryMock.findUnique.mockResolvedValue({
       publisherId: "annonceur-1",
-      publisherOrganizationId: "organization-1",
-      type: "BENEVOLAT",
       deletedAt: null,
-      publisherOrganization: {
-        clientId: "organization-client-1",
-        parentOrganizations: ["network-1"],
-      },
     });
-    ruleServiceMock.findDistributionPublisherIdsForMission.mockResolvedValue(["diffuseur-1", "diffuseur-2"]);
+    const scopes = [
+      {
+        distributionPublisherId: "diffuseur-1",
+        rules: [{ field: "publisherId", fieldType: "string", operator: "is", value: "annonceur-1", combinator: "or" }],
+      },
+    ];
+    ruleServiceMock.findDistributionPublisherScopesForMission.mockResolvedValue(scopes);
+    missionDiffusionRepositoryMock.findDistributionPublisherIdsForMission.mockResolvedValue(["diffuseur-1", "diffuseur-2"]);
     missionDiffusionRepositoryMock.replaceForMission.mockResolvedValue({ added: 1, removed: 2 });
 
     const result = await missionDiffusionService.rebuildForMission("mission-1");
 
-    expect(ruleServiceMock.findDistributionPublisherIdsForMission).toHaveBeenCalledWith({
-      publisherId: "annonceur-1",
-      publisherOrganizationId: "organization-1",
-      type: "BENEVOLAT",
-      publisherOrganization: {
-        clientId: "organization-client-1",
-        parentOrganizations: ["network-1"],
-      },
-    });
+    expect(ruleServiceMock.findDistributionPublisherScopesForMission).toHaveBeenCalledWith("annonceur-1");
+    expect(missionDiffusionRepositoryMock.findDistributionPublisherIdsForMission).toHaveBeenCalledWith("mission-1", scopes);
     expect(missionDiffusionRepositoryMock.replaceForMission).toHaveBeenCalledWith("mission-1", ["diffuseur-1", "diffuseur-2"]);
     expect(result).toMatchObject({ missionId: "mission-1", desired: 2, added: 1, removed: 2 });
   });
@@ -252,10 +249,7 @@ describe("missionDiffusionService.rebuildForMission", () => {
       "supprimée",
       {
         publisherId: "annonceur-1",
-        publisherOrganizationId: null,
-        type: "BENEVOLAT",
         deletedAt: new Date(),
-        publisherOrganization: null,
       },
     ],
   ])("purge le snapshot d'une mission %s", async (_label, mission) => {
@@ -264,7 +258,8 @@ describe("missionDiffusionService.rebuildForMission", () => {
 
     const result = await missionDiffusionService.rebuildForMission("mission-1");
 
-    expect(ruleServiceMock.findDistributionPublisherIdsForMission).not.toHaveBeenCalled();
+    expect(ruleServiceMock.findDistributionPublisherScopesForMission).not.toHaveBeenCalled();
+    expect(missionDiffusionRepositoryMock.findDistributionPublisherIdsForMission).toHaveBeenCalledWith("mission-1", []);
     expect(missionDiffusionRepositoryMock.replaceForMission).toHaveBeenCalledWith("mission-1", []);
     expect(result).toMatchObject({ desired: 0, added: 0, removed: 2 });
   });

--- a/api/src/services/mission-diffusion/__tests__/index.test.ts
+++ b/api/src/services/mission-diffusion/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/repositories/mission", () => ({
   missionRepository: {
+    findUnique: vi.fn(),
     findIds: vi.fn(),
     findIdsPage: vi.fn(),
   },
@@ -14,15 +15,23 @@ vi.mock("@/repositories/mission-diffusion", () => ({
     findExistingMissionIdsForDistributionPublisher: vi.fn(),
     createManyForDistributionPublisher: vi.fn(),
     deleteManyForDistributionPublisher: vi.fn(),
+    replaceForMission: vi.fn(),
   },
 }));
 
 vi.mock("@/services/publisher-diffusion-rule", () => {
   const service = {
     buildMissionDiffuseurSnapshotWhere: vi.fn(),
+    findDistributionPublisherIdsForMission: vi.fn(),
   };
   return { default: service, publisherDiffusionRuleService: service };
 });
+
+vi.mock("@/services/async-task", () => ({
+  asyncTaskBus: {
+    publish: vi.fn(),
+  },
+}));
 
 import { missionRepository } from "@/repositories/mission";
 import { missionDiffusionRepository } from "@/repositories/mission-diffusion";
@@ -30,6 +39,7 @@ import { missionDiffusionService } from "@/services/mission-diffusion";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 
 const missionRepositoryMock = missionRepository as unknown as {
+  findUnique: ReturnType<typeof vi.fn>;
   findIds: ReturnType<typeof vi.fn>;
   findIdsPage: ReturnType<typeof vi.fn>;
 };
@@ -39,9 +49,11 @@ const missionDiffusionRepositoryMock = missionDiffusionRepository as unknown as 
   findExistingMissionIdsForDistributionPublisher: ReturnType<typeof vi.fn>;
   createManyForDistributionPublisher: ReturnType<typeof vi.fn>;
   deleteManyForDistributionPublisher: ReturnType<typeof vi.fn>;
+  replaceForMission: ReturnType<typeof vi.fn>;
 };
 const ruleServiceMock = publisherDiffusionRuleService as unknown as {
   buildMissionDiffuseurSnapshotWhere: ReturnType<typeof vi.fn>;
+  findDistributionPublisherIdsForMission: ReturnType<typeof vi.fn>;
 };
 
 beforeEach(() => {
@@ -49,10 +61,12 @@ beforeEach(() => {
   // Par défaut, les compteurs des écritures reflètent le nombre d'ids passés.
   missionRepositoryMock.findIds.mockResolvedValue([]);
   missionRepositoryMock.findIdsPage.mockResolvedValue([]);
+  missionRepositoryMock.findUnique.mockResolvedValue(null);
   missionDiffusionRepositoryMock.findMissionIdsPageByDistributionPublisher.mockResolvedValue([]);
   missionDiffusionRepositoryMock.findExistingMissionIdsForDistributionPublisher.mockResolvedValue([]);
   missionDiffusionRepositoryMock.createManyForDistributionPublisher.mockImplementation(async (_distributionPublisherId: string, ids: string[]) => ids.length);
   missionDiffusionRepositoryMock.deleteManyForDistributionPublisher.mockImplementation(async (_distributionPublisherId: string, ids: string[]) => ids.length);
+  missionDiffusionRepositoryMock.replaceForMission.mockResolvedValue({ added: 0, removed: 0 });
 });
 
 describe("missionDiffusionService.rebuildForDistributionPublisher", () => {
@@ -199,5 +213,59 @@ describe("missionDiffusionService.rebuildForDistributionPublisher", () => {
     await missionDiffusionService.rebuildForDistributionPublisher("publisher-1", { dryRun: true, onMissionsTouched });
 
     expect(onMissionsTouched).not.toHaveBeenCalled();
+  });
+});
+
+describe("missionDiffusionService.rebuildForMission", () => {
+  it("remplace le snapshot de la mission par les diffuseurs calculés", async () => {
+    missionRepositoryMock.findUnique.mockResolvedValue({
+      publisherId: "annonceur-1",
+      publisherOrganizationId: "organization-1",
+      type: "BENEVOLAT",
+      deletedAt: null,
+      publisherOrganization: {
+        clientId: "organization-client-1",
+        parentOrganizations: ["network-1"],
+      },
+    });
+    ruleServiceMock.findDistributionPublisherIdsForMission.mockResolvedValue(["diffuseur-1", "diffuseur-2"]);
+    missionDiffusionRepositoryMock.replaceForMission.mockResolvedValue({ added: 1, removed: 2 });
+
+    const result = await missionDiffusionService.rebuildForMission("mission-1");
+
+    expect(ruleServiceMock.findDistributionPublisherIdsForMission).toHaveBeenCalledWith({
+      publisherId: "annonceur-1",
+      publisherOrganizationId: "organization-1",
+      type: "BENEVOLAT",
+      publisherOrganization: {
+        clientId: "organization-client-1",
+        parentOrganizations: ["network-1"],
+      },
+    });
+    expect(missionDiffusionRepositoryMock.replaceForMission).toHaveBeenCalledWith("mission-1", ["diffuseur-1", "diffuseur-2"]);
+    expect(result).toMatchObject({ missionId: "mission-1", desired: 2, added: 1, removed: 2 });
+  });
+
+  it.each([
+    ["absente", null],
+    [
+      "supprimée",
+      {
+        publisherId: "annonceur-1",
+        publisherOrganizationId: null,
+        type: "BENEVOLAT",
+        deletedAt: new Date(),
+        publisherOrganization: null,
+      },
+    ],
+  ])("purge le snapshot d'une mission %s", async (_label, mission) => {
+    missionRepositoryMock.findUnique.mockResolvedValue(mission);
+    missionDiffusionRepositoryMock.replaceForMission.mockResolvedValue({ added: 0, removed: 2 });
+
+    const result = await missionDiffusionService.rebuildForMission("mission-1");
+
+    expect(ruleServiceMock.findDistributionPublisherIdsForMission).not.toHaveBeenCalled();
+    expect(missionDiffusionRepositoryMock.replaceForMission).toHaveBeenCalledWith("mission-1", []);
+    expect(result).toMatchObject({ desired: 0, added: 0, removed: 2 });
   });
 });

--- a/api/src/services/mission-diffusion/__tests__/triggers.test.ts
+++ b/api/src/services/mission-diffusion/__tests__/triggers.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { changesRequireDiffusion } from "@/services/mission-diffusion/triggers";
+
+describe("changesRequireDiffusion", () => {
+  it.each(["publisherId", "publisherOrganizationId", "deletedAt"])("déclenche pour %s", (field) => {
+    expect(changesRequireDiffusion({ [field]: { previous: null, current: "value" } })).toBe(true);
+  });
+
+  it("ignore les changements sans impact sur le snapshot", () => {
+    expect(changesRequireDiffusion({ places: { previous: 1, current: 2 } })).toBe(false);
+  });
+});

--- a/api/src/services/mission-diffusion/index.ts
+++ b/api/src/services/mission-diffusion/index.ts
@@ -132,27 +132,12 @@ export const missionDiffusionService = {
       where: { id: missionId },
       select: {
         publisherId: true,
-        publisherOrganizationId: true,
-        type: true,
         deletedAt: true,
-        publisherOrganization: {
-          select: {
-            clientId: true,
-            parentOrganizations: true,
-          },
-        },
       },
     });
 
-    const desiredPublisherIds =
-      mission && mission.deletedAt === null
-        ? await publisherDiffusionRuleService.findDistributionPublisherIdsForMission({
-            publisherId: mission.publisherId,
-            publisherOrganizationId: mission.publisherOrganizationId,
-            type: mission.type,
-            publisherOrganization: mission.publisherOrganization,
-          })
-        : [];
+    const scopes = mission && mission.deletedAt === null ? await publisherDiffusionRuleService.findDistributionPublisherScopesForMission(mission.publisherId) : [];
+    const desiredPublisherIds = await missionDiffusionRepository.findDistributionPublisherIdsForMission(missionId, scopes);
     const { added, removed } = await missionDiffusionRepository.replaceForMission(missionId, desiredPublisherIds);
 
     return {

--- a/api/src/services/mission-diffusion/index.ts
+++ b/api/src/services/mission-diffusion/index.ts
@@ -1,5 +1,6 @@
 import { missionRepository } from "@/repositories/mission";
 import { missionDiffusionRepository } from "@/repositories/mission-diffusion";
+import { asyncTaskBus } from "@/services/async-task";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 
 // Taille des lots d'écriture (createMany/deleteMany) : borne la taille des requêtes et des
@@ -98,7 +99,19 @@ const createMissingRowsByPages = async (distributionPublisherId: string, snapsho
   return { desired, added };
 };
 
+export type MissionDiffusionRebuildMissionResult = {
+  missionId: string;
+  desired: number;
+  added: number;
+  removed: number;
+  durationMs: number;
+};
+
 export const missionDiffusionService = {
+  async enqueue(missionId: string): Promise<void> {
+    await asyncTaskBus.publish({ type: "mission.diffusion", payload: { missionId } });
+  },
+
   /**
    * Reconstruit le snapshot d'un publisher de diffusion par diff paginé. Les suppressions sont
    * appliquées avant les insertions pour éviter un snapshot transitoirement plus permissif.
@@ -111,6 +124,44 @@ export const missionDiffusionService = {
     const { desired, added } = await createMissingRowsByPages(distributionPublisherId, snapshotWhere, options);
 
     return { distributionPublisherId, desired, added, removed, durationMs: Date.now() - start, dryRun: options.dryRun || undefined };
+  },
+
+  async rebuildForMission(missionId: string): Promise<MissionDiffusionRebuildMissionResult> {
+    const start = Date.now();
+    const mission = await missionRepository.findUnique({
+      where: { id: missionId },
+      select: {
+        publisherId: true,
+        publisherOrganizationId: true,
+        type: true,
+        deletedAt: true,
+        publisherOrganization: {
+          select: {
+            clientId: true,
+            parentOrganizations: true,
+          },
+        },
+      },
+    });
+
+    const desiredPublisherIds =
+      mission && mission.deletedAt === null
+        ? await publisherDiffusionRuleService.findDistributionPublisherIdsForMission({
+            publisherId: mission.publisherId,
+            publisherOrganizationId: mission.publisherOrganizationId,
+            type: mission.type,
+            publisherOrganization: mission.publisherOrganization,
+          })
+        : [];
+    const { added, removed } = await missionDiffusionRepository.replaceForMission(missionId, desiredPublisherIds);
+
+    return {
+      missionId,
+      desired: desiredPublisherIds.length,
+      added,
+      removed,
+      durationMs: Date.now() - start,
+    };
   },
 };
 

--- a/api/src/services/mission-diffusion/triggers.ts
+++ b/api/src/services/mission-diffusion/triggers.ts
@@ -1,0 +1,9 @@
+const DIFFUSION_TRIGGER_FIELDS = new Set(["publisherId", "publisherOrganizationId", "deletedAt"]);
+
+/**
+ * Champs de mission qui peuvent modifier son appartenance à `mission_diffusion`.
+ * Ce prédicat reste séparé de l'enrichissement : une mission peut devoir être
+ * rematérialisée sans nouvel appel au fournisseur LLM.
+ */
+export const changesRequireDiffusion = (changes: Record<string, unknown>): boolean =>
+  Object.keys(changes).some((field) => DIFFUSION_TRIGGER_FIELDS.has(field));

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -7,6 +7,8 @@ import { missionRepository } from "@/repositories/mission";
 import { activityService } from "@/services/activity";
 import { buildMissionEnrichmentScoringWhere, missionEnrichmentService } from "@/services/mission-enrichment";
 import { changesRequireEnrichment } from "@/services/mission-enrichment/triggers";
+import { missionDiffusionService } from "@/services/mission-diffusion";
+import { changesRequireDiffusion } from "@/services/mission-diffusion/triggers";
 import { missionEventService } from "@/services/mission-event";
 import type {
   MissionCreateInput,
@@ -589,6 +591,14 @@ export const missionService = {
     }
   },
 
+  async enqueueMissionDiffusion(missionId: string): Promise<void> {
+    try {
+      await missionDiffusionService.enqueue(missionId);
+    } catch (error) {
+      captureException(error, { extra: { context: "enqueueMissionDiffusion", missionId } });
+    }
+  },
+
   async findMissionsByIds(ids: string[]): Promise<MissionRecord[]> {
     if (!ids.length) {
       return [];
@@ -812,7 +822,7 @@ export const missionService = {
     return toMissionRecord(mission as MissionWithRelations);
   },
 
-  async update(id: string, patch: MissionUpdatePatch): Promise<MissionRecord> {
+  async update(id: string, patch: MissionUpdatePatch, options: { relatedDiffusionDataChanged?: boolean } = {}): Promise<MissionRecord> {
     const previousMission = await missionRepository.findFirst({ where: { id }, include: baseInclude });
     if (!previousMission) {
       throw new Error(`[missionService] Mission ${id} not found before update`);
@@ -977,6 +987,9 @@ export const missionService = {
     const updated = toMissionRecord(mission as MissionWithRelations);
     const changes = getMissionChanges(previous, updated);
     if (!changes) {
+      if (options.relatedDiffusionDataChanged) {
+        await this.enqueueMissionDiffusion(id);
+      }
       return updated;
     }
 
@@ -988,6 +1001,8 @@ export const missionService = {
 
     if (changesRequireEnrichment(changes)) {
       await this.enqueueMissionProcessing(id);
+    } else if (changesRequireDiffusion(changes) || options.relatedDiffusionDataChanged) {
+      await this.enqueueMissionDiffusion(id);
     }
 
     return updated;

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -9,6 +9,7 @@ const prismaMock = prisma as unknown as {
   };
   publisher: {
     findMany: ReturnType<typeof vi.fn>;
+    findFirst: ReturnType<typeof vi.fn>;
   };
 };
 
@@ -132,6 +133,80 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
     const where = await publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere("publisher-1", ["publisher-1"]);
 
     expect(where).toEqual({ AND: [{ publisherId: "publisher-1" }, { type: "benevolat" }] });
+  });
+});
+
+describe("publisherDiffusionRuleService.findDistributionPublisherIdsForMission", () => {
+  const mission = {
+    publisherId: "annonceur-1",
+    publisherOrganizationId: "organization-1",
+    type: "BENEVOLAT",
+    publisherOrganization: {
+      clientId: "organization-client-1",
+      parentOrganizations: ["network-1"],
+    },
+  };
+
+  beforeEach(() => {
+    prismaMock.publisherDiffusionRule.findMany.mockReset();
+    prismaMock.publisher.findFirst.mockReset();
+  });
+
+  it("retient les roots dont tous les critères enfants correspondent", async () => {
+    const matchingRoot = buildRule({ id: "root-1", publisherId: "diffuseur-1" });
+    const excludedRoot = buildRule({ id: "root-2", publisherId: "diffuseur-2" });
+    prismaMock.publisherDiffusionRule.findMany
+      .mockResolvedValueOnce([matchingRoot, excludedRoot])
+      .mockResolvedValueOnce([
+        matchingRoot,
+        buildRule({
+          id: "child-1",
+          publisherId: "diffuseur-1",
+          combinedWithId: "root-1",
+          field: "publisherOrganization.clientId",
+          operator: "is",
+          value: "organization-client-1",
+        }),
+        excludedRoot,
+        buildRule({
+          id: "child-2",
+          publisherId: "diffuseur-2",
+          combinedWithId: "root-2",
+          field: "publisherOrganization.clientId",
+          operator: "is_not",
+          value: "organization-client-1",
+        }),
+      ]);
+    prismaMock.publisher.findFirst.mockResolvedValue(null);
+
+    await expect(publisherDiffusionRuleService.findDistributionPublisherIdsForMission(mission)).resolves.toEqual(["diffuseur-1"]);
+  });
+
+  it("ajoute le scope propre implicite d'un publisher de diffusion", async () => {
+    prismaMock.publisherDiffusionRule.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    prismaMock.publisher.findFirst.mockResolvedValue({ id: "annonceur-1" });
+
+    await expect(publisherDiffusionRuleService.findDistributionPublisherIdsForMission(mission)).resolves.toEqual(["annonceur-1"]);
+  });
+
+  it("respecte les critères d'une root propre explicite", async () => {
+    const ownRoot = buildRule({ id: "root-own", publisherId: "annonceur-1" });
+    prismaMock.publisherDiffusionRule.findMany
+      .mockResolvedValueOnce([ownRoot])
+      .mockResolvedValueOnce([
+        ownRoot,
+        buildRule({
+          id: "child-own",
+          publisherId: "annonceur-1",
+          combinedWithId: "root-own",
+          field: "publisherOrganization.parentOrganizations",
+          operator: "does_not_contain",
+          value: "network-1",
+        }),
+      ]);
+    prismaMock.publisher.findFirst.mockResolvedValue({ id: "annonceur-1" });
+
+    await expect(publisherDiffusionRuleService.findDistributionPublisherIdsForMission(mission)).resolves.toEqual([]);
   });
 });
 

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -136,57 +136,50 @@ describe("publisherDiffusionRuleService.buildMissionDiffuseurCandidateWhere", ()
   });
 });
 
-describe("publisherDiffusionRuleService.findDistributionPublisherIdsForMission", () => {
-  const mission = {
-    publisherId: "annonceur-1",
-    publisherOrganizationId: "organization-1",
-    type: "BENEVOLAT",
-    publisherOrganization: {
-      clientId: "organization-client-1",
-      parentOrganizations: ["network-1"],
-    },
-  };
-
+describe("publisherDiffusionRuleService.findDistributionPublisherScopesForMission", () => {
   beforeEach(() => {
     prismaMock.publisherDiffusionRule.findMany.mockReset();
     prismaMock.publisher.findFirst.mockReset();
   });
 
-  it("retient les roots dont tous les critères enfants correspondent", async () => {
-    const matchingRoot = buildRule({ id: "root-1", publisherId: "diffuseur-1" });
-    const excludedRoot = buildRule({ id: "root-2", publisherId: "diffuseur-2" });
+  it("retourne les scopes candidats avec leurs critères récursifs", async () => {
+    const root = buildRule({ id: "root-1", publisherId: "diffuseur-1" });
+    const child = buildRule({
+      id: "child-1",
+      publisherId: "diffuseur-1",
+      combinedWithId: "root-1",
+      field: "publisherOrganization.clientId",
+      operator: "is",
+      value: "organization-client-1",
+    });
+    const grandchild = buildRule({
+      id: "grandchild-1",
+      publisherId: "diffuseur-1",
+      combinedWithId: "child-1",
+      field: "publisherOrganization.parentOrganizations",
+      operator: "contains",
+      value: "network-1",
+    });
     prismaMock.publisherDiffusionRule.findMany
-      .mockResolvedValueOnce([matchingRoot, excludedRoot])
-      .mockResolvedValueOnce([
-        matchingRoot,
-        buildRule({
-          id: "child-1",
-          publisherId: "diffuseur-1",
-          combinedWithId: "root-1",
-          field: "publisherOrganization.clientId",
-          operator: "is",
-          value: "organization-client-1",
-        }),
-        excludedRoot,
-        buildRule({
-          id: "child-2",
-          publisherId: "diffuseur-2",
-          combinedWithId: "root-2",
-          field: "publisherOrganization.clientId",
-          operator: "is_not",
-          value: "organization-client-1",
-        }),
-      ]);
+      .mockResolvedValueOnce([root])
+      .mockResolvedValueOnce([root, child, grandchild]);
     prismaMock.publisher.findFirst.mockResolvedValue(null);
 
-    await expect(publisherDiffusionRuleService.findDistributionPublisherIdsForMission(mission)).resolves.toEqual(["diffuseur-1"]);
+    const scopes = await publisherDiffusionRuleService.findDistributionPublisherScopesForMission("annonceur-1");
+
+    expect(scopes).toEqual([{ distributionPublisherId: "diffuseur-1", rules: [root, child, grandchild] }]);
   });
 
   it("ajoute le scope propre implicite d'un publisher de diffusion", async () => {
     prismaMock.publisherDiffusionRule.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
     prismaMock.publisher.findFirst.mockResolvedValue({ id: "annonceur-1" });
 
-    await expect(publisherDiffusionRuleService.findDistributionPublisherIdsForMission(mission)).resolves.toEqual(["annonceur-1"]);
+    await expect(publisherDiffusionRuleService.findDistributionPublisherScopesForMission("annonceur-1")).resolves.toEqual([
+      {
+        distributionPublisherId: "annonceur-1",
+        rules: [{ field: "publisherId", fieldType: "string", operator: "is", value: "annonceur-1", combinator: "or" }],
+      },
+    ]);
   });
 
   it("respecte les critères d'une root propre explicite", async () => {
@@ -206,7 +199,21 @@ describe("publisherDiffusionRuleService.findDistributionPublisherIdsForMission",
       ]);
     prismaMock.publisher.findFirst.mockResolvedValue({ id: "annonceur-1" });
 
-    await expect(publisherDiffusionRuleService.findDistributionPublisherIdsForMission(mission)).resolves.toEqual([]);
+    const scopes = await publisherDiffusionRuleService.findDistributionPublisherScopesForMission("annonceur-1");
+
+    expect(scopes).toEqual([
+      {
+        distributionPublisherId: "annonceur-1",
+        rules: expect.arrayContaining([
+          ownRoot,
+          expect.objectContaining({
+            id: "child-own",
+            field: "publisherOrganization.parentOrganizations",
+            operator: "does_not_contain",
+          }),
+        ]),
+      },
+    ]);
   });
 });
 

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -8,7 +8,13 @@ import type {
   PublisherDiffusionRuleFindParams,
   PublisherDiffusionRuleRecord,
 } from "@/types/publisher-diffusion-rule";
-import { buildMissionPublisherDiffusionRuleConditionFromRule, isPublisherDiffusionRuleArrayField, optimizeMissionDiffusionRuleWhere } from "@/utils/publisher-diffusion-rule-query";
+import {
+  buildMissionPublisherDiffusionRuleConditionFromRule,
+  isPublisherDiffusionRuleArrayField,
+  matchesMissionPublisherDiffusionRule,
+  type MissionDiffusionRuleCandidate,
+  optimizeMissionDiffusionRuleWhere,
+} from "@/utils/publisher-diffusion-rule-query";
 
 type PublisherDiffusionRuleWithChildren = PublisherDiffusionRule & {
   combinedRules?: PublisherDiffusionRule[];
@@ -123,6 +129,25 @@ const findOrderedRules = (publisherId: string): Promise<PublisherDiffusionRule[]
     orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
   });
 
+const matchesScope = (
+  mission: MissionDiffusionRuleCandidate,
+  rule: PublisherDiffusionRule,
+  childrenByParentId: Map<string, PublisherDiffusionRule[]>,
+  visited = new Set<string>()
+): boolean => {
+  if (visited.has(rule.id)) {
+    return false;
+  }
+
+  const nextVisited = new Set(visited).add(rule.id);
+  const selfMatches = matchesMissionPublisherDiffusionRule(mission, rule);
+  if (selfMatches === false) {
+    return false;
+  }
+
+  return (childrenByParentId.get(rule.id) ?? []).every((child) => matchesScope(mission, child, childrenByParentId, nextVisited));
+};
+
 const toRecord = (rule: PublisherDiffusionRuleWithChildren): PublisherDiffusionRuleRecord => ({
   id: rule.id,
   publisherId: rule.publisherId,
@@ -226,6 +251,66 @@ export const publisherDiffusionRuleService = {
       select: { id: true },
     });
     return publishers.map((publisher) => publisher.id);
+  },
+
+  /**
+   * Calcule le pendant mission-centric de `buildMissionDiffuseurSnapshotWhere`.
+   * Les candidats sont bornés aux diffuseurs ayant une root pour l'annonceur de la
+   * mission, plus son éventuel scope propre.
+   */
+  async findDistributionPublisherIdsForMission(mission: MissionDiffusionRuleCandidate): Promise<string[]> {
+    const [candidateRoots, ownDistributionPublisher] = await Promise.all([
+      publisherDiffusionRuleRepository.findMany({
+        where: {
+          ...DIFFUSION_SCOPE_ROOT_CRITERIA,
+          value: mission.publisherId,
+          publisher: { deletedAt: null },
+        },
+        orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
+      }),
+      publisherRepository.findFirst({
+        where: {
+          id: mission.publisherId,
+          deletedAt: null,
+          OR: [{ hasApiRights: true }, { diffusionRules: { some: DIFFUSION_SCOPE_ROOT_CRITERIA } }],
+        },
+      }),
+    ]);
+
+    const candidatePublisherIds = Array.from(new Set(candidateRoots.map((root) => root.publisherId)));
+    if (ownDistributionPublisher) {
+      candidatePublisherIds.push(ownDistributionPublisher.id);
+    }
+    const uniqueCandidatePublisherIds = Array.from(new Set(candidatePublisherIds));
+    if (uniqueCandidatePublisherIds.length === 0) {
+      return [];
+    }
+
+    const rules = await publisherDiffusionRuleRepository.findMany({
+      where: { publisherId: { in: uniqueCandidatePublisherIds } },
+      orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
+    });
+    const { roots, childrenByParentId } = groupRulesByParent(rules);
+    const rootsByPublisherId = new Map<string, PublisherDiffusionRule[]>();
+    for (const root of roots.filter((rule) => rule.field === "publisherId" && rule.operator === "is" && rule.value === mission.publisherId)) {
+      const publisherRoots = rootsByPublisherId.get(root.publisherId) ?? [];
+      publisherRoots.push(root);
+      rootsByPublisherId.set(root.publisherId, publisherRoots);
+    }
+
+    const desiredPublisherIds = new Set<string>();
+    for (const [publisherId, publisherRoots] of rootsByPublisherId) {
+      if (publisherRoots.some((root) => matchesScope(mission, root, childrenByParentId))) {
+        desiredPublisherIds.add(publisherId);
+      }
+    }
+
+    // Le scope propre est implicite, sauf si une root propre explicite lui applique des critères.
+    if (ownDistributionPublisher && !rootsByPublisherId.has(ownDistributionPublisher.id)) {
+      desiredPublisherIds.add(ownDistributionPublisher.id);
+    }
+
+    return Array.from(desiredPublisherIds);
   },
 
   async findRules(params: PublisherDiffusionRuleFindParams = {}, tx?: Prisma.TransactionClient): Promise<PublisherDiffusionRuleRecord[]> {

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -11,9 +11,8 @@ import type {
 import {
   buildMissionPublisherDiffusionRuleConditionFromRule,
   isPublisherDiffusionRuleArrayField,
-  matchesMissionPublisherDiffusionRule,
-  type MissionDiffusionRuleCandidate,
   optimizeMissionDiffusionRuleWhere,
+  type PublisherDiffusionRuleCondition,
 } from "@/utils/publisher-diffusion-rule-query";
 
 type PublisherDiffusionRuleWithChildren = PublisherDiffusionRule & {
@@ -129,23 +128,22 @@ const findOrderedRules = (publisherId: string): Promise<PublisherDiffusionRule[]
     orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
   });
 
-const matchesScope = (
-  mission: MissionDiffusionRuleCandidate,
+const collectScopeRules = (
   rule: PublisherDiffusionRule,
   childrenByParentId: Map<string, PublisherDiffusionRule[]>,
   visited = new Set<string>()
-): boolean => {
+): PublisherDiffusionRule[] => {
   if (visited.has(rule.id)) {
-    return false;
+    return [];
   }
 
   const nextVisited = new Set(visited).add(rule.id);
-  const selfMatches = matchesMissionPublisherDiffusionRule(mission, rule);
-  if (selfMatches === false) {
-    return false;
-  }
+  return [rule, ...(childrenByParentId.get(rule.id) ?? []).flatMap((child) => collectScopeRules(child, childrenByParentId, nextVisited))];
+};
 
-  return (childrenByParentId.get(rule.id) ?? []).every((child) => matchesScope(mission, child, childrenByParentId, nextVisited));
+export type MissionDistributionPublisherScope = {
+  distributionPublisherId: string;
+  rules: PublisherDiffusionRuleCondition[];
 };
 
 const toRecord = (rule: PublisherDiffusionRuleWithChildren): PublisherDiffusionRuleRecord => ({
@@ -253,24 +251,19 @@ export const publisherDiffusionRuleService = {
     return publishers.map((publisher) => publisher.id);
   },
 
-  /**
-   * Calcule le pendant mission-centric de `buildMissionDiffuseurSnapshotWhere`.
-   * Les candidats sont bornés aux diffuseurs ayant une root pour l'annonceur de la
-   * mission, plus son éventuel scope propre.
-   */
-  async findDistributionPublisherIdsForMission(mission: MissionDiffusionRuleCandidate): Promise<string[]> {
+  async findDistributionPublisherScopesForMission(publisherId: string): Promise<MissionDistributionPublisherScope[]> {
     const [candidateRoots, ownDistributionPublisher] = await Promise.all([
       publisherDiffusionRuleRepository.findMany({
         where: {
           ...DIFFUSION_SCOPE_ROOT_CRITERIA,
-          value: mission.publisherId,
+          value: publisherId,
           publisher: { deletedAt: null },
         },
         orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
       }),
       publisherRepository.findFirst({
         where: {
-          id: mission.publisherId,
+          id: publisherId,
           deletedAt: null,
           OR: [{ hasApiRights: true }, { diffusionRules: { some: DIFFUSION_SCOPE_ROOT_CRITERIA } }],
         },
@@ -290,27 +283,20 @@ export const publisherDiffusionRuleService = {
       where: { publisherId: { in: uniqueCandidatePublisherIds } },
       orderBy: [{ position: Prisma.SortOrder.asc }, { createdAt: Prisma.SortOrder.asc }],
     });
-    const { roots, childrenByParentId } = groupRulesByParent(rules);
-    const rootsByPublisherId = new Map<string, PublisherDiffusionRule[]>();
-    for (const root of roots.filter((rule) => rule.field === "publisherId" && rule.operator === "is" && rule.value === mission.publisherId)) {
-      const publisherRoots = rootsByPublisherId.get(root.publisherId) ?? [];
-      publisherRoots.push(root);
-      rootsByPublisherId.set(root.publisherId, publisherRoots);
+    const { childrenByParentId } = groupRulesByParent(rules);
+    const scopes: MissionDistributionPublisherScope[] = candidateRoots.map((root) => ({
+      distributionPublisherId: root.publisherId,
+      rules: collectScopeRules(root, childrenByParentId),
+    }));
+
+    if (ownDistributionPublisher && !candidateRoots.some((root) => root.publisherId === ownDistributionPublisher.id)) {
+      scopes.push({
+        distributionPublisherId: ownDistributionPublisher.id,
+        rules: [{ field: "publisherId", fieldType: "string", operator: "is", value: publisherId, combinator: "or" }],
+      });
     }
 
-    const desiredPublisherIds = new Set<string>();
-    for (const [publisherId, publisherRoots] of rootsByPublisherId) {
-      if (publisherRoots.some((root) => matchesScope(mission, root, childrenByParentId))) {
-        desiredPublisherIds.add(publisherId);
-      }
-    }
-
-    // Le scope propre est implicite, sauf si une root propre explicite lui applique des critères.
-    if (ownDistributionPublisher && !rootsByPublisherId.has(ownDistributionPublisher.id)) {
-      desiredPublisherIds.add(ownDistributionPublisher.id);
-    }
-
-    return Array.from(desiredPublisherIds);
+    return scopes;
   },
 
   async findRules(params: PublisherDiffusionRuleFindParams = {}, tx?: Prisma.TransactionClient): Promise<PublisherDiffusionRuleRecord[]> {

--- a/api/src/utils/__tests__/publisher-diffusion-rule-query.test.ts
+++ b/api/src/utils/__tests__/publisher-diffusion-rule-query.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildMissionPublisherDiffusionRuleConditionFromRule,
+  buildMissionPublisherDiffusionScopeSqlFromRules,
   buildMissionPublisherDiffusionRuleSqlFromRules,
   optimizeMissionDiffusionRuleWhere,
   type PublisherDiffusionRuleCondition,
@@ -31,6 +32,19 @@ describe("buildMissionPublisherDiffusionRuleSqlFromRules - array fields", () => 
 
     expect(sql.sql).toContain("NOT");
     expect(sql.sql).toContain("lower(elem) = lower(");
+  });
+});
+
+describe("buildMissionPublisherDiffusionScopeSqlFromRules", () => {
+  it("combine toutes les règles d'un scope en AND indépendamment de leur combinator", () => {
+    const sql = buildMissionPublisherDiffusionScopeSqlFromRules([
+      rule({ field: "publisherId", fieldType: "string", operator: "is", value: "annonceur-1", combinator: "or" }),
+      rule({ field: "publisherOrganization.clientId", fieldType: "string", operator: "is_not", value: "organization-1", combinator: "or" }),
+    ]);
+
+    expect(sql.sql).toContain('m."publisher_id" = ? AND EXISTS');
+    expect(sql.sql).not.toContain(" OR ");
+    expect(sql.values).toEqual(["annonceur-1", "organization-1"]);
   });
 });
 

--- a/api/src/utils/mission.ts
+++ b/api/src/utils/mission.ts
@@ -127,6 +127,7 @@ export const IMPORT_FIELDS_TO_COMPARE = [
   "places",
   "postedAt",
   "priority",
+  "publisherId",
   "romeSkills",
   "snu",
   "snuPlaces",

--- a/api/src/utils/publisher-diffusion-rule-query.ts
+++ b/api/src/utils/publisher-diffusion-rule-query.ts
@@ -11,16 +11,6 @@ import {
 
 export type PublisherDiffusionRuleCondition = Pick<PublisherDiffusionRule, "field" | "fieldType" | "operator" | "value" | "combinator">;
 
-export type MissionDiffusionRuleCandidate = {
-  publisherId: string;
-  publisherOrganizationId: string | null;
-  type: string | null;
-  publisherOrganization: {
-    clientId: string;
-    parentOrganizations: string[];
-  } | null;
-};
-
 /**
  * Champs array (chemin Prisma) adossés à `PublisherOrganization` → colonne PostgreSQL.
  * Source de vérité unique d'où l'on dérive `ARRAY_FIELD_PATHS`.
@@ -32,92 +22,6 @@ const ARRAY_FIELD_PATHS = new Set(Object.keys(ARRAY_FIELD_PATH_TO_COLUMN));
 
 // Vrai si le champ est adossé à un tableau Postgres : l'appartenance est exacte (et non par sous-chaîne).
 export const isPublisherDiffusionRuleArrayField = (field: string): boolean => ARRAY_FIELD_PATHS.has(field);
-
-const getMissionRuleCandidateValue = (mission: MissionDiffusionRuleCandidate, field: string): unknown => {
-  switch (field) {
-    case "publisherId":
-      return mission.publisherId;
-    case "publisherOrganizationId":
-      return mission.publisherOrganizationId;
-    case "type":
-      return mission.type;
-    case "publisherOrganization.clientId":
-      return mission.publisherOrganization?.clientId;
-    case "publisherOrganization.parentOrganizations":
-      return mission.publisherOrganization?.parentOrganizations;
-    default:
-      return undefined;
-  }
-};
-
-const compareMissionRuleValues = (actual: unknown, expected: unknown, direction: "greater" | "less"): boolean => {
-  if (typeof actual === "number" && typeof expected === "number") {
-    return direction === "greater" ? actual > expected : actual < expected;
-  }
-  if (typeof actual === "string" && typeof expected === "string") {
-    return direction === "greater" ? actual > expected : actual < expected;
-  }
-  return false;
-};
-
-/**
- * Évalue une règle sur une mission déjà chargée. `null` signifie que la règle n'est pas
- * supportée, comme `buildMissionPublisherDiffusionRuleConditionFromRule` qui l'ignore.
- */
-export const matchesMissionPublisherDiffusionRule = (mission: MissionDiffusionRuleCandidate, rule: PublisherDiffusionRuleCondition): boolean | null => {
-  const isArrayField = isPublisherDiffusionRuleArrayField(rule.field) || rule.fieldType === "array";
-  const actual = getMissionRuleCandidateValue(mission, rule.field);
-  const expected = normalizeTypedRuleValue(rule);
-
-  if (actual === undefined && !["does_not_contain"].includes(rule.operator)) {
-    return FIELD_TO_SQL_CONFIG[rule.field] ? false : null;
-  }
-  if (!["exists", "does_not_exist"].includes(rule.operator) && shouldSkipMissionRuleValue(expected)) {
-    return null;
-  }
-
-  if (isArrayField) {
-    const values = Array.isArray(actual) ? actual.map(String) : [];
-    const contains = values.includes(String(expected));
-    switch (rule.operator) {
-      case "is":
-      case "contains":
-        return contains;
-      case "is_not":
-      case "does_not_contain":
-        return !contains;
-      case "exists":
-        return values.length > 0;
-      case "does_not_exist":
-        return values.length === 0;
-      default:
-        return null;
-    }
-  }
-
-  switch (rule.operator) {
-    case "is":
-      return actual === expected;
-    case "is_not":
-      return actual !== null && actual !== undefined && actual !== expected;
-    case "contains":
-      return actual !== null && actual !== undefined && String(actual).toLowerCase().includes(String(expected).toLowerCase());
-    case "does_not_contain":
-      return actual === undefined || (actual !== null && !String(actual).toLowerCase().includes(String(expected).toLowerCase()));
-    case "starts_with":
-      return actual !== null && actual !== undefined && String(actual).toLowerCase().startsWith(String(expected).toLowerCase());
-    case "is_greater_than":
-      return compareMissionRuleValues(actual, expected, "greater");
-    case "is_less_than":
-      return compareMissionRuleValues(actual, expected, "less");
-    case "exists":
-      return actual !== null && actual !== undefined;
-    case "does_not_exist":
-      return actual === null;
-    default:
-      return null;
-  }
-};
 
 type SqlFieldConfig = {
   column: string;
@@ -360,4 +264,10 @@ export const buildMissionPublisherDiffusionRuleSqlFromRules = (rules: PublisherD
   }
 
   return Prisma.sql`AND ${condition}`;
+};
+
+export const buildMissionPublisherDiffusionScopeSqlFromRules = (rules: PublisherDiffusionRuleCondition[], options: { missionAlias?: string } = {}): Prisma.Sql => {
+  const missionAlias = options.missionAlias ?? "m";
+  const conditions = rules.map((rule) => buildRuleSqlCondition(rule, missionAlias)).filter((condition): condition is Prisma.Sql => condition !== null);
+  return conditions.length > 0 ? Prisma.sql`AND ${Prisma.join(conditions, " AND ")}` : Prisma.empty;
 };

--- a/api/src/utils/publisher-diffusion-rule-query.ts
+++ b/api/src/utils/publisher-diffusion-rule-query.ts
@@ -11,6 +11,16 @@ import {
 
 export type PublisherDiffusionRuleCondition = Pick<PublisherDiffusionRule, "field" | "fieldType" | "operator" | "value" | "combinator">;
 
+export type MissionDiffusionRuleCandidate = {
+  publisherId: string;
+  publisherOrganizationId: string | null;
+  type: string | null;
+  publisherOrganization: {
+    clientId: string;
+    parentOrganizations: string[];
+  } | null;
+};
+
 /**
  * Champs array (chemin Prisma) adossés à `PublisherOrganization` → colonne PostgreSQL.
  * Source de vérité unique d'où l'on dérive `ARRAY_FIELD_PATHS`.
@@ -22,6 +32,92 @@ const ARRAY_FIELD_PATHS = new Set(Object.keys(ARRAY_FIELD_PATH_TO_COLUMN));
 
 // Vrai si le champ est adossé à un tableau Postgres : l'appartenance est exacte (et non par sous-chaîne).
 export const isPublisherDiffusionRuleArrayField = (field: string): boolean => ARRAY_FIELD_PATHS.has(field);
+
+const getMissionRuleCandidateValue = (mission: MissionDiffusionRuleCandidate, field: string): unknown => {
+  switch (field) {
+    case "publisherId":
+      return mission.publisherId;
+    case "publisherOrganizationId":
+      return mission.publisherOrganizationId;
+    case "type":
+      return mission.type;
+    case "publisherOrganization.clientId":
+      return mission.publisherOrganization?.clientId;
+    case "publisherOrganization.parentOrganizations":
+      return mission.publisherOrganization?.parentOrganizations;
+    default:
+      return undefined;
+  }
+};
+
+const compareMissionRuleValues = (actual: unknown, expected: unknown, direction: "greater" | "less"): boolean => {
+  if (typeof actual === "number" && typeof expected === "number") {
+    return direction === "greater" ? actual > expected : actual < expected;
+  }
+  if (typeof actual === "string" && typeof expected === "string") {
+    return direction === "greater" ? actual > expected : actual < expected;
+  }
+  return false;
+};
+
+/**
+ * Évalue une règle sur une mission déjà chargée. `null` signifie que la règle n'est pas
+ * supportée, comme `buildMissionPublisherDiffusionRuleConditionFromRule` qui l'ignore.
+ */
+export const matchesMissionPublisherDiffusionRule = (mission: MissionDiffusionRuleCandidate, rule: PublisherDiffusionRuleCondition): boolean | null => {
+  const isArrayField = isPublisherDiffusionRuleArrayField(rule.field) || rule.fieldType === "array";
+  const actual = getMissionRuleCandidateValue(mission, rule.field);
+  const expected = normalizeTypedRuleValue(rule);
+
+  if (actual === undefined && !["does_not_contain"].includes(rule.operator)) {
+    return FIELD_TO_SQL_CONFIG[rule.field] ? false : null;
+  }
+  if (!["exists", "does_not_exist"].includes(rule.operator) && shouldSkipMissionRuleValue(expected)) {
+    return null;
+  }
+
+  if (isArrayField) {
+    const values = Array.isArray(actual) ? actual.map(String) : [];
+    const contains = values.includes(String(expected));
+    switch (rule.operator) {
+      case "is":
+      case "contains":
+        return contains;
+      case "is_not":
+      case "does_not_contain":
+        return !contains;
+      case "exists":
+        return values.length > 0;
+      case "does_not_exist":
+        return values.length === 0;
+      default:
+        return null;
+    }
+  }
+
+  switch (rule.operator) {
+    case "is":
+      return actual === expected;
+    case "is_not":
+      return actual !== null && actual !== undefined && actual !== expected;
+    case "contains":
+      return actual !== null && actual !== undefined && String(actual).toLowerCase().includes(String(expected).toLowerCase());
+    case "does_not_contain":
+      return actual === undefined || (actual !== null && !String(actual).toLowerCase().includes(String(expected).toLowerCase()));
+    case "starts_with":
+      return actual !== null && actual !== undefined && String(actual).toLowerCase().startsWith(String(expected).toLowerCase());
+    case "is_greater_than":
+      return compareMissionRuleValues(actual, expected, "greater");
+    case "is_less_than":
+      return compareMissionRuleValues(actual, expected, "less");
+    case "exists":
+      return actual !== null && actual !== undefined;
+    case "does_not_exist":
+      return actual === null;
+    default:
+      return null;
+  }
+};
 
 type SqlFieldConfig = {
   column: string;

--- a/api/src/v2/mission/controller.ts
+++ b/api/src/v2/mission/controller.ts
@@ -292,7 +292,11 @@ router.put("/:clientId", passport.authenticate(["apikey", "api"], { session: fal
       patch.description = moderation.description;
     }
 
-    const mission = await missionService.update(existing.id, patch);
+    const mission = await missionService.update(existing.id, patch, {
+      // `parentOrganizations` vit sur l'organisation liée : sa modification ne
+      // ressort pas du diff de la ligne mission, mais change les règles de diffusion.
+      relatedDiffusionDataChanged: body.organizationReseaux !== undefined,
+    });
     return res.status(200).send({ ok: true, data: buildData(mission) });
   } catch (error) {
     next(error);

--- a/api/src/v2/mission/controller.ts
+++ b/api/src/v2/mission/controller.ts
@@ -155,7 +155,7 @@ router.post("/", passport.authenticate(["apikey", "api"], { session: false }), p
 
     let publisherOrganizationId: string | null = null;
     if (hasOrgFields(body)) {
-      publisherOrganizationId = await upsertPublisherOrganization(body, publisher.id);
+      publisherOrganizationId = (await upsertPublisherOrganization(body, publisher.id)).id;
     }
 
     const input: MissionCreateInput = {
@@ -251,10 +251,12 @@ router.put("/:clientId", passport.authenticate(["apikey", "api"], { session: fal
     }
 
     let publisherOrganizationId: string | undefined;
+    let publisherOrganizationChanged = false;
     if (hasOrgFields(body)) {
-      const orgId = await upsertPublisherOrganization(body, publisher.id);
-      if (orgId) {
-        publisherOrganizationId = orgId;
+      const organization = await upsertPublisherOrganization(body, publisher.id);
+      publisherOrganizationChanged = organization.changed;
+      if (organization.id) {
+        publisherOrganizationId = organization.id;
       }
     }
 
@@ -293,9 +295,7 @@ router.put("/:clientId", passport.authenticate(["apikey", "api"], { session: fal
     }
 
     const mission = await missionService.update(existing.id, patch, {
-      // `parentOrganizations` vit sur l'organisation liée : sa modification ne
-      // ressort pas du diff de la ligne mission, mais change les règles de diffusion.
-      relatedDiffusionDataChanged: body.organizationReseaux !== undefined,
+      relatedDiffusionDataChanged: publisherOrganizationChanged,
     });
     return res.status(200).send({ ok: true, data: buildData(mission) });
   } catch (error) {

--- a/api/src/v2/mission/helpers.ts
+++ b/api/src/v2/mission/helpers.ts
@@ -101,10 +101,10 @@ const buildOrgDataForUpdate = (body: OrgBody) => {
   };
 };
 
-export const upsertPublisherOrganization = async (body: OrgBody, publisherId: string): Promise<string | null> => {
+export const upsertPublisherOrganization = async (body: OrgBody, publisherId: string): Promise<{ id: string | null; changed: boolean }> => {
   const orgClientId = deriveOrganizationClientId(body);
   if (!orgClientId) {
-    return null;
+    return { id: null, changed: false };
   }
 
   const existing = await publisherOrganizationService.findMany({ publisherId, clientId: orgClientId });
@@ -115,11 +115,7 @@ export const upsertPublisherOrganization = async (body: OrgBody, publisherId: st
     if (changes) {
       await publisherOrganizationService.update(existing[0].id, orgData);
     }
-    // Limitation connue : les modifications du contenu d'organisation ne
-    // ré-enrichissent pas les missions déjà liées. Seul le rattachement
-    // mission -> organisation (`publisherOrganizationId`) est considéré comme
-    // un changement mission pertinent.
-    return existing[0].id;
+    return { id: existing[0].id, changed: changes !== null };
   }
 
   const orgData = buildOrgDataForCreate(body);
@@ -131,7 +127,7 @@ export const upsertPublisherOrganization = async (body: OrgBody, publisherId: st
     organizationIdVerified: null,
     verificationStatus: null,
   });
-  return created.id;
+  return { id: created.id, changed: true };
 };
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/api/src/worker/__tests__/mission-diffusion.test.ts
+++ b/api/src/worker/__tests__/mission-diffusion.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/mission-diffusion", () => ({
+  missionDiffusionService: {
+    rebuildForMission: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/async-task", () => ({
+  asyncTaskBus: {
+    publish: vi.fn(),
+  },
+}));
+
+import { asyncTaskBus } from "@/services/async-task";
+import { missionDiffusionService } from "@/services/mission-diffusion";
+import { handleMissionDiffusion } from "@/worker/handlers/mission-diffusion";
+import { missionDiffusionPayloadSchema } from "@/worker/types";
+
+const missionDiffusionServiceMock = missionDiffusionService as unknown as {
+  rebuildForMission: ReturnType<typeof vi.fn>;
+};
+const asyncTaskBusMock = asyncTaskBus as unknown as {
+  publish: ReturnType<typeof vi.fn>;
+};
+
+describe("mission diffusion worker", () => {
+  it("valide le payload mission.diffusion", () => {
+    expect(missionDiffusionPayloadSchema.parse({ missionId: "mission-1" })).toEqual({ missionId: "mission-1" });
+  });
+
+  it("recalcule la diffusion avant de publier mission.index", async () => {
+    missionDiffusionServiceMock.rebuildForMission.mockResolvedValue({
+      missionId: "mission-1",
+      desired: 2,
+      added: 1,
+      removed: 1,
+      durationMs: 10,
+    });
+    asyncTaskBusMock.publish.mockResolvedValue(undefined);
+
+    await handleMissionDiffusion({ missionId: "mission-1" });
+
+    expect(missionDiffusionServiceMock.rebuildForMission).toHaveBeenCalledWith("mission-1");
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({
+      type: "mission.index",
+      payload: { missionId: "mission-1", action: "upsert" },
+    });
+  });
+
+  it("ne publie pas mission.index si le recalcul échoue", async () => {
+    missionDiffusionServiceMock.rebuildForMission.mockRejectedValue(new Error("diffusion failed"));
+
+    await expect(handleMissionDiffusion({ missionId: "mission-1" })).rejects.toThrow("diffusion failed");
+
+    expect(asyncTaskBusMock.publish).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/worker/__tests__/mission-scoring.test.ts
+++ b/api/src/worker/__tests__/mission-scoring.test.ts
@@ -56,12 +56,12 @@ describe("mission scoring worker", () => {
       force: true,
     });
     expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({
-      type: "mission.index",
-      payload: { missionId: "mission-1", action: "upsert" },
+      type: "mission.diffusion",
+      payload: { missionId: "mission-1" },
     });
   });
 
-  it("does not publish mission.index when scoring throws", async () => {
+  it("does not publish mission.diffusion when scoring throws", async () => {
     missionScoringServiceMock.score.mockRejectedValue(new Error("scoring failed"));
 
     await expect(handleMissionScoring({ missionId: "mission-1" })).rejects.toThrow("scoring failed");

--- a/api/src/worker/handlers/mission-diffusion.ts
+++ b/api/src/worker/handlers/mission-diffusion.ts
@@ -1,0 +1,11 @@
+import { asyncTaskBus } from "@/services/async-task";
+import { missionDiffusionService } from "@/services/mission-diffusion";
+
+export const handleMissionDiffusion = async (payload: { missionId: string }) => {
+  console.log(`[mission.diffusion] start missionId=${payload.missionId}`);
+  const result = await missionDiffusionService.rebuildForMission(payload.missionId);
+  console.log(
+    `[mission.diffusion] done missionId=${payload.missionId} desired=${result.desired} added=${result.added} removed=${result.removed} → queuing mission.index`
+  );
+  await asyncTaskBus.publish({ type: "mission.index", payload: { missionId: payload.missionId, action: "upsert" } });
+};

--- a/api/src/worker/handlers/mission-scoring.ts
+++ b/api/src/worker/handlers/mission-scoring.ts
@@ -4,6 +4,6 @@ import { missionScoringService } from "@/services/mission-scoring";
 export const handleMissionScoring = async (payload: { missionId: string; missionEnrichmentId?: string; force?: boolean }) => {
   console.log(`[mission.scoring] start missionId=${payload.missionId}`);
   await missionScoringService.score(payload);
-  console.log(`[mission.scoring] done missionId=${payload.missionId} → queuing mission.index`);
-  await asyncTaskBus.publish({ type: "mission.index", payload: { missionId: payload.missionId, action: "upsert" } });
+  console.log(`[mission.scoring] done missionId=${payload.missionId} → queuing mission.diffusion`);
+  await asyncTaskBus.publish({ type: "mission.diffusion", payload: { missionId: payload.missionId } });
 };

--- a/api/src/worker/registry.ts
+++ b/api/src/worker/registry.ts
@@ -1,7 +1,8 @@
+import { handleMissionDiffusion } from "./handlers/mission-diffusion";
 import { handleMissionEnrichment } from "./handlers/mission-enrichment";
 import { handleMissionIndex } from "./handlers/mission-index";
 import { handleMissionScoring } from "./handlers/mission-scoring";
-import { defineTask, missionEnrichmentPayloadSchema, missionIndexPayloadSchema, missionScoringPayloadSchema, TaskRegistryEntry } from "./types";
+import { defineTask, missionDiffusionPayloadSchema, missionEnrichmentPayloadSchema, missionIndexPayloadSchema, missionScoringPayloadSchema, TaskRegistryEntry } from "./types";
 
 export const taskRegistry: Record<string, TaskRegistryEntry> = {
   "mission.enrichment": defineTask({
@@ -13,6 +14,11 @@ export const taskRegistry: Record<string, TaskRegistryEntry> = {
     queueUrl: process.env.SCW_QUEUE_URL_MISSION_SCORING ?? "",
     schema: missionScoringPayloadSchema,
     handler: handleMissionScoring,
+  }),
+  "mission.diffusion": defineTask({
+    queueUrl: process.env.SCW_QUEUE_URL_MISSION_DIFFUSION ?? "",
+    schema: missionDiffusionPayloadSchema,
+    handler: handleMissionDiffusion,
   }),
   "mission.index": defineTask({
     queueUrl: process.env.SCW_QUEUE_URL_MISSION_INDEX ?? "",

--- a/api/src/worker/types.ts
+++ b/api/src/worker/types.ts
@@ -4,6 +4,8 @@ export const missionPayloadSchema = z.object({
   missionId: z.string().min(1),
 });
 
+export const missionDiffusionPayloadSchema = missionPayloadSchema;
+
 export const missionScoringPayloadSchema = z.object({
   missionId: z.string().min(1),
   missionEnrichmentId: z.string().min(1).optional(),

--- a/api/tests/integration/services/mission-diffusion.test.ts
+++ b/api/tests/integration/services/mission-diffusion.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// createTestMission → missionService.create publie sur le bus (enrichment/scoring). On neutralise
+// pour cibler le chemin par-mission et sa correction du snapshot Postgres.
+vi.mock("@/services/async-task", () => ({ asyncTaskBus: { publish: vi.fn().mockResolvedValue(undefined) } }));
+
+import { prisma } from "@/db/postgres";
+import { missionDiffusionService } from "@/services/mission-diffusion";
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
+
+import { createTestMission, createTestPublisher } from "../../fixtures";
+
+/**
+ * Tests d'intégration du chemin événementiel `rebuildForMission`.
+ *
+ * Périmètre : ce qui n'est prouvable que contre une vraie base — la compilation SQL des scopes
+ * (jointure `publisher_organization`, champ array `parentOrganizations` via `unnest`, soft-delete)
+ * et sa PARITÉ avec le `where` de référence du rebuild global (`buildMissionDiffuseurSnapshotWhere`).
+ * La sélection des scopes candidats et la logique de remplacement sont couvertes en tests unitaires
+ * (src/services/mission-diffusion, src/services/publisher-diffusion-rule, src/repositories).
+ */
+
+const snapshotPublisherIds = async (missionId: string): Promise<Set<string>> => {
+  const rows = await prisma.missionDiffusion.findMany({ where: { missionId }, select: { distributionPublisherId: true } });
+  return new Set(rows.map((row) => row.distributionPublisherId));
+};
+
+describe("missionDiffusionService.rebuildForMission (intégration)", () => {
+  let diffuser: Awaited<ReturnType<typeof createTestPublisher>>;
+  let annonceur: Awaited<ReturnType<typeof createTestPublisher>>;
+
+  beforeEach(async () => {
+    diffuser = await createTestPublisher({ name: "Diffuseur", hasApiRights: false });
+    annonceur = await createTestPublisher({ name: "Annonceur", hasApiRights: true });
+  });
+
+  it("matérialise l'allowlist du diffuseur et le scope propre de l'annonceur", async () => {
+    await publisherDiffusionRuleService.findOrCreateScopeRoot(diffuser.id, annonceur.id);
+    const mission = await createTestMission({ publisherId: annonceur.id, statusCode: "ACCEPTED", clientId: "a-1" });
+
+    const result = await missionDiffusionService.rebuildForMission(mission.id);
+
+    // Le diffuseur (via sa root) + l'annonceur lui-même (scope propre, hasApiRights).
+    expect(await snapshotPublisherIds(mission.id)).toEqual(new Set([diffuser.id, annonceur.id]));
+    expect(result).toMatchObject({ missionId: mission.id, desired: 2, added: 2, removed: 0 });
+  });
+
+  it("respecte une exclusion d'organisation via la jointure publisher_organization réelle", async () => {
+    await publisherDiffusionRuleService.createScopedRule({
+      diffuseurPublisherId: diffuser.id,
+      annonceurPublisherId: annonceur.id,
+      field: "publisherOrganization.clientId",
+      fieldType: "string",
+      operator: "is_not",
+      value: "excluded-org",
+    });
+
+    const kept = await createTestMission({ publisherId: annonceur.id, statusCode: "ACCEPTED", clientId: "kept", organizationClientId: "kept-org" });
+    const excluded = await createTestMission({ publisherId: annonceur.id, statusCode: "ACCEPTED", clientId: "excluded", organizationClientId: "excluded-org" });
+
+    await missionDiffusionService.rebuildForMission(kept.id);
+    await missionDiffusionService.rebuildForMission(excluded.id);
+
+    expect((await snapshotPublisherIds(kept.id)).has(diffuser.id)).toBe(true);
+    expect((await snapshotPublisherIds(excluded.id)).has(diffuser.id)).toBe(false);
+  });
+
+  it("respecte une exclusion sur le champ array parentOrganizations (unnest réel)", async () => {
+    await publisherDiffusionRuleService.createScopedRule({
+      diffuseurPublisherId: diffuser.id,
+      annonceurPublisherId: annonceur.id,
+      field: "publisherOrganization.parentOrganizations",
+      fieldType: "string",
+      operator: "does_not_contain",
+      value: "reseau-exclu",
+    });
+
+    const inReseau = await createTestMission({
+      publisherId: annonceur.id,
+      statusCode: "ACCEPTED",
+      clientId: "in",
+      organizationClientId: "org-in",
+      organizationReseaux: ["reseau-exclu", "autre"],
+    });
+    const outReseau = await createTestMission({
+      publisherId: annonceur.id,
+      statusCode: "ACCEPTED",
+      clientId: "out",
+      organizationClientId: "org-out",
+      organizationReseaux: ["autre"],
+    });
+
+    await missionDiffusionService.rebuildForMission(inReseau.id);
+    await missionDiffusionService.rebuildForMission(outReseau.id);
+
+    expect((await snapshotPublisherIds(inReseau.id)).has(diffuser.id)).toBe(false);
+    expect((await snapshotPublisherIds(outReseau.id)).has(diffuser.id)).toBe(true);
+  });
+
+  it("purge le snapshot d'une mission soft-deleted (deleted_at IS NULL dans le SQL)", async () => {
+    await publisherDiffusionRuleService.findOrCreateScopeRoot(diffuser.id, annonceur.id);
+    const mission = await createTestMission({ publisherId: annonceur.id, statusCode: "ACCEPTED", clientId: "a-1" });
+
+    await missionDiffusionService.rebuildForMission(mission.id);
+    expect((await snapshotPublisherIds(mission.id)).size).toBeGreaterThan(0);
+
+    await prisma.mission.update({ where: { id: mission.id }, data: { deletedAt: new Date() } });
+    const result = await missionDiffusionService.rebuildForMission(mission.id);
+
+    expect(await snapshotPublisherIds(mission.id)).toEqual(new Set());
+    expect(result).toMatchObject({ desired: 0, added: 0 });
+  });
+
+  it("est à parité avec le where de référence du rebuild global (buildMissionDiffuseurSnapshotWhere)", async () => {
+    const diffuserAll = await createTestPublisher({ name: "Diffuseur all", hasApiRights: false });
+    const diffuserExcl = await createTestPublisher({ name: "Diffuseur excl", hasApiRights: false });
+    const autreAnnonceur = await createTestPublisher({ name: "Autre annonceur", hasApiRights: false });
+
+    // diffuserAll diffuse toutes les missions de l'annonceur ; diffuserExcl l'exclut si dans "reseau-exclu"
+    // et ne diffuse par ailleurs qu'un autre annonceur (jamais candidat pour cette mission).
+    await publisherDiffusionRuleService.findOrCreateScopeRoot(diffuserAll.id, annonceur.id);
+    await publisherDiffusionRuleService.createScopedRule({
+      diffuseurPublisherId: diffuserExcl.id,
+      annonceurPublisherId: annonceur.id,
+      field: "publisherOrganization.parentOrganizations",
+      fieldType: "string",
+      operator: "does_not_contain",
+      value: "reseau-exclu",
+    });
+    await publisherDiffusionRuleService.findOrCreateScopeRoot(diffuserExcl.id, autreAnnonceur.id);
+
+    const mission = await createTestMission({
+      publisherId: annonceur.id,
+      statusCode: "ACCEPTED",
+      clientId: "m-1",
+      organizationClientId: "org-1",
+      organizationReseaux: ["reseau-exclu"],
+    });
+
+    await missionDiffusionService.rebuildForMission(mission.id);
+
+    // Oracle : parcourt les diffuseurs candidats et garde ceux dont le where de référence matche la mission.
+    const candidates = [diffuserAll.id, diffuserExcl.id, annonceur.id, autreAnnonceur.id];
+    const expected = new Set<string>();
+    for (const publisherId of candidates) {
+      const where = await publisherDiffusionRuleService.buildMissionDiffuseurSnapshotWhere(publisherId);
+      const match = await prisma.mission.findFirst({ where: { AND: [where, { id: mission.id, deletedAt: null }] }, select: { id: true } });
+      if (match) {
+        expected.add(publisherId);
+      }
+    }
+
+    expect(await snapshotPublisherIds(mission.id)).toEqual(expected);
+    // Contrôle explicite : all inclus, excl retiré (réseau exclu), annonceur en scope propre.
+    expect(expected).toEqual(new Set([diffuserAll.id, annonceur.id]));
+  });
+});

--- a/terraform/containers.tf
+++ b/terraform/containers.tf
@@ -51,6 +51,7 @@ resource "scaleway_container" "api" {
     "SCW_QUEUE_ENDPOINT"               = var.enable_async_tasks ? "https://sqs.mnq.fr-par.scaleway.com" : ""
     "SCW_QUEUE_URL_MISSION_ENRICHMENT" = var.enable_async_tasks ? module.async_task_queues["mission_enrichment"].url : ""
     "SCW_QUEUE_URL_MISSION_SCORING"    = var.enable_async_tasks ? module.async_task_queues["mission_scoring"].url : ""
+    "SCW_QUEUE_URL_MISSION_DIFFUSION"  = var.enable_async_tasks ? module.async_task_queues["mission_diffusion"].url : ""
     "SCW_QUEUE_URL_MISSION_INDEX"      = var.enable_async_tasks ? module.async_task_queues["mission_index"].url : ""
   }
 
@@ -110,6 +111,7 @@ resource "scaleway_container" "api_worker" {
     "SCW_QUEUE_ENDPOINT"                = "https://sqs.mnq.fr-par.scaleway.com"
     "SCW_QUEUE_URL_MISSION_ENRICHMENT"  = module.async_task_queues["mission_enrichment"].url
     "SCW_QUEUE_URL_MISSION_SCORING"     = module.async_task_queues["mission_scoring"].url
+    "SCW_QUEUE_URL_MISSION_DIFFUSION"   = module.async_task_queues["mission_diffusion"].url
     "SCW_QUEUE_URL_MISSION_INDEX"       = module.async_task_queues["mission_index"].url
     "ALBERT_BASE_URL"                   = lookup(local.secrets, "ALBERT_BASE_URL", "https://albert.api.etalab.gouv.fr")
     "MISSION_ENRICHMENT_PROMPT_VERSION" = var.mission_enrichment_prompt_version

--- a/terraform/jobs.tf
+++ b/terraform/jobs.tf
@@ -19,6 +19,7 @@ locals {
     "SCW_QUEUE_ENDPOINT"               = var.enable_async_tasks ? "https://sqs.mnq.fr-par.scaleway.com" : ""
     "SCW_QUEUE_URL_MISSION_ENRICHMENT" = var.enable_async_tasks ? module.async_task_queues["mission_enrichment"].url : ""
     "SCW_QUEUE_URL_MISSION_SCORING"    = var.enable_async_tasks ? module.async_task_queues["mission_scoring"].url : ""
+    "SCW_QUEUE_URL_MISSION_DIFFUSION"  = var.enable_async_tasks ? module.async_task_queues["mission_diffusion"].url : ""
     "SCW_QUEUE_URL_MISSION_INDEX"      = var.enable_async_tasks ? module.async_task_queues["mission_index"].url : ""
     "SCW_QUEUE_ACCESS_KEY"             = var.enable_async_tasks ? scaleway_mnq_sqs_credentials.async_task_publisher[0].access_key : ""
     "SCW_QUEUE_SECRET_KEY"             = var.enable_async_tasks ? scaleway_mnq_sqs_credentials.async_task_publisher[0].secret_key : ""

--- a/terraform/queues.tf
+++ b/terraform/queues.tf
@@ -61,6 +61,10 @@ locals {
       task_type = "mission.scoring"
       name      = "${var.workspace}-mission-scoring"
     }
+    mission_diffusion = {
+      task_type = "mission.diffusion"
+      name      = "${var.workspace}-mission-diffusion"
+    }
     mission_index = {
       task_type = "mission.index"
       name      = "${var.workspace}-mission-index"


### PR DESCRIPTION
## Description

Cette PR ajoute la mise à jour événementielle de `mission_diffusion` au cycle de vie d'une mission.

Le pipeline devient :

`mission.enrichment` → `mission.scoring` → `mission.diffusion` → `mission.index`

Elle apporte notamment :

- un worker idempotent `mission.diffusion` qui recalcule le snapshot d'une mission avant son indexation ;
- une sélection mission-centric des scopes candidats, évalués en une requête PostgreSQL en réutilisant le compilateur SQL existant des règles de diffusion ;
- la purge du snapshot pour les missions supprimées ou inexistantes ;
- des déclencheurs séparés de l'enrichissement pour éviter un appel LLM inutile ;
- un signal générique de modification de l'organisation liée pour couvrir les changements qui ne ressortent pas du diff de la ligne mission ;
- l'alignement du job `update-mission-scoring` sur ce nouveau pipeline ;
- la queue Scaleway, son trigger et les variables d'environnement associées.

Le rebuild global et son cron restent inchangés dans cette PR. Les déclenchements liés aux modifications des règles publisher feront l'objet d'une PR séparée.

## Liens utiles

- Ticket Notion : non renseigné

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés
- [x] Respect des standards de code (ESLint)
- [x] Typecheck TypeScript
- [x] Format Terraform vérifié
- [x] Aucune migration de données nécessaire

## Validation

- 61 fichiers de tests unitaires passés
- 679 tests passés
- `tsc --noEmit` passé
- ESLint passé
- `terraform fmt -check` passé

## Notes complémentaires

La queue `mission_diffusion` doit être créée avec le déploiement Terraform avant que les producteurs ne publient durablement sur ce nouveau type de tâche. Les traitements sont conçus pour être rejouables dans le contexte at-least-once de SQS.