### PR TITLE
feat(api): parallelize update-mission-enrichment job

### DIFF
--- a/api/src/jobs/update-mission-enrichment/__tests__/handler.test.ts
+++ b/api/src/jobs/update-mission-enrichment/__tests__/handler.test.ts
@@ -49,6 +49,35 @@ describe("UpdateMissionEnrichmentHandler", () => {
     expect(result.message).toContain("version: v5");
   });
 
+  it("traite toutes les missions avec plusieurs workers concurrents", async () => {
+    const missions = Array.from({ length: 5 }, (_, i) => ({ id: `mission-${i}` }));
+    prismaMock.mission.findMany.mockResolvedValueOnce(missions).mockResolvedValueOnce([]);
+
+    const result = await new UpdateMissionEnrichmentHandler().handle({ promptVersion: "v5", concurrency: 3, rpm: 120 });
+
+    expect(enrichmentServiceMock.enrich).toHaveBeenCalledTimes(5);
+    for (const mission of missions) {
+      expect(enrichmentServiceMock.enrich).toHaveBeenCalledWith(mission.id, { force: false, promptVersion: "v5" });
+    }
+    expect(result).toMatchObject({ success: true, processed: 5, failed: 0 });
+  });
+
+  it.each([0, -1, 1.5])("refuse une concurrency invalide (%s)", async (concurrency) => {
+    const result = await new UpdateMissionEnrichmentHandler().handle({ promptVersion: "v5", concurrency });
+
+    expect(result).toMatchObject({ success: false, processed: 0, failed: 0 });
+    expect(prismaMock.mission.findMany).not.toHaveBeenCalled();
+    expect(enrichmentServiceMock.enrich).not.toHaveBeenCalled();
+  });
+
+  it.each([0, -5])("refuse un rpm invalide (%s)", async (rpm) => {
+    const result = await new UpdateMissionEnrichmentHandler().handle({ promptVersion: "v5", rpm });
+
+    expect(result).toMatchObject({ success: false, processed: 0, failed: 0 });
+    expect(prismaMock.mission.findMany).not.toHaveBeenCalled();
+    expect(enrichmentServiceMock.enrich).not.toHaveBeenCalled();
+  });
+
   it("refuse une version de prompt inconnue", async () => {
     const result = await new UpdateMissionEnrichmentHandler().handle({ promptVersion: "v999" as "v5" });
 

--- a/api/src/jobs/update-mission-enrichment/handler.ts
+++ b/api/src/jobs/update-mission-enrichment/handler.ts
@@ -3,7 +3,7 @@ import { captureException } from "@/error";
 import { BaseHandler } from "@/jobs/base/handler";
 import { JobResult } from "@/jobs/types";
 import { missionEnrichmentService } from "@/services/mission-enrichment";
-import { JOB_ENRICH_SLEEP_MS } from "@/services/mission-enrichment/config";
+import { DEFAULT_ENRICH_CONCURRENCY, DEFAULT_ENRICH_RPM } from "@/services/mission-enrichment/config";
 import { MissionEnrichmentRateLimitError } from "@/services/mission-enrichment/errors";
 import { CURRENT_PROMPT_VERSION, isPromptVersion, type PromptVersion } from "@/services/mission-enrichment/prompts";
 import fs from "fs";
@@ -18,6 +18,8 @@ export interface UpdateMissionEnrichmentJobPayload {
   onlyMissing?: boolean; // ne traite que les missions sans aucun enrichment
   missionIds?: string[];
   missionIdsFile?: string;
+  concurrency?: number; // nombre de missions traitées en parallèle (défaut DEFAULT_ENRICH_CONCURRENCY)
+  rpm?: number; // plafond de calls LLM par minute, respecte le TPM du provider (défaut DEFAULT_ENRICH_RPM)
 }
 
 export interface UpdateMissionEnrichmentJobResult extends JobResult {
@@ -28,12 +30,30 @@ export interface UpdateMissionEnrichmentJobResult extends JobResult {
 export class UpdateMissionEnrichmentHandler implements BaseHandler<UpdateMissionEnrichmentJobPayload, UpdateMissionEnrichmentJobResult> {
   name = "Enrichissement des missions";
 
-  async handle({ promptVersion, publisherId, limit, onlyMissing, missionIds, missionIdsFile }: UpdateMissionEnrichmentJobPayload = {}): Promise<UpdateMissionEnrichmentJobResult> {
+  async handle({
+    promptVersion,
+    publisherId,
+    limit,
+    onlyMissing,
+    missionIds,
+    missionIdsFile,
+    concurrency,
+    rpm,
+  }: UpdateMissionEnrichmentJobPayload = {}): Promise<UpdateMissionEnrichmentJobResult> {
     try {
       if (promptVersion !== undefined && !isPromptVersion(promptVersion)) {
         throw new Error(`Version de prompt inconnue : ${promptVersion}`);
       }
       const targetPromptVersion = promptVersion ?? CURRENT_PROMPT_VERSION;
+
+      if (concurrency !== undefined && (!Number.isInteger(concurrency) || concurrency < 1)) {
+        throw new Error("concurrency doit être un entier >= 1");
+      }
+      if (rpm !== undefined && (typeof rpm !== "number" || !Number.isFinite(rpm) || rpm <= 0)) {
+        throw new Error("rpm doit être un nombre > 0");
+      }
+      const workerCount = concurrency ?? DEFAULT_ENRICH_CONCURRENCY;
+      const targetRpm = rpm ?? DEFAULT_ENRICH_RPM;
 
       if (missionIds !== undefined && (!Array.isArray(missionIds) || missionIds.some((missionId) => typeof missionId !== "string"))) {
         throw new Error("missionIds doit être un tableau de chaînes de caractères");
@@ -105,31 +125,61 @@ export class UpdateMissionEnrichmentHandler implements BaseHandler<UpdateMission
 
       console.log(
         hasFixedSelection
-          ? `${LOG_PREFIX} ${missions.length} missions to force enrich (fixed selection, version: ${targetPromptVersion})`
+          ? `${LOG_PREFIX} ${missions.length} missions to force enrich (fixed selection, version: ${targetPromptVersion}, concurrency: ${workerCount}, rpm: ${targetRpm})`
           : `${LOG_PREFIX} ${missions.length} missions to enrich ` +
               `(${missingMissions.length} sans enrichment + ${staleMissions.length} obsolètes, ` +
-              `publisher: ${publisherId ?? "all"}, version: ${targetPromptVersion}, onlyMissing: ${onlyMissing ?? false})`
+              `publisher: ${publisherId ?? "all"}, version: ${targetPromptVersion}, onlyMissing: ${onlyMissing ?? false}, ` +
+              `concurrency: ${workerCount}, rpm: ${targetRpm})`
       );
 
       let processed = 0;
       let failed = 0;
 
-      for (const mission of missions) {
-        try {
-          await missionEnrichmentService.enrich(mission.id, { force: hasFixedSelection, promptVersion: targetPromptVersion });
-          processed++;
-          console.log(`${LOG_PREFIX} [${processed}/${missions.length}] enriched ${mission.id}`);
-        } catch (error) {
-          failed++;
-          const rateLimitDetails = error instanceof MissionEnrichmentRateLimitError ? error.details : undefined;
-          console.error(`${LOG_PREFIX} failed to enrich ${mission.id}`, error, rateLimitDetails ?? {});
-          if ((error as { name?: string })?.name !== "AI_NoObjectGeneratedError") {
-            captureException(error, { extra: { missionId: mission.id, ...(rateLimitDetails ? { rateLimit: rateLimitDetails } : {}) } });
+      // Rate limiter à intervalle minimum : espace les DÉPARTS de calls d'au moins (60000 / rpm) ms.
+      // C'est lui qui gouverne le débit (respect du TPM du provider) ; la concurrence ne sert qu'à
+      // avoir assez de requêtes en vol pour atteindre cet intervalle malgré la latence par call.
+      const minIntervalMs = 60000 / targetRpm;
+      let nextSlot = 0;
+      const acquireSlot = async (): Promise<void> => {
+        const now = Date.now();
+        const slot = Math.max(now, nextSlot);
+        nextSlot = slot + minIntervalMs;
+        const wait = slot - now;
+        if (wait > 0) {
+          await sleep(wait);
+        }
+      };
+
+      // Pool de workers concurrents partageant un curseur sur `missions`. La sûreté vis-à-vis d'un
+      // double-traitement est garantie côté DB par `claimForRun` (réservation atomique de la ligne
+      // d'enrichment), donc plusieurs workers peuvent avancer en parallèle sans coordination ici.
+      let cursor = 0;
+      const worker = async (): Promise<void> => {
+        while (true) {
+          const index = cursor++;
+          if (index >= missions.length) {
+            return;
+          }
+          const mission = missions[index];
+
+          await acquireSlot();
+
+          try {
+            await missionEnrichmentService.enrich(mission.id, { force: hasFixedSelection, promptVersion: targetPromptVersion });
+            processed++;
+            console.log(`${LOG_PREFIX} [${processed + failed}/${missions.length}] enriched ${mission.id}`);
+          } catch (error) {
+            failed++;
+            const rateLimitDetails = error instanceof MissionEnrichmentRateLimitError ? error.details : undefined;
+            console.error(`${LOG_PREFIX} failed to enrich ${mission.id}`, error, rateLimitDetails ?? {});
+            if ((error as { name?: string })?.name !== "AI_NoObjectGeneratedError") {
+              captureException(error, { extra: { missionId: mission.id, ...(rateLimitDetails ? { rateLimit: rateLimitDetails } : {}) } });
+            }
           }
         }
+      };
 
-        await sleep(JOB_ENRICH_SLEEP_MS);
-      }
+      await Promise.all(Array.from({ length: Math.min(workerCount, missions.length) }, () => worker()));
 
       const message = `${processed} missions enrichies, ${failed} échecs (${hasFixedSelection ? "sélection fixe" : `publisher: ${publisherId ?? "all"}`}, version: ${targetPromptVersion})`;
       console.log(`${LOG_PREFIX} done — ${message}`);

--- a/api/src/services/mission-enrichment/config.ts
+++ b/api/src/services/mission-enrichment/config.ts
@@ -1,7 +1,14 @@
 export const CONFIDENCE_THRESHOLD = 0.3;
 export const LLM_MAX_RETRIES = 5;
 export const LLM_NO_OBJECT_MAX_RETRIES = 3;
-export const JOB_ENRICH_SLEEP_MS = 500;
+
+// Défauts du job `update-mission-enrichment` (traitement parallèle).
+// Le débit est plafonné par le TPM du provider, pas par la concurrence : à ~6k tokens/call et
+// 246k TPM, la limite est ~41 calls/min. Avec ~5-6s de latence par call, ~4 requêtes en vol
+// suffisent à saturer ce plafond. Le RPM par défaut garde une marge sous les 41 calls/min ; la
+// concurrence n'est là que pour avoir assez de requêtes en vol malgré la latence.
+export const DEFAULT_ENRICH_CONCURRENCY = 4;
+export const DEFAULT_ENRICH_RPM = 38;
 
 // Caps de longueur (en caractères) appliqués aux champs non fiables de la mission avant leur
 // injection dans le prompt LLM. Défense contre l'injection de prompt et l'inflation de tokens.


### PR DESCRIPTION
## Description

Le job `update-mission-enrichment` traitait les missions **séquentiellement** (une par une, avec un `sleep` entre chaque appel), ce qui plafonne le débit à ~7 enrichissements/min et rend un backfill (ex. les ~38k missions de prod sur `v5`) interminable.

Or le vrai facteur limitant n'est pas la latence unitaire du LLM mais le **TPM du provider** : à ~6k tokens/call et 246k TPM, le plafond théorique est ~41 calls/min. À ~5-6s de latence par call, il suffit d'avoir **~4 requêtes en vol** pour saturer ce plafond.

Cette PR remplace la boucle séquentielle par un **pool de workers concurrents** partageant un curseur sur la sélection de missions, gouverné par un **rate limiter à intervalle minimum** (le vrai régulateur du débit, pour rester sous le TPM). La sélection des missions (missing + stale) et le comportement fonctionnel (publication du scoring après chaque enrichissement, idempotence) sont inchangés.

La sûreté vis-à-vis d'un double-traitement est **déjà garantie côté DB** par `claimForRun` (réservation atomique de la ligne `(mission_id, prompt_version)` via `INSERT … ON CONFLICT … WHERE status NOT IN ('pending','processing')`), donc plusieurs workers peuvent avancer en parallèle sans coordination applicative.

### Nouveaux paramètres (optionnels)

| Param | Défaut | Rôle |
|---|---|---|
| `concurrency` | `4` | Nombre de missions traitées en parallèle |
| `rpm` | `38` | Plafond de calls LLM/min (marge sous les ~41 calls/min du quota TPM) |

Le job restant **on-demand** (pas de cron), ces défauts parallèles n'impactent aucun run planifié. Exemple :

```bash
npm run job -- update-mission-enrichment '{"promptVersion":"v5","concurrency":4,"rpm":38}' --env production
```

## Liens utiles

- 📝 Ticket Notion : _n/a_

## Type de changement

- [ ] Nouvelle fonctionnalité
- [ ] Correction de bug
- [x] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Le débit ne dépasse pas ~41 calls/min quelle que soit la concurrence : au-delà de ~4-5 workers on ne fait que déclencher des 429 (retentés en backoff par le SDK AI). Le seul levier pour aller plus vite serait un TPM plus élevé côté provider.
- Si un call est mesuré à plus de 6k tokens (ou si le TPM compte input **et** output), baisser `rpm` (34-36) pour garder de la marge.
- `JOB_ENRICH_SLEEP_MS` (uniquement utilisé par ce job) est retiré au profit du rate limiter `rpm`.
