### PR TITLE
fix(app): add security headers to back-office and widget

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,13 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script defer data-domain="app.api-engagement.beta.gouv.fr" src="https://plausible.io/js/script.js"></script>
-    <script>
-      window.plausible =
-        window.plausible ||
-        function () {
-          (window.plausible.q = window.plausible.q || []).push(arguments);
-        };
-    </script>
   </head>
   <body>
     <a class="skip-link" href="#main-content">Aller au contenu principal</a>

--- a/app/package.json
+++ b/app/package.json
@@ -36,6 +36,7 @@
     "date-fns": "4.4.0",
     "dotenv": "^17.4.2",
     "express": "5.2.1",
+    "helmet": "8.2.0",
     "lodash": "4.18.1",
     "react": "19.2.7",
     "react-chartjs-2": "5.3.1",

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import express from "express";
+import helmet from "helmet";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -7,6 +8,44 @@ const app = express();
 const port = process.env.PORT || 8080;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Le conteneur ne reçoit aucune variable d'environnement au runtime : les hostnames API/widget/Sentry
+// (différents par environnement) sont inconnus ici, d'où les sources génériques "https:" ci-dessous.
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      useDefaults: false,
+      directives: {
+        "default-src": ["'self'"],
+        "base-uri": ["'self'"],
+        "object-src": ["'none'"],
+        "frame-ancestors": ["'none'"],
+        "script-src": ["'self'", "https://plausible.io"],
+        "script-src-attr": ["'none'"],
+        "style-src": ["'self'", "'unsafe-inline'"],
+        "img-src": ["'self'", "https:", "data:"],
+        "font-src": ["'self'", "data:"],
+        "connect-src": ["'self'", "https:"],
+        "frame-src": ["https:"],
+        "worker-src": ["'self'", "blob:"],
+        "form-action": ["'self'"],
+        "upgrade-insecure-requests": [],
+      },
+    },
+    frameguard: { action: "deny" },
+    referrerPolicy: { policy: "strict-origin-when-cross-origin" },
+    hsts: { maxAge: 31536000, includeSubDomains: true },
+    // jstag.js est chargé en <script> cross-origin par les sites partenaires : le CORP "same-origin"
+    // par défaut de helmet bloquerait ce chargement.
+    crossOriginResourcePolicy: { policy: "cross-origin" },
+  }),
+);
+
+// geolocation reste déléguable : l'aperçu du widget (iframe allow="geolocation") en a besoin.
+app.use((req, res, next) => {
+  res.setHeader("Permissions-Policy", "camera=(), microphone=()");
+  next();
+});
 
 app.use(express.static(path.join(__dirname, "../dist")));
 

--- a/app/src/main.jsx
+++ b/app/src/main.jsx
@@ -7,8 +7,15 @@ import ReactDOM from "react-dom/client";
 import "react-tooltip/dist/react-tooltip.css";
 
 import App from "@/App";
-import "./index.css";
 import { ENV, SENTRY_DSN } from "@/services/config";
+import "./index.css";
+
+// Stub Plausible (déplacé depuis index.html pour permettre une CSP sans script inline).
+window.plausible =
+  window.plausible ||
+  function () {
+    (window.plausible.q = window.plausible.q || []).push(arguments);
+  };
 
 if (ENV !== "development") {
   Sentry.init({

--- a/package-lock.json
+++ b/package-lock.json
@@ -396,6 +396,7 @@
         "date-fns": "4.4.0",
         "dotenv": "^17.4.2",
         "express": "5.2.1",
+        "helmet": "^8.2.0",
         "lodash": "4.18.1",
         "react": "19.2.7",
         "react-chartjs-2": "5.3.1",

--- a/widget/next.config.js
+++ b/widget/next.config.js
@@ -18,6 +18,19 @@ const nextConfig = {
   turbopack: {
     root: path.resolve(__dirname, ".."),
   },
+  // Pas de X-Frame-Options / frame-ancestors : le widget est embarqué en iframe par les sites partenaires.
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "Strict-Transport-Security", value: "max-age=31536000; includeSubDomains" },
+        ],
+      },
+    ];
+  },
 };
 
 module.exports = withSentryConfig(withPlausibleProxy()(nextConfig), {


### PR DESCRIPTION
## Description

Corrige le constat **F6** de l'audit de sécurité : aucun header de sécurité sur les deux frontends.

**Back-office (`app`)** :
- Ajout de `helmet` sur le serveur Express de prod (`app/server/index.js`) : CSP stricte (`default-src 'self'`, `script-src 'self' https://plausible.io` sans `unsafe-inline`), `frame-ancestors 'none'` + `X-Frame-Options: DENY` (anti-clickjacking sur le back-office authentifié), HSTS 1 an, `Referrer-Policy`, `X-Content-Type-Options: nosniff`, `Permissions-Policy`.
- Déplacement du stub `window.plausible` inline de `index.html` vers `main.jsx` : c'était le seul script inline, le déplacer permet un `script-src` strict sans hash ni `unsafe-inline` (mitigation XSS attendue pour F3).

**Widget (`widget`)** :
- Ajout de `headers()` dans `next.config.js` : `X-Content-Type-Options: nosniff`, `Referrer-Policy`, HSTS. Volontairement **sans** `X-Frame-Options` / `frame-ancestors` : le widget doit rester embarquable en iframe par les sites partenaires.

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/Header-de-securit-frontend-39972a322d50800690dbd87947cf0c8f?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

**Points d'attention** :

- `Cross-Origin-Resource-Policy` est forcé à `cross-origin` : `jstag.js` est chargé en `<script>` cross-origin par les sites partenaires, le `same-origin` par défaut de helmet l'aurait cassé (vérifié au curl en local).
- Le conteneur `app` ne reçoit aucune variable d'environnement au runtime (`terraform/containers.tf`) : les hostnames API/widget/Sentry (différents entre staging et prod) sont inconnus du serveur, d'où les sources génériques `connect-src https:`, `frame-src https:` et `img-src https:` (les logos de missions viennent de domaines arbitraires). Pour des allowlists exactes, il faudrait injecter les URLs via Terraform.
- `geolocation` n'est pas désactivé dans la Permissions-Policy : l'aperçu du widget dans le back-office (`Edit.jsx`, iframe `allow="geolocation"`) en a besoin.
- Comportement Plausible inchangé : tous les appels `window.plausible` dans `App.jsx` sont gardés par des `if`.
- Nouvelle dépendance : `helmet@8.2.0` (app).

**Test local** : serveur `app` démarré et headers vérifiés au curl (`/` et `/jstag.js`), `headers()` du widget résolu correctement à travers `withSentryConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)