### PR TITLE
fix(api): skip publish when queue not configured

### DIFF
--- a/api/src/services/async-task/providers/__tests__/scaleway.test.ts
+++ b/api/src/services/async-task/providers/__tests__/scaleway.test.ts
@@ -1,0 +1,14 @@
+import { ScalewayQueueProvider } from "@/services/async-task/providers/scaleway";
+import { SQSClient } from "@aws-sdk/client-sqs";
+import { describe, expect, it, vi } from "vitest";
+
+describe("ScalewayQueueProvider", () => {
+  it("ignore la publication lorsque la file n'est pas configuree", async () => {
+    const send = vi.spyOn(SQSClient.prototype, "send");
+    const provider = new ScalewayQueueProvider();
+
+    await provider.publish("", JSON.stringify({ type: "mission.index" }));
+
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/services/async-task/providers/scaleway.ts
+++ b/api/src/services/async-task/providers/scaleway.ts
@@ -17,6 +17,12 @@ export class ScalewayQueueProvider implements QueueProvider {
   }
 
   async publish(queueUrl: string, message: string): Promise<void> {
+    if (!queueUrl) {
+      console.warn("[async-task] File SQS not configured, publication ignored.");
+
+      return;
+    }
+
     await this.client.send(
       new SendMessageCommand({
         QueueUrl: queueUrl,


### PR DESCRIPTION
## Description

Pour éviter de publier sur des queues SQS pas configurer, on rajoute une vérification avec un skip au moment pour publish pour ne pas avoir ce genre d'erreur https://sentry.api-engagement.beta.gouv.fr/organizations/sentry/issues/2097/?project=2&query=is%3Aunresolved&referrer=issue-stream

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Tout ce qui peut être utile au reviewer (explications, points d'attention, captures d'écran, etc).
