### PR TITLE
feat(ci): add sentry-webhook function to relay Sentry alerts to Slack

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -115,6 +115,9 @@ jobs:
           DATABASE_URL_CORE: ${{ secrets.DATABASE_URL_CORE }}
         run: npm --workspace api run prisma:migrate:deploy
 
+      - name: Build functions bundle (sentry-webhook)
+        run: npx -y esbuild@0.25.5 functions/src/functions/sentry-webhook/handler.ts --bundle --platform=node --format=esm --outfile=terraform/build/sentry-webhook/handler.mjs
+
       - name: Terraform Init
         working-directory: ./terraform
         run: terraform init

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+.env.*

--- a/functions/README.md
+++ b/functions/README.md
@@ -1,0 +1,56 @@
+# Functions
+
+Scaleway Serverless Functions du projet. Pour l'instant une seule fonction :
+
+- **sentry-webhook** — relais entre le Sentry self-hosted et Slack : reçoit le payload du plugin legacy WebHooks de Sentry en `POST`, le reformate et le poste via l'app Slack (`chat.postMessage`, même token que l'api) dans le channel indiqué par `SLACK_CHANNEL_ID`. Une fonction par workspace (staging, production, sandbox), chacune avec son channel — le sandbox pointe sur le même channel que la production.
+
+## Structure
+
+```
+functions/
+  src/
+    functions/
+      sentry-webhook/handler.ts     # Une fonction = un dossier avec un handler.ts (export handle)
+```
+
+## Déploiement (Terraform)
+
+La fonction est déployée par Terraform (`terraform/functions.tf`) via le workflow `terraform-deploy.yml` :
+
+1. La CI bundle le handler avec esbuild vers `terraform/build/sentry-webhook/handler.mjs`.
+2. `terraform apply` zippe le bundle et crée/met à jour la fonction (namespace `functions`).
+
+Chaque workspace déploie sa propre fonction (`enable_sentry_webhook = true` dans `envs/<workspace>.tfvars`).
+
+Variables de la fonction :
+
+- `SLACK_TOKEN` (secrète) — token de l'app Slack, repris du Secret Manager (`<workspace>-secret`, le même que l'api).
+- `SLACK_CHANNEL_ID` — id du channel Slack, renseigné via `sentry_slack_channel_id` dans `envs/<workspace>.tfvars` (le sandbox utilise le même id que la production).
+
+L'app Slack doit être invitée dans les channels (`/invite @NomDeLApp`).
+
+Pour un `terraform plan`/`apply` local sur le workspace production, construire d'abord le bundle :
+
+```bash
+npx -y esbuild functions/src/functions/sentry-webhook/handler.ts --bundle --platform=node --format=esm --outfile=terraform/build/sentry-webhook/handler.mjs
+```
+
+## Développement
+
+```bash
+cd functions
+bun install
+bun run typecheck
+```
+
+## Brancher Sentry
+
+Dans le Sentry self-hosted, pour chaque projet à notifier :
+
+1. **Settings → Legacy Integrations → WebHooks** : activer le plugin et renseigner l'URL de la fonction correspondant à l'environnement du projet (`terraform output sentry_webhook_endpoint` sur le bon workspace pour la retrouver).
+2. Dans les **Alert rules** du projet, ajouter l'action « Send a notification via WebHooks ».
+
+## Notes
+
+- La fonction est publique (Sentry doit pouvoir la joindre) et le plugin WebHooks ne signe pas ses requêtes : l'URL fait office de secret. Si besoin de durcir, ajouter un token partagé en variable de fonction.
+- Ajouter une fonction = créer `src/functions/<nom>/handler.ts` (export `handle`), ajouter une ligne de build esbuild dans `terraform-deploy.yml` et une ressource `scaleway_function` dans `terraform/functions.tf`.

--- a/functions/bun.lock
+++ b/functions/bun.lock
@@ -1,0 +1,20 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "functions",
+      "devDependencies": {
+        "@types/node": "^24.3.1",
+        "typescript": "^5.9.2",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+  }
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "functions",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Scaleway Serverless Functions (relais Sentry → Slack)",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.1",
+    "typescript": "^5.9.2"
+  }
+}

--- a/functions/src/functions/sentry-webhook/handler.ts
+++ b/functions/src/functions/sentry-webhook/handler.ts
@@ -1,0 +1,114 @@
+// Relais entre le webhook Sentry (plugin legacy WebHooks) et Slack. Une fonction par
+// environnement : le message est posté via l'app Slack (même token que l'api) dans le
+// channel indiqué par SLACK_CHANNEL_ID.
+// Payload « issue alerts » du plugin legacy : https://develop.sentry.dev/integrations/webhooks/
+type FunctionEvent = {
+  httpMethod: string;
+  body?: string;
+  isBase64Encoded?: boolean;
+};
+
+type SentryEvent = {
+  event_id?: string;
+  title?: string;
+  level?: string;
+  platform?: string;
+  environment?: string | null;
+  release?: string | null;
+  timestamp?: number;
+  culprit?: string | null;
+  logentry?: { formatted?: string | null; message?: string | null } | null;
+  metadata?: { type?: string; value?: string; title?: string; filename?: string } | null;
+  request?: { method?: string | null; url?: string | null } | null;
+  tags?: [string, string][];
+};
+
+type SentryWebhookPayload = {
+  id?: string;
+  project?: string;
+  project_name?: string;
+  project_slug?: string;
+  logger?: string | null;
+  level?: string;
+  culprit?: string | null;
+  message?: string;
+  url?: string;
+  triggering_rules?: string[];
+  event?: SentryEvent;
+};
+
+const LEVEL_EMOJIS: Record<string, string> = { fatal: "⚫️", error: "🔴", warning: "🟡", info: "🔵", debug: "🟢" };
+// Couleur de la barre latérale de l'attachment Slack, indexée sur le niveau Sentry.
+const LEVEL_COLORS: Record<string, string> = { fatal: "#b3131a", error: "#e03e2f", warning: "#f2a100", info: "#439fe0", debug: "#9b9b9b" };
+
+const json = (body: object, statusCode: number) => ({ statusCode, headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+
+// Slack impose d'échapper &, < et > dans tout texte mrkdwn (y compris les blocs de code).
+const escapeMrkdwn = (text: string) => text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+export const handle = async (event: FunctionEvent) => {
+  if (event.httpMethod !== "POST") return json({ error: "Method not allowed" }, 405);
+
+  const raw = event.isBase64Encoded ? Buffer.from(event.body ?? "", "base64").toString() : (event.body ?? "");
+  let payload: SentryWebhookPayload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const sentryEvent = payload.event ?? {};
+  const channelId = process.env.SLACK_CHANNEL_ID || "";
+  const slackToken = process.env.SLACK_TOKEN || "";
+  if (slackToken === "" || channelId === "") return json({ error: "Slack token or channel id is not set" }, 500);
+
+  const level = sentryEvent.level ?? payload.level ?? "error";
+  const title = sentryEvent.metadata?.type ?? sentryEvent.title ?? payload.message ?? "Nouvel événement Sentry";
+  const culprit = payload.culprit ?? sentryEvent.culprit ?? [sentryEvent.request?.method, sentryEvent.request?.url].filter(Boolean).join(" ");
+  const preview = sentryEvent.metadata?.value ?? sentryEvent.logentry?.formatted ?? payload.message;
+
+  const emoji = LEVEL_EMOJIS[level] ?? LEVEL_EMOJIS.error;
+  const lines = [`${emoji} *${payload.url ? `<${payload.url}|${escapeMrkdwn(title)}>` : escapeMrkdwn(title)}*`];
+  if (culprit && culprit !== title) lines.push(`\`${escapeMrkdwn(culprit)}\``);
+  if (preview && preview !== title) lines.push(`\`\`\`${escapeMrkdwn(preview.replaceAll("```", "'''").slice(0, 400))}\`\`\``);
+
+  const context = [`Projet : \`${payload.project_name ?? payload.project ?? "?"}\``];
+  if (sentryEvent.environment) context.push(`Env : \`${sentryEvent.environment}\``);
+  if (sentryEvent.release) context.push(`Release : \`${sentryEvent.release}\``);
+  if (payload.triggering_rules?.length) context.push(`Alerte : ${escapeMrkdwn(payload.triggering_rules.join(", "))}`);
+  if (sentryEvent.timestamp) context.push(`<!date^${Math.floor(sentryEvent.timestamp)}^{date_short_pretty} {time_secs}|${new Date(sentryEvent.timestamp * 1000).toISOString()}>`);
+
+  // Attachment + blocks : barre de couleur par niveau, ligne de contexte en petit texte gris.
+  const slackMessage = {
+    channel: channelId,
+    attachments: [
+      {
+        color: LEVEL_COLORS[level] ?? LEVEL_COLORS.error,
+        fallback: `${emoji} [${level}] ${title}`,
+        blocks: [
+          { type: "section", text: { type: "mrkdwn", text: lines.join("\n") } },
+          { type: "context", elements: [{ type: "mrkdwn", text: context.join("  ·  ") }] },
+        ],
+      },
+    ],
+  };
+
+  try {
+    const response = await fetch("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${slackToken}`, "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify(slackMessage),
+    });
+    // L'API Slack répond 200 même en cas d'échec : le statut est dans le champ ok.
+    const data = (await response.json()) as { ok?: boolean; error?: string };
+    if (data.ok !== true) {
+      console.error(`Slack error: ${data.error ?? response.status}`);
+      return json({ error: "Slack request failed" }, 502);
+    }
+  } catch (error) {
+    console.error(error);
+    return json({ error: "Internal error" }, 500);
+  }
+
+  return json({ ok: true }, 200);
+};

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,1 +1,2 @@
 .envrc
+build/

--- a/terraform/envs/production.tfvars
+++ b/terraform/envs/production.tfvars
@@ -7,7 +7,11 @@ benevolat_hostname         = "mission.api-engagement.beta.gouv.fr"
 volontariat_hostname       = "sc.api-engagement.beta.gouv.fr"
 piloty_hostname            = "api.piloty.fr"
 bucket_name                = "api-engagement-bucket"
+
+enable_sentry_webhook   = true
 slack_jobteaser_channel_id = "C080H9MH56W"
+sentry_slack_channel_id = "C052V2UF918"
+
 core_database_id           = "9a0421d5-c618-4d88-956b-3f758ab9aa0e"
 
 mission_enrichment_prompt_version = "v3"

--- a/terraform/envs/sandbox.tfvars
+++ b/terraform/envs/sandbox.tfvars
@@ -25,3 +25,6 @@ enable_intern_jobs         = false
 enable_analytics_jobs      = false
 
 private_network_cidr = "10.42.0.0/22"
+
+enable_sentry_webhook   = true
+sentry_slack_channel_id = "C052V2UF918"

--- a/terraform/envs/staging.tfvars
+++ b/terraform/envs/staging.tfvars
@@ -48,3 +48,6 @@ typesense_nodes = {
     typesense_version = "30.2"
   }
 }
+
+enable_sentry_webhook   = true
+sentry_slack_channel_id = "C08QQT4702D"

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -1,0 +1,50 @@
+# Fonction sentry-webhook : relais Sentry self-hosted → Slack, une fonction par workspace.
+# Le channel de destination est fourni par SLACK_CHANNEL_ID (le sandbox pointe sur le même
+# channel que la production). Le bundle est construit avant le plan (CI ou local) : voir
+# functions/README.md.
+
+data "archive_file" "sentry_webhook" {
+  count = var.enable_sentry_webhook ? 1 : 0
+
+  type        = "zip"
+  source_file = "${path.module}/build/sentry-webhook/handler.mjs"
+  output_path = "${path.module}/build/sentry-webhook.zip"
+}
+
+resource "scaleway_function_namespace" "functions" {
+  count = var.enable_sentry_webhook ? 1 : 0
+
+  name        = "${var.workspace}-functions"
+  description = "${var.workspace} functions namespace"
+  project_id  = var.project_id
+}
+
+resource "scaleway_function" "sentry_webhook" {
+  count = var.enable_sentry_webhook ? 1 : 0
+
+  name         = "sentry-webhook"
+  description  = "Relais Sentry → Slack"
+  namespace_id = scaleway_function_namespace.functions[0].id
+  runtime      = "node22"
+  handler      = "handler.handle"
+  privacy      = "public"
+  http_option  = "redirected"
+  memory_limit = 128
+  min_scale    = 0
+  max_scale    = 1
+  deploy       = true
+  zip_file     = data.archive_file.sentry_webhook[0].output_path
+  zip_hash     = data.archive_file.sentry_webhook[0].output_sha256
+
+  environment_variables = {
+    "SLACK_CHANNEL_ID" = var.sentry_slack_channel_id
+  }
+
+  secret_environment_variables = {
+    "SLACK_TOKEN" = local.secrets.SLACK_TOKEN
+  }
+}
+
+output "sentry_webhook_endpoint" {
+  value = var.enable_sentry_webhook ? "https://${scaleway_function.sentry_webhook[0].domain_name}" : ""
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -234,6 +234,20 @@ variable "plateform_max_scale" {
   default = 1
 }
 
+# Functions
+
+variable "enable_sentry_webhook" {
+  type        = bool
+  default     = false
+  description = "Deploy the sentry-webhook function (Sentry → Slack relay)"
+}
+
+variable "sentry_slack_channel_id" {
+  type        = string
+  default     = ""
+  description = "Slack channel id where the sentry-webhook function posts (sandbox uses the same channel as production)"
+}
+
 # Network
 
 variable "private_network_cidr" {


### PR DESCRIPTION
## Description

Met en place des notifications Slack pour les alertes du Sentry self-hosted (l'intégration Slack native n'étant pas activée), via une Scaleway Serverless Function déployée par Terraform.

**Changements** :

- Nouveau dossier `functions/` : le handler `sentry-webhook` (TypeScript, sans dépendance) reçoit le payload du plugin legacy WebHooks de Sentry, le reformate (titre cliquable vers l'issue, culprit, aperçu de l'erreur, contexte projet/env/release/alerte/date, barre de couleur par niveau) et le poste via l'app Slack existante (`chat.postMessage`, même token que l'api) dans le channel indiqué par `SLACK_CHANNEL_ID`.
- `terraform/functions.tf` : une fonction par workspace (namespace `<workspace>-functions`), `SLACK_TOKEN` repris du Secret Manager (`<workspace>-secret`), channel par environnement via la variable `sentry_slack_channel_id` (sandbox = même channel que la production).
- `terraform-deploy.yml` : étape de build esbuild du bundle avant le plan Terraform.

Le setup est en place mais il faut encore config le sentry et faire les changements des DSN

## Liens utiles

- 📝 Ticket Notion : [ticket](https://app.notion.com/p/jeveuxaider/Changement-de-l-espace-Sentry-23c72a322d5082668fa9816a238d2fad?v=1f872a322d5080a38ab2000ce606db06&source=copy_link)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [ ] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Testé de bout en bout : fonction déployée manuellement dans un namespace de test, payload « Test plugin » de Sentry reçu et message posté dans le channel Slack de test.
- **Actions post-merge** :
  - Renseigner l'URL de chaque fonction (`terraform output sentry_webhook_endpoint` par workspace) dans le plugin WebHooks des projets Sentry correspondants + action « Send a notification via WebHooks » dans les alert rules.
  - Vérifier que l'app Slack est invitée dans les channels cibles (`not_in_channel` sinon).
  - Vérifier que `SLACK_TOKEN` est bien présent/valide dans les secrets `staging-secret` et `sandbox-secret` (jusqu'ici seul celui de prod servait réellement).
  - Supprimer les namespaces de test (`api-engagement`, `api-engagement-test`) dans la console Scaleway.
- La fonction est publique et le plugin WebHooks ne signe pas ses requêtes : l'URL fait office de secret (durcissement possible plus tard via un token partagé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
