### PR TITLE
refactor(api): mesure indexing duration

### DIFF
--- a/api/src/services/mission-index/index.ts
+++ b/api/src/services/mission-index/index.ts
@@ -69,6 +69,7 @@ const buildTaxonomyIndex = (
 
 export const missionIndexService = {
   async upsert(missionId: string): Promise<void> {
+    const postgresStartedAt = Date.now();
     const mission = await prisma.mission.findUnique({
       where: { id: missionId },
       select: {
@@ -121,12 +122,14 @@ export const missionIndexService = {
         },
       },
     });
+    console.log(`[mission.index] dependency=postgres operation=mission.findUnique missionId=${missionId} durationMs=${Date.now() - postgresStartedAt}`);
 
     if (!mission || mission.deletedAt !== null || mission.statusCode !== "ACCEPTED") {
       await this.delete(missionId);
       return;
     }
 
+    const buildStartedAt = Date.now();
     const uniqueStrings = (values: Array<string | null | undefined>): string[] => [...new Set(values.filter((value): value is string => Boolean(value)))];
     const departmentCodes = uniqueStrings(mission.addresses.map((address) => address.departmentCode));
     const departmentNames = uniqueStrings(mission.addresses.map((address) => address.departmentName));
@@ -172,16 +175,22 @@ export const missionIndexService = {
       ...taxonomyIndex,
     };
 
+    console.log(`[mission.index] operation=document.build status=success missionId=${missionId} durationMs=${Date.now() - buildStartedAt}`);
+    const typesenseStartedAt = Date.now();
     await missionSearchClient.upsert(document);
+    console.log(`[mission.index] dependency=typesense operation=document.upsert missionId=${missionId} durationMs=${Date.now() - typesenseStartedAt}`);
   },
 
   async delete(missionId: string): Promise<void> {
+    const typesenseStartedAt = Date.now();
     try {
       await missionSearchClient.delete(missionId);
     } catch (err: unknown) {
       if ((err as { httpStatus?: number }).httpStatus !== 404) {
         throw err;
       }
+    } finally {
+      console.log(`[mission.index] dependency=typesense operation=document.delete missionId=${missionId} durationMs=${Date.now() - typesenseStartedAt}`);
     }
   },
 };

--- a/api/src/worker/handlers/mission-index.ts
+++ b/api/src/worker/handlers/mission-index.ts
@@ -1,11 +1,18 @@
 import { missionIndexService } from "@/services/mission-index";
 
 export const handleMissionIndex = async (payload: { missionId: string; action: "upsert" | "delete" }) => {
+  const startedAt = Date.now();
   console.log(`[mission.index] start missionId=${payload.missionId} action=${payload.action}`);
-  if (payload.action === "delete") {
-    await missionIndexService.delete(payload.missionId);
-  } else {
-    await missionIndexService.upsert(payload.missionId);
+
+  try {
+    if (payload.action === "delete") {
+      await missionIndexService.delete(payload.missionId);
+    } else {
+      await missionIndexService.upsert(payload.missionId);
+    }
+    console.log(`[mission.index] done missionId=${payload.missionId} action=${payload.action} durationMs=${Date.now() - startedAt}`);
+  } catch (error) {
+    console.error(`[mission.index] failed missionId=${payload.missionId} action=${payload.action} durationMs=${Date.now() - startedAt}`);
+    throw error;
   }
-  console.log(`[mission.index] done missionId=${payload.missionId} action=${payload.action}`);
 };


### PR DESCRIPTION
## Description

Cette PR ajoute des mesures de durée sur le traitement `mission.index` afin d'identifier le goulot d'étranglement observé pendant la réindexation des missions en production.

Les logs distinguent désormais :

- la lecture de la mission et de ses relations dans PostgreSQL ;
- la construction du document d'indexation ;
- l'upsert ou la suppression du document dans Typesense ;
- la durée totale du handler `mission.index`, y compris en cas d'erreur.

Chaque log contient le `missionId`, l'opération exécutée et sa durée en millisecondes. Cela permet de déterminer si la latence provient de PostgreSQL, de la transformation du document ou de Typesense.

Cette instrumentation ne modifie pas le comportement fonctionnel de l'indexation.

## Liens utiles

- PR à l'origine de l'évolution de l'indexation : #1337

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [x] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Tests

- Tests unitaires du service d'indexation : 6 tests réussis
- ESLint ciblé sur les fichiers modifiés

## Notes complémentaires

Exemple de séquence de logs :

```text
[mission.index] dependency=postgres operation=mission.findUnique missionId=... durationMs=...
[mission.index] operation=document.build status=success missionId=... durationMs=...
[mission.index] dependency=typesense operation=document.upsert missionId=... durationMs=...
[mission.index] done missionId=... action=upsert durationMs=...
```
