### PR TITLE
fix(analytics): improve run time for this model

### DIFF
--- a/analytics/dbt/analytics/models/marts/stats/global_events_monthly.sql
+++ b/analytics/dbt/analytics/models/marts/stats/global_events_monthly.sql
@@ -82,6 +82,27 @@ base as (
     {% endif %}
 ),
 
+-- Le seul axe de fan-out du join de `base` est `department`
+-- (int_mission_active_department_range est unique sur (mission_id, department),
+-- et mission_domain / mission_type y sont constants par mission). Il y a donc au
+-- plus 1 ligne par (stat_event_id, department) : dans `dept` et `dept_all_mission`
+-- (groupés par department), `count(*)` est exact et remplace le `count(distinct)`
+-- coûteux. Pour les rollups « tous départements » qui collapsent department, on
+-- déduplique d'abord au grain événement dans `events_all_department` ci-dessous.
+events_all_department as (
+  select
+    stat_event_id,
+    year,
+    month,
+    month_start,
+    mission_domain,
+    mission_type,
+    type,
+    max(updated_at) as updated_at
+  from base
+  group by stat_event_id, year, month, month_start, mission_domain, mission_type, type
+),
+
 dept as (
   select
     year,
@@ -92,7 +113,7 @@ dept as (
     mission_domain,
     mission_type,
     type,
-    count(distinct stat_event_id) as event_count,
+    count(*) as event_count,
     max(updated_at) as max_updated_at
   from base
   where department is not null
@@ -110,7 +131,7 @@ dept_all_mission as (
     mission_domain,
     'all' as mission_type,
     type,
-    count(distinct stat_event_id) as event_count,
+    count(*) as event_count,
     max(updated_at) as max_updated_at
   from base
   where department is not null
@@ -127,9 +148,9 @@ all_dept as (
     mission_domain,
     mission_type,
     type,
-    count(distinct stat_event_id) as event_count,
+    count(*) as event_count,
     max(updated_at) as max_updated_at
-  from base
+  from events_all_department
   group by year, month, month_start, mission_domain, mission_type, type
 ),
 
@@ -143,9 +164,9 @@ all_dept_all_mission as (
     mission_domain,
     'all' as mission_type,
     type,
-    count(distinct stat_event_id) as event_count,
+    count(*) as event_count,
     max(updated_at) as max_updated_at
-  from base
+  from events_all_department
   group by year, month, month_start, mission_domain, type
 )
 

--- a/analytics/dbt/analytics/models/marts/stats/global_events_monthly.sql
+++ b/analytics/dbt/analytics/models/marts/stats/global_events_monthly.sql
@@ -82,13 +82,13 @@ base as (
     {% endif %}
 ),
 
--- Le seul axe de fan-out du join de `base` est `department`
+-- Le seul axe de fan-out du join de `base` est le département
 -- (int_mission_active_department_range est unique sur (mission_id, department),
--- et mission_domain / mission_type y sont constants par mission). Il y a donc au
--- plus 1 ligne par (stat_event_id, department) : dans `dept` et `dept_all_mission`
--- (groupés par department), `count(*)` est exact et remplace le `count(distinct)`
--- coûteux. Pour les rollups « tous départements » qui collapsent department, on
--- déduplique d'abord au grain événement dans `events_all_department` ci-dessous.
+-- et mission_domain / mission_type y sont constants par mission) : il y a donc
+-- au plus 1 ligne par (stat_event_id, department). Dans `dept` et
+-- `dept_all_mission` (groupés par département), `count(*)` est donc exact.
+-- Pour les rollups « tous départements » qui collapsent le département, on
+-- déduplique d'abord au grain événement ici, puis on fera `count(*)`.
 events_all_department as (
   select
     stat_event_id,
@@ -100,7 +100,8 @@ events_all_department as (
     type,
     max(updated_at) as updated_at
   from base
-  group by stat_event_id, year, month, month_start, mission_domain, mission_type, type
+  group by
+    stat_event_id, year, month, month_start, mission_domain, mission_type, type
 ),
 
 dept as (


### PR DESCRIPTION
## Description

Optimise le mart `global_events_monthly`, dont le temps de run avait doublé (~600 s → ~1346 s) depuis la PR #1332. Cette PR remplace les `count(distinct stat_event_id)` par des `count(*)`, **à résultat strictement identique**.

Le `count(distinct)` forçait PostgreSQL à un tri par groupe sur toute la base, **quatre fois** (une par CTE d'agrégation) : c'était le goulot.

On exploite le fait que le seul axe de fan-out du join est le **département** (`int_mission_active_department_range` est unique sur `(mission_id, department)`, et `mission_domain` / `mission_type` y sont constants par mission) :

- `dept` et `dept_all_mission` (groupés par département) → `count(*)` est exact, car il y a au plus 1 ligne par `(stat_event_id, department)`.
- `all_dept` et `all_dept_all_mission` (qui collapsent le département) → déduplication préalable au grain événement dans une nouvelle CTE `events_all_department`, puis `count(*)`.

## Liens utiles

- 🔗 PR à l'origine de la régression : #1332

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [x] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Équivalence des résultats vérifiée** (aucun changement de valeurs ni de row counts) :

- `dbt compile --select global_events_monthly` : OK.
- Audit old-vs-new (full join sur la clé unique, sur un mois) : **0 écart**, totaux identiques.
- Prémisses structurelles vérifiées sur 2026 : au plus 1 ligne par `(stat_event_id, department)` (**0 violation**) et `mission_type` unique par événement (**0 violation**) → équivalence garantie quel que soit le volume.
