### PR TITLE
feat(analytics): reconcile front/back clicks and quiz applies in trac…

### DIFF
--- a/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
+++ b/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
@@ -81,13 +81,31 @@ models:
       - name: matched_to_backend
         description: Vrai si le clic a été rattaché à une mission du résultat de matching de la session.
 
+  - name: int_tracking_backend_conversion
+    description: >
+      Attribution backend d'une session quiz (`quiz_session_id` = `user_scoring_id`) : clics sortants
+      trackés côté `stat_event` (porteurs de `custom_attributes.user_scoring_id`) et candidatures (`apply`)
+      rattachées via `apply.click_id = click.stat_event_id`. Bots exclus. Une ligne par session ayant
+      au moins un clic backend.
+    columns:
+      - name: quiz_session_id
+        tests:
+          - not_null
+          - unique
+      - name: backend_click_count
+        description: Nombre de clics backend trackés pour la session.
+      - name: apply_count
+        description: Nombre de candidatures rattachées aux clics backend de la session.
+      - name: has_apply
+        description: Vrai si au moins une candidature a été rattachée.
+
   - name: int_tracking_quiz_backend
     description: >
       Réconciliation d'une session quiz avec le backend via `quiz_session_id` = `user_scoring_id`.
       `score_top5` est la moyenne des `taxonomyScores` des 5 premiers résultats du dernier run de
       matching (`matching_engine_result` le plus récent par `user_scoring_id`, plusieurs runs possibles).
-      Les métriques de candidature (`has_apply`, `apply_count`, `first_apply_at`) restent des
-      placeholders à figer (clé d'attribution des candidatures). Personnes internes exclues au niveau du `distinct_id`.
+      Les métriques de conversion backend (clics sortants et candidatures) sont issues de
+      `int_tracking_backend_conversion`. Personnes internes exclues au niveau du `distinct_id`.
     columns:
       - name: quiz_session_id
         tests:
@@ -97,6 +115,12 @@ models:
         description: >
           Moyenne des `taxonomyScores` sur le top 5 des résultats du dernier run de matching de la
           session. Null si aucun `matching_engine_result` exploitable.
+      - name: has_backend_click
+        description: Vrai si la session a au moins un clic sortant tracké côté `stat_event`.
+      - name: has_apply
+        description: Vrai si au moins une candidature a été rattachée aux clics backend de la session.
+      - name: apply_count
+        description: Nombre de candidatures rattachées aux clics backend de la session.
 
   - name: int_tracking_page_view
     description: >

--- a/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_backend_conversion.sql
+++ b/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_backend_conversion.sql
@@ -1,0 +1,55 @@
+-- Réconciliation backend d'une session quiz (`user_scoring_id`) : clics
+-- sortants trackés côté `stat_event` (porteurs de
+-- `custom_attributes.user_scoring_id`) et candidatures (`apply`) rattachées à
+-- ces clics via `click_id`. Grain : une ligne par `quiz_session_id`.
+with backend_clicks as (
+  select
+    stat_event_id,
+    user_scoring_id as quiz_session_id,
+    created_at as clicked_at,
+    mission_id,
+    source as click_channel
+  from {{ ref('stg_stat_event__click') }}
+  where
+    user_scoring_id is not null
+    and not is_bot
+),
+
+applies as (
+  select distinct
+    bc.quiz_session_id,
+    a.stat_event_id as apply_id,
+    a.created_at as applied_at
+  from {{ ref('stg_stat_event__apply') }} as a
+  inner join backend_clicks as bc on a.click_id = bc.stat_event_id
+),
+
+click_agg as (
+  select
+    quiz_session_id,
+    count(*) as backend_click_count,
+    count(distinct mission_id) as backend_clicked_mission_count,
+    min(clicked_at) as first_backend_click_at
+  from backend_clicks
+  group by quiz_session_id
+),
+
+apply_agg as (
+  select
+    quiz_session_id,
+    count(*) as apply_count,
+    min(applied_at) as first_apply_at
+  from applies
+  group by quiz_session_id
+)
+
+select
+  ca.quiz_session_id,
+  ca.backend_click_count,
+  ca.backend_clicked_mission_count,
+  ca.first_backend_click_at,
+  aa.first_apply_at,
+  coalesce(aa.apply_count, 0) as apply_count,
+  coalesce(aa.apply_count, 0) > 0 as has_apply
+from click_agg as ca
+left join apply_agg as aa on ca.quiz_session_id = aa.quiz_session_id

--- a/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_quiz_backend.sql
+++ b/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_quiz_backend.sql
@@ -34,6 +34,18 @@ backend_scoring as (
     with ordinality as t (elem, ord)
   where t.ord <= 5
   group by lr.user_scoring_id
+),
+
+backend_conversion as (
+  select
+    quiz_session_id,
+    backend_click_count,
+    backend_clicked_mission_count,
+    first_backend_click_at,
+    apply_count,
+    has_apply,
+    first_apply_at
+  from {{ ref('int_tracking_backend_conversion') }}
 )
 
 select
@@ -42,9 +54,14 @@ select
   s.session_date,
   bsc.matching_engine_version,
   bsc.score_top5,
-  null::boolean as has_apply,
-  0::integer as apply_count,
-  null::timestamp as first_apply_at
+  bc.backend_clicked_mission_count,
+  bc.first_backend_click_at,
+  bc.first_apply_at,
+  coalesce(bc.backend_click_count, 0) as backend_click_count,
+  coalesce(bc.backend_click_count, 0) > 0 as has_backend_click,
+  coalesce(bc.has_apply, false) as has_apply,
+  coalesce(bc.apply_count, 0) as apply_count
 from sessions as s
 left join backend_scoring as bsc on s.quiz_session_id = bsc.quiz_session_id
+left join backend_conversion as bc on s.quiz_session_id = bc.quiz_session_id
 where {{ exclude_internal_distinct_ids('s.distinct_id') }}

--- a/analytics/dbt/analytics/models/marts/tracking/tracking_engagement_kpi_daily.sql
+++ b/analytics/dbt/analytics/models/marts/tracking/tracking_engagement_kpi_daily.sql
@@ -31,6 +31,17 @@ pages as (
       as home_pageview_count
   from {{ ref('tracking_page_view_daily') }}
   group by kpi_date
+),
+
+backend as (
+  select
+    session_date as kpi_date,
+    count(*) filter (where has_backend_click) as sessions_with_backend_click,
+    count(*) filter (where has_apply) as sessions_with_apply,
+    sum(apply_count) as apply_count
+  from {{ ref('int_tracking_quiz_backend') }}
+  where session_date is not null
+  group by session_date
 )
 
 select
@@ -54,8 +65,16 @@ select
   s.change_results_count::numeric
   / nullif(r.results_viewed_count, 0) as change_results_rate,
   s.quiz_started_count::numeric
-  / nullif(p.home_pageview_count, 0) as quiz_start_rate
+  / nullif(p.home_pageview_count, 0) as quiz_start_rate,
+  coalesce(bk.sessions_with_backend_click, 0) as sessions_with_backend_click,
+  coalesce(bk.sessions_with_apply, 0) as sessions_with_apply,
+  coalesce(bk.apply_count, 0) as apply_count,
+  coalesce(bk.sessions_with_apply, 0)::numeric
+  / nullif(s.quiz_started_count, 0) as quiz_to_apply_rate,
+  coalesce(bk.sessions_with_apply, 0)::numeric
+  / nullif(r.sessions_with_click_after_results, 0) as click_to_apply_rate
 from sessions as s
 left join results as r on s.kpi_date = r.kpi_date
 left join pages as p on s.kpi_date = p.kpi_date
+left join backend as bk on s.kpi_date = bk.kpi_date
 order by s.kpi_date desc

--- a/analytics/dbt/analytics/models/marts/tracking/tracking_quiz_session.sql
+++ b/analytics/dbt/analytics/models/marts/tracking/tracking_quiz_session.sql
@@ -23,7 +23,11 @@ backend as (
     quiz_session_id,
     score_top5,
     has_apply,
-    apply_count
+    apply_count,
+    first_apply_at,
+    backend_click_count,
+    has_backend_click,
+    first_backend_click_at
   from {{ ref('int_tracking_quiz_backend') }}
 )
 
@@ -58,13 +62,17 @@ select
   r.avg_distance_km_top5,
   b.score_top5,
   b.has_apply,
+  b.first_apply_at,
+  b.first_backend_click_at,
   coalesce(r.click_count, 0) as click_count,
   coalesce(r.has_click_after_results, false) as has_click_after_results,
   coalesce(r.has_click_results, false) as has_click_results,
   coalesce(r.has_click_pinned, false) as has_click_pinned,
   coalesce(r.has_click_external, false) as has_click_external,
   coalesce(r.is_zero_click, false) as is_zero_click,
-  coalesce(b.apply_count, 0) as apply_count
+  coalesce(b.apply_count, 0) as apply_count,
+  coalesce(b.backend_click_count, 0) as backend_click_count,
+  coalesce(b.has_backend_click, false) as has_backend_click
 from sessions as s
 left join results as r on s.quiz_session_id = r.quiz_session_id
 left join backend as b on s.quiz_session_id = b.quiz_session_id

--- a/analytics/dbt/analytics/models/staging/stat_event/__models.yml
+++ b/analytics/dbt/analytics/models/staging/stat_event/__models.yml
@@ -70,6 +70,10 @@ models:
         description: Origine normalisée du clic (api/widget/campaign…).
       - name: click_id
         description: Identifiant du clic dans l’entrepôt analytics.
+      - name: user_scoring_id
+        description: >
+          Identifiant de la session quiz (`userScoringId`) porté par le clic quand il vient des résultats
+          du quiz ou d'un email (extrait de `custom_attributes`). Null sinon.
 
   - name: stg_stat_event__apply
     description: >

--- a/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__click.sql
+++ b/analytics/dbt/analytics/models/staging/stat_event/stg_stat_event__click.sql
@@ -10,6 +10,7 @@ with events as (
     e.click_id,
     e.source,
     e.tags,
+    e.custom_attributes,
     nullif(e.mission_id, '') as mission_id,
     nullif(e.to_publisher_id, '') as to_publisher_id_clean,
     nullif(e.from_publisher_id, '') as from_publisher_id_clean,
@@ -32,6 +33,7 @@ select
   e.to_publisher_id_clean as to_publisher_id,
   e.source_id_clean as source_id,
   coalesce(e.tags, array[]::text []) as tags,
+  nullif(e.custom_attributes ->> 'user_scoring_id', '') as user_scoring_id,
   case
     when coalesce(e.source, 'publisher') in ('publisher', 'api') then 'api'
     else e.source

--- a/analytics/dbt/analytics/tests/assert_backend_conversion_apply_consistency.sql
+++ b/analytics/dbt/analytics/tests/assert_backend_conversion_apply_consistency.sql
@@ -1,0 +1,6 @@
+-- Une session has_apply doit avoir apply_count > 0 et un first_apply_at.
+select quiz_session_id
+from {{ ref('int_tracking_backend_conversion') }}
+where
+  has_apply
+  and (apply_count = 0 or first_apply_at is null)


### PR DESCRIPTION

### Détail des changements

- **`stg_stat_event__click`** : expose `user_scoring_id` (extrait de
  `custom_attributes ->> 'user_scoring_id'`, `nullif` sur chaîne vide).
- **`int_tracking_backend_conversion`** *(nouveau)* : attribution backend par
  session (grain `quiz_session_id`) — agrège les clics back
  (`backend_click_count`, `backend_clicked_mission_count`,
  `first_backend_click_at`) et les candidatures rattachées via `apply.click_id`
  (`apply_count`, `has_apply`, `first_apply_at`). Bots exclus.
- **`int_tracking_quiz_backend`** : remplace les placeholders `has_apply` /
  `apply_count` / `first_apply_at` par les vraies valeurs et ajoute la
  réconciliation front↔back (`backend_click_count`, `has_backend_click`,
  `first_backend_click_at`). Exclusion des internes conservée au grain
  `distinct_id`.
- **`tracking_quiz_session`** : ajoute `has_backend_click`,
  `backend_click_count` et les timestamps ; permet de comparer
  `has_click_after_results` (front) vs `has_backend_click` (back).
- **`tracking_engagement_kpi_daily`** : ajoute `sessions_with_backend_click`,
  `sessions_with_apply`, `apply_count`, `quiz_to_apply_rate` et
  `click_to_apply_rate`.
- **Docs & tests** : descriptions `__models.yml` mises à jour + test singulier
  `assert_backend_conversion_apply_consistency` (`has_apply` ⇒ `apply_count > 0`
  et `first_apply_at` non nul).

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/Ajout-r-conciliation-clics-front-back-dans-les-mod-les-dbt-3aa72a322d50807a8434d8b76ba17d04)
- 🔗 PR back liée : #1335

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- **Validation locale (staging)** : `sqlfluff lint` OK, `dbt run` OK sur les 8
  nœuds, tests ciblés (`not_null`/`unique` + test singulier) au vert.
- **Volumes encore minuscules** tant que #1335 n'est pas en prod : la chaîne
  staging→conversion est vérifiée (1 clic porteur d'`user_scoring_id` →
  1 ligne de conversion), mais le recoupement front↔back est encore vide sur
  staging (ce clic n'a pas d'event `quiz.completed` côté front). La logique est
  **structurellement correcte** et se remplira en prod.
- **Point d'attention CI** : un test *préexistant*
  `not_null_stg_stat_event__click_from_publisher_id` échoue sur staging (5 clics
  à `from_publisher_id` nul), sans rapport avec cette PR. Comme `dbt build`
  skippe les descendants d'un nœud dont un test échoue, la validation locale est
  passée par `dbt run` + `dbt test` ciblés.
- **Prochaine étape (hors périmètre)** : faire apparaître la candidature comme
  étape finale d'un funnel unifié (mart dédié `tracking_conversion_funnel`).
