### PR TITLE
refactor(jobs): index missions synchronously

### DIFF
--- a/api/src/jobs/update-mission-index/__tests__/handler.test.ts
+++ b/api/src/jobs/update-mission-index/__tests__/handler.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/mission-index", () => ({
+  missionIndexService: {
+    upsert: vi.fn(),
+  },
+}));
+
+vi.mock("@/error", () => ({ captureException: vi.fn() }));
+
+import { prisma } from "@/db/postgres";
+import { UpdateMissionIndexHandler } from "@/jobs/update-mission-index/handler";
+import { missionIndexService } from "@/services/mission-index";
+
+const prismaMock = prisma as unknown as {
+  mission: { findMany: ReturnType<typeof vi.fn> };
+};
+
+const missionIndexServiceMock = missionIndexService as unknown as {
+  upsert: ReturnType<typeof vi.fn>;
+};
+
+describe("UpdateMissionIndexHandler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    prismaMock.mission.findMany.mockReset();
+    missionIndexServiceMock.upsert.mockResolvedValue(undefined);
+  });
+
+  it("indexe directement chaque mission sélectionnée", async () => {
+    prismaMock.mission.findMany.mockResolvedValue([{ id: "mission-1" }, { id: "mission-2" }]);
+
+    const result = await new UpdateMissionIndexHandler().handle({ publisherId: "publisher-1", limit: 2 });
+
+    expect(prismaMock.mission.findMany).toHaveBeenCalledWith({
+      where: { deletedAt: null, statusCode: "ACCEPTED", publisherId: "publisher-1" },
+      select: { id: true },
+      take: 2,
+      orderBy: { updatedAt: "desc" },
+    });
+    expect(missionIndexServiceMock.upsert).toHaveBeenCalledTimes(2);
+    expect(missionIndexServiceMock.upsert).toHaveBeenNthCalledWith(1, "mission-1");
+    expect(missionIndexServiceMock.upsert).toHaveBeenNthCalledWith(2, "mission-2");
+    expect(result).toMatchObject({ success: true, total: 2, indexed: 2, failed: 0 });
+  });
+
+  it("n'indexe pas en dry-run", async () => {
+    prismaMock.mission.findMany.mockResolvedValue([{ id: "mission-1" }]);
+
+    const result = await new UpdateMissionIndexHandler().handle({ dryRun: true });
+
+    expect(missionIndexServiceMock.upsert).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ success: true, total: 1, indexed: 1, failed: 0 });
+  });
+
+  it("comptabilise un échec d'indexation sans interrompre les autres missions", async () => {
+    prismaMock.mission.findMany.mockResolvedValue([{ id: "mission-1" }, { id: "mission-2" }]);
+    missionIndexServiceMock.upsert.mockRejectedValueOnce(new Error("index unavailable"));
+
+    const result = await new UpdateMissionIndexHandler().handle({ batchSize: 1 });
+
+    expect(missionIndexServiceMock.upsert).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ success: false, total: 2, indexed: 1, failed: 1 });
+  });
+});

--- a/api/src/jobs/update-mission-index/handler.ts
+++ b/api/src/jobs/update-mission-index/handler.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/db/postgres";
 import { captureException } from "@/error";
 import { BaseHandler } from "@/jobs/base/handler";
 import { JobResult } from "@/jobs/types";
-import { asyncTaskBus } from "@/services/async-task";
+import { missionIndexService } from "@/services/mission-index";
 
 const LOG_PREFIX = "[update-mission-index-job]";
 const DEFAULT_BATCH_SIZE = 50;
@@ -50,7 +50,7 @@ export class UpdateMissionIndexHandler implements BaseHandler<UpdateMissionIndex
           batch.map(async ({ id }) => {
             try {
               if (!dryRun) {
-                await asyncTaskBus.publish({ type: "mission.index", payload: { missionId: id, action: "upsert" } });
+                await missionIndexService.upsert(id);
               }
               indexed++;
             } catch (error) {


### PR DESCRIPTION
## Description

Le job `update-mission-index` appelle désormais directement `missionIndexService.upsert` et attend la fin de l’indexation, au lieu de publier une tâche `mission.index` sur le bus asynchrone.

Le traitement par lots, le mode `dryRun` et l’isolation des erreurs par mission sont conservés. Des tests unitaires couvrent l’appel direct, le dry-run et la poursuite du traitement après un échec individuel.

## Liens utiles

- Aucun ticket associé.

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire