### PR TITLE
fix(plateform): restore quiz results preloading

### DIFF
--- a/plateform/app/components/quiz/loading-recap.tsx
+++ b/plateform/app/components/quiz/loading-recap.tsx
@@ -1,0 +1,76 @@
+import type { TaxonomyValueKey } from "@engagement/taxonomy";
+import { useEffect, useMemo } from "react";
+import { OPTIONS } from "~/config/quiz-options";
+import { fetchInitialMatches } from "~/services/matching";
+import { useQuizStore } from "~/stores/quiz";
+
+type Props = {
+  onComplete: () => void;
+};
+
+// Steps résumés à l'écran, dans l'ordre d'affichage.
+const RECAP_STEP_IDS = ["statut", "duree", "motivation"] as const;
+
+export default function LoadingRecap({ onComplete }: Props) {
+  const answers = useQuizStore((state) => state.answers);
+
+  // Une ligne par question ; les réponses multiples d'une même question
+  // sont regroupées sur la même ligne, séparées par des virgules.
+  const items = useMemo(
+    () =>
+      RECAP_STEP_IDS.flatMap((stepId) => {
+        const answer = answers[stepId];
+        if (!answer || answer.type !== "options") return [];
+        const labels = answer.option_ids.map((id) => OPTIONS[`${answer.taxonomy}.${id}` as TaxonomyValueKey]?.label).filter(Boolean) as string[];
+        return labels.length > 0 ? [labels.join(", ")] : [];
+      }),
+    [answers],
+  );
+
+  // Charge les résultats avant la navigation. La promesse est conservée dans le
+  // cache du service et réutilisée à l'arrivée sur /results/:id.
+  useEffect(() => {
+    const userScoringId = useQuizStore.getState().userScoringId;
+    if (!userScoringId) {
+      onComplete();
+      return;
+    }
+
+    let active = true;
+    fetchInitialMatches(userScoringId)
+      .catch(() => {
+        // Le cache est vidé en cas d'erreur : la page de résultats pourra réessayer.
+      })
+      .finally(() => {
+        if (active) onComplete();
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [onComplete]);
+
+  return (
+    <div className="flex flex-col gap-10">
+      <h1 className="fr-h1 mb-0!">
+        Parfait.
+        <br />
+        On recherche des missions pour toi !
+      </h1>
+      <ul className="list-none! p-0! m-0! flex flex-col gap-3">
+        {items.map((label) => (
+          <li key={label} className="flex items-center fr-text--lead gap-3">
+            <span
+              className="fr-icon-arrow-right-line fr-icon--sm opacity-50 flex items-center justify-center bg-background-default-grey-active h-6 w-6 rounded-full"
+              aria-hidden="true"
+            />
+            {label}
+          </li>
+        ))}
+      </ul>
+      <p className="fr-text--sm mb-0!" role="status">
+        Chargement de tes résultats…
+      </p>
+    </div>
+  );
+}

--- a/plateform/app/routes/quiz/_layout.tsx
+++ b/plateform/app/routes/quiz/_layout.tsx
@@ -43,9 +43,10 @@ export default function QuizLayout() {
   const navigate = useNavigate();
   const { answers, setUserScoringId } = useQuizStore();
   const [steps, setSteps] = useState<StepDef[]>(QUIZ_FLOW.filter((s) => !s.condition || evalCondition(s.condition, answers)));
-  const [loadingResults, setLoadingResults] = useState(false);
+  const [loadingResultsPath, setLoadingResultsPath] = useState<string | null>(null);
   const [scoringError, setScoringError] = useState<string | null>(null);
   const currentStep = useMemo(() => steps.find((s) => s.route === location.pathname) ?? null, [location.pathname, steps]);
+  const loadingResults = loadingResultsPath === location.pathname;
   // Promise en cours de save — partagée entre saveScoring() et goNext() pour éviter un double appel.
   const scoringPromiseRef = useRef<Promise<boolean> | null>(null);
 
@@ -100,9 +101,12 @@ export default function QuizLayout() {
     return scoringPromiseRef.current;
   };
 
-  // Réinitialise la promise de save à chaque changement de step.
+  // Réinitialise le save et interrompt l'écran de préchargement à chaque changement de route.
+  // Le pathname mémorisé garantit que l'Outlet précédent est rendu dès un retour navigateur,
+  // avant même l'exécution de cet effet et le nettoyage de la promesse par LoadingRecap.
   useEffect(() => {
     scoringPromiseRef.current = null;
+    setLoadingResultsPath(null);
   }, [location.pathname]);
 
   const goNext = async () => {
@@ -125,7 +129,7 @@ export default function QuizLayout() {
       navigate(next.route);
     } else {
       trackQuizCompleted({ answers: freshAnswers, completionType: "full", quizStartedAt: useQuizStore.getState().quizStartedAt });
-      setLoadingResults(true);
+      setLoadingResultsPath(location.pathname);
     }
   };
 

--- a/plateform/app/routes/quiz/_layout.tsx
+++ b/plateform/app/routes/quiz/_layout.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router";
 import BackButton from "~/components/quiz/back-button";
 import QuizHeader from "~/components/quiz/header";
+import LoadingRecap from "~/components/quiz/loading-recap";
 import { QUIZ_FLOW, type StepDef, type StepId } from "~/config/quiz-flow";
 import { invalidateInitialMatches } from "~/services/matching";
 import { trackQuizBackNavigated, trackQuizCompleted, trackQuizStepCompleted } from "~/services/tracking/events";
@@ -42,6 +43,7 @@ export default function QuizLayout() {
   const navigate = useNavigate();
   const { answers, setUserScoringId } = useQuizStore();
   const [steps, setSteps] = useState<StepDef[]>(QUIZ_FLOW.filter((s) => !s.condition || evalCondition(s.condition, answers)));
+  const [loadingResults, setLoadingResults] = useState(false);
   const [scoringError, setScoringError] = useState<string | null>(null);
   const currentStep = useMemo(() => steps.find((s) => s.route === location.pathname) ?? null, [location.pathname, steps]);
   // Promise en cours de save — partagée entre saveScoring() et goNext() pour éviter un double appel.
@@ -123,10 +125,14 @@ export default function QuizLayout() {
       navigate(next.route);
     } else {
       trackQuizCompleted({ answers: freshAnswers, completionType: "full", quizStartedAt: useQuizStore.getState().quizStartedAt });
-      const id = useQuizStore.getState().userScoringId;
-      navigate(id ? `/results/${id}` : "/");
+      setLoadingResults(true);
     }
   };
+
+  const handleLoadingComplete = useCallback(() => {
+    const id = useQuizStore.getState().userScoringId;
+    navigate(id ? `/results/${id}` : "/");
+  }, [navigate]);
 
   const goBack = () => {
     if (!currentStep) return;
@@ -143,29 +149,40 @@ export default function QuizLayout() {
 
   return (
     <div className="flex flex-col flex-1">
-      <QuizHeader step={currentIndex + 1} stepCount={steps.length} backHref={currentIndex > 0 ? steps[currentIndex - 1].route : "/"} onBack={handleBackNavigated} />
+      <QuizHeader
+        step={loadingResults ? steps.length + 1 : currentIndex + 1}
+        stepCount={steps.length + 1}
+        backHref={!loadingResults ? (currentIndex > 0 ? steps[currentIndex - 1].route : "/") : undefined}
+        onBack={handleBackNavigated}
+      />
       <main id="contenu" tabIndex={-1} className="flex-1 bg-gradient-to-l from-blue-france-950/40 md:from-blue-france-950 to-transparent pt-10 pb-24 md:pb-10">
         <div className="fr-container flex flex-col gap-10">
-          <div className="hidden lg:block">
-            <BackButton href={currentIndex > 0 ? steps[currentIndex - 1].route : "/"} onBack={handleBackNavigated} />
-          </div>
-          {scoringError && (
+          {!loadingResults && (
+            <div className="hidden lg:block">
+              <BackButton href={currentIndex > 0 ? steps[currentIndex - 1].route : "/"} onBack={handleBackNavigated} />
+            </div>
+          )}
+          {scoringError && !loadingResults && (
             <div className="fr-alert fr-alert--error" role="alert">
               <p>{scoringError}</p>
             </div>
           )}
-          {/* `goNext` / `goBack` / `saveScoring` exposés aux routes enfants via Outlet context. */}
-          <Outlet
-            context={
-              {
-                goNext,
-                goBack,
-                saveScoring,
-                currentStepId: currentStep?.id ?? null,
-                currentStepIndex: currentIndex + 1,
-              } satisfies QuizOutletContext
-            }
-          />
+          {loadingResults ? (
+            <LoadingRecap onComplete={handleLoadingComplete} />
+          ) : (
+            // `goNext` / `goBack` / `saveScoring` exposés aux routes enfants via Outlet context.
+            <Outlet
+              context={
+                {
+                  goNext,
+                  goBack,
+                  saveScoring,
+                  currentStepId: currentStep?.id ?? null,
+                  currentStepIndex: currentIndex + 1,
+                } satisfies QuizOutletContext
+              }
+            />
+          )}
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Description

Rétablit l’écran de préchargement affiché entre la dernière étape du quiz et la page de résultats.

La régression a été introduite par la PR #1321, qui avait supprimé le composant de récapitulatif en même temps que les transitions temporisées du quiz.

Ce correctif :

- réaffiche le récapitulatif des réponses avant les résultats ;
- précharge la première page de missions et réutilise le cache existant à l’arrivée sur `/results/:id` ;
- masque les actions de retour pendant le chargement ;
- conserve la correction RGAA de la PR #1321 en ne réintroduisant aucune révélation ou transition temporisée.

## Liens utiles

- Régression : #1321

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement (ESLint ciblé et vérification TypeScript ciblée)
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire