### PR TITLE
feat(analytics): new tracking property quiz_version

### DIFF
--- a/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
+++ b/analytics/dbt/analytics/models/intermediate/tracking/__models.yml
@@ -28,6 +28,8 @@ models:
           - unique
       - name: quiz_session_id
         description: Identifiant backend (`userScoringId`), présent si le quiz a été complété.
+      - name: quiz_version
+        description: Version du quiz au démarrage de la tentative.
       - name: is_completed
         description: Vrai si un événement `quiz.completed` a été observé pour la tentative.
 

--- a/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_quiz_session.sql
+++ b/analytics/dbt/analytics/models/intermediate/tracking/int_tracking_quiz_session.sql
@@ -8,6 +8,7 @@ with started as (
     max(utm_source) as utm_source,
     max(utm_campaign) as utm_campaign,
     max(utm_medium) as utm_medium,
+    max(quiz_version) as quiz_version,
     max(prompt_version) as prompt_version,
     max(algo_version) as algo_version
   from {{ ref('stg_tracking__quiz_started') }}
@@ -58,6 +59,7 @@ joined as (
     s.utm_source,
     s.utm_campaign,
     s.utm_medium,
+    s.quiz_version,
     s.prompt_version,
     s.algo_version,
     c.completed_at,

--- a/analytics/dbt/analytics/models/marts/tracking/__models.yml
+++ b/analytics/dbt/analytics/models/marts/tracking/__models.yml
@@ -16,6 +16,8 @@ models:
           - unique
       - name: quiz_session_id
         description: Identifiant backend, présent pour les sessions complétées.
+      - name: quiz_version
+        description: Version du quiz au démarrage de la tentative.
       - name: has_click_after_results
         description: >
           Vrai si la session a vu les résultats ET a cliqué sur au moins une mission (toutes sections

--- a/analytics/dbt/analytics/models/marts/tracking/tracking_quiz_session.sql
+++ b/analytics/dbt/analytics/models/marts/tracking/tracking_quiz_session.sql
@@ -37,6 +37,7 @@ select
   s.utm_source,
   s.utm_campaign,
   s.utm_medium,
+  s.quiz_version,
   s.prompt_version,
   s.algo_version,
   s.is_completed,

--- a/analytics/dbt/analytics/models/staging/tracking/__models.yml
+++ b/analytics/dbt/analytics/models/staging/tracking/__models.yml
@@ -32,6 +32,8 @@ models:
         description: UUID de la tentative de quiz (présent sur tout le tunnel).
       - name: quiz_session_id
         description: Identifiant de session backend (`userScoringId`), présent sur les events post-quiz.
+      - name: quiz_version
+        description: Version du quiz ayant émis l'événement.
 
   - name: stg_tracking__quiz_started
     description: Entrée du tunnel quiz (`quiz.started`), événement de référence de tous les ratios.

--- a/analytics/dbt/analytics/models/staging/tracking/stg_tracking__event.sql
+++ b/analytics/dbt/analytics/models/staging/tracking/stg_tracking__event.sql
@@ -14,6 +14,7 @@ with base as (
     (properties ->> '$screen_height')::int as screen_height,
     properties ->> 'quiz_attempt_id' as quiz_attempt_id,
     properties ->> 'quiz_session_id' as quiz_session_id,
+    properties ->> 'quiz_version' as quiz_version,
     properties ->> 'prompt_version' as prompt_version,
     properties ->> 'algo_version' as algo_version,
     properties ->> '$device_type' as device_type,

--- a/analytics/dbt/analytics/models/staging/tracking/stg_tracking__quiz_completed.sql
+++ b/analytics/dbt/analytics/models/staging/tracking/stg_tracking__quiz_completed.sql
@@ -5,6 +5,7 @@ with base as (
     distinct_id,
     quiz_attempt_id,
     quiz_session_id,
+    quiz_version,
     prompt_version,
     algo_version,
     device_type,

--- a/analytics/dbt/analytics/models/staging/tracking/stg_tracking__quiz_started.sql
+++ b/analytics/dbt/analytics/models/staging/tracking/stg_tracking__quiz_started.sql
@@ -5,6 +5,7 @@ with base as (
     distinct_id,
     quiz_attempt_id,
     quiz_session_id,
+    quiz_version,
     prompt_version,
     algo_version,
     device_type,

--- a/analytics/dbt/analytics/models/staging/tracking/stg_tracking__quiz_step_completed.sql
+++ b/analytics/dbt/analytics/models/staging/tracking/stg_tracking__quiz_step_completed.sql
@@ -5,6 +5,7 @@ with base as (
     distinct_id,
     quiz_attempt_id,
     quiz_session_id,
+    quiz_version,
     prompt_version,
     algo_version,
     device_type,


### PR DESCRIPTION
## Description

Ajoute l'extraction et la propagation de la propriété PostHog `quiz_version` dans les modèles dbt de tracking, jusqu'à la vue `tracking_quiz_session` exposée dans Metabase.

Les événements historiques qui ne portent pas encore cette propriété auront naturellement une valeur `NULL`, sans traitement spécifique.

## Liens utiles

- 📝 Ticket Notion : [Nouvelle propriété de version du quiz](https://app.notion.com/p/jeveuxaider/Nouvelle-propri-t-de-version-du-quiz-3a572a322d5080049c9fd78a8a5b65e5?source=copy_link)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [x] Respect des standards de code (SQLFluff)
- [ ] Migration de données nécessaire

## Notes complémentaires

- Validation effectuée avec `dbt compile -s tracking_quiz_session` et SQLFluff.
- Aucune migration de données n'est nécessaire.