### PR TITLE
fix(app): use session storage in jstag

### DIFF
--- a/app/public/jstag.js
+++ b/app/public/jstag.js
@@ -105,13 +105,14 @@
         if (window._apieng.humanConfirmed) return;
         if (!window._apieng.pageLoadTime || Date.now() - window._apieng.pageLoadTime < 2000) return;
 
-        const apiengagementId = window._apieng.getCookieValue("apiengagement");
-        const trackingToken = window._apieng.getCookieValue("apiengagement_tracking_token");
-        if (!apiengagementId || !trackingToken) return;
+        const apiengagementId = window.sessionStorage.getItem("apiengagement_tracking_id");
+        const trackingToken = window.sessionStorage.getItem("apiengagement_tracking_token");
+        if (!apiengagementId) return;
 
-        fetch(`${window._apieng.eventHost}/r/${apiengagementId}/confirm-human?token=${encodeURIComponent(trackingToken)}`).then((response) =>
-          response.ok ? (window._apieng.humanConfirmed = true) : null,
-        );
+        const confirmationUrl = new URL(`${window._apieng.eventHost}/r/${apiengagementId}/confirm-human`);
+        if (trackingToken) confirmationUrl.searchParams.set("token", trackingToken);
+
+        fetch(confirmationUrl.href).then((response) => (response.ok ? (window._apieng.humanConfirmed = true) : null));
       }),
       // Impression tracking
       (window._apieng.getTrackers = function (e) {
@@ -246,5 +247,10 @@
     };
     let e = window._apieng.getQueryParameter("apiengagement_id");
     let n = window._apieng.getQueryParameter("apiengagement_tracking_token");
-    (null != e && window._apieng.setCookieValue("apiengagement", e), null != n && window._apieng.setCookieValue("apiengagement_tracking_token", n));
+    if (null != e) {
+      window._apieng.setCookieValue("apiengagement", e);
+      window.sessionStorage.setItem("apiengagement_tracking_id", e);
+      if (null != n) window.sessionStorage.setItem("apiengagement_tracking_token", n);
+      else window.sessionStorage.removeItem("apiengagement_tracking_token");
+    }
   })());

--- a/app/tests/e2e/jstag/humanDetection.spec.ts
+++ b/app/tests/e2e/jstag/humanDetection.spec.ts
@@ -11,6 +11,8 @@ test.describe("jstag.js - Human detection", () => {
     });
 
     await page.goto("/test-jstag.html?apiengagement_id=stat-123&apiengagement_tracking_token=test-token");
+    expect(await page.evaluate(() => window.sessionStorage.getItem("apiengagement_tracking_id"))).toBe("stat-123");
+    expect(await page.evaluate(() => window.sessionStorage.getItem("apiengagement_tracking_token"))).toBe("test-token");
 
     // Wait 2.5s (2s threshold)
     await page.waitForTimeout(2500);
@@ -21,6 +23,52 @@ test.describe("jstag.js - Human detection", () => {
     await confirmationRequest;
 
     expect(confirmCalled).toBe(true);
+  });
+
+  test("keeps confirmation data isolated between tabs", async ({ context, page }) => {
+    const secondPage = await context.newPage();
+    const firstClickId = "stat-first";
+    const secondClickId = "stat-second";
+    const firstToken = "token-first";
+    const secondToken = "token-second";
+
+    await context.route("**/r/*/confirm-human*", async (route) => {
+      await route.fulfill({ status: 200 });
+    });
+
+    await Promise.all([
+      page.goto(`/test-jstag.html?apiengagement_id=${firstClickId}&apiengagement_tracking_token=${firstToken}`),
+      secondPage.goto(`/test-jstag.html?apiengagement_id=${secondClickId}&apiengagement_tracking_token=${secondToken}`),
+    ]);
+    await page.waitForTimeout(2500);
+
+    const firstConfirmation = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return url.pathname === `/r/${firstClickId}/confirm-human` && url.searchParams.get("token") === firstToken;
+    });
+    await page.mouse.move(100, 100);
+    await firstConfirmation;
+
+    const secondConfirmation = secondPage.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return url.pathname === `/r/${secondClickId}/confirm-human` && url.searchParams.get("token") === secondToken;
+    });
+    await secondPage.mouse.move(100, 100);
+    await secondConfirmation;
+  });
+
+  test("confirms a legacy redirect without a token", async ({ page }) => {
+    await page.route("**/r/*/confirm-human*", async (route) => {
+      expect(new URL(route.request().url()).searchParams.has("token")).toBe(false);
+      await route.fulfill({ status: 200 });
+    });
+
+    await page.goto("/test-jstag.html?apiengagement_id=legacy-stat");
+    await page.waitForTimeout(2500);
+
+    const confirmationRequest = page.waitForRequest("**/r/legacy-stat/confirm-human");
+    await page.mouse.move(100, 100);
+    await confirmationRequest;
   });
 
   test("does not confirm before 2s", async ({ page }) => {


### PR DESCRIPTION
## Description

Isole les données nécessaires à `confirm-human` au niveau de chaque onglet afin d’éviter qu’un clic ouvert dans une autre fenêtre remplace le `clickId` ou le jeton utilisé pour la confirmation. Ce qui causait des 403 dans le cas où un utilisateur ouvrait plusieurs missions dans des onglets différents.

<img width="2407" height="812" alt="Capture d’écran 2026-08-05 à 18 04 14" src="https://github.com/user-attachments/assets/4ad1a357-6cea-4c2b-b96d-9faa6c3d29da" />

Le script `jstag.js` conserve désormais la paire `clickId` / jeton de tracking dans `sessionStorage`. Les cookies historiques restent utilisés par les autres mécanismes de tracking.

Les redirections legacy sans jeton restent prises en charge : le jeton de l’onglet est supprimé et la confirmation est envoyée sans token, afin d’activer le fallback temporaire et sa remontée Sentry côté API.

## Liens utiles

- 📝 Audit de sécurité : F8 — mutation d’état non authentifiée sur le tracking

## Type de changement

- [x] Correction de bug
- [ ] Nouvelle fonctionnalité
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (ESLint)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Ajout de tests E2E pour vérifier l’isolation des confirmations entre deux onglets et le comportement d’une redirection legacy sans jeton.
- Les tests E2E nécessitent Chromium Playwright, disponible dans la CI.