### PR TITLE
feat(analytics): mission_diffusion analytics pipeline

### DIFF
--- a/analytics/db/migrations/20260813124830_add_mission_diffusion.sql
+++ b/analytics/db/migrations/20260813124830_add_mission_diffusion.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+CREATE TABLE IF NOT EXISTS "analytics_raw"."mission_diffusion" (
+  "distribution_publisher_id" TEXT NOT NULL,
+  "mission_id" TEXT NOT NULL,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY ("distribution_publisher_id", "mission_id")
+);
+
+
+-- migrate:down
+DROP TABLE IF EXISTS "analytics_raw"."mission_diffusion";

--- a/analytics/db/migrations/20260813124830_add_mission_diffusion.sql
+++ b/analytics/db/migrations/20260813124830_add_mission_diffusion.sql
@@ -1,9 +1,12 @@
 -- migrate:up
 CREATE TABLE IF NOT EXISTS "analytics_raw"."mission_diffusion" (
+  "id" TEXT PRIMARY KEY,
   "distribution_publisher_id" TEXT NOT NULL,
   "mission_id" TEXT NOT NULL,
+  "is_deleted" BOOLEAN NOT NULL DEFAULT FALSE,
   "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY ("distribution_publisher_id", "mission_id")
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3)
 );
 
 

--- a/analytics/dbt/analytics/models/intermediate/mission/__models.yml
+++ b/analytics/dbt/analytics/models/intermediate/mission/__models.yml
@@ -281,3 +281,44 @@ models:
         description: Timestamp de dernière mise à jour propagé mission/événements.
         tests:
           - not_null
+  - name: int_mission_diffusion
+    description: >
+      Table intermédiaire incrémentale des périodes de diffusion de mission. Chaque ligne représente
+      un cycle mission / partenaire diffuseur ; les retraits sont conservés via `is_deleted`
+      et `deleted_at`.
+    columns:
+      - name: id
+        description: Identifiant technique unique de la diffusion.
+        tests:
+          - not_null
+          - unique
+      - name: distribution_publisher_id
+        description: Identifiant du partenaire diffuseur.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('publisher')
+                field: id
+      - name: mission_id
+        description: Identifiant de la mission diffusée.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('mission')
+                field: id
+      - name: is_deleted
+        description: Indique que la diffusion a été retirée du snapshot courant.
+        tests:
+          - not_null
+      - name: created_at
+        description: Horodatage de création de la diffusion.
+        tests:
+          - not_null
+      - name: updated_at
+        description: Horodatage de dernière modification, utilisé pour l'incrémental.
+        tests:
+          - not_null
+      - name: deleted_at
+        description: Horodatage du retrait de la diffusion (nullable).

--- a/analytics/dbt/analytics/models/intermediate/mission/int_mission_diffusion.sql
+++ b/analytics/dbt/analytics/models/intermediate/mission/int_mission_diffusion.sql
@@ -1,0 +1,40 @@
+{{ config(
+  materialized = 'incremental',
+  unique_key = 'id',
+  incremental_strategy = 'delete+insert',
+  on_schema_change = 'sync_all_columns',
+  post_hook = [
+    'create index if not exists "int_mission_diffusion_mission_id_idx" on {{ this }} (mission_id)',
+    'create index if not exists "int_mission_diffusion_updated_at_idx" on {{ this }} (updated_at)',
+  ]
+) }}
+
+with source as (
+  select
+    id,
+    distribution_publisher_id,
+    mission_id,
+    is_deleted,
+    created_at,
+    updated_at,
+    deleted_at
+  from {{ ref('stg_mission_diffusion') }}
+  {% if is_incremental() %}
+    where
+      updated_at
+      >= (
+        select coalesce(max(imd.updated_at), '1900-01-01')
+        from {{ this }} as imd
+      )
+  {% endif %}
+)
+
+select
+  id,
+  distribution_publisher_id,
+  mission_id,
+  is_deleted,
+  created_at,
+  updated_at,
+  deleted_at
+from source

--- a/analytics/dbt/analytics/models/marts/mission/__models.yml
+++ b/analytics/dbt/analytics/models/marts/mission/__models.yml
@@ -221,9 +221,15 @@ models:
           - not_null
   - name: mission_diffusion
     description: >
-      Vue des diffusions autorisées par mission, directement exposée depuis le staging
-      `stg_mission_diffusion`. Le grain est le couple mission / partenaire diffuseur.
+      Vue des périodes de diffusion de mission, directement exposée depuis l'intermediate
+      `int_mission_diffusion`. Le grain est un cycle mission / partenaire diffuseur ;
+      les retraits restent disponibles grâce à `is_deleted` et `deleted_at`.
     columns:
+      - name: id
+        description: Identifiant technique unique de la diffusion.
+        tests:
+          - not_null
+          - unique
       - name: distribution_publisher_id
         description: Identifiant du partenaire autorisé à diffuser la mission.
         tests:
@@ -240,10 +246,20 @@ models:
               arguments:
                 to: ref('mission')
                 field: id
+      - name: is_deleted
+        description: Indique que la diffusion a été retirée du snapshot courant.
+        tests:
+          - not_null
       - name: created_at
         description: Horodatage de création de la diffusion autorisée.
         tests:
           - not_null
+      - name: updated_at
+        description: Horodatage de dernière modification de la diffusion.
+        tests:
+          - not_null
+      - name: deleted_at
+        description: Horodatage du retrait de la diffusion du snapshot courant (nullable).
   - name: mission_jobboard_daily
     description: >
       Agrégat quotidien des diffusions jobboard au grain jour + domaine de mission +

--- a/analytics/dbt/analytics/models/marts/mission/__models.yml
+++ b/analytics/dbt/analytics/models/marts/mission/__models.yml
@@ -219,6 +219,31 @@ models:
         description: Timestamp de dernière mise à jour (curseur incrémental).
         tests:
           - not_null
+  - name: mission_diffusion
+    description: >
+      Vue des diffusions autorisées par mission, directement exposée depuis le staging
+      `stg_mission_diffusion`. Le grain est le couple mission / partenaire diffuseur.
+    columns:
+      - name: distribution_publisher_id
+        description: Identifiant du partenaire autorisé à diffuser la mission.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('publisher')
+                field: id
+      - name: mission_id
+        description: Identifiant de la mission diffusée.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('mission')
+                field: id
+      - name: created_at
+        description: Horodatage de création de la diffusion autorisée.
+        tests:
+          - not_null
   - name: mission_jobboard_daily
     description: >
       Agrégat quotidien des diffusions jobboard au grain jour + domaine de mission +

--- a/analytics/dbt/analytics/models/marts/mission/mission_diffusion.sql
+++ b/analytics/dbt/analytics/models/marts/mission/mission_diffusion.sql
@@ -1,7 +1,11 @@
 {{ config(materialized = 'view') }}
 
 select
+  id,
   distribution_publisher_id,
   mission_id,
-  created_at
-from {{ ref('stg_mission_diffusion') }}
+  is_deleted,
+  created_at,
+  updated_at,
+  deleted_at
+from {{ ref('int_mission_diffusion') }}

--- a/analytics/dbt/analytics/models/marts/mission/mission_diffusion.sql
+++ b/analytics/dbt/analytics/models/marts/mission/mission_diffusion.sql
@@ -1,0 +1,7 @@
+{{ config(materialized = 'view') }}
+
+select
+  distribution_publisher_id,
+  mission_id,
+  created_at
+from {{ ref('stg_mission_diffusion') }}

--- a/analytics/dbt/analytics/models/raw.yml
+++ b/analytics/dbt/analytics/models/raw.yml
@@ -560,15 +560,23 @@ sources:
             description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
       - name: mission_diffusion
         description: >-
-          Instantané des diffusions autorisées d'une mission vers un partenaire diffuseur. Chaque ligne correspond
-          à un couple mission / partenaire diffuseur matérialisé dans la base opérationnelle.
+          Historique des périodes de diffusion autorisées d'une mission vers un partenaire diffuseur. Chaque ligne
+          correspond à un cycle de diffusion matérialisé dans la base opérationnelle.
         columns:
+          - name: id
+            description: Identifiant technique unique de la diffusion, utilisé pour l'export incrémental.
           - name: distribution_publisher_id
             description: Identifiant du partenaire autorisé à diffuser la mission.
           - name: mission_id
             description: Identifiant de la mission diffusée.
+          - name: is_deleted
+            description: Indique que la diffusion a été retirée du snapshot courant.
           - name: created_at
             description: Horodatage de création de la diffusion autorisée.
+          - name: updated_at
+            description: Horodatage de dernière modification de la diffusion, utilisé pour l'export incrémental.
+          - name: deleted_at
+            description: Horodatage du retrait de la diffusion du snapshot courant (nullable).
       - name: organization
         description: >-
           Référentiel des organisations synchronisé depuis la base opérationnelle (`core.Organization`). Ces données

--- a/analytics/dbt/analytics/models/raw.yml
+++ b/analytics/dbt/analytics/models/raw.yml
@@ -558,6 +558,17 @@ sources:
             description: Timestamp de création de la ligne.
           - name: updated_at
             description: Timestamp de dernière mise à jour, utilisé comme curseur d'export.
+      - name: mission_diffusion
+        description: >-
+          Instantané des diffusions autorisées d'une mission vers un partenaire diffuseur. Chaque ligne correspond
+          à un couple mission / partenaire diffuseur matérialisé dans la base opérationnelle.
+        columns:
+          - name: distribution_publisher_id
+            description: Identifiant du partenaire autorisé à diffuser la mission.
+          - name: mission_id
+            description: Identifiant de la mission diffusée.
+          - name: created_at
+            description: Horodatage de création de la diffusion autorisée.
       - name: organization
         description: >-
           Référentiel des organisations synchronisé depuis la base opérationnelle (`core.Organization`). Ces données

--- a/analytics/dbt/analytics/models/staging/mission/__models.yml
+++ b/analytics/dbt/analytics/models/staging/mission/__models.yml
@@ -433,3 +433,20 @@ models:
         description: Timestamp de dernière mise à jour (curseur d'export).
         tests:
           - not_null
+  - name: stg_mission_diffusion
+    description: >
+      Staging des diffusions autorisées par mission depuis `analytics_raw.mission_diffusion`.
+      Le modèle conserve le grain du couple mission / partenaire diffuseur et type le timestamp de création.
+    columns:
+      - name: distribution_publisher_id
+        description: Identifiant du partenaire autorisé à diffuser la mission.
+        tests:
+          - not_null
+      - name: mission_id
+        description: Identifiant de la mission diffusée.
+        tests:
+          - not_null
+      - name: created_at
+        description: Horodatage de création de la diffusion autorisée.
+        tests:
+          - not_null

--- a/analytics/dbt/analytics/models/staging/mission/__models.yml
+++ b/analytics/dbt/analytics/models/staging/mission/__models.yml
@@ -435,9 +435,14 @@ models:
           - not_null
   - name: stg_mission_diffusion
     description: >
-      Staging des diffusions autorisées par mission depuis `analytics_raw.mission_diffusion`.
-      Le modèle conserve le grain du couple mission / partenaire diffuseur et type le timestamp de création.
+      Staging des périodes de diffusion autorisées par mission depuis `analytics_raw.mission_diffusion`.
+      Le modèle conserve chaque cycle de diffusion et type les timestamps métier.
     columns:
+      - name: id
+        description: Identifiant technique unique de la diffusion.
+        tests:
+          - not_null
+          - unique
       - name: distribution_publisher_id
         description: Identifiant du partenaire autorisé à diffuser la mission.
         tests:
@@ -446,7 +451,17 @@ models:
         description: Identifiant de la mission diffusée.
         tests:
           - not_null
+      - name: is_deleted
+        description: Indique que la diffusion a été retirée du snapshot courant.
+        tests:
+          - not_null
       - name: created_at
         description: Horodatage de création de la diffusion autorisée.
         tests:
           - not_null
+      - name: updated_at
+        description: Horodatage de dernière modification de la diffusion, utilisé pour l'incrémental.
+        tests:
+          - not_null
+      - name: deleted_at
+        description: Horodatage du retrait de la diffusion du snapshot courant (nullable).

--- a/analytics/dbt/analytics/models/staging/mission/stg_mission_diffusion.sql
+++ b/analytics/dbt/analytics/models/staging/mission/stg_mission_diffusion.sql
@@ -1,5 +1,9 @@
 select
+  id,
   distribution_publisher_id,
   mission_id,
-  created_at::timestamp as created_at
+  is_deleted::boolean as is_deleted,
+  created_at::timestamp as created_at,
+  updated_at::timestamp as updated_at,
+  deleted_at::timestamp as deleted_at
 from {{ source('analytics_raw', 'mission_diffusion') }}

--- a/analytics/dbt/analytics/models/staging/mission/stg_mission_diffusion.sql
+++ b/analytics/dbt/analytics/models/staging/mission/stg_mission_diffusion.sql
@@ -1,0 +1,5 @@
+select
+  distribution_publisher_id,
+  mission_id,
+  created_at::timestamp as created_at
+from {{ source('analytics_raw', 'mission_diffusion') }}

--- a/analytics/src/jobs/export-to-analytics-raw/config.ts
+++ b/analytics/src/jobs/export-to-analytics-raw/config.ts
@@ -751,10 +751,10 @@ export const exportDefinitions: ExportDefinition[] = [
     source: {
       table: "mission_diffusion",
       cursor: {
-        field: "created_at",
+        field: "updated_at",
         idField: "id",
       },
-      columns: ["distribution_publisher_id", "mission_id", "created_at"],
+      columns: ["id", "distribution_publisher_id", "mission_id", "created_at", "is_deleted", "deleted_at", "updated_at"],
     },
     destination: {
       table: "mission_diffusion",

--- a/analytics/src/jobs/export-to-analytics-raw/config.ts
+++ b/analytics/src/jobs/export-to-analytics-raw/config.ts
@@ -745,4 +745,20 @@ export const exportDefinitions: ExportDefinition[] = [
       conflictColumns: ["id"],
     },
   },
+  {
+    key: "mission_diffusion",
+    batchSize: 2000,
+    source: {
+      table: "mission_diffusion",
+      cursor: {
+        field: "created_at",
+        idField: "id",
+      },
+      columns: ["distribution_publisher_id", "mission_id", "created_at"],
+    },
+    destination: {
+      table: "mission_diffusion",
+      conflictColumns: ["id"],
+    },
+  },
 ];

--- a/api/prisma/migrations/20260813132806_add_mission_diffusion_soft_delete/migration.sql
+++ b/api/prisma/migrations/20260813132806_add_mission_diffusion_soft_delete/migration.sql
@@ -1,10 +1,28 @@
 -- AlterTable
-ALTER TABLE "mission_diffusion" ADD COLUMN     "deleted_at" TIMESTAMP(3),
-ADD COLUMN     "is_deleted" BOOLEAN NOT NULL DEFAULT false,
-ADD COLUMN     "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "mission_diffusion"
+ADD COLUMN "deleted_at" TIMESTAMP(3),
+ADD COLUMN "is_deleted" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN "id" TEXT;
+
+-- La colonne est ajoutée nullable pour permettre le backfill des lignes existantes.
+UPDATE "mission_diffusion"
+SET "id" = gen_random_uuid()::text
+WHERE "id" IS NULL;
+
+ALTER TABLE "mission_diffusion" ALTER COLUMN "id" SET NOT NULL;
+
+-- L'identifiant technique permet de conserver un cycle de diffusion à chaque réactivation.
+ALTER TABLE "mission_diffusion" DROP CONSTRAINT "mission_diffusion_pkey";
+
+ALTER TABLE "mission_diffusion"
+ADD CONSTRAINT "mission_diffusion_pkey" PRIMARY KEY ("id");
 
 -- CreateIndex
 CREATE INDEX "mission_diffusion_distribution_publisher_active_idx" ON "mission_diffusion"("distribution_publisher_id", "is_deleted", "mission_id");
 
--- CreateIndex
-CREATE INDEX "mission_diffusion_updated_at_idx" ON "mission_diffusion"("updated_at");
+-- Une seule période active est autorisée pour un couple mission / diffuseur. Les périodes
+-- clôturées restent présentes afin de conserver l'historique des retraits et réactivations.
+CREATE UNIQUE INDEX "mission_diffusion_distribution_publisher_mission_active_key"
+ON "mission_diffusion" ("distribution_publisher_id", "mission_id")
+WHERE "is_deleted" = false;

--- a/api/prisma/migrations/20260813132806_add_mission_diffusion_soft_delete/migration.sql
+++ b/api/prisma/migrations/20260813132806_add_mission_diffusion_soft_delete/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "mission_diffusion" ADD COLUMN     "deleted_at" TIMESTAMP(3),
+ADD COLUMN     "is_deleted" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- CreateIndex
+CREATE INDEX "mission_diffusion_distribution_publisher_active_idx" ON "mission_diffusion"("distribution_publisher_id", "is_deleted", "mission_id");
+
+-- CreateIndex
+CREATE INDEX "mission_diffusion_updated_at_idx" ON "mission_diffusion"("updated_at");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -435,10 +435,10 @@ model PublisherDiffusionRule {
   @@map("publisher_diffusion_rule")
 }
 
-// Snapshot batch du périmètre de diffusion complet : une ligne (publisher de diffusion, mission)
-// encode l'allowlist explicite ou le scope propre du publisher. Le statut, le soft-delete et la
-// restriction `publisher` restent évalués en lecture (cf. mission-diffusion service).
+// Historique des périodes de diffusion : une ligne représente un cycle de diffusion d'une mission
+// vers un publisher. Le statut courant reste évalué en lecture via `isDeleted = false`.
 model MissionDiffusion {
+  id                      String    @id @default(uuid())
   distributionPublisherId String    @map("distribution_publisher_id")
   missionId               String    @map("mission_id")
   isDeleted               Boolean   @default(false) @map("is_deleted")
@@ -449,11 +449,9 @@ model MissionDiffusion {
   distributionPublisher Publisher @relation("MissionDiffusionDistributionPublisher", fields: [distributionPublisherId], references: [id], onDelete: Cascade)
   mission               Mission   @relation("MissionDiffusionMission", fields: [missionId], references: [id], onDelete: Cascade)
 
-  @@id([distributionPublisherId, missionId], map: "mission_diffusion_pkey")
   @@index([missionId], map: "mission_diffusion_mission_id_idx")
   @@index([distributionPublisherId, isDeleted, missionId], map: "mission_diffusion_distribution_publisher_active_idx")
   @@index([createdAt], map: "mission_diffusion_created_at_idx")
-  @@index([updatedAt], map: "mission_diffusion_updated_at_idx")
   @@map("mission_diffusion")
 }
 

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -439,16 +439,21 @@ model PublisherDiffusionRule {
 // encode l'allowlist explicite ou le scope propre du publisher. Le statut, le soft-delete et la
 // restriction `publisher` restent évalués en lecture (cf. mission-diffusion service).
 model MissionDiffusion {
-  distributionPublisherId String   @map("distribution_publisher_id")
-  missionId               String   @map("mission_id")
-  createdAt               DateTime @default(now()) @map("created_at")
+  distributionPublisherId String    @map("distribution_publisher_id")
+  missionId               String    @map("mission_id")
+  isDeleted               Boolean   @default(false) @map("is_deleted")
+  createdAt               DateTime  @default(now()) @map("created_at")
+  updatedAt               DateTime  @default(now()) @updatedAt @map("updated_at")
+  deletedAt               DateTime? @map("deleted_at")
 
   distributionPublisher Publisher @relation("MissionDiffusionDistributionPublisher", fields: [distributionPublisherId], references: [id], onDelete: Cascade)
   mission               Mission   @relation("MissionDiffusionMission", fields: [missionId], references: [id], onDelete: Cascade)
 
   @@id([distributionPublisherId, missionId], map: "mission_diffusion_pkey")
   @@index([missionId], map: "mission_diffusion_mission_id_idx")
+  @@index([distributionPublisherId, isDeleted, missionId], map: "mission_diffusion_distribution_publisher_active_idx")
   @@index([createdAt], map: "mission_diffusion_created_at_idx")
+  @@index([updatedAt], map: "mission_diffusion_updated_at_idx")
   @@map("mission_diffusion")
 }
 

--- a/api/src/controllers/iframe.ts
+++ b/api/src/controllers/iframe.ts
@@ -242,7 +242,7 @@ const buildMissionFilters = async (widget: WidgetRecord, query: { [key: string]:
       if (publishersWithSnapshot.length > 0) {
         accessConditions.push({
           publisherId: { in: publishersWithSnapshot },
-          missionDiffusions: { some: { distributionPublisherId: widget.fromPublisherId } },
+          missionDiffusions: { some: { distributionPublisherId: widget.fromPublisherId, isDeleted: false } },
         });
       }
       if (publishersWithFallback.length > 0) {

--- a/api/src/repositories/mission-diffusion.ts
+++ b/api/src/repositories/mission-diffusion.ts
@@ -60,16 +60,11 @@ export const missionDiffusionRepository = {
     if (missionIds.length === 0) {
       return 0;
     }
-    const now = new Date();
-    const restored = await client(tx).missionDiffusion.updateMany({
-      where: { distributionPublisherId, missionId: { in: missionIds }, isDeleted: true },
-      data: { isDeleted: false, deletedAt: null, updatedAt: now },
-    });
     const result = await client(tx).missionDiffusion.createMany({
       data: missionIds.map((missionId) => ({ distributionPublisherId, missionId })),
       skipDuplicates: true,
     });
-    return restored.count + result.count;
+    return result.count;
   },
 
   async deleteManyForDistributionPublisher(distributionPublisherId: string, missionIds: string[], tx?: Prisma.TransactionClient): Promise<number> {

--- a/api/src/repositories/mission-diffusion.ts
+++ b/api/src/repositories/mission-diffusion.ts
@@ -9,7 +9,7 @@ export const missionDiffusionRepository = {
   // Utilise l'index `mission_diffusion_mission_id_idx`.
   async findDistributionPublishersByMission(missionId: string, tx?: Prisma.TransactionClient) {
     return client(tx).missionDiffusion.findMany({
-      where: { missionId },
+      where: { missionId, isDeleted: false },
       select: {
         createdAt: true,
         distributionPublisher: { select: { id: true, name: true, logo: true } },
@@ -21,7 +21,7 @@ export const missionDiffusionRepository = {
   // Liste des `mission_id` déjà matérialisés pour un publisher de diffusion (source du diff du rebuild).
   async findMissionIdsByDistributionPublisher(distributionPublisherId: string, tx?: Prisma.TransactionClient): Promise<string[]> {
     const rows = await client(tx).missionDiffusion.findMany({
-      where: { distributionPublisherId },
+      where: { distributionPublisherId, isDeleted: false },
       select: { missionId: true },
     });
     return rows.map((row) => row.missionId);
@@ -35,6 +35,7 @@ export const missionDiffusionRepository = {
     const rows = await client(tx).missionDiffusion.findMany({
       where: {
         distributionPublisherId,
+        isDeleted: false,
         ...(afterMissionId ? { missionId: { gt: afterMissionId } } : {}),
       },
       orderBy: { missionId: "asc" },
@@ -49,7 +50,7 @@ export const missionDiffusionRepository = {
       return [];
     }
     const rows = await client(tx).missionDiffusion.findMany({
-      where: { distributionPublisherId, missionId: { in: missionIds } },
+      where: { distributionPublisherId, missionId: { in: missionIds }, isDeleted: false },
       select: { missionId: true },
     });
     return rows.map((row) => row.missionId);
@@ -59,19 +60,26 @@ export const missionDiffusionRepository = {
     if (missionIds.length === 0) {
       return 0;
     }
+    const now = new Date();
+    const restored = await client(tx).missionDiffusion.updateMany({
+      where: { distributionPublisherId, missionId: { in: missionIds }, isDeleted: true },
+      data: { isDeleted: false, deletedAt: null, updatedAt: now },
+    });
     const result = await client(tx).missionDiffusion.createMany({
       data: missionIds.map((missionId) => ({ distributionPublisherId, missionId })),
       skipDuplicates: true,
     });
-    return result.count;
+    return restored.count + result.count;
   },
 
   async deleteManyForDistributionPublisher(distributionPublisherId: string, missionIds: string[], tx?: Prisma.TransactionClient): Promise<number> {
     if (missionIds.length === 0) {
       return 0;
     }
-    const result = await client(tx).missionDiffusion.deleteMany({
-      where: { distributionPublisherId, missionId: { in: missionIds } },
+    const now = new Date();
+    const result = await client(tx).missionDiffusion.updateMany({
+      where: { distributionPublisherId, missionId: { in: missionIds }, isDeleted: false },
+      data: { isDeleted: true, deletedAt: now, updatedAt: now },
     });
     return result.count;
   },
@@ -84,7 +92,7 @@ export const missionDiffusionRepository = {
   async findMissionIdsForDistributionPublishersNotIn(distributionPublisherIds: string[], tx?: Prisma.TransactionClient): Promise<string[]> {
     const rows = await client(tx).missionDiffusion.groupBy({
       by: ["missionId"],
-      where: distributionPublisherIds.length ? { distributionPublisherId: { notIn: distributionPublisherIds } } : {},
+      where: { isDeleted: false, ...(distributionPublisherIds.length ? { distributionPublisherId: { notIn: distributionPublisherIds } } : {}) },
     });
     return rows.map((row) => row.missionId);
   },
@@ -92,23 +100,25 @@ export const missionDiffusionRepository = {
   // Purge les lignes des publishers de diffusion sortis de la population du snapshot.
   // Liste vide ⇒ table vidée.
   async deleteRowsForDistributionPublishersNotIn(distributionPublisherIds: string[], tx?: Prisma.TransactionClient): Promise<number> {
-    const result = await client(tx).missionDiffusion.deleteMany({
-      where: distributionPublisherIds.length ? { distributionPublisherId: { notIn: distributionPublisherIds } } : {},
+    const now = new Date();
+    const result = await client(tx).missionDiffusion.updateMany({
+      where: { isDeleted: false, ...(distributionPublisherIds.length ? { distributionPublisherId: { notIn: distributionPublisherIds } } : {}) },
+      data: { isDeleted: true, deletedAt: now, updatedAt: now },
     });
     return result.count;
   },
 
   async countRowsForDistributionPublishersNotIn(distributionPublisherIds: string[], tx?: Prisma.TransactionClient): Promise<number> {
     return client(tx).missionDiffusion.count({
-      where: distributionPublisherIds.length ? { distributionPublisherId: { notIn: distributionPublisherIds } } : {},
+      where: { isDeleted: false, ...(distributionPublisherIds.length ? { distributionPublisherId: { notIn: distributionPublisherIds } } : {}) },
     });
   },
 
   async countByDistributionPublisher(distributionPublisherId: string, tx?: Prisma.TransactionClient): Promise<number> {
-    return client(tx).missionDiffusion.count({ where: { distributionPublisherId } });
+    return client(tx).missionDiffusion.count({ where: { distributionPublisherId, isDeleted: false } });
   },
 
   async count(tx?: Prisma.TransactionClient): Promise<number> {
-    return client(tx).missionDiffusion.count();
+    return client(tx).missionDiffusion.count({ where: { isDeleted: false } });
   },
 };

--- a/api/src/services/__tests__/mission.test.ts
+++ b/api/src/services/__tests__/mission.test.ts
@@ -20,7 +20,7 @@ describe("buildWhere diffusion publisher filter", () => {
   it("uses the whole diffusion snapshot when publisherIds is undefined", async () => {
     const where = await buildWhere({ diffuseurPublisherId: "diffuseur-1", skip: 0, limit: 10 });
 
-    expect(where.AND).toEqual([{ missionDiffusions: { some: { distributionPublisherId: "diffuseur-1" } } }]);
+    expect(where.AND).toEqual([{ missionDiffusions: { some: { distributionPublisherId: "diffuseur-1", isDeleted: false } } }]);
   });
 
   it("builds an impossible condition when publisherIds is explicitly empty", async () => {
@@ -34,7 +34,7 @@ describe("buildWhere diffusion publisher filter", () => {
 
     expect(where.AND).toEqual([
       {
-        AND: [{ missionDiffusions: { some: { distributionPublisherId: "diffuseur-1" } } }, { publisherId: { in: ["publisher-1"] } }],
+        AND: [{ missionDiffusions: { some: { distributionPublisherId: "diffuseur-1", isDeleted: false } } }, { publisherId: { in: ["publisher-1"] } }],
       },
     ]);
   });

--- a/api/src/services/matching-engine/__tests__/matching-engine.test.ts
+++ b/api/src/services/matching-engine/__tests__/matching-engine.test.ts
@@ -188,6 +188,7 @@ describe("matchingEngineService", () => {
       expect(rankingSql).toContain('JOIN "mission_diffusion" md');
       expect(rankingSql).toContain('md."mission_id" = m."id"');
       expect(rankingSql).toContain('md."distribution_publisher_id" =');
+      expect(rankingSql).toContain('md."is_deleted" = false');
       expect(rankingSql).not.toContain('FROM "mission_diffusion" md\n      WHERE');
     });
 

--- a/api/src/services/matching-engine/index.ts
+++ b/api/src/services/matching-engine/index.ts
@@ -603,7 +603,8 @@ const buildPublisherDiffusionJoinSql = (publisherId?: string): Prisma.Sql => {
 
   return Prisma.sql`JOIN "mission_diffusion" md
     ON md."mission_id" = m."id"
-   AND md."distribution_publisher_id" = ${publisherId}`;
+   AND md."distribution_publisher_id" = ${publisherId}
+   AND md."is_deleted" = false`;
 };
 
 const buildTaxonomyScoresSql = (params: {

--- a/api/src/services/mission-browse/__tests__/index.test.ts
+++ b/api/src/services/mission-browse/__tests__/index.test.ts
@@ -215,7 +215,7 @@ describe("missionBrowseService.browse", () => {
 
     expect(findOneMissionByMock).toHaveBeenCalledWith({
       id: "mission-1",
-      missionDiffusions: { some: { distributionPublisherId: "diffuseur-1" } },
+      missionDiffusions: { some: { distributionPublisherId: "diffuseur-1", isDeleted: false } },
       deletedAt: null,
       statusCode: "ACCEPTED",
     });

--- a/api/src/services/mission-browse/index.ts
+++ b/api/src/services/mission-browse/index.ts
@@ -245,7 +245,7 @@ export const missionBrowseService = {
   async findById(id: string, diffuseurPublisherId: string, addressId?: string): Promise<MissionDetailResponse | null> {
     const mission = await missionService.findOneMissionBy({
       id,
-      missionDiffusions: { some: { distributionPublisherId: diffuseurPublisherId } },
+      missionDiffusions: { some: { distributionPublisherId: diffuseurPublisherId, isDeleted: false } },
       deletedAt: null,
       statusCode: "ACCEPTED",
     });

--- a/api/src/services/mission-index/index.ts
+++ b/api/src/services/mission-index/index.ts
@@ -103,6 +103,7 @@ export const missionIndexService = {
           select: { activity: { select: { name: true } } },
         },
         missionDiffusions: {
+          where: { isDeleted: false },
           select: { distributionPublisherId: true },
         },
         moderationStatuses: {

--- a/api/src/services/mission.ts
+++ b/api/src/services/mission.ts
@@ -214,7 +214,7 @@ export const buildWhere = async (filters: MissionSearchFilters): Promise<Prisma.
 
   // Le snapshot contient l'allowlist explicite et le scope propre du diffuseur.
   if (filters.diffuseurPublisherId) {
-    const diffusionWhere: Prisma.MissionWhereInput = { missionDiffusions: { some: { distributionPublisherId: filters.diffuseurPublisherId } } };
+    const diffusionWhere: Prisma.MissionWhereInput = { missionDiffusions: { some: { distributionPublisherId: filters.diffuseurPublisherId, isDeleted: false } } };
     const restrictedDiffusionWhere: Prisma.MissionWhereInput =
       filters.publisherIds === undefined
         ? diffusionWhere

--- a/api/src/v0/mission/controller.ts
+++ b/api/src/v0/mission/controller.ts
@@ -248,7 +248,7 @@ router.get("/:id", async (req: PublisherRequest, res: Response, next: NextFuncti
       id: params.data.id,
       statusCode: "ACCEPTED",
       deletedAt: null,
-      missionDiffusions: { some: { distributionPublisherId: user.id } },
+      missionDiffusions: { some: { distributionPublisherId: user.id, isDeleted: false } },
       ...(user.moderator ? { moderationStatuses: { some: { publisherId: user.id, status: "ACCEPTED" } } } : {}),
     };
 

--- a/api/src/v2/activity.ts
+++ b/api/src/v2/activity.ts
@@ -142,7 +142,7 @@ router.post("/", async (req: PublisherRequest, res: Response, next: NextFunction
       const canAccessMission =
         (await missionService.countBy({
           id: mission.id,
-          missionDiffusions: { some: { distributionPublisherId: user.id } },
+          missionDiffusions: { some: { distributionPublisherId: user.id, isDeleted: false } },
         })) > 0;
       if (!canAccessMission) {
         return res.status(403).send({ ok: false, code: FORBIDDEN, message: "Mission not accessible" });


### PR DESCRIPTION
## Description

Ajoute le pipeline analytics de `mission_diffusion` afin de suivre l'historique des périodes de diffusion d'une mission vers un publisher.

- fait évoluer le modèle core avec un identifiant technique, le soft delete (`is_deleted`, `deleted_at`) et `updated_at` ;
- conserve les cycles successifs diffusion → suppression → rediffusion : une réactivation crée une nouvelle ligne, tandis qu'une contrainte partielle garantit qu'un seul cycle est actif pour un couple mission / publisher ;
- adapte les lectures applicatives pour ne considérer que les diffusions actives ;
- exporte la table vers `analytics_raw` de manière incrémentale avec le curseur `updated_at` / `id` et un upsert par `id` ;
- ajoute les modèles dbt staging, intermediate incrémental et mart (vue) en conservant l'historique.

## Liens utiles

- 📝 Ticket Notion : [Pipeline mission_diffusion](https://app.notion.com/p/jeveuxaider/Pipeline-mission_diffusion-3a572a322d50804e9babcf03e50691cf?v=1f872a322d50808a915e000ceb54dce3&source=copy_link)

## Type de changement

- [x] Nouvelle fonctionnalité
- [ ] Correction de bug
- [ ] Amélioration de performance
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [ ] Code testé localement
- [x] Tests unitaires ajoutés/modifiés si nécessaire
- [ ] Respect des standards de code (ESLint)
- [x] Migration de données nécessaire

## Notes complémentaires

La migration core ajoute `id` nullable puis le renseigne avant de le rendre obligatoire et de remplacer la clé primaire composite. Cela permet de migrer les lignes existantes sans bloquer la table.

Pour les analyses, le mart `mission_diffusion` expose tous les cycles. Les diffusions actuellement actives s'obtiennent avec `where is_deleted = false`.

Les migrations Prisma et dbmate doivent être appliquées avant le premier export raw, puis les modèles dbt doivent être exécutés.