### PR TITLE
fix(app): allow widget location removal and disable admin-only actions

### DIFF
--- a/app/src/components/Toggle.jsx
+++ b/app/src/components/Toggle.jsx
@@ -12,7 +12,7 @@ const Toggle = ({ id = "toggle-id", value, onChange = () => null, className = ""
       aria-checked={checked}
       tabIndex={0}
       onClick={() => onChange(!checked)}
-      className={`${checked ? "bg-blue-france" : "bg-white"} border-blue-france focus-visible:outline-outline-blue relative inline-flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full border p-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${className}`}
+      className={`${checked ? "bg-blue-france" : "bg-white"} border-blue-france focus-visible:outline-outline-blue relative inline-flex h-6 w-10 shrink-0 cursor-pointer items-center rounded-full border p-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-60 ${className}`}
     >
       <span
         aria-hidden="true"

--- a/app/src/scenes/broadcast/Campaigns.jsx
+++ b/app/src/scenes/broadcast/Campaigns.jsx
@@ -175,21 +175,31 @@ const Campaigns = () => {
             {data.slice((filters.page - 1) * filters.pageSize, filters.page * filters.pageSize).map((item, i) => (
               <tr key={i} className={`${i % 2 === 0 ? "bg-table-even" : "bg-table-odd"} table-row`}>
                 <td className="px-4 py-3">
-                  <Link to={`/broadcast/campaign/${item.id}`} className="text-blue-france break-words">
-                    {item.name}
-                  </Link>
+                  {user.role === "admin" ? (
+                    <Link to={`/broadcast/campaign/${item.id}`} className="text-blue-france break-words">
+                      {item.name}
+                    </Link>
+                  ) : (
+                    <span className="break-words">{item.name}</span>
+                  )}
                 </td>
                 <td className={`px-4 py-3 ${!item.active ? "opacity-50" : "opacity-100"}`}>{item.toPublisherName}</td>
                 <td className={`px-4 py-3 ${!item.active ? "opacity-50" : "opacity-100"}`}>{new Date(item.createdAt).toLocaleDateString("fr")}</td>
                 <td className="px-4 py-3">
                   <div className="flex w-fit gap-2 text-lg">
-                    <Link className="secondary-btn flex items-center" to={`/broadcast/campaign/${item.id}`}>
-                      <RiEditFill className="text-lg" role="img" aria-label="Modifier la campagne" />
-                    </Link>
+                    {user.role === "admin" ? (
+                      <Link className="secondary-btn flex items-center" to={`/broadcast/campaign/${item.id}`}>
+                        <RiEditFill className="text-lg" role="img" aria-label="Modifier la campagne" />
+                      </Link>
+                    ) : (
+                      <button type="button" className="secondary-btn flex items-center" disabled>
+                        <RiEditFill className="text-lg" role="img" aria-label="Modifier la campagne" />
+                      </button>
+                    )}
                     <button className="secondary-btn flex items-center" onClick={() => handleCopy(item.id)}>
                       <RiLink className="text-lg" role="img" aria-label="Copier le lien de la campagne" />
                     </button>
-                    <button className="secondary-btn flex items-center" onClick={() => handleDuplicate(item.id)}>
+                    <button className="secondary-btn flex items-center" onClick={() => handleDuplicate(item.id)} disabled={user.role !== "admin"}>
                       <RiFileCopyLine className="text-lg" role="img" aria-label="Dupliquer la campagne" />
                     </button>
                     <Link className="secondary-btn flex items-center" to={`/settings/real-time?sourceId=${item.id}&sourceType=campaign`}>
@@ -197,15 +207,14 @@ const Campaigns = () => {
                     </Link>
                   </div>
                 </td>
-                {user.role === "admin" && (
-                  <td className="px-4 py-3">
-                    <Toggle
-                      aria-label={`${item.active ? "Désactiver" : "Activer"} la campagne ${item.name || ""}`.trim()}
-                      value={item.active}
-                      onChange={(v) => handleActivate(v, item)}
-                    />
-                  </td>
-                )}
+                <td className="px-4 py-3">
+                  <Toggle
+                    aria-label={`${item.active ? "Désactiver" : "Activer"} la campagne ${item.name || ""}`.trim()}
+                    value={item.active}
+                    onChange={(v) => handleActivate(v, item)}
+                    disabled={user.role !== "admin"}
+                  />
+                </td>
               </tr>
             ))}
           </Table>

--- a/app/src/scenes/broadcast/Widgets.jsx
+++ b/app/src/scenes/broadcast/Widgets.jsx
@@ -114,9 +114,13 @@ const Widgets = () => {
           {data.slice((filters.page - 1) * filters.pageSize, filters.page * filters.pageSize).map((item, i) => (
             <tr key={i} className={`${i % 2 === 0 ? "bg-table-even" : "bg-table-odd"} table-row`}>
               <td className="px-4">
-                <Link to={`/broadcast/widget/${item.id}`} className="text-blue-france truncate">
-                  {item.name}
-                </Link>
+                {user.role === "admin" ? (
+                  <Link to={`/broadcast/widget/${item.id}`} className="text-blue-france truncate">
+                    {item.name}
+                  </Link>
+                ) : (
+                  <span className="truncate">{item.name}</span>
+                )}
               </td>
               <td className={`px-4 ${!item.active ? "opacity-50" : "opacity-100"}`}>
                 {item.publishers
@@ -127,9 +131,15 @@ const Widgets = () => {
               </td>
               <td className={`${!item.active ? "opacity-50" : "opacity-100"} px-4`}>{new Date(item.createdAt).toLocaleDateString("fr")}</td>
               <td className="mt-3 flex gap-2 px-4 text-lg">
-                <Link className="secondary-btn flex items-center" to={`/broadcast/widget/${item.id}`}>
-                  <RiEditFill className="text-lg" role="img" aria-label="Modifier le widget" />
-                </Link>
+                {user.role === "admin" ? (
+                  <Link className="secondary-btn flex items-center" to={`/broadcast/widget/${item.id}`}>
+                    <RiEditFill className="text-lg" role="img" aria-label="Modifier le widget" />
+                  </Link>
+                ) : (
+                  <button type="button" className="secondary-btn flex items-center" disabled>
+                    <RiEditFill className="text-lg" role="img" aria-label="Modifier le widget" />
+                  </button>
+                )}
                 <a
                   className="secondary-btn flex items-center"
                   href={`${item.type === "volontariat" ? VOLONTARIAT_URL : BENEVOLAT_URL}?widget=${item.id}&notrack=true`}
@@ -142,15 +152,14 @@ const Widgets = () => {
                   <RiPulseLine className="text-lg" role="img" aria-label={`Voir les événements en direct du widget ${item.name || ""}`.trim()} />
                 </Link>
               </td>
-              {user.role === "admin" && (
-                <td className="px-4">
-                  <Toggle
-                    aria-label={`${item.active ? "Désactiver" : "Activer"} le widget ${item.name || ""}`.trim()}
-                    value={item.active}
-                    onChange={(v) => handleActivate(v, item)}
-                  />
-                </td>
-              )}
+              <td className="px-4">
+                <Toggle
+                  aria-label={`${item.active ? "Désactiver" : "Activer"} le widget ${item.name || ""}`.trim()}
+                  value={item.active}
+                  onChange={(v) => handleActivate(v, item)}
+                  disabled={user.role !== "admin"}
+                />
+              </td>
             </tr>
           ))}
         </Table>

--- a/app/src/scenes/widget/components/Settings.jsx
+++ b/app/src/scenes/widget/components/Settings.jsx
@@ -35,6 +35,7 @@ const Settings = ({ widget, values, onChange, loading }) => {
   const [total, setTotal] = useState(0);
   const [showAll, setShowAll] = useState(false);
   const [selectAll, setSelectAll] = useState(false);
+  const [locationKey, setLocationKey] = useState(0);
 
   const availableTypes = useMemo(() => {
     const types = new Set();
@@ -150,13 +151,29 @@ const Settings = ({ widget, values, onChange, loading }) => {
             <label className="text-base" htmlFor="location">
               Ville ou code postal
             </label>
+            {/* key force un remontage du combobox à l'effacement pour vider son champ de recherche interne */}
             <LocationCombobox
+              key={locationKey}
               id="location"
               ariaDescribedby="location-hint"
               selected={values.location ? { label: values.location.label, value: `${values.location.lat}-${values.location.lon}` } : null}
               onSelect={(v) => onChange({ ...values, location: v ? { label: v.label, lat: parseFloat(v.value.split("-")[0]), lon: parseFloat(v.value.split("-")[1]) } : null })}
               placeholder="Localisation"
             />
+            {values.location ? (
+              <div className="mt-2">
+                <button
+                  type="button"
+                  className="text-blue-france cursor-pointer underline"
+                  onClick={() => {
+                    onChange({ ...values, location: null });
+                    setLocationKey(locationKey + 1);
+                  }}
+                >
+                  Supprimer la localisation
+                </button>
+              </div>
+            ) : null}
             <div className="text-info mt-4 flex items-center gap-2">
               <BiSolidInfoSquare className="text-sm" aria-hidden="true" />
               <p id="location-hint" className="text-xs">


### PR DESCRIPTION
## Description

Deux corrections sur le back-office pour les widgets et campagnes :

**Suppression de la localisation d'un widget** (pages création/édition)
- Ajout d'un bouton « Supprimer la localisation » sous le champ, visible uniquement quand une localisation est sélectionnée. Il n'y avait auparavant aucun moyen de désélectionner une localisation.
- Choix d'un bouton texte explicite plutôt qu'une croix dans le combobox, pour des raisons d'accessibilité.

**Listings widgets/campagnes pour les utilisateurs non-admin**
- Le nom n'est plus un lien (la route d'édition est réservée aux admins et redirigeait vers le dashboard).
- Le bouton « Modifier » est affiché désactivé au lieu de rediriger.
- La colonne « Actif » est toujours affichée : le toggle est visible mais désactivé pour les non-admins (elle était vide avant, ce qui décalait aussi les colonnes du tableau).
- Le bouton « Dupliquer la campagne » est désactivé pour les non-admins (la route `POST /campaign/:id/duplicate` est protégée admin côté API, le clic échouait silencieusement).

## Liens utiles

- 📝 [Ticket Notion](https://app.notion.com/p/jeveuxaider/On-ne-peut-pas-enlever-une-location-sur-un-widget-39f72a322d5080f1a8bbfaeabb0bb552?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- La suppression de la localisation utilise une `key` incrémentée sur `LocationCombobox` pour forcer son remontage : le combobox conserve le texte tapé dans un état interne, sans ça le champ afficherait encore l'ancienne saisie après effacement.
- Le composant `Toggle` gagne les styles `disabled:cursor-not-allowed disabled:opacity-60` ; l'attribut `disabled` passait déjà via `...rest` mais sans retour visuel. Aucun impact sur les usages existants (aucun ne passe `disabled`).
- Restent actifs pour les non-admins : « Voir le widget », « Copier le lien » (action client, lien public) et « Événements en direct » (route accessible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)