### PR TITLE
feat(plateform): redesign results map pins with dsfr icons

### DIFF
--- a/plateform/app/components/results/mission-map.tsx
+++ b/plateform/app/components/results/mission-map.tsx
@@ -1,9 +1,9 @@
+import type { MissionMatchItem } from "@engagement/dto";
 import L from "leaflet";
 import "leaflet/dist/leaflet.css";
-import type { MissionMatchItem } from "@engagement/dto";
 import { useEffect, useId, useMemo, useRef } from "react";
 import { MapContainer, Marker, Popup, TileLayer, Tooltip, ZoomControl, useMap } from "react-leaflet";
-import { TILE_LAYER_PROPS, createEmojiIcon } from "~/components/ui/location-map";
+import { TILE_LAYER_PROPS } from "~/components/ui/location-map";
 import { type GeoPosition, getNearbyPosition } from "~/utils/geo";
 
 type MapMission = {
@@ -11,15 +11,17 @@ type MapMission = {
   position: GeoPosition;
   addressLabel: string | null;
   icon: L.DivIcon;
+  activeIcon: L.DivIcon;
 };
 
-const activeIcon = L.divIcon({
-  className: "",
-  html: `<div class="mission-map__emoji-marker mission-map__emoji-marker--active" role="img" aria-label="Mission sélectionnée">📍</div>`,
-  iconSize: [22, 22],
-  iconAnchor: [11, 11],
-  popupAnchor: [0, -12],
-});
+const createPinIcon = (iconClass: string, ariaLabel: string, active = false) =>
+  L.divIcon({
+    className: "",
+    html: `<div class="mission-map__pin${active ? " mission-map__pin--active" : ""}" role="img" aria-label="${ariaLabel}"><span class="${iconClass} fr-icon--sm" aria-hidden="true"></span></div>`,
+    iconSize: [30, 30],
+    iconAnchor: [15, 15],
+    popupAnchor: [0, -16],
+  });
 
 const getAddressLabel = (item: MissionMatchItem): string | null => item.mission.location.closestAddress ?? item.mission.location.city;
 const hasNeutralizedAddress = (item: MissionMatchItem): boolean => item.mission.remote === "full" || item.mission.remote === "local";
@@ -94,12 +96,14 @@ export default function MissionMap({ items, center, onMarkerClick, selectionPadd
 
       const usesRemoteIcon = item.mission.remote === "full" || (!hasPreciseCoordinates && !addressLabel && item.mission.remote !== "local");
       const markerLabel = usesRemoteIcon ? "Mission à distance" : item.mission.location.city ? `Mission à ${item.mission.location.city}` : "Mission en présentiel";
+      const iconClass = usesRemoteIcon ? "fr-icon-computer-fill" : "fr-icon-map-pin-2-fill";
 
       return {
         item,
         addressLabel,
         position,
-        icon: createEmojiIcon(usesRemoteIcon ? "👨‍💻" : "📍", markerLabel),
+        icon: createPinIcon(iconClass, markerLabel),
+        activeIcon: createPinIcon(iconClass, markerLabel, true),
       };
     });
 
@@ -121,7 +125,7 @@ export default function MissionMap({ items, center, onMarkerClick, selectionPadd
         <ZoomControl zoomInTitle="Zoomer" zoomOutTitle="Dézoomer" />
         <TileLayer {...TILE_LAYER_PROPS} />
         <BoundsFitter positions={boundsPositions} />
-        {missions.map(({ item, position, addressLabel, icon }) => {
+        {missions.map(({ item, position, addressLabel, icon, activeIcon }) => {
           const isActive = item.mission.id === activeMissionId;
           return (
             <Marker
@@ -136,7 +140,7 @@ export default function MissionMap({ items, center, onMarkerClick, selectionPadd
               }}
             >
               {onMissionHover && (
-                <Tooltip interactive direction="top" offset={[0, -8]} opacity={1} className="mission-map__tooltip">
+                <Tooltip interactive direction="top" offset={[0, -16]} opacity={1} className="mission-map__tooltip">
                   <strong className="mission-map__tooltip-title">{item.mission.title}</strong>
                   <span className="mission-map__tooltip-address">{addressLabel ?? getFallbackAddressLabel(item)}</span>
                 </Tooltip>

--- a/plateform/app/main.css
+++ b/plateform/app/main.css
@@ -250,9 +250,24 @@
   width: 22px;
 }
 
-.mission-map__emoji-marker--active {
-  background: #000091;
-  transform: scale(1.18);
+/* Pins de la carte des résultats : bleu d'action DSFR (blue-france-sun-113) comme les CTA,
+   hover/actif en bleu clair pour matérialiser la sélection. */
+.mission-map__pin {
+  align-items: center;
+  background-color: #000091;
+  border: 1px solid #ffffff;
+  border-radius: 9999px;
+  box-shadow: 0 3px 10px rgb(0 0 0 / 24%);
+  color: #ffffff;
+  display: grid;
+  height: 30px;
+  justify-items: center;
+  width: 30px;
+}
+
+.mission-map__pin:hover,
+.mission-map__pin--active {
+  background-color: #1212ff;
 }
 
 .mission-map__tooltip.leaflet-tooltip {


### PR DESCRIPTION
## Description

Refonte des pins de la carte des résultats (`/results/:id`) pour suivre la nouvelle maquette :

- Icônes DSFR `map-pin-2` (missions localisées) et `computer` (missions à distance) à la place des emojis 📍 / 👨‍💻
- Pins de 30x30px pour une meilleure visibilité et une sélection plus facile
- Fond bleu d'action `blue-france-sun-113` (#000091), comme les CTA, pour la cohérence
- Hover et état actif (survol d'une carte mission dans la liste) en #1212ff

Au passage, la variante active du pin conserve désormais l'icône ordinateur pour les missions à distance (avant, elle repassait sur le 📍 générique).

## Liens utiles

- 📝 Ticket Notion : [Lien vers le ticket](https://app.notion.com/p/jeveuxaider/Revoir-les-contrastes-de-la-carte-au-survol-3a572a322d508099965ccbf3a1f597c9?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Changement purement visuel : `typecheck` et `lint` passent, pas de logique modifiée.
- Les labels d'accessibilité des pins (`role="img"` + `aria-label`) sont conservés à l'identique.
- Le pin de la carte de la page détail mission (`location-map.tsx`) garde l'ancien style emoji — hors périmètre, à harmoniser dans une PR dédiée si souhaité.
- À vérifier sur les deux layouts (desktop et mobile) de la page résultats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)