### PR TITLE
feat(api): refresh mission diffusion on publisher rule changes

### DIFF
--- a/api/src/services/__tests__/publisher-diffusion-task.test.ts
+++ b/api/src/services/__tests__/publisher-diffusion-task.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { asyncTaskBus } from "@/services/async-task";
+import { publisherDiffusionTaskService } from "@/services/publisher-diffusion-task";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("publisherDiffusionTaskService", () => {
+  it("publie une tâche par publisher de diffusion", async () => {
+    await publisherDiffusionTaskService.enqueue(["publisher-1", "publisher-2"]);
+
+    expect(asyncTaskBus.publish).toHaveBeenCalledWith({ type: "publisher.diffusion", payload: { publisherId: "publisher-1" } });
+    expect(asyncTaskBus.publish).toHaveBeenCalledWith({ type: "publisher.diffusion", payload: { publisherId: "publisher-2" } });
+  });
+
+  it("déduplique les publishers", async () => {
+    await publisherDiffusionTaskService.enqueue(["publisher-1", "publisher-1"]);
+
+    expect(asyncTaskBus.publish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/api/src/services/mission-diffusion/__tests__/index.test.ts
+++ b/api/src/services/mission-diffusion/__tests__/index.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/services/publisher-diffusion-rule", () => {
   const service = {
     buildMissionDiffuseurSnapshotWhere: vi.fn(),
     findDistributionPublisherScopesForMission: vi.fn(),
+    isDistributionPublisherForSnapshot: vi.fn(),
   };
   return { default: service, publisherDiffusionRuleService: service };
 });
@@ -36,6 +37,7 @@ vi.mock("@/services/async-task", () => ({
 
 import { missionRepository } from "@/repositories/mission";
 import { missionDiffusionRepository } from "@/repositories/mission-diffusion";
+import { asyncTaskBus } from "@/services/async-task";
 import { missionDiffusionService } from "@/services/mission-diffusion";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 
@@ -56,6 +58,10 @@ const missionDiffusionRepositoryMock = missionDiffusionRepository as unknown as 
 const ruleServiceMock = publisherDiffusionRuleService as unknown as {
   buildMissionDiffuseurSnapshotWhere: ReturnType<typeof vi.fn>;
   findDistributionPublisherScopesForMission: ReturnType<typeof vi.fn>;
+  isDistributionPublisherForSnapshot: ReturnType<typeof vi.fn>;
+};
+const asyncTaskBusMock = asyncTaskBus as unknown as {
+  publish: ReturnType<typeof vi.fn>;
 };
 
 beforeEach(() => {
@@ -70,6 +76,44 @@ beforeEach(() => {
   missionDiffusionRepositoryMock.deleteManyForDistributionPublisher.mockImplementation(async (_distributionPublisherId: string, ids: string[]) => ids.length);
   missionDiffusionRepositoryMock.findDistributionPublisherIdsForMission.mockResolvedValue([]);
   missionDiffusionRepositoryMock.replaceForMission.mockResolvedValue({ added: 0, removed: 0 });
+  ruleServiceMock.isDistributionPublisherForSnapshot.mockResolvedValue(true);
+  asyncTaskBusMock.publish.mockResolvedValue(undefined);
+});
+
+describe("missionDiffusionService publisher fan-out", () => {
+  it("publie uniquement les missions ajoutées ou retirées du snapshot", async () => {
+    ruleServiceMock.buildMissionDiffuseurSnapshotWhere.mockResolvedValue({ publisherId: "annonceur-1" });
+    missionDiffusionRepositoryMock.findMissionIdsPageByDistributionPublisher.mockResolvedValue(["kept", "removed"]);
+    missionRepositoryMock.findIds.mockResolvedValue(["kept"]);
+    missionRepositoryMock.findIdsPage.mockResolvedValue(["kept", "added"]);
+    missionDiffusionRepositoryMock.findExistingMissionIdsForDistributionPublisher.mockResolvedValue(["kept"]);
+
+    const result = await missionDiffusionService.enqueueChangedMissionsForDistributionPublisher("publisher-1");
+
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledTimes(2);
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.diffusion", payload: { missionId: "removed" } });
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.diffusion", payload: { missionId: "added" } });
+    expect(result).toMatchObject({
+      distributionPublisherId: "publisher-1",
+      desired: 2,
+      queued: 2,
+      added: 1,
+      removed: 1,
+    });
+  });
+
+  it("purge toutes les missions quand le publisher sort de la population du snapshot", async () => {
+    ruleServiceMock.isDistributionPublisherForSnapshot.mockResolvedValue(false);
+    missionDiffusionRepositoryMock.findMissionIdsPageByDistributionPublisher.mockResolvedValue(["mission-1", "mission-2"]);
+
+    const result = await missionDiffusionService.enqueueChangedMissionsForDistributionPublisher("publisher-1");
+
+    expect(ruleServiceMock.buildMissionDiffuseurSnapshotWhere).not.toHaveBeenCalled();
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.diffusion", payload: { missionId: "mission-1" } });
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.diffusion", payload: { missionId: "mission-2" } });
+    expect(result).toMatchObject({ desired: 0, queued: 2, added: 0, removed: 2 });
+  });
+
 });
 
 describe("missionDiffusionService.rebuildForDistributionPublisher", () => {

--- a/api/src/services/mission-diffusion/index.ts
+++ b/api/src/services/mission-diffusion/index.ts
@@ -7,6 +7,7 @@ import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 // paramètres liés, sans transaction longue globale.
 const WRITE_BATCH_SIZE = 5000;
 const READ_PAGE_SIZE = 5000;
+const PUBLISH_BATCH_SIZE = 100;
 
 export type MissionDiffusionRebuildDistributionPublisherResult = {
   distributionPublisherId: string;
@@ -35,7 +36,20 @@ const chunk = <T>(items: T[], size: number): T[][] => {
 
 type SnapshotWhere = Awaited<ReturnType<typeof publisherDiffusionRuleService.buildMissionDiffuseurSnapshotWhere>>;
 
-const deleteStaleRowsByPages = async (distributionPublisherId: string, snapshotWhere: SnapshotWhere, options: RebuildOptions): Promise<number> => {
+const enqueueMissionDiffusion = async (missionId: string): Promise<void> => {
+  await asyncTaskBus.publish({ type: "mission.diffusion", payload: { missionId } });
+};
+
+type DiffHandlers = {
+  onAdded: (missionIds: string[]) => Promise<number>;
+  onRemoved: (missionIds: string[]) => Promise<number>;
+};
+
+const visitDistributionPublisherDiff = async (
+  distributionPublisherId: string,
+  snapshotWhere: SnapshotWhere,
+  handlers: DiffHandlers
+): Promise<{ desired: number; added: number; removed: number }> => {
   let removed = 0;
   let afterMissionId: string | undefined;
 
@@ -50,12 +64,8 @@ const deleteStaleRowsByPages = async (distributionPublisherId: string, snapshotW
     const desiredExistingSet = new Set(desiredExistingIds);
     const toRemove = existingIds.filter((id) => !desiredExistingSet.has(id));
 
-    for (const batch of chunk(toRemove, WRITE_BATCH_SIZE)) {
-      removed += options.dryRun ? batch.length : await missionDiffusionRepository.deleteManyForDistributionPublisher(distributionPublisherId, batch);
-    }
-
-    if (!options.dryRun && toRemove.length > 0 && options.onMissionsTouched) {
-      await options.onMissionsTouched(toRemove);
+    if (toRemove.length > 0) {
+      removed += await handlers.onRemoved(toRemove);
     }
 
     if (existingIds.length < READ_PAGE_SIZE) {
@@ -63,10 +73,6 @@ const deleteStaleRowsByPages = async (distributionPublisherId: string, snapshotW
     }
   }
 
-  return removed;
-};
-
-const createMissingRowsByPages = async (distributionPublisherId: string, snapshotWhere: SnapshotWhere, options: RebuildOptions): Promise<{ desired: number; added: number }> => {
   let desired = 0;
   let added = 0;
   let afterId: string | undefined;
@@ -83,12 +89,8 @@ const createMissingRowsByPages = async (distributionPublisherId: string, snapsho
     const existingDesiredSet = new Set(existingDesiredIds);
     const toAdd = desiredIds.filter((id) => !existingDesiredSet.has(id));
 
-    for (const batch of chunk(toAdd, WRITE_BATCH_SIZE)) {
-      added += options.dryRun ? batch.length : await missionDiffusionRepository.createManyForDistributionPublisher(distributionPublisherId, batch);
-    }
-
-    if (!options.dryRun && toAdd.length > 0 && options.onMissionsTouched) {
-      await options.onMissionsTouched(toAdd);
+    if (toAdd.length > 0) {
+      added += await handlers.onAdded(toAdd);
     }
 
     if (desiredIds.length < READ_PAGE_SIZE) {
@@ -96,7 +98,7 @@ const createMissingRowsByPages = async (distributionPublisherId: string, snapsho
     }
   }
 
-  return { desired, added };
+  return { desired, added, removed };
 };
 
 export type MissionDiffusionRebuildMissionResult = {
@@ -107,9 +109,44 @@ export type MissionDiffusionRebuildMissionResult = {
   durationMs: number;
 };
 
+export type MissionDiffusionPublisherFanOutResult = {
+  distributionPublisherId: string;
+  desired: number;
+  added: number;
+  removed: number;
+  queued: number;
+  durationMs: number;
+};
+
 export const missionDiffusionService = {
   async enqueue(missionId: string): Promise<void> {
-    await asyncTaskBus.publish({ type: "mission.diffusion", payload: { missionId } });
+    await enqueueMissionDiffusion(missionId);
+  },
+
+  async enqueueChangedMissionsForDistributionPublisher(distributionPublisherId: string): Promise<MissionDiffusionPublisherFanOutResult> {
+    const start = Date.now();
+    const isDistributionPublisher = await publisherDiffusionRuleService.isDistributionPublisherForSnapshot(distributionPublisherId);
+    const snapshotWhere = isDistributionPublisher
+      ? await publisherDiffusionRuleService.buildMissionDiffuseurSnapshotWhere(distributionPublisherId)
+      : ({ id: { in: [] } } satisfies SnapshotWhere);
+    const enqueue = async (missionIds: string[]): Promise<number> => {
+      for (const batch of chunk(missionIds, PUBLISH_BATCH_SIZE)) {
+        await Promise.all(batch.map(enqueueMissionDiffusion));
+      }
+      return missionIds.length;
+    };
+
+    const result = await visitDistributionPublisherDiff(distributionPublisherId, snapshotWhere, {
+      onAdded: enqueue,
+      onRemoved: enqueue,
+    });
+
+    return {
+      distributionPublisherId,
+      ...result,
+      queued: result.added + result.removed,
+      durationMs: Date.now() - start,
+    };
   },
 
   /**
@@ -119,9 +156,20 @@ export const missionDiffusionService = {
   async rebuildForDistributionPublisher(distributionPublisherId: string, options: RebuildOptions = {}): Promise<MissionDiffusionRebuildDistributionPublisherResult> {
     const start = Date.now();
     const snapshotWhere = await publisherDiffusionRuleService.buildMissionDiffuseurSnapshotWhere(distributionPublisherId);
-
-    const removed = await deleteStaleRowsByPages(distributionPublisherId, snapshotWhere, options);
-    const { desired, added } = await createMissingRowsByPages(distributionPublisherId, snapshotWhere, options);
+    const apply = (operation: (batch: string[]) => Promise<number>) => async (missionIds: string[]): Promise<number> => {
+      let changed = 0;
+      for (const batch of chunk(missionIds, WRITE_BATCH_SIZE)) {
+        changed += options.dryRun ? batch.length : await operation(batch);
+      }
+      if (!options.dryRun && options.onMissionsTouched) {
+        await options.onMissionsTouched(missionIds);
+      }
+      return changed;
+    };
+    const { desired, added, removed } = await visitDistributionPublisherDiff(distributionPublisherId, snapshotWhere, {
+      onAdded: apply((batch) => missionDiffusionRepository.createManyForDistributionPublisher(distributionPublisherId, batch)),
+      onRemoved: apply((batch) => missionDiffusionRepository.deleteManyForDistributionPublisher(distributionPublisherId, batch)),
+    });
 
     return { distributionPublisherId, desired, added, removed, durationMs: Date.now() - start, dryRun: options.dryRun || undefined };
   },

--- a/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/index.test.ts
@@ -367,3 +367,29 @@ describe("publisherDiffusionRuleService.findDistributionPublisherIdsForSnapshot"
     expect(publisherIds).toEqual(["api-only", "rule-only", "both"]);
   });
 });
+
+describe("publisherDiffusionRuleService.isDistributionPublisherForSnapshot", () => {
+  beforeEach(() => {
+    prismaMock.publisher.findFirst.mockReset();
+  });
+
+  it("reconnaît un publisher actif avec droits API ou scope root", async () => {
+    prismaMock.publisher.findFirst.mockResolvedValue({ id: "publisher-1" });
+
+    await expect(publisherDiffusionRuleService.isDistributionPublisherForSnapshot("publisher-1")).resolves.toBe(true);
+    expect(prismaMock.publisher.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "publisher-1",
+        deletedAt: null,
+        OR: [{ hasApiRights: true }, { diffusionRules: { some: DIFFUSION_SCOPE_ROOT_CRITERIA } }],
+      },
+      select: { id: true },
+    });
+  });
+
+  it("refuse un publisher sorti de la population", async () => {
+    prismaMock.publisher.findFirst.mockResolvedValue(null);
+
+    await expect(publisherDiffusionRuleService.isDistributionPublisherForSnapshot("publisher-1")).resolves.toBe(false);
+  });
+});

--- a/api/src/services/publisher-diffusion-rule/__tests__/mutations.test.ts
+++ b/api/src/services/publisher-diffusion-rule/__tests__/mutations.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/publisher-diffusion-rule", () => ({
+  default: {
+    createScopedRuleWithStatus: vi.fn(),
+    deleteRule: vi.fn(),
+    deleteRulesWithPublisherIds: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/publisher-diffusion-task", () => ({
+  publisherDiffusionTaskService: {
+    enqueue: vi.fn(),
+  },
+}));
+
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
+import { publisherDiffusionRuleMutationService } from "@/services/publisher-diffusion-rule/mutations";
+import { publisherDiffusionTaskService } from "@/services/publisher-diffusion-task";
+
+const rule = {
+  id: "rule-1",
+  publisherId: "publisher-1",
+  combinedWithId: "root-1",
+  field: "publisherOrganization.clientId",
+  fieldType: "string",
+  operator: "is_not",
+  value: "organization-1",
+  combinator: "or" as const,
+  position: 0,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+
+const ruleServiceMock = publisherDiffusionRuleService as unknown as {
+  createScopedRuleWithStatus: ReturnType<typeof vi.fn>;
+  deleteRule: ReturnType<typeof vi.fn>;
+  deleteRulesWithPublisherIds: ReturnType<typeof vi.fn>;
+};
+const taskServiceMock = publisherDiffusionTaskService as unknown as {
+  enqueue: ReturnType<typeof vi.fn>;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  taskServiceMock.enqueue.mockResolvedValue(undefined);
+});
+
+describe("publisherDiffusionRuleMutationService", () => {
+  it("déclenche le publisher après la création effective d'une règle", async () => {
+    ruleServiceMock.createScopedRuleWithStatus.mockResolvedValue({ rule, changed: true });
+
+    await expect(
+      publisherDiffusionRuleMutationService.createScopedRule({
+        diffuseurPublisherId: "publisher-1",
+        annonceurPublisherId: "annonceur-1",
+        field: rule.field,
+        fieldType: rule.fieldType,
+        operator: rule.operator,
+        value: rule.value,
+      })
+    ).resolves.toEqual(rule);
+
+    expect(taskServiceMock.enqueue).toHaveBeenCalledWith(["publisher-1"]);
+  });
+
+  it("ne publie rien quand la règle existe déjà à l'identique", async () => {
+    ruleServiceMock.createScopedRuleWithStatus.mockResolvedValue({ rule, changed: false });
+
+    await publisherDiffusionRuleMutationService.createScopedRule({
+      diffuseurPublisherId: "publisher-1",
+      annonceurPublisherId: "annonceur-1",
+      field: rule.field,
+      fieldType: rule.fieldType,
+      operator: rule.operator,
+      value: rule.value,
+    });
+
+    expect(taskServiceMock.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("déclenche le publisher après une suppression", async () => {
+    ruleServiceMock.deleteRule.mockResolvedValue(rule);
+
+    await publisherDiffusionRuleMutationService.deleteRule("rule-1");
+
+    expect(taskServiceMock.enqueue).toHaveBeenCalledWith(["publisher-1"]);
+  });
+
+  it("déduplique les publishers touchés par une suppression multiple", async () => {
+    ruleServiceMock.deleteRulesWithPublisherIds.mockResolvedValue({ count: 3, publisherIds: ["publisher-1", "publisher-2"] });
+
+    await publisherDiffusionRuleMutationService.deleteRules({ field: rule.field, value: rule.value });
+
+    expect(taskServiceMock.enqueue).toHaveBeenCalledWith(["publisher-1", "publisher-2"]);
+  });
+
+  it("ne publie rien quand la suppression multiple est un no-op", async () => {
+    ruleServiceMock.deleteRulesWithPublisherIds.mockResolvedValue({ count: 0, publisherIds: [] });
+
+    await publisherDiffusionRuleMutationService.deleteRules({ field: rule.field, value: rule.value });
+
+    expect(taskServiceMock.enqueue).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/services/publisher-diffusion-rule/index.ts
+++ b/api/src/services/publisher-diffusion-rule/index.ts
@@ -251,6 +251,18 @@ export const publisherDiffusionRuleService = {
     return publishers.map((publisher) => publisher.id);
   },
 
+  async isDistributionPublisherForSnapshot(publisherId: string): Promise<boolean> {
+    const publisher = await publisherRepository.findFirst({
+      where: {
+        id: publisherId,
+        deletedAt: null,
+        OR: [{ hasApiRights: true }, { diffusionRules: { some: DIFFUSION_SCOPE_ROOT_CRITERIA } }],
+      },
+      select: { id: true },
+    });
+    return publisher !== null;
+  },
+
   async findDistributionPublisherScopesForMission(publisherId: string): Promise<MissionDistributionPublisherScope[]> {
     const [candidateRoots, ownDistributionPublisher] = await Promise.all([
       publisherDiffusionRuleRepository.findMany({
@@ -383,31 +395,36 @@ export const publisherDiffusionRuleService = {
    * et création des manquants. Pas de delete+recreate global, pour préserver les
    * rules enfants (ex. exclusions d'organisations) des roots conservés.
    */
-  async syncScopeRoots(diffuseurPublisherId: string, annonceurPublisherIds: string[], tx?: Prisma.TransactionClient): Promise<void> {
+  async syncScopeRoots(diffuseurPublisherId: string, annonceurPublisherIds: string[], tx?: Prisma.TransactionClient): Promise<boolean> {
     const roots = await this.findRules({ publisherId: diffuseurPublisherId, ...DIFFUSION_SCOPE_ROOT_CRITERIA }, tx);
     const desired = new Set(annonceurPublisherIds);
     const existing = new Set(roots.map((root) => root.value));
+    let changed = false;
 
     for (const root of roots) {
       if (!desired.has(root.value)) {
         await this.deleteRule(root.id, tx);
+        changed = true;
       }
     }
     for (const annonceurPublisherId of annonceurPublisherIds) {
       if (!existing.has(annonceurPublisherId)) {
         await this.findOrCreateScopeRoot(diffuseurPublisherId, annonceurPublisherId, tx);
+        changed = true;
       }
     }
+
+    return changed;
   },
 
-  async createScopedRule(input: {
+  async createScopedRuleWithStatus(input: {
     diffuseurPublisherId: string;
     annonceurPublisherId: string;
     field: string;
     fieldType?: string | null;
     operator: string;
     value: string;
-  }): Promise<PublisherDiffusionRuleRecord> {
+  }): Promise<{ rule: PublisherDiffusionRuleRecord; changed: boolean }> {
     const root = await this.findOrCreateScopeRoot(input.diffuseurPublisherId, input.annonceurPublisherId);
 
     const existing = await publisherDiffusionRuleRepository.findFirst({
@@ -419,7 +436,7 @@ export const publisherDiffusionRuleService = {
       // renvoyer silencieusement une règle qui ne correspond pas à la demande (clé unique sur field + value).
       const isSameRule = existing.operator === input.operator && (existing.fieldType ?? null) === (input.fieldType ?? null);
       if (isSameRule) {
-        return toRecord(existing as PublisherDiffusionRuleWithChildren);
+        return { rule: toRecord(existing as PublisherDiffusionRuleWithChildren), changed: false };
       }
       const conflict = new Error(`A diffusion rule already exists for field "${input.field}" and value "${input.value}" with a different operator`) as Error & {
         code: string;
@@ -444,11 +461,24 @@ export const publisherDiffusionRuleService = {
       include: { combinedRules: true },
     })) as PublisherDiffusionRuleWithChildren;
 
-    return toRecord(created);
+    return { rule: toRecord(created), changed: true };
   },
 
-  async deleteRule(id: string, tx?: Prisma.TransactionClient): Promise<void> {
-    await publisherDiffusionRuleRepository.delete({ where: { id } }, tx);
+  async createScopedRule(input: {
+    diffuseurPublisherId: string;
+    annonceurPublisherId: string;
+    field: string;
+    fieldType?: string | null;
+    operator: string;
+    value: string;
+  }): Promise<PublisherDiffusionRuleRecord> {
+    const result = await this.createScopedRuleWithStatus(input);
+    return result.rule;
+  },
+
+  async deleteRule(id: string, tx?: Prisma.TransactionClient): Promise<PublisherDiffusionRuleRecord> {
+    const deleted = await publisherDiffusionRuleRepository.delete({ where: { id } }, tx);
+    return toRecord(deleted);
   },
 
   async deleteRules(params: PublisherDiffusionRuleFindParams): Promise<number> {
@@ -456,6 +486,16 @@ export const publisherDiffusionRuleService = {
       where: buildFindWhere(params),
     });
     return result.count;
+  },
+
+  async deleteRulesWithPublisherIds(params: PublisherDiffusionRuleFindParams): Promise<{ count: number; publisherIds: string[] }> {
+    const rules = await this.findRules(params);
+    if (rules.length === 0) {
+      return { count: 0, publisherIds: [] };
+    }
+
+    const count = await this.deleteRules(params);
+    return { count, publisherIds: Array.from(new Set(rules.map((rule) => rule.publisherId))) };
   },
 };
 

--- a/api/src/services/publisher-diffusion-rule/mutations.ts
+++ b/api/src/services/publisher-diffusion-rule/mutations.ts
@@ -1,0 +1,35 @@
+import { publisherDiffusionTaskService } from "@/services/publisher-diffusion-task";
+import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
+import type { PublisherDiffusionRuleFindParams, PublisherDiffusionRuleRecord } from "@/types/publisher-diffusion-rule";
+
+type CreateScopedRuleInput = {
+  diffuseurPublisherId: string;
+  annonceurPublisherId: string;
+  field: string;
+  fieldType?: string | null;
+  operator: string;
+  value: string;
+};
+
+export const publisherDiffusionRuleMutationService = {
+  async createScopedRule(input: CreateScopedRuleInput): Promise<PublisherDiffusionRuleRecord> {
+    const { rule, changed } = await publisherDiffusionRuleService.createScopedRuleWithStatus(input);
+    if (changed) {
+      await publisherDiffusionTaskService.enqueue([input.diffuseurPublisherId]);
+    }
+    return rule;
+  },
+
+  async deleteRule(id: string): Promise<void> {
+    const deleted = await publisherDiffusionRuleService.deleteRule(id);
+    await publisherDiffusionTaskService.enqueue([deleted.publisherId]);
+  },
+
+  async deleteRules(params: PublisherDiffusionRuleFindParams): Promise<number> {
+    const { count, publisherIds } = await publisherDiffusionRuleService.deleteRulesWithPublisherIds(params);
+    if (count > 0) {
+      await publisherDiffusionTaskService.enqueue(publisherIds);
+    }
+    return count;
+  },
+};

--- a/api/src/services/publisher-diffusion-task.ts
+++ b/api/src/services/publisher-diffusion-task.ts
@@ -1,0 +1,8 @@
+import { asyncTaskBus } from "@/services/async-task";
+
+export const publisherDiffusionTaskService = {
+  async enqueue(distributionPublisherIds: string[]): Promise<void> {
+    const publisherIds = Array.from(new Set(distributionPublisherIds));
+    await Promise.all(publisherIds.map((publisherId) => asyncTaskBus.publish({ type: "publisher.diffusion", payload: { publisherId } })));
+  },
+};

--- a/api/src/services/publisher.ts
+++ b/api/src/services/publisher.ts
@@ -4,6 +4,7 @@ import { MissionType, Prisma, Publisher } from "@/db/core";
 import { prisma } from "@/db/postgres";
 import { publisherRepository } from "@/repositories/publisher";
 import { publisherDiffusionRuleRepository } from "@/repositories/publisher-diffusion-rule";
+import { publisherDiffusionTaskService } from "@/services/publisher-diffusion-task";
 import { normalizeDemarches, publisherDemarcheSimplifieesService } from "@/services/publisher-demarches-simplifiees";
 import publisherDiffusionRuleService, { DIFFUSION_SCOPE_ROOT_CRITERIA } from "@/services/publisher-diffusion-rule";
 import {
@@ -165,9 +166,9 @@ export const publisherService = (() => {
    * Valide les partenaires puis aligne les scope roots via le service des
    * diffusion rules (diff création/suppression, rules enfants préservées).
    */
-  const syncDiffusionScopeRoots = async (tx: Prisma.TransactionClient, publisherId: string, desiredPartnerIds: string[]): Promise<void> => {
+  const syncDiffusionScopeRoots = async (tx: Prisma.TransactionClient, publisherId: string, desiredPartnerIds: string[]): Promise<boolean> => {
     await ensureDiffusionPartnersExist(tx, desiredPartnerIds);
-    await publisherDiffusionRuleService.syncScopeRoots(publisherId, desiredPartnerIds, tx);
+    return publisherDiffusionRuleService.syncScopeRoots(publisherId, desiredPartnerIds, tx);
   };
 
   const buildWhereClause = (params: PublisherSearchParams): Prisma.PublisherWhereInput => {
@@ -278,13 +279,18 @@ export const publisherService = (() => {
       data.demarcheSimplifiees = { create: normalizedDemarches };
     }
 
-    const created = await prisma.$transaction(async (tx) => {
+    const { publisher: created, diffusionChanged } = await prisma.$transaction(async (tx) => {
       const publisher = await tx.publisher.create({ data, include: defaultInclude });
       if (rightsEnabled && normalizedPartnerIds.length) {
-        await syncDiffusionScopeRoots(tx, publisher.id, normalizedPartnerIds);
+        const diffusionChanged = await syncDiffusionScopeRoots(tx, publisher.id, normalizedPartnerIds);
+        return { publisher, diffusionChanged };
       }
-      return publisher;
+      return { publisher, diffusionChanged: false };
     });
+
+    if (diffusionChanged || created.hasApiRights) {
+      await publisherDiffusionTaskService.enqueue([created.id]);
+    }
 
     return toPublisherRecordWithDiffusions(created);
   };
@@ -391,6 +397,7 @@ export const publisherService = (() => {
       where: { id },
       data: { deletedAt: new Date() },
     });
+    await publisherDiffusionTaskService.enqueue([id]);
     return toPublisherRecordWithDiffusions(updated);
   };
 
@@ -491,20 +498,26 @@ export const publisherService = (() => {
 
     const shouldClearDiffusions = patch.publishers === null || !rightsEnabled;
 
-    const updated = await prisma.$transaction(async (tx) => {
+    const { publisher: updated, diffusionChanged } = await prisma.$transaction(async (tx) => {
       const publisher = await tx.publisher.update({
         where: { id },
         data,
       });
 
+      let diffusionChanged = false;
       if (shouldClearDiffusions) {
-        await syncDiffusionScopeRoots(tx, id, []);
+        diffusionChanged = await syncDiffusionScopeRoots(tx, id, []);
       } else if (normalizedPartnerIds) {
-        await syncDiffusionScopeRoots(tx, id, normalizedPartnerIds);
+        diffusionChanged = await syncDiffusionScopeRoots(tx, id, normalizedPartnerIds);
       }
 
-      return publisher;
+      return { publisher, diffusionChanged };
     });
+
+    const diffusionEligibilityChanged = patch.hasApiRights !== undefined && patch.hasApiRights !== existing.hasApiRights;
+    if (diffusionChanged || diffusionEligibilityChanged) {
+      await publisherDiffusionTaskService.enqueue([id]);
+    }
 
     return toPublisherRecordWithDiffusions(updated);
   };

--- a/api/src/v0/diffusion-rule/controller.ts
+++ b/api/src/v0/diffusion-rule/controller.ts
@@ -7,6 +7,7 @@ import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { publisherService } from "@/services/publisher";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import { SUPPORTED_CHILD_FIELDS } from "@/services/publisher-diffusion-rule/config";
+import { publisherDiffusionRuleMutationService } from "@/services/publisher-diffusion-rule/mutations";
 import { PublisherRequest } from "@/types/passport";
 import type { PublisherRecord } from "@/types/publisher";
 
@@ -122,7 +123,7 @@ router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction
 
     const created = await Promise.all(
       diffuseurIds.map((diffuseurId) =>
-        publisherDiffusionRuleService.createScopedRule({
+        publisherDiffusionRuleMutationService.createScopedRule({
           diffuseurPublisherId: diffuseurId,
           annonceurPublisherId: user.id,
           field: body.data.field,
@@ -177,7 +178,7 @@ router.delete("/:id", async (req: PublisherRequest, res: Response, next: NextFun
       return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Rule not scoped to user" });
     }
 
-    await publisherDiffusionRuleService.deleteRule(rule.id);
+    await publisherDiffusionRuleMutationService.deleteRule(rule.id);
 
     return res.status(200).send({ ok: true });
   } catch (error) {

--- a/api/src/v0/myorganization/controller.ts
+++ b/api/src/v0/myorganization/controller.ts
@@ -6,6 +6,7 @@ import { INVALID_BODY, INVALID_PARAMS, NOT_FOUND } from "@/error";
 import { publisherRateLimiter } from "@/middlewares/rate-limit";
 import { publisherService } from "@/services/publisher";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
+import { publisherDiffusionRuleMutationService } from "@/services/publisher-diffusion-rule/mutations";
 import publisherOrganizationService from "@/services/publisher-organization";
 import { statEventService } from "@/services/stat-event";
 import { PublisherRequest } from "@/types/passport";
@@ -109,7 +110,7 @@ router.put("/:organizationClientId", async (req: PublisherRequest, res: Response
     const toCreate = targetExcludedIds.filter((id) => !previousExclusions.has(id));
 
     if (toDelete.length) {
-      await publisherDiffusionRuleService.deleteRules({
+      await publisherDiffusionRuleMutationService.deleteRules({
         publisherIds: toDelete,
         field: EXCLUSION_RULE_FIELD,
         value: params.data.organizationClientId,
@@ -118,7 +119,7 @@ router.put("/:organizationClientId", async (req: PublisherRequest, res: Response
 
     await Promise.all(
       toCreate.map((diffuseurId) =>
-        publisherDiffusionRuleService.createScopedRule({
+        publisherDiffusionRuleMutationService.createScopedRule({
           diffuseurPublisherId: diffuseurId,
           annonceurPublisherId: user.id,
           field: EXCLUSION_RULE_FIELD,

--- a/api/src/worker/__tests__/publisher-diffusion.test.ts
+++ b/api/src/worker/__tests__/publisher-diffusion.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/mission-diffusion", () => ({
+  missionDiffusionService: {
+    enqueueChangedMissionsForDistributionPublisher: vi.fn(),
+  },
+}));
+
+import { missionDiffusionService } from "@/services/mission-diffusion";
+import { handlePublisherDiffusion } from "@/worker/handlers/publisher-diffusion";
+import { publisherDiffusionPayloadSchema } from "@/worker/types";
+
+const missionDiffusionServiceMock = missionDiffusionService as unknown as {
+  enqueueChangedMissionsForDistributionPublisher: ReturnType<typeof vi.fn>;
+};
+
+describe("publisher diffusion worker", () => {
+  it("valide le payload publisher.diffusion", () => {
+    expect(publisherDiffusionPayloadSchema.parse({ publisherId: "publisher-1" })).toEqual({ publisherId: "publisher-1" });
+  });
+
+  it("déclenche le fan-out des missions modifiées", async () => {
+    missionDiffusionServiceMock.enqueueChangedMissionsForDistributionPublisher.mockResolvedValue({
+      distributionPublisherId: "publisher-1",
+      desired: 3,
+      queued: 2,
+      added: 1,
+      removed: 1,
+      durationMs: 10,
+    });
+
+    await handlePublisherDiffusion({ publisherId: "publisher-1" });
+
+    expect(missionDiffusionServiceMock.enqueueChangedMissionsForDistributionPublisher).toHaveBeenCalledWith("publisher-1");
+  });
+});

--- a/api/src/worker/handlers/publisher-diffusion.ts
+++ b/api/src/worker/handlers/publisher-diffusion.ts
@@ -1,0 +1,9 @@
+import { missionDiffusionService } from "@/services/mission-diffusion";
+
+export const handlePublisherDiffusion = async (payload: { publisherId: string }) => {
+  console.log(`[publisher.diffusion] start publisherId=${payload.publisherId}`);
+  const result = await missionDiffusionService.enqueueChangedMissionsForDistributionPublisher(payload.publisherId);
+  console.log(
+    `[publisher.diffusion] done publisherId=${payload.publisherId} desired=${result.desired} queued=${result.queued} added=${result.added} removed=${result.removed}`
+  );
+};

--- a/api/src/worker/registry.ts
+++ b/api/src/worker/registry.ts
@@ -2,7 +2,16 @@ import { handleMissionDiffusion } from "./handlers/mission-diffusion";
 import { handleMissionEnrichment } from "./handlers/mission-enrichment";
 import { handleMissionIndex } from "./handlers/mission-index";
 import { handleMissionScoring } from "./handlers/mission-scoring";
-import { defineTask, missionDiffusionPayloadSchema, missionEnrichmentPayloadSchema, missionIndexPayloadSchema, missionScoringPayloadSchema, TaskRegistryEntry } from "./types";
+import { handlePublisherDiffusion } from "./handlers/publisher-diffusion";
+import {
+  defineTask,
+  missionDiffusionPayloadSchema,
+  missionEnrichmentPayloadSchema,
+  missionIndexPayloadSchema,
+  missionScoringPayloadSchema,
+  publisherDiffusionPayloadSchema,
+  TaskRegistryEntry,
+} from "./types";
 
 export const taskRegistry: Record<string, TaskRegistryEntry> = {
   "mission.enrichment": defineTask({
@@ -19,6 +28,11 @@ export const taskRegistry: Record<string, TaskRegistryEntry> = {
     queueUrl: process.env.SCW_QUEUE_URL_MISSION_DIFFUSION ?? "",
     schema: missionDiffusionPayloadSchema,
     handler: handleMissionDiffusion,
+  }),
+  "publisher.diffusion": defineTask({
+    queueUrl: process.env.SCW_QUEUE_URL_MISSION_DIFFUSION ?? "",
+    schema: publisherDiffusionPayloadSchema,
+    handler: handlePublisherDiffusion,
   }),
   "mission.index": defineTask({
     queueUrl: process.env.SCW_QUEUE_URL_MISSION_INDEX ?? "",

--- a/api/src/worker/types.ts
+++ b/api/src/worker/types.ts
@@ -6,6 +6,10 @@ export const missionPayloadSchema = z.object({
 
 export const missionDiffusionPayloadSchema = missionPayloadSchema;
 
+export const publisherDiffusionPayloadSchema = z.object({
+  publisherId: z.string().min(1),
+});
+
 export const missionScoringPayloadSchema = z.object({
   missionId: z.string().min(1),
   missionEnrichmentId: z.string().min(1).optional(),

--- a/api/tests/integration/api/endpoints/publisher.test.ts
+++ b/api/tests/integration/api/endpoints/publisher.test.ts
@@ -2,6 +2,7 @@ import request from "supertest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PUBLISHER_IDS } from "@/config";
+import { asyncTaskBus } from "@/services/async-task";
 import { publisherService } from "@/services/publisher";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import { PublisherMissionType } from "@/types/publisher";
@@ -204,6 +205,7 @@ describe("Dashboard publisher controller", () => {
   it("logs an audit event when updating a publisher", async () => {
     const { token: adminToken } = await createTestUser({ role: "admin" });
 
+    vi.mocked(asyncTaskBus.publish).mockClear();
     const res = await request(app)
       .put(`/publisher/${publisherId}`)
       .set({ Authorization: `jwt ${adminToken}` })
@@ -213,6 +215,7 @@ describe("Dashboard publisher controller", () => {
       });
 
     expect(res.status).toBe(200);
+    expect(asyncTaskBus.publish).not.toHaveBeenCalledWith(expect.objectContaining({ type: "publisher.diffusion" }));
     expect(getAuditLogs(consoleInfoSpy)).toContainEqual(
       expect.objectContaining({
         type: "security_audit",
@@ -242,6 +245,7 @@ describe("Dashboard publisher controller", () => {
       value: "org-1",
     });
 
+    vi.mocked(asyncTaskBus.publish).mockClear();
     const res = await request(app)
       .put(`/publisher/${diffuseur.id}`)
       .set({ Authorization: `jwt ${adminToken}` })
@@ -255,6 +259,7 @@ describe("Dashboard publisher controller", () => {
     expect(roots.map((rule) => rule.value).sort()).toEqual([annonceur1.id, annonceur2.id].sort());
     expect(roots.find((rule) => rule.value === annonceur1.id)?.id).toBe(rootBefore.id);
     expect(rules.find((rule) => rule.id === child.id)).toBeDefined();
+    expect(asyncTaskBus.publish).toHaveBeenCalledWith({ type: "publisher.diffusion", payload: { publisherId: diffuseur.id } });
   });
 
   it("deletes the root and its child rules when PUT /publisher/:id removes a partner", async () => {
@@ -269,6 +274,7 @@ describe("Dashboard publisher controller", () => {
       value: "org-1",
     });
 
+    vi.mocked(asyncTaskBus.publish).mockClear();
     const res = await request(app)
       .put(`/publisher/${diffuseur.id}`)
       .set({ Authorization: `jwt ${adminToken}` })
@@ -277,6 +283,22 @@ describe("Dashboard publisher controller", () => {
     expect(res.status).toBe(200);
     expect(res.body.data.publishers).toHaveLength(0);
     expect(await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id })).toHaveLength(0);
+    expect(asyncTaskBus.publish).toHaveBeenCalledWith({ type: "publisher.diffusion", payload: { publisherId: diffuseur.id } });
+  });
+
+  it("does not enqueue publisher.diffusion when PUT /publisher/:id keeps the same partner list", async () => {
+    const { token: adminToken } = await createTestUser({ role: "admin" });
+    const annonceur = await createTestPublisher({ name: "Annonceur unchanged" });
+    const diffuseur = await createTestPublisher({ name: "Diffuseur unchanged", publishers: [{ publisherId: annonceur.id }] });
+
+    vi.mocked(asyncTaskBus.publish).mockClear();
+    const res = await request(app)
+      .put(`/publisher/${diffuseur.id}`)
+      .set({ Authorization: `jwt ${adminToken}` })
+      .send({ publishers: [{ publisherId: annonceur.id }] });
+
+    expect(res.status).toBe(200);
+    expect(asyncTaskBus.publish).not.toHaveBeenCalled();
   });
 
   it("clears all scope roots when PUT /publisher/:id disables diffusion rights", async () => {
@@ -284,6 +306,7 @@ describe("Dashboard publisher controller", () => {
     const annonceur = await createTestPublisher({ name: "Annonceur" });
     const diffuseur = await createTestPublisher({ name: "Diffuseur", publishers: [{ publisherId: annonceur.id }] });
 
+    vi.mocked(asyncTaskBus.publish).mockClear();
     const res = await request(app)
       .put(`/publisher/${diffuseur.id}`)
       .set({ Authorization: `jwt ${adminToken}` })
@@ -291,6 +314,7 @@ describe("Dashboard publisher controller", () => {
 
     expect(res.status).toBe(200);
     expect(await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, combinedWithId: null })).toHaveLength(0);
+    expect(asyncTaskBus.publish).toHaveBeenCalledWith({ type: "publisher.diffusion", payload: { publisherId: diffuseur.id } });
   });
 
   it("returns true from GET /publisher/:id/moderated when JVA has a scope root for the publisher", async () => {
@@ -331,6 +355,7 @@ describe("Dashboard publisher controller", () => {
     const annonceur = await createTestPublisher({ name: "Annonceur existing" });
     const diffuseur = await createTestPublisher({ name: "Diffuseur before unknown partner", publishers: [{ publisherId: annonceur.id }] });
 
+    vi.mocked(asyncTaskBus.publish).mockClear();
     const res = await request(app)
       .put(`/publisher/${diffuseur.id}`)
       .set({ Authorization: `jwt ${adminToken}` })
@@ -343,5 +368,6 @@ describe("Dashboard publisher controller", () => {
     expect(persisted?.name).toBe("Diffuseur before unknown partner");
     expect(await publisherDiffusionRuleService.findRules({ publisherId: diffuseur.id, combinedWithId: null })).toHaveLength(1);
     expect(await publisherDiffusionRuleService.findRules({ value: "unknown-publisher-id" })).toHaveLength(0);
+    expect(asyncTaskBus.publish).not.toHaveBeenCalled();
   });
 });

--- a/api/tests/integration/api/endpoints/v0/diffusion-rule.test.ts
+++ b/api/tests/integration/api/endpoints/v0/diffusion-rule.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { asyncTaskBus } from "@/services/async-task";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 import { type PublisherRecord } from "@/types";
 
@@ -257,6 +258,7 @@ describe("DiffusionRule API Integration Tests", () => {
     });
 
     it("should create rules for allowed diffuseurs and ignore unrelated ones", async () => {
+      vi.mocked(asyncTaskBus.publish).mockClear();
       const response = await request(app)
         .post("/v0/diffusion-rule")
         .set("x-api-key", apiKey)
@@ -269,6 +271,8 @@ describe("DiffusionRule API Integration Tests", () => {
 
       const publisherIds = response.body.data.map((rule: any) => rule.publisherId).sort();
       expect(publisherIds).toEqual([diffuseur1.id, diffuseur2.id].sort());
+      expect(asyncTaskBus.publish).toHaveBeenCalledWith({ type: "publisher.diffusion", payload: { publisherId: diffuseur1.id } });
+      expect(asyncTaskBus.publish).toHaveBeenCalledWith({ type: "publisher.diffusion", payload: { publisherId: diffuseur2.id } });
       response.body.data.forEach((rule: any) => {
         expect(rule).toMatchObject({
           field: validRule.field,
@@ -304,6 +308,7 @@ describe("DiffusionRule API Integration Tests", () => {
         .send({ ...validRule, publisherIds: [diffuseur1.id] });
       expect(first.status).toBe(201);
 
+      vi.mocked(asyncTaskBus.publish).mockClear();
       const second = await request(app)
         .post("/v0/diffusion-rule")
         .set("x-api-key", apiKey)
@@ -312,6 +317,7 @@ describe("DiffusionRule API Integration Tests", () => {
       expect(second.status).toBe(201);
       expect(second.body.ok).toBe(true);
       expect(second.body.data[0].id).toBe(first.body.data[0].id);
+      expect(asyncTaskBus.publish).not.toHaveBeenCalled();
 
       const persisted = await publisherDiffusionRuleService.findRules({
         publisherId: diffuseur1.id,
@@ -409,12 +415,14 @@ describe("DiffusionRule API Integration Tests", () => {
       });
       const root = await publisherDiffusionRuleService.findOrCreateScopeRoot(diffuseur1.id, publisher.id);
 
+      vi.mocked(asyncTaskBus.publish).mockClear();
       const response = await request(app).delete(`/v0/diffusion-rule/${child.id}`).set("x-api-key", apiKey);
       expect(response.status).toBe(200);
       expect(response.body.ok).toBe(true);
 
       expect(await publisherDiffusionRuleService.findRuleById(child.id)).toBeNull();
       expect(await publisherDiffusionRuleService.findRuleById(root.id)).not.toBeNull();
+      expect(asyncTaskBus.publish).toHaveBeenCalledWith({ type: "publisher.diffusion", payload: { publisherId: diffuseur1.id } });
     });
   });
 });

--- a/terraform/jobs.tf
+++ b/terraform/jobs.tf
@@ -310,7 +310,7 @@ resource "scaleway_job_definition" "import-missions" {
   env = local.all_env_vars
 }
 
-# Job Definition for the 'mission-diffusion-rebuild' task (after import-missions)
+# Job Definition for the on-demand 'mission-diffusion-rebuild' safeguard
 resource "scaleway_job_definition" "mission-diffusion-rebuild" {
   count                  = var.enable_mission_jobs ? 1 : 0
   name                   = "${terraform.workspace}-mission-diffusion-rebuild"
@@ -322,13 +322,6 @@ resource "scaleway_job_definition" "mission-diffusion-rebuild" {
   startup_command        = ["node"]
   args                   = ["dist/jobs/run-job.js", "mission-diffusion-rebuild"]
   timeout                = "60m"
-
-  cron {
-    # import-missions démarre à HH:15 avec un timeout de 60 min ; ce décalage
-    # laisse 15 min de marge avant le rebuild suivant.
-    schedule = "30 1,7,13,19 * * *"
-    timezone = "Europe/Paris"
-  }
 
   env = local.all_env_vars
 }


### PR DESCRIPTION
## Description

Cette PR déclenche la mise à jour événementielle du snapshot `mission_diffusion` lorsqu'une configuration de diffusion publisher évolue.

Elle ajoute un worker de coordination `publisher.diffusion`, réutilisant la file `mission.diffusion`. Celui-ci compare le snapshot existant aux règles courantes, puis publie une tâche `mission.diffusion` uniquement pour les missions ajoutées ou retirées.

Les déclenchements sont centralisés dans les services et couvrent :

- les créations et suppressions via `v0/diffusion-rule` ;
- les modifications de partenaires et de droits via `PUT /publisher/:id` ;
- les exclusions via `v0/myorganization` ;
- la création et la suppression d'un publisher lorsque son éligibilité au snapshot change.

Le CRON `mission-diffusion-rebuild` est supprimé. La définition du job est conservée pour une exécution manuelle de contrôle ou de rattrapage.

## Liens utiles

- PR dépendante : #1341

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Validation

- 65 fichiers de tests unitaires, 695 tests réussis
- TypeScript : OK
- ESLint : OK
- `terraform fmt -check` : OK
- Tests d'intégration ciblés ajoutés, mais non exécutés localement faute de runtime Docker/Testcontainers

## Notes complémentaires

La PR est empilée sur #1341 afin de conserver un diff ciblé. Elle devra être rebasée ou retargetée sur `staging` après fusion de la PR précédente.

Le fan-out est paginé et publie les tâches par lots bornés. Les traitements restent idempotents et tolèrent les doublons liés aux retries SQS.