### PR TITLE
fix(api): dedup mission.index republish in diffusion rebuild

### DIFF
--- a/api/src/jobs/mission-diffusion-rebuild/__tests__/handler.test.ts
+++ b/api/src/jobs/mission-diffusion-rebuild/__tests__/handler.test.ts
@@ -138,6 +138,27 @@ describe("MissionDiffusionRebuildHandler", () => {
     expect(result).toMatchObject({ reindexTouches: 3, distinctMissionsReindexed: 2, reindexRequested: 2, reindexFailed: 0 });
   });
 
+  it("republie les missions déjà collectées même si un diffuseur ultérieur échoue, puis propage l'erreur", async () => {
+    ruleServiceMock.findDistributionPublisherIdsForSnapshot.mockResolvedValue(["d1", "d2"]);
+    serviceMock.rebuildForDistributionPublisher
+      .mockImplementationOnce(async (_id: string, options: { onMissionsTouched?: (ids: string[]) => Promise<void> }) => {
+        await options.onMissionsTouched?.(["m1", "m2"]);
+        return { distributionPublisherId: "d1", desired: 2, added: 2, removed: 0, durationMs: 1 };
+      })
+      .mockImplementationOnce(async () => {
+        throw new Error("diffuseur d2 en échec");
+      });
+
+    // L'erreur du rebuild remonte...
+    await expect(new MissionDiffusionRebuildHandler().handle({})).rejects.toThrow("diffuseur d2 en échec");
+
+    // ...mais les missions déjà touchées par d1 (SQL déjà commité) ont bien été republiées avant.
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.index", payload: { missionId: "m1", action: "upsert" } });
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.index", payload: { missionId: "m2", action: "upsert" } });
+    // La purge ne doit pas avoir tourné (le try a levé avant).
+    expect(repositoryMock.deleteRowsForDistributionPublishersNotIn).not.toHaveBeenCalled();
+  });
+
   it("compte les échecs de republication sans faire échouer le rebuild global", async () => {
     ruleServiceMock.findDistributionPublisherIdsForSnapshot.mockResolvedValue(["d1"]);
     asyncTaskBusMock.publish.mockRejectedValue(new Error("SQS down"));

--- a/api/src/jobs/mission-diffusion-rebuild/__tests__/handler.test.ts
+++ b/api/src/jobs/mission-diffusion-rebuild/__tests__/handler.test.ts
@@ -113,7 +113,29 @@ describe("MissionDiffusionRebuildHandler", () => {
 
     expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.index", payload: { missionId: "m1", action: "upsert" } });
     expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.index", payload: { missionId: "m2", action: "upsert" } });
-    expect(result).toMatchObject({ reindexRequested: 2, reindexFailed: 0 });
+    expect(result).toMatchObject({ reindexTouches: 2, distinctMissionsReindexed: 2, reindexRequested: 2, reindexFailed: 0 });
+  });
+
+  it("déduplique les missions touchées par plusieurs diffuseurs : un seul message index par mission", async () => {
+    ruleServiceMock.findDistributionPublisherIdsForSnapshot.mockResolvedValue(["d1", "d2"]);
+    // m1 touchée par les deux diffuseurs, m2 par un seul : 3 touches, 2 missions distinctes.
+    serviceMock.rebuildForDistributionPublisher
+      .mockImplementationOnce(async (_id: string, options: { onMissionsTouched?: (ids: string[]) => Promise<void> }) => {
+        await options.onMissionsTouched?.(["m1", "m2"]);
+        return { distributionPublisherId: "d1", desired: 2, added: 2, removed: 0, durationMs: 1 };
+      })
+      .mockImplementationOnce(async (_id: string, options: { onMissionsTouched?: (ids: string[]) => Promise<void> }) => {
+        await options.onMissionsTouched?.(["m1"]);
+        return { distributionPublisherId: "d2", desired: 1, added: 1, removed: 0, durationMs: 1 };
+      });
+    repositoryMock.deleteRowsForDistributionPublishersNotIn.mockResolvedValue(0);
+
+    const result = await new MissionDiffusionRebuildHandler().handle({});
+
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledTimes(2);
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.index", payload: { missionId: "m1", action: "upsert" } });
+    expect(asyncTaskBusMock.publish).toHaveBeenCalledWith({ type: "mission.index", payload: { missionId: "m2", action: "upsert" } });
+    expect(result).toMatchObject({ reindexTouches: 3, distinctMissionsReindexed: 2, reindexRequested: 2, reindexFailed: 0 });
   });
 
   it("compte les échecs de republication sans faire échouer le rebuild global", async () => {

--- a/api/src/jobs/mission-diffusion-rebuild/handler.ts
+++ b/api/src/jobs/mission-diffusion-rebuild/handler.ts
@@ -19,6 +19,10 @@ export interface MissionDiffusionRebuildJobResult extends JobResult {
   added?: number;
   removed?: number;
   prunedDistributionPublishers?: number;
+  // Nombre de touches (mission, diffuseur) collectées (avec doublons entre diffuseurs).
+  reindexTouches?: number;
+  // Nombre de missions distinctes réellement republiées sur le bus (après déduplication).
+  distinctMissionsReindexed?: number;
   reindexRequested?: number;
   reindexFailed?: number;
   durationMs?: number;
@@ -44,34 +48,30 @@ export class MissionDiffusionRebuildHandler implements BaseHandler<MissionDiffus
     const distributionPublisherIds = scoped ? [publisherId as string] : await publisherDiffusionRuleService.findDistributionPublisherIdsForSnapshot();
     let added = 0;
     let removed = 0;
-    let reindexRequested = 0;
-    let reindexFailed = 0;
 
-    // Resynchronise Typesense au fil du rebuild : chaque mission dont l'appartenance au snapshot a
-    // changé est republiée sur le bus (at-least-once, récupérable via SQS). On empile tout dans la
-    // file d'un coup ; c'est au worker de réguler son débit de traitement. Les doublons entre
-    // diffuseurs sont sans effet (upsert idempotent côté worker).
+    // Resynchronise Typesense après le rebuild : chaque mission dont l'appartenance au snapshot a changé
+    // (pour un diffuseur quelconque) est republiée UNE seule fois sur le bus. Comme une mission est
+    // diffusée à ~150 diffuseurs, republier par ligne (mission, diffuseur) amplifiait le trafic d'un
+    // facteur ~150 alors que l'upsert worker reconstruit le document complet (liste des diffuseurs
+    // incluse) depuis PostgreSQL : un seul message par mission suffit. On collecte donc les missionId
+    // touchés (toutes les touches, y compris la purge) dans un Set, puis on publie à la fin, une fois
+    // toutes les écritures SQL convergées (chaque doc est ainsi construit depuis l'état final).
     // Récupération : un échec de publish laisse `reindexFailed>0` (success=false) sans que la ligne SQL
     // déjà écrite soit rejouée ⇒ relancer alors `update-mission-index` (réindexation complète) pour
     // reconverger Typesense sur PostgreSQL.
-    const republishTouchedMissions = async (missionIds: string[]): Promise<void> => {
-      await Promise.all(
-        missionIds.map(async (missionId) => {
-          try {
-            await asyncTaskBus.publish({ type: "mission.index", payload: { missionId, action: "upsert" } });
-            reindexRequested++;
-          } catch (error) {
-            reindexFailed++;
-            captureException(error, { extra: { missionId } });
-          }
-        })
-      );
+    const touchedMissionIds = new Set<string>();
+    let reindexTouches = 0;
+    const collectTouchedMissions = async (missionIds: string[]): Promise<void> => {
+      for (const missionId of missionIds) {
+        reindexTouches++;
+        touchedMissionIds.add(missionId);
+      }
     };
 
     for (const distributionPublisherId of distributionPublisherIds) {
       const distributionPublisher = await missionDiffusionService.rebuildForDistributionPublisher(distributionPublisherId, {
         dryRun,
-        onMissionsTouched: republishTouchedMissions,
+        onMissionsTouched: collectTouchedMissions,
       });
       added += distributionPublisher.added;
       removed += distributionPublisher.removed;
@@ -94,13 +94,30 @@ export class MissionDiffusionRebuildHandler implements BaseHandler<MissionDiffus
         : await missionDiffusionRepository.deleteRowsForDistributionPublishersNotIn(distributionPublisherIds);
       removed += prunedDistributionPublishers;
 
-      await republishTouchedMissions(prunedMissionIds);
+      await collectTouchedMissions(prunedMissionIds);
     }
+
+    // Publication dédupliquée : un seul message par mission distincte, après convergence des écritures.
+    const distinctMissionsReindexed = touchedMissionIds.size;
+    let reindexRequested = 0;
+    let reindexFailed = 0;
+    await Promise.all(
+      Array.from(touchedMissionIds).map(async (missionId) => {
+        try {
+          await asyncTaskBus.publish({ type: "mission.index", payload: { missionId, action: "upsert" } });
+          reindexRequested++;
+        } catch (error) {
+          reindexFailed++;
+          captureException(error, { extra: { missionId } });
+        }
+      })
+    );
+
     const durationMs = Date.now() - start.getTime();
 
     const mode = dryRun ? "Dry-run done" : "Done";
     console.log(
-      `[MissionDiffusionRebuild] ${mode}${scoped ? ` (publisher=${publisherId})` : ""}: ${distributionPublisherIds.length} distribution publishers, +${added} / -${removed} lignes (dont ${prunedDistributionPublishers} purgées), ${reindexRequested} réindexations demandées (${reindexFailed} échecs), en ${durationMs}ms`
+      `[MissionDiffusionRebuild] ${mode}${scoped ? ` (publisher=${publisherId})` : ""}: ${distributionPublisherIds.length} distribution publishers, +${added} / -${removed} lignes (dont ${prunedDistributionPublishers} purgées), ${reindexTouches} touches dédupliquées en ${distinctMissionsReindexed} missions réindexées (${reindexRequested} demandées, ${reindexFailed} échecs), en ${durationMs}ms`
     );
 
     return {
@@ -110,12 +127,14 @@ export class MissionDiffusionRebuildHandler implements BaseHandler<MissionDiffus
       added,
       removed,
       prunedDistributionPublishers,
+      reindexTouches,
+      distinctMissionsReindexed,
       reindexRequested,
       reindexFailed,
       durationMs,
       dryRun,
       publisherId,
-      message: `${dryRun ? "Dry-run : " : ""}${scoped ? `1 diffuseur ciblé (${publisherId})` : `${distributionPublisherIds.length} publishers de diffusion`} rebuild : +${added} / -${removed} lignes, ${reindexRequested} réindexations en ${durationMs}ms`,
+      message: `${dryRun ? "Dry-run : " : ""}${scoped ? `1 diffuseur ciblé (${publisherId})` : `${distributionPublisherIds.length} publishers de diffusion`} rebuild : +${added} / -${removed} lignes, ${distinctMissionsReindexed} missions réindexées (${reindexTouches} touches) en ${durationMs}ms`,
     };
   }
 }

--- a/api/src/jobs/mission-diffusion-rebuild/handler.ts
+++ b/api/src/jobs/mission-diffusion-rebuild/handler.ts
@@ -6,6 +6,10 @@ import { asyncTaskBus } from "@/services/async-task";
 import { missionDiffusionService } from "@/services/mission-diffusion";
 import publisherDiffusionRuleService from "@/services/publisher-diffusion-rule";
 
+// Concurrence bornée des publications sur le bus (aligné sur le job update-mission-index) : évite qu'un
+// rebuild touchant des dizaines de milliers de missions ne lance autant de requêtes SQS simultanées.
+const REINDEX_PUBLISH_BATCH_SIZE = 50;
+
 export interface MissionDiffusionRebuildJobPayload {
   dryRun?: boolean;
   // Restreint le rebuild à un seul publisher de diffusion (utile après correction de ses rules).
@@ -54,11 +58,8 @@ export class MissionDiffusionRebuildHandler implements BaseHandler<MissionDiffus
     // diffusée à ~150 diffuseurs, republier par ligne (mission, diffuseur) amplifiait le trafic d'un
     // facteur ~150 alors que l'upsert worker reconstruit le document complet (liste des diffuseurs
     // incluse) depuis PostgreSQL : un seul message par mission suffit. On collecte donc les missionId
-    // touchés (toutes les touches, y compris la purge) dans un Set, puis on publie à la fin, une fois
-    // toutes les écritures SQL convergées (chaque doc est ainsi construit depuis l'état final).
-    // Récupération : un échec de publish laisse `reindexFailed>0` (success=false) sans que la ligne SQL
-    // déjà écrite soit rejouée ⇒ relancer alors `update-mission-index` (réindexation complète) pour
-    // reconverger Typesense sur PostgreSQL.
+    // touchés (toutes les touches, y compris la purge) dans un Set, puis on publie par lots à
+    // concurrence bornée.
     const touchedMissionIds = new Set<string>();
     let reindexTouches = 0;
     const collectTouchedMissions = async (missionIds: string[]): Promise<void> => {
@@ -68,50 +69,68 @@ export class MissionDiffusionRebuildHandler implements BaseHandler<MissionDiffus
       }
     };
 
-    for (const distributionPublisherId of distributionPublisherIds) {
-      const distributionPublisher = await missionDiffusionService.rebuildForDistributionPublisher(distributionPublisherId, {
-        dryRun,
-        onMissionsTouched: collectTouchedMissions,
-      });
-      added += distributionPublisher.added;
-      removed += distributionPublisher.removed;
-      console.log(
-        `[MissionDiffusionRebuild] distributionPublisher=${distributionPublisher.distributionPublisherId} desired=${distributionPublisher.desired} added=${distributionPublisher.added} removed=${distributionPublisher.removed} in ${distributionPublisher.durationMs}ms`
-      );
-    }
-
-    // Missions des diffuseurs sortis de la population : collectées AVANT la purge, puis republiées pour
-    // qu'elles perdent le diffuseur dans `distributionPublisherIds` côté Typesense (sinon elles
-    // continueraient d'apparaître dans /browse pour ce diffuseur jusqu'à une réindexation externe).
-    // Ignorée en mode ciblé : `distributionPublisherIds` ne contient qu'un diffuseur, la purge
-    // `notIn` viderait la table pour tous les autres.
-    let prunedDistributionPublishers = 0;
-    if (!scoped) {
-      const prunedMissionIds = dryRun ? [] : await missionDiffusionRepository.findMissionIdsForDistributionPublishersNotIn(distributionPublisherIds);
-
-      prunedDistributionPublishers = dryRun
-        ? await missionDiffusionRepository.countRowsForDistributionPublishersNotIn(distributionPublisherIds)
-        : await missionDiffusionRepository.deleteRowsForDistributionPublishersNotIn(distributionPublisherIds);
-      removed += prunedDistributionPublishers;
-
-      await collectTouchedMissions(prunedMissionIds);
-    }
-
-    // Publication dédupliquée : un seul message par mission distincte, après convergence des écritures.
-    const distinctMissionsReindexed = touchedMissionIds.size;
+    // La publication est exécutée dans un `finally` pour préserver le contrat at-least-once même si le
+    // rebuild échoue en cours de route : les diffuseurs déjà traités ont validé leurs écritures SQL, donc
+    // une relance ne reverrait plus ces lignes comme modifiées (diff convergé) et ne les republierait
+    // pas. On republie donc systématiquement les missionId déjà collectés avant de laisser l'erreur
+    // remonter. Résiduel non couvert : un kill brutal du process (timeout/OOM) coupe avant le `finally` ⇒
+    // reconverger alors Typesense via `update-mission-index` (réindexation complète). Un échec de publish
+    // isolé laisse `reindexFailed>0` (success=false), même remédiation.
+    let distinctMissionsReindexed = 0;
     let reindexRequested = 0;
     let reindexFailed = 0;
-    await Promise.all(
-      Array.from(touchedMissionIds).map(async (missionId) => {
-        try {
-          await asyncTaskBus.publish({ type: "mission.index", payload: { missionId, action: "upsert" } });
-          reindexRequested++;
-        } catch (error) {
-          reindexFailed++;
-          captureException(error, { extra: { missionId } });
-        }
-      })
-    );
+    const publishTouchedMissions = async (): Promise<void> => {
+      const ids = Array.from(touchedMissionIds);
+      distinctMissionsReindexed = ids.length;
+      for (let i = 0; i < ids.length; i += REINDEX_PUBLISH_BATCH_SIZE) {
+        const batch = ids.slice(i, i + REINDEX_PUBLISH_BATCH_SIZE);
+        await Promise.all(
+          batch.map(async (missionId) => {
+            try {
+              await asyncTaskBus.publish({ type: "mission.index", payload: { missionId, action: "upsert" } });
+              reindexRequested++;
+            } catch (error) {
+              reindexFailed++;
+              captureException(error, { extra: { missionId } });
+            }
+          })
+        );
+      }
+    };
+
+    let prunedDistributionPublishers = 0;
+    try {
+      for (const distributionPublisherId of distributionPublisherIds) {
+        const distributionPublisher = await missionDiffusionService.rebuildForDistributionPublisher(distributionPublisherId, {
+          dryRun,
+          onMissionsTouched: collectTouchedMissions,
+        });
+        added += distributionPublisher.added;
+        removed += distributionPublisher.removed;
+        console.log(
+          `[MissionDiffusionRebuild] distributionPublisher=${distributionPublisher.distributionPublisherId} desired=${distributionPublisher.desired} added=${distributionPublisher.added} removed=${distributionPublisher.removed} in ${distributionPublisher.durationMs}ms`
+        );
+      }
+
+      // Missions des diffuseurs sortis de la population : collectées AVANT la purge, puis republiées pour
+      // qu'elles perdent le diffuseur dans `distributionPublisherIds` côté Typesense (sinon elles
+      // continueraient d'apparaître dans /browse pour ce diffuseur jusqu'à une réindexation externe).
+      // Ignorée en mode ciblé : `distributionPublisherIds` ne contient qu'un diffuseur, la purge
+      // `notIn` viderait la table pour tous les autres.
+      if (!scoped) {
+        const prunedMissionIds = dryRun ? [] : await missionDiffusionRepository.findMissionIdsForDistributionPublishersNotIn(distributionPublisherIds);
+
+        prunedDistributionPublishers = dryRun
+          ? await missionDiffusionRepository.countRowsForDistributionPublishersNotIn(distributionPublisherIds)
+          : await missionDiffusionRepository.deleteRowsForDistributionPublishersNotIn(distributionPublisherIds);
+        removed += prunedDistributionPublishers;
+
+        await collectTouchedMissions(prunedMissionIds);
+      }
+    } finally {
+      // Publication dédupliquée, par lots bornés, y compris si le `try` a levé (avant re-propagation).
+      await publishTouchedMissions();
+    }
 
     const durationMs = Date.now() - start.getTime();
 


### PR DESCRIPTION
## Description

Le job `mission-diffusion-rebuild` publiait **un message `mission.index` par ligne `(mission, diffuseur)`** ajoutée ou retirée du snapshot `mission_diffusion`. Or une mission est diffusée à ~150 diffuseurs en moyenne : une seule mission nouvelle/éligible générait donc ~150 messages `mission.index` identiques (même payload `{missionId, action:"upsert"}`).

Cette amplification est la cause des **pics du worker `mission-index`** observés sur staging juste après le cron du rebuild (1h30). Mesure sur le dernier rebuild staging : **189 missions distinctes → 27 243 messages** (amplification ~144×, jusqu'à 253 messages pour une même mission).

Le `mission.index` est idempotent : `missionIndexService.upsert(missionId)` reconstruit le document Typesense complet depuis PostgreSQL, **liste `distributionPublisherIds` incluse**. Un seul message par mission suffit donc.

### Correctif

- Les `missionId` touchés (tous diffuseurs + missions des diffuseurs purgés) sont collectés dans un `Set` sur tout le rebuild, puis republiés **une seule fois par mission distincte, après convergence des écritures SQL** (chaque document est ainsi construit depuis l'état final).
- Nouveaux compteurs dans le résultat/log : `reindexTouches` (touches brutes, doublons inclus) et `distinctMissionsReindexed` (messages réellement publiés) pour monitorer le ratio d'amplification.
- Aucun changement de contrat : la fenêtre de staleness (6h+) et la sémantique at-least-once/récupération via `update-mission-index` sont inchangées.

Impact attendu : ~27k → ~189 messages par cycle sur staging (÷144).


## Type de changement

- [x] Correction de bug
- [x] Amélioration de performance

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

