### PR TITLE
fix(api): change CPU scaling by request concurrency

### DIFF
--- a/terraform/containers.tf
+++ b/terraform/containers.tf
@@ -105,7 +105,7 @@ resource "scaleway_container" "api_worker" {
   }
 
   scaling_option {
-    cpu_usage_threshold = 70
+    concurrent_requests_threshold = 20
   }
 
   environment_variables = {


### PR DESCRIPTION
## Description

On ne peut pas faire un scaling via le CPU dans le cas d'un `min_scale: 0`

│ Error: scaleway-sdk-go: invalid argument(s): scaling_option.rule does not respect constraint, cannot use CPU or Memory scaling option when min_scale is 0


## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire
