### PR TITLE
feat(analytics): add recommendations-per-publisher KPI and clicked mission score

### DIFF
--- a/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
+++ b/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
@@ -98,6 +98,31 @@ models:
           Moyenne des `taxonomyScores` sur le top 5 des résultats du dernier run de matching de la
           session. Null si aucun `matching_engine_result` exploitable.
 
+  - name: int_tracking_recommendation
+    description: >
+      Missions recommandées par le moteur de matching, une ligne par mission du DERNIER run de chaque
+      session quiz (`user_scoring_id`). Source : `stg_matching_engine_result.results` (tableau JSON de
+      `missionScoringId`). Pont vers la mission puis l'annonceur via `mission_scoring`
+      (`results[i].missionScoringId` = `mission_scoring.id` -> `mission_id`), puis `mission.publisher_id`
+      -> `publisher.name`. Usage : KPI de contrôle « part des recommandations par annonceur » (détecter
+      qu'un seul annonceur capte l'essentiel des recommandations). Personnes internes exclues au niveau
+      du `distinct_id`. `mission_id` en `text` (formats mixtes ObjectId Mongo / UUID), jamais casté.
+    columns:
+      - name: quiz_session_id
+        description: Session quiz (`user_scoring_id`) du run de matching.
+        tests:
+          - not_null
+      - name: mission_id
+        description: Mission recommandée (text ; formats mixtes ObjectId Mongo / UUID).
+        tests:
+          - not_null
+      - name: publisher_id
+        description: Annonceur propriétaire de la mission recommandée.
+        tests:
+          - not_null
+      - name: backend_rank
+        description: Rang de la mission dans le run de matching (position dans `results`).
+
   - name: int_tracking_page_view
     description: >
       Visites de pages filtrées (personnes internes exclues au niveau du `distinct_id`), une ligne par événement `page.viewed`. Alimente le trafic

--- a/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
+++ b/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
@@ -80,6 +80,11 @@ models:
         description: Version du moteur de matching du run rattaché (nullable si non rattaché).
       - name: matched_to_backend
         description: Vrai si le clic a été rattaché à une mission du résultat de matching de la session.
+      - name: mission_score
+        description: >
+          Score de la mission cliquée = moyenne de ses `taxonomyScores` dans le run de matching actif au
+          clic. Même base que `score_top5` (sous-score thématique), donc PAS le score total pondéré géo
+          (non persisté). Null si le clic n'est pas réconcilié au backend (`matched_to_backend = false`).
 
   - name: int_tracking_quiz_backend
     description: >

--- a/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_mission_click.sql
+++ b/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_mission_click.sql
@@ -29,7 +29,8 @@ click_backend as (
   select
     c.event_uuid,
     active_result.matching_engine_version,
-    ranked.backend_rank
+    ranked.backend_rank,
+    ranked.mission_score
   from clicks as c
   cross join
     lateral (
@@ -46,13 +47,20 @@ click_backend as (
     ) as active_result
   cross join
     lateral (
-      select min(t.ord) as backend_rank
+      select
+        t.ord as backend_rank,
+        (
+          select avg(jt.value::numeric)
+          from jsonb_each_text(t.elem -> 'taxonomyScores') as jt
+        ) as mission_score
       from
         jsonb_array_elements(active_result.results)
         with ordinality as t (elem, ord)
       inner join {{ ref('stg_mission_scoring') }} as ms
         on ms.id = t.elem ->> 'missionScoringId'
       where ms.mission_id = c.mission_id
+      order by t.ord asc
+      limit 1
     ) as ranked
   where ranked.backend_rank is not null
 )
@@ -79,7 +87,7 @@ select
   c.entry_page,
   cb.backend_rank,
   cb.matching_engine_version,
-  null::numeric as mission_score,
+  cb.mission_score,
   cb.event_uuid is not null as matched_to_backend
 from clicks as c
 left join click_backend as cb on c.event_uuid = cb.event_uuid

--- a/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_recommendation.sql
+++ b/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_recommendation.sql
@@ -1,0 +1,84 @@
+-- Missions recommandées par le moteur de matching, une ligne par mission du
+-- DERNIER run de chaque session quiz (`user_scoring_id`). Le pont vers la
+-- mission puis le publisher passe par `mission_scoring`
+-- (`results[i].missionScoringId` = `mission_scoring.id` -> `mission_id` ->
+-- `mission.publisher_id`). Base du KPI « part des recommandations par
+-- annonceur ». Personnes internes exclues au niveau du `distinct_id`.
+with latest_result as (
+  select distinct on (user_scoring_id)
+    user_scoring_id,
+    matching_engine_version,
+    results,
+    created_at
+  from {{ ref('stg_matching_engine_result') }}
+  where results is not null
+  order by user_scoring_id asc, created_at desc
+),
+
+exploded as (
+  select
+    lr.user_scoring_id as quiz_session_id,
+    lr.matching_engine_version,
+    lr.created_at::date as session_date,
+    t.ord as backend_rank,
+    t.elem ->> 'missionScoringId' as mission_scoring_id
+  from latest_result as lr
+  cross join
+    lateral jsonb_array_elements(lr.results)
+    with ordinality as t (elem, ord)
+),
+
+with_mission as (
+  select
+    e.quiz_session_id,
+    e.matching_engine_version,
+    e.session_date,
+    e.backend_rank,
+    e.mission_scoring_id,
+    ms.mission_id
+  from exploded as e
+  inner join {{ ref('stg_mission_scoring') }} as ms
+    on e.mission_scoring_id = ms.id
+),
+
+with_publisher as (
+  select
+    wm.quiz_session_id,
+    wm.matching_engine_version,
+    wm.session_date,
+    wm.backend_rank,
+    wm.mission_scoring_id,
+    wm.mission_id,
+    m.publisher_id,
+    p.name as publisher_name
+  from with_mission as wm
+  inner join {{ ref('stg_mission') }} as m on wm.mission_id = m.id
+  left join {{ ref('stg_publisher') }} as p on m.publisher_id = p.id
+),
+
+with_distinct as (
+  select
+    wp.quiz_session_id,
+    wp.matching_engine_version,
+    wp.session_date,
+    wp.backend_rank,
+    wp.mission_scoring_id,
+    wp.mission_id,
+    wp.publisher_id,
+    wp.publisher_name,
+    us.distinct_id
+  from with_publisher as wp
+  left join {{ ref('stg_user_scoring') }} as us on wp.quiz_session_id = us.id
+)
+
+select
+  quiz_session_id,
+  session_date,
+  matching_engine_version,
+  backend_rank,
+  mission_scoring_id,
+  mission_id,
+  publisher_id,
+  publisher_name
+from with_distinct
+where {{ exclude_internal_distinct_ids('distinct_id') }}

--- a/analytics/dbt/analytics/models/marts/tracking/__models.yml
+++ b/analytics/dbt/analytics/models/marts/tracking/__models.yml
@@ -95,3 +95,28 @@ models:
         tests:
           - not_null
           - unique
+
+  - name: tracking_recommendation
+    description: >
+      Fait « une ligne par mission recommandée » (dernier run de matching de chaque session), exposé à
+      Metabase pour le KPI de contrôle « part des recommandations par annonceur ». Pas de pré-agrégation :
+      agréger librement par `publisher_name`, `session_date` ou `backend_rank`. Voir
+      `int_tracking_recommendation` pour la chaîne de jointure (pont `mission_scoring` -> mission ->
+      publisher). Personnes internes exclues au niveau du `distinct_id`.
+    columns:
+      - name: quiz_session_id
+        description: Session quiz (`user_scoring_id`) du run de matching.
+        tests:
+          - not_null
+      - name: mission_id
+        description: Mission recommandée (text ; formats mixtes ObjectId Mongo / UUID).
+        tests:
+          - not_null
+      - name: publisher_id
+        description: Annonceur propriétaire de la mission recommandée.
+        tests:
+          - not_null
+      - name: publisher_name
+        description: Nom de l'annonceur, pour l'agrégation « part par annonceur » côté Metabase.
+      - name: backend_rank
+        description: Rang de la mission dans le run de matching (position dans `results`).

--- a/analytics/dbt/analytics/models/marts/tracking/__models.yml
+++ b/analytics/dbt/analytics/models/marts/tracking/__models.yml
@@ -37,12 +37,17 @@ models:
       Fait clic mission (grain événement) pour les breakdowns rang / distance / section / publisher,
       enrichi du statut et de la tranche d'âge de la session. Réconcilié avec le moteur de matching :
       `backend_rank`, `matching_engine_version` et `matched_to_backend` permettent d'analyser le CTR par rang.
-      `mission_score` reste un placeholder (non alimenté).
+      `mission_score` porte le score de la mission cliquée (répartition des clics par score).
     columns:
       - name: event_uuid
         tests:
           - not_null
           - unique
+      - name: mission_score
+        description: >
+          Score de la mission cliquée = moyenne de ses `taxonomyScores` dans le run de matching actif au
+          clic. Même base que `score_top5` (sous-score thématique), donc PAS le score total pondéré géo
+          (non persisté). Null si le clic n'est pas réconcilié au backend (`matched_to_backend = false`).
 
   - name: tracking_page_view_daily
     description: >

--- a/analytics/dbt/analytics/models/marts/tracking/tracking_recommendation.sql
+++ b/analytics/dbt/analytics/models/marts/tracking/tracking_recommendation.sql
@@ -1,0 +1,14 @@
+-- Grain « une ligne par mission recommandée » exposé à Metabase pour agréger
+-- librement la part des recommandations par annonceur (`publisher_name`), par
+-- jour (`session_date`) ou par rang (`backend_rank`). Aucune pré-agrégation :
+-- la souplesse d'agrégation est laissée à Metabase.
+select
+  quiz_session_id,
+  session_date,
+  matching_engine_version,
+  backend_rank,
+  mission_scoring_id,
+  mission_id,
+  publisher_id,
+  publisher_name
+from {{ ref('int_tracking_recommendation') }}

--- a/analytics/dbt/analytics/tests/assert_mission_click_matched_has_backend_rank.sql
+++ b/analytics/dbt/analytics/tests/assert_mission_click_matched_has_backend_rank.sql
@@ -1,5 +1,5 @@
--- Un clic rattaché au backend doit toujours porter un rang et une version.
--- Le test échoue s'il remonte des lignes (invariant de la jointure violé).
+-- Un clic rattaché au backend doit toujours porter un rang, une version et un
+-- score. Échoue s'il remonte des lignes (invariant de la jointure violé).
 select
   event_uuid,
   quiz_session_id,
@@ -7,4 +7,8 @@ select
 from {{ ref('int_tracking_mission_click') }}
 where
   matched_to_backend
-  and (backend_rank is null or matching_engine_version is null)
+  and (
+    backend_rank is null
+    or matching_engine_version is null
+    or mission_score is null
+  )


### PR DESCRIPTION
## Description

Deux KPI de contrôle sur les modèles dbt de tracking, indépendants et
complémentaires. Les deux s'appuient uniquement sur des modèles existants
(`stg_matching_engine_result`, `stg_mission_scoring`, `stg_mission`,
`stg_publisher`, `stg_user_scoring`).

### KPI 1 — Part des recommandations par annonceur (commit 1)

KPI de contrôle P1 « Nb de missions recommandées par publisher » : pour chaque
annonceur, combien de missions il place dans les recommandations du moteur de
matching, et sa part. Objectif : détecter si un seul annonceur capte l'essentiel
des recommandations.

La donnée source existe déjà : `matching_engine_result.results` (tableau JSON de
`{ missionScoringId, ... }`, sans `mission_id`). Le pont vers la mission puis
l'annonceur passe par `mission_scoring`.

- **`int_tracking_recommendation`** *(nouveau, vue)* : une ligne par mission
  recommandée dans le **dernier run de matching** de chaque session
  (`distinct on (user_scoring_id) order by created_at desc`). Explode `results`
  via `jsonb_array_elements ... with ordinality` (`backend_rank` = position).
  Personnes internes exclues au niveau du `distinct_id`.
- **`tracking_recommendation`** *(nouveau, mart table)* : grain « une ligne par
  mission recommandée » **non pré-agrégé**, pour agréger librement côté Metabase
  par `publisher_name`, `session_date` ou `backend_rank`.

### KPI 2 — Score de la mission cliquée (commit 2)

`int_tracking_mission_click` réconciliait déjà chaque clic mission avec le run de
matching actif (`backend_rank`), mais laissait `mission_score` en placeholder
(`null::numeric`) alors que la donnée est disponible au même endroit.

- **`int_tracking_mission_click`** : la lateral `ranked` renvoie désormais le
  rang **et** le score du **même item** (`order by t.ord asc limit 1`), avec la
  même formule que `score_top5` (moyenne des `taxonomyScores` de la mission).
  `null::numeric as mission_score` → `cb.mission_score`.
- **`tracking_mission_click`** : sélectionnait déjà `c.mission_score` (aucune
  modif de code), il propage maintenant une vraie valeur.

Usage : KPI « répartition des clics par score » et comparaison du score des
missions cliquées au `score_top5` moyen.

### Points d'implémentation

- Références aux modèles **staging** pour respecter le layering int → staging.
- `mission_id` gardé en **`text`** (formats mixtes ObjectId Mongo / UUID),
  jamais casté.
- `mission_score` = sous-score **thématique** (`taxonomyScores`), donc **pas** le
  score total pondéré géo, qui n'est pas persisté côté backend.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/Metabase-de-suivi-du-funnel-via-tracking-3a572a322d5080ac84f5c4c575ada953)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [x] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- **Validation locale (staging)** : `sqlfluff lint` OK ;
  `dbt build --select int_tracking_recommendation+` et
  `dbt build --select int_tracking_mission_click+` verts.
- **KPI 1** : somme des parts = **1**, aucun `publisher_name` null.
  Répartition cohérente — **Service Civique 53,5 %** et
  **JeVeuxAider.gouv.fr 44 %** captent l'essentiel, longue traîne de SDIS —
  exactement le signal attendu.
- **KPI 2** : `clics_reconcilies == avec_score` (tout clic réconcilié porte un
  score) ; test singulier `assert_mission_click_matched_has_backend_rank` étendu
  pour garantir l'invariant (matché ⇒ `backend_rank`, `matching_engine_version`
  et `mission_score` non nuls).
- **Distinctions utiles pour la review** : trois axes de réconciliation à ne pas
  confondre — `tracking_recommendation` mesure l'**offre** de recommandation
  (qui est recommandé), `mission_score`/`backend_rank` de
  `tracking_mission_click` qualifient la mission **cliquée**, et la réconciliation
  clic/candidature (autre PR) mesure la conversion.


