### PR TITLE
feat(api): boost remote=local geo score above remote=full in m3

### DIFF
--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -163,9 +163,7 @@ describe("matchingEngineService", () => {
     });
 
     it("joint directement le snapshot complet pour le diffuseur", async () => {
-      prismaMock.$queryRaw
-        .mockResolvedValueOnce([{ id: "user-scoring-table-filter" }])
-        .mockResolvedValueOnce([]);
+      prismaMock.$queryRaw.mockResolvedValueOnce([{ id: "user-scoring-table-filter" }]).mockResolvedValueOnce([]);
       missionMatchingResultRepositoryMock.createForUserScoringVersion.mockResolvedValue({
         id: "mission-matching-result-table-filter",
       });
@@ -484,9 +482,9 @@ describe("matchingEngineService", () => {
       expect(rankingSql).toContain("EXCEPT");
       expect(rankingSql).toContain("m.\"remote\"::text IN ('full', 'local')");
       expect(rankingSql).toContain("FROM forced_remote_candidates rfc");
-      expect(rankingSql).toContain('WHEN m."remote"::text IN (\'full\', \'local\') THEN NULL ELSE gs."distance_km" END');
+      expect(rankingSql).toContain("WHEN m.\"remote\"::text IN ('full', 'local') THEN NULL ELSE gs.\"distance_km\" END");
       expect(rankingValues).toContain(0.9);
-      expect(rankingValues).toContain(0.7);
+      expect(rankingValues).toContain(0.95);
     });
 
     it("does not inject the remote=full branch for the m2 version (non-regression)", async () => {
@@ -561,9 +559,9 @@ describe("matchingEngineService", () => {
           {
             mission_id: "mission-remote-local",
             mission_scoring_id: "mission-scoring-remote-local",
-            total_score: 0.77,
+            total_score: 0.815,
             taxonomy_score: 0.8,
-            geo_score: 0.7,
+            geo_score: 0.95,
             distance_km: null,
             closest_address_id: null,
           },
@@ -584,7 +582,7 @@ describe("matchingEngineService", () => {
         version: "m3",
       });
 
-      expect(result.items[0].geoScore).toBe(0.7);
+      expect(result.items[0].geoScore).toBe(0.95);
       expect(result.items[0].distanceKm).toBeNull();
     });
   });

--- a/api/src/services/matching-engine/config.ts
+++ b/api/src/services/matching-engine/config.ts
@@ -40,6 +40,8 @@ export const MATCHING_ENGINE_VERSIONS = {
   },
   m3: {
     // Identique à m2, mais les missions remote=full/local sont considérées comme naturellement proches.
+    // Le remote=local est le signal géo le plus fort (au-dessus de remote=full) : une mission "locale"
+    // (engagement de proximité) est mise en avant devant une mission entièrement à distance.
     taxonomyWeights: {
       domaine: 1,
       secteur_activite: 1,
@@ -52,7 +54,7 @@ export const MATCHING_ENGINE_VERSIONS = {
     } satisfies MatchingEngineTaxonomyWeights,
     geoWeight: 0.3,
     remoteFullGeoScore: 0.9,
-    remoteLocalGeoScore: 0.7,
+    remoteLocalGeoScore: 0.95,
   },
 } as const satisfies Record<MatchingEngineVersion, MatchingEngineVersionConfig>;
 

--- a/api/tests/integration/api/mission-match.test.ts
+++ b/api/tests/integration/api/mission-match.test.ts
@@ -232,7 +232,7 @@ describe("GET /missions/match", () => {
     expect(response.status).toBe(200);
     const item = response.body.data.items.find((entry: { mission: { id: string } }) => entry.mission.id === mission.id);
     expect(item).toBeDefined();
-    expect(item.match.geoScore).toBe(0.7);
+    expect(item.match.geoScore).toBe(0.95);
     expect(item.mission.remote).toBe("local");
     expect(item.mission.location.distanceKm).toBeNull();
     expect(item.mission.location.city).toBeNull();


### PR DESCRIPTION
## Description

En version de matching **m3**, le score géo des missions `remote=local` passe de `0.7` à **`0.95`**, ce qui le place **au-dessus** de `remote=full` (`0.9`).

Objectif : mettre en avant les missions d'**engagement de proximité** (`local`) devant les missions **entièrement à distance** (`full`) pour un utilisateur géolocalisé. Jusqu'ici une mission `local` était structurellement plafonnée sous les missions `full` équivalentes en taxonomie.

Rappel du calcul (m3) : `total_score = (0.3·taxonomy_score + 0.3·geo_score) / 0.6`, où `geo_score` est un plancher fixé par le type remote quand l'utilisateur est géolocalisé (`full → 0.9`, `local → 0.95`).

## Type de changement

- [x] Nouvelle fonctionnalité (ajustement du classement m3)

## Checklist

- [x] Code testé localement
- [x] Tests unitaires modifiés (`matching-engine.test.ts` : score `local` attendu `0.95`)
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire