### PR TITLE
fix(api): revert worker autoscaling configuration

### DIFF
--- a/terraform/containers.tf
+++ b/terraform/containers.tf
@@ -105,10 +105,6 @@ resource "scaleway_container" "api_worker" {
     failure_threshold = 3
   }
 
-  scaling_option {
-    concurrent_requests_threshold = 20
-  }
-
   environment_variables = {
     "ENV"                               = var.env
     "IMAGE_VERSION"                     = var.image_tag

--- a/terraform/envs/production.tfvars
+++ b/terraform/envs/production.tfvars
@@ -28,9 +28,6 @@ widget_memory_limit = 1024
 widget_min_scale    = 1
 widget_max_scale    = 2
 
-worker_cpu_limit = 500
-worker_max_scale = 4
-
 enable_widget         = true
 enable_intern_jobs    = true
 enable_analytics_jobs = true

--- a/terraform/envs/staging.tfvars
+++ b/terraform/envs/staging.tfvars
@@ -27,8 +27,6 @@ widget_memory_limit = 512
 widget_min_scale    = 0
 widget_max_scale    = 1
 
-worker_max_scale = 2
-
 enable_widget         = true
 enable_intern_jobs    = true
 enable_analytics_jobs = true


### PR DESCRIPTION
## Description

Annule la configuration d'autoscaling du worker introduite par les PR #1359 et #1361.

Ce rollback :
- supprime le scaling basé sur 20 requêtes concurrentes ;
- restaure la limite CPU du worker de production à sa valeur par défaut de 250 ;
- restaure le nombre maximal d'instances à 1 en production et en staging.

## Liens utiles

- PR à annuler : #1359
- Correctif associé à annuler : #1361

## Type de changement

- [ ] Nouvelle fonctionnalité
- [x] Correction de bug
- [x] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

Depuis la mise en production, le worker dépile les messages beaucoup plus lentement. La configuration déployée combine une concurrence maximale de 1 avec un seuil d'autoscaling de 20 requêtes concurrentes. Ce rollback remet en place le dernier comportement connu comme fonctionnel avant de réintroduire un autoscaling cohérent dans une PR séparée.