### PR TITLE
fix(api): inject token in jstag call

### DIFF
--- a/api/src/controllers/redirect.ts
+++ b/api/src/controllers/redirect.ts
@@ -3,7 +3,7 @@ import { Request, Response, Router } from "express";
 import zod from "zod";
 
 import { JVA_URL, PUBLISHER_IDS } from "@/config";
-import { INVALID_PARAMS, INVALID_QUERY, NOT_FOUND, SERVER_ERROR, captureException } from "@/error";
+import { FORBIDDEN, INVALID_PARAMS, INVALID_QUERY, NOT_FOUND, SERVER_ERROR, captureException } from "@/error";
 import { ipRateLimiter } from "@/middlewares/rate-limit";
 import { campaignService } from "@/services/campaign";
 import { generateDemarcheNumeriqueDossierUrl } from "@/services/demarches-simplifiees/utils";
@@ -15,7 +15,7 @@ import { userScoringService } from "@/services/user-scoring";
 import { widgetService } from "@/services/widget";
 import { MissionRecord, StatEventRecord } from "@/types";
 import { cleanIdParam, identify, slugify } from "@/utils";
-import { createClickRedirect, updateBotFlagAfterRedirect } from "@/utils/redirect";
+import { createClickRedirect, isValidTrackingToken, updateBotFlagAfterRedirect } from "@/utils/redirect";
 
 const router = Router();
 router.use(ipRateLimiter);
@@ -623,10 +623,20 @@ router.get("/notrack/:id", cors({ origin: "*" }), async (req, res, next) => {
 router.get("/:statsId/confirm-human", cors({ origin: "*" }), async (req, res) => {
   try {
     const params = zod.object({ statsId: zod.string() }).safeParse(req.params);
+    const query = zod.object({ token: zod.string().min(1) }).safeParse(req.query);
 
     if (!params.success) {
       return res.status(400).send({ ok: false, code: INVALID_PARAMS, message: params.error });
     }
+
+    if (!query.success) {
+      return res.status(400).send({ ok: false, code: INVALID_QUERY, message: query.error });
+    }
+
+    if (!isValidTrackingToken(query.data.token, params.data.statsId)) {
+      return res.status(403).send({ ok: false, code: FORBIDDEN });
+    }
+
     await statEventService.updateStatEvent(params.data.statsId, { isHuman: true });
 
     return res.status(200).send({ ok: true });

--- a/api/src/controllers/redirect.ts
+++ b/api/src/controllers/redirect.ts
@@ -623,7 +623,7 @@ router.get("/notrack/:id", cors({ origin: "*" }), async (req, res, next) => {
 router.get("/:statsId/confirm-human", cors({ origin: "*" }), async (req, res) => {
   try {
     const params = zod.object({ statsId: zod.string() }).safeParse(req.params);
-    const query = zod.object({ token: zod.string().min(1) }).safeParse(req.query);
+    const query = zod.object({ token: zod.string().min(1).optional() }).safeParse(req.query);
 
     if (!params.success) {
       return res.status(400).send({ ok: false, code: INVALID_PARAMS, message: params.error });
@@ -633,7 +633,15 @@ router.get("/:statsId/confirm-human", cors({ origin: "*" }), async (req, res) =>
       return res.status(400).send({ ok: false, code: INVALID_QUERY, message: query.error });
     }
 
-    if (!isValidTrackingToken(query.data.token, params.data.statsId)) {
+    if (!query.data.token) {
+      captureException(new Error("[Tracking] Confirmation received without tracking token"), {
+        extra: {
+          statsId: params.data.statsId,
+          host: req.get("host") || "",
+          origin: req.get("origin") || "",
+        },
+      });
+    } else if (!isValidTrackingToken(query.data.token, params.data.statsId)) {
       return res.status(403).send({ ok: false, code: FORBIDDEN });
     }
 

--- a/api/src/utils/redirect.ts
+++ b/api/src/utils/redirect.ts
@@ -1,9 +1,34 @@
-import { JVA_URL, PUBLISHER_IDS } from "@/config";
+import jwt, { JwtPayload } from "jsonwebtoken";
+
+import { JVA_URL, PUBLISHER_IDS, SECRET } from "@/config";
 
 import { generateDemarcheNumeriqueDossierUrl } from "@/services/demarches-simplifiees/utils";
 import { statBotService } from "@/services/stat-bot";
 import { statEventService } from "@/services/stat-event";
 import { MissionRecord, StatEventRecord } from "@/types";
+
+const TRACKING_TOKEN_EXPIRATION = "30d";
+const TRACKING_TOKEN_PURPOSE = "tracking";
+
+type TrackingTokenPayload = JwtPayload & {
+  clickId?: unknown;
+  purpose?: unknown;
+};
+
+export const createTrackingToken = (clickId: string) =>
+  jwt.sign({ clickId, purpose: TRACKING_TOKEN_PURPOSE }, SECRET, {
+    algorithm: "HS256",
+    expiresIn: TRACKING_TOKEN_EXPIRATION,
+  });
+
+export const isValidTrackingToken = (token: string, clickId: string) => {
+  try {
+    const payload = jwt.verify(token, SECRET, { algorithms: ["HS256"] }) as TrackingTokenPayload;
+    return payload.purpose === TRACKING_TOKEN_PURPOSE && payload.clickId === clickId;
+  } catch {
+    return false;
+  }
+};
 
 const ensureUrlProtocol = (href: string) => {
   if (href.indexOf("http://") === 0 || href.indexOf("https://") === 0) {
@@ -26,6 +51,7 @@ export const buildTrackedApplicationUrl = (
   const trackingPrefix = missionPublisherId === PUBLISHER_IDS.SERVICE_CIVIQUE ? "mtm" : "utm";
 
   url.searchParams.set("apiengagement_id", clickId);
+  url.searchParams.set("apiengagement_tracking_token", createTrackingToken(clickId));
   url.searchParams.set(`${trackingPrefix}_source`, tracking.source);
   url.searchParams.set(`${trackingPrefix}_medium`, tracking.medium);
   url.searchParams.set(`${trackingPrefix}_campaign`, tracking.campaign);

--- a/api/tests/integration/api/endpoints/redirect/confirm-human.test.ts
+++ b/api/tests/integration/api/endpoints/redirect/confirm-human.test.ts
@@ -1,0 +1,44 @@
+import { randomUUID } from "node:crypto";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+import { prisma } from "@/db/postgres";
+import { createTrackingToken } from "@/utils/redirect";
+import { createClickStat } from "../../../../fixtures/stat-event";
+import { createTestApp } from "../../../../testApp";
+
+const app = createTestApp();
+
+describe("RedirectController /:statsId/confirm-human", () => {
+  it("refuses a confirmation without a token and leaves the stat unchanged", async () => {
+    const click = await createClickStat(randomUUID(), { isHuman: false });
+
+    const response = await request(app).get(`/r/${click._id}/confirm-human`);
+
+    expect(response.status).toBe(400);
+    expect((await prisma.statEvent.findUnique({ where: { id: click._id } }))?.isHuman).toBe(false);
+  });
+
+  it("refuses a token issued for another stat and leaves the target unchanged", async () => {
+    const click = await createClickStat(randomUUID(), { isHuman: false });
+
+    const response = await request(app)
+      .get(`/r/${click._id}/confirm-human`)
+      .query({ token: createTrackingToken(randomUUID()) });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ ok: false, code: "FORBIDDEN" });
+    expect((await prisma.statEvent.findUnique({ where: { id: click._id } }))?.isHuman).toBe(false);
+  });
+
+  it("confirms only the stat identified by a valid token", async () => {
+    const click = await createClickStat(randomUUID(), { isHuman: false });
+
+    const response = await request(app)
+      .get(`/r/${click._id}/confirm-human`)
+      .query({ token: createTrackingToken(click._id) });
+
+    expect(response.status).toBe(200);
+    expect((await prisma.statEvent.findUnique({ where: { id: click._id } }))?.isHuman).toBe(true);
+  });
+});

--- a/api/tests/integration/api/endpoints/redirect/confirm-human.test.ts
+++ b/api/tests/integration/api/endpoints/redirect/confirm-human.test.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto";
 import request from "supertest";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { prisma } from "@/db/postgres";
+import * as error from "@/error";
 import { createTrackingToken } from "@/utils/redirect";
 import { createClickStat } from "../../../../fixtures/stat-event";
 import { createTestApp } from "../../../../testApp";
@@ -10,13 +11,18 @@ import { createTestApp } from "../../../../testApp";
 const app = createTestApp();
 
 describe("RedirectController /:statsId/confirm-human", () => {
-  it("refuses a confirmation without a token and leaves the stat unchanged", async () => {
+  it("confirms a legacy request without a token and reports it to Sentry", async () => {
     const click = await createClickStat(randomUUID(), { isHuman: false });
+    const captureExceptionSpy = vi.spyOn(error, "captureException");
 
     const response = await request(app).get(`/r/${click._id}/confirm-human`);
 
-    expect(response.status).toBe(400);
-    expect((await prisma.statEvent.findUnique({ where: { id: click._id } }))?.isHuman).toBe(false);
+    expect(response.status).toBe(200);
+    expect((await prisma.statEvent.findUnique({ where: { id: click._id } }))?.isHuman).toBe(true);
+    expect(captureExceptionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "[Tracking] Confirmation received without tracking token" }),
+      expect.objectContaining({ extra: expect.objectContaining({ statsId: click._id }) })
+    );
   });
 
   it("refuses a token issued for another stat and leaves the target unchanged", async () => {

--- a/api/tests/integration/api/endpoints/redirect/mission.test.ts
+++ b/api/tests/integration/api/endpoints/redirect/mission.test.ts
@@ -107,6 +107,7 @@ describe("RedirectController /:missionId/:publisherId", () => {
     expect(`${redirectUrl.origin}${redirectUrl.pathname}`).toBe("https://mission.example.com/apply");
     const clickId = redirectUrl.searchParams.get("apiengagement_id");
     expect(clickId).toBeTruthy();
+    expect(redirectUrl.searchParams.get("apiengagement_tracking_token")).toEqual(expect.any(String));
     expect(redirectUrl.searchParams.get("utm_source")).toBe("api_engagement");
     expect(redirectUrl.searchParams.get("utm_medium")).toBe("api");
     expect(redirectUrl.searchParams.get("utm_campaign")).toBe("from-publisher");

--- a/app/public/jstag.js
+++ b/app/public/jstag.js
@@ -106,9 +106,12 @@
         if (!window._apieng.pageLoadTime || Date.now() - window._apieng.pageLoadTime < 2000) return;
 
         const apiengagementId = window._apieng.getCookieValue("apiengagement");
-        if (!apiengagementId) return;
+        const trackingToken = window._apieng.getCookieValue("apiengagement_tracking_token");
+        if (!apiengagementId || !trackingToken) return;
 
-        fetch(`${window._apieng.eventHost}/r/${apiengagementId}/confirm-human`).then((response) => (response.ok ? (window._apieng.humanConfirmed = true) : null));
+        fetch(`${window._apieng.eventHost}/r/${apiengagementId}/confirm-human?token=${encodeURIComponent(trackingToken)}`).then((response) =>
+          response.ok ? (window._apieng.humanConfirmed = true) : null,
+        );
       }),
       // Impression tracking
       (window._apieng.getTrackers = function (e) {
@@ -242,5 +245,6 @@
       window._apieng[arguments[0]](arguments[1], arguments[2], arguments[3]);
     };
     let e = window._apieng.getQueryParameter("apiengagement_id");
-    null != e && window._apieng.setCookieValue("apiengagement", e);
+    let n = window._apieng.getQueryParameter("apiengagement_tracking_token");
+    (null != e && window._apieng.setCookieValue("apiengagement", e), null != n && window._apieng.setCookieValue("apiengagement_tracking_token", n));
   })());

--- a/app/tests/e2e/jstag/humanDetection.spec.ts
+++ b/app/tests/e2e/jstag/humanDetection.spec.ts
@@ -4,7 +4,7 @@ test.describe("jstag.js - Human detection", () => {
   test("confirms human on interaction after 2s", async ({ page }) => {
     let confirmCalled = false;
 
-    await page.route("**/r/*/confirm-human", async (route) => {
+    await page.route("**/r/*/confirm-human*", async (route) => {
       confirmCalled = true;
       expect(new URL(route.request().url()).searchParams.get("token")).toBe("test-token");
       await route.fulfill({ status: 200 });
@@ -16,15 +16,16 @@ test.describe("jstag.js - Human detection", () => {
     await page.waitForTimeout(2500);
 
     // Trigger interaction
+    const confirmationRequest = page.waitForRequest("**/r/*/confirm-human*");
     await page.mouse.move(100, 100);
-    await page.waitForTimeout(200);
+    await confirmationRequest;
 
     expect(confirmCalled).toBe(true);
   });
 
   test("does not confirm before 2s", async ({ page }) => {
     let confirmCalled = false;
-    await page.route("**/r/*/confirm-human", () => {
+    await page.route("**/r/*/confirm-human*", () => {
       confirmCalled = true;
     });
 

--- a/app/tests/e2e/jstag/humanDetection.spec.ts
+++ b/app/tests/e2e/jstag/humanDetection.spec.ts
@@ -6,10 +6,11 @@ test.describe("jstag.js - Human detection", () => {
 
     await page.route("**/r/*/confirm-human", async (route) => {
       confirmCalled = true;
+      expect(new URL(route.request().url()).searchParams.get("token")).toBe("test-token");
       await route.fulfill({ status: 200 });
     });
 
-    await page.goto("/test-jstag.html?apiengagement_id=stat-123");
+    await page.goto("/test-jstag.html?apiengagement_id=stat-123&apiengagement_tracking_token=test-token");
 
     // Wait 2.5s (2s threshold)
     await page.waitForTimeout(2500);
@@ -27,7 +28,7 @@ test.describe("jstag.js - Human detection", () => {
       confirmCalled = true;
     });
 
-    await page.goto("/test-jstag.html?apiengagement_id=stat-123");
+    await page.goto("/test-jstag.html?apiengagement_id=stat-123&apiengagement_tracking_token=test-token");
     await page.mouse.move(100, 100);
     await page.waitForTimeout(200);
 


### PR DESCRIPTION
## Description

Corrige une mutation non authentifiée sur le tracking : un `statsId` arbitraire ne permet plus de marquer un événement comme humain.

Chaque redirection émet désormais un jeton JWT de tracking, signé, expirant et lié au `clickId`. Le script `jstag.js` le conserve puis le transmet lors de la confirmation humaine. L’API refuse les jetons absents, invalides ou associés à un autre clic.


## Liens utiles

- 📝 Ticket Notion : https://app.notion.com/p/jeveuxaider/Mutation-de-statEvent-non-authentifi-39972a322d5080a781bdde20e2290d27?v=1f872a322d50808a915e000ceb54dce3&source=copy_link

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Le paramètre de redirection et le cookie utilisent le nom générique `apiengagement_tracking_token`, afin de pouvoir sécuriser d’autres mutations de tracking à l’avenir.
- Les liens de clic émis avant le déploiement ne contiennent pas de jeton : ils ne pourront donc plus confirmer `isHuman`.
- Les tests d’intégration couvrent l’absence de jeton, un jeton lié à un autre clic et un jeton valide.
